### PR TITLE
feat: add cache stats command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Expand the relay allowlist to public repo metadata, PR and issue lists, commits, and workflow metadata.
 - Add cached top-level CLI translations for common read-only `gh pr`, `gh issue`, `gh run`, and `gh repo` commands, including conservative `--json` and `--jq` support.
+- Add persisted cache hit/miss/bypass metrics, `GET /v1/pools/:pool/stats`, `octopool stats`, and dashboard top-route hit-rate views.
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ octopool gh api repos/openclaw/openclaw/pulls/85341 --jq .number
 
 octopool gh pr view 85341 -R openclaw/openclaw --json number,title,url
 octopool gh pr checks 85341 -R openclaw/openclaw --json name,state,bucket
+octopool stats
 ```
 
 Symlink it as `gh` for a transparent shim — supported reads go through the pool, everything else (and any mutation) passes straight to the real GitHub CLI:
@@ -86,7 +87,7 @@ A Durable Object (`PoolCoordinator`, one per pool) holds per-identity rate snaps
 Each links to its page on [docs.octopool.dev](https://docs.octopool.dev):
 
 - **[GitHub read relay](https://docs.octopool.dev/relay.html)** — `POST /v1/github/request`, the supported route allowlist, response envelope, and safety caps.
-- **[Octopool CLI](https://docs.octopool.dev/cli.html)** — `octopool login`, the `gh` shim, and real-`gh` fallback.
+- **[Octopool CLI](https://docs.octopool.dev/cli.html)** — `octopool login`, the `gh` shim, cache stats, and real-`gh` fallback.
 - **[Pooled identities & routing](https://docs.octopool.dev/identities.html)** — PAT and GitHub App identities, scopes, and the coordinator's selection, leases, and cooldowns.
 - **[Cache & public-repo guard](https://docs.octopool.dev/cache.html)** — the D1 read-through cache and public-only visibility enforcement.
 - **[Auth & org membership](https://docs.octopool.dev/auth.html)** — caller auth, admin auth, website sessions, and the GitHub-CLI login exchange.

--- a/cmd/octopool/main.go
+++ b/cmd/octopool/main.go
@@ -76,6 +76,8 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		return runGH(ctx, args[1:], stdout, stderr)
 	case "health":
 		return runHealth(ctx, args[1:], stdout)
+	case "stats":
+		return runStats(ctx, args[1:], stdout)
 	case "request":
 		return runRequest(ctx, args[1:], stdout)
 	case "admin":
@@ -288,12 +290,20 @@ func runAdminIdentity(ctx context.Context, args []string, stdout io.Writer) erro
 }
 
 func getJSON(ctx context.Context, stdout io.Writer, url string, token string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	resp, err := getJSONRaw(ctx, url, token)
 	if err != nil {
 		return err
 	}
+	return writeJSONResponse(stdout, resp)
+}
+
+func getJSONRaw(ctx context.Context, url string, token string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
 	req.Header.Set("authorization", "Bearer "+token)
-	return do(stdout, req)
+	return httpClient.Do(req)
 }
 
 func postJSON(ctx context.Context, stdout io.Writer, url string, token string, body map[string]any) error {
@@ -461,5 +471,5 @@ func apiURL(base string, path string) string {
 }
 
 func usage(w io.Writer) {
-	fmt.Fprintln(w, "usage: octopool <login|gh|health|request|admin> [flags]")
+	fmt.Fprintln(w, "usage: octopool <login|gh|health|stats|request|admin> [flags]")
 }

--- a/cmd/octopool/stats.go
+++ b/cmd/octopool/stats.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type statsResponse struct {
+	Pool        string         `json:"pool"`
+	Window      statsWindow    `json:"window"`
+	Operator    statsOperator  `json:"operator"`
+	PoolUsage   statsAggregate `json:"pool_usage"`
+	CallerUsage statsAggregate `json:"caller_usage"`
+	Routes      []statsRoute   `json:"routes"`
+	Cache       statsCache     `json:"cache"`
+}
+
+type statsWindow struct {
+	Label   string `json:"label"`
+	Seconds int    `json:"seconds"`
+}
+
+type statsOperator struct {
+	GitHubLogin string `json:"github_login"`
+}
+
+type statsAggregate struct {
+	Requests          int      `json:"requests"`
+	Errors            int      `json:"errors"`
+	AvgDurationMS     *float64 `json:"avg_duration_ms"`
+	CacheHits         int      `json:"cache_hits"`
+	CacheMisses       int      `json:"cache_misses"`
+	CacheBypass       int      `json:"cache_bypass"`
+	CacheUnknown      int      `json:"cache_unknown"`
+	CacheableRequests int      `json:"cacheable_requests"`
+	CacheHitRate      *float64 `json:"cache_hit_rate"`
+}
+
+type statsRoute struct {
+	RouteKind    string `json:"route_kind"`
+	LatestSeenAt string `json:"latest_seen_at"`
+	statsAggregate
+}
+
+type statsCache struct {
+	TotalEntries   int   `json:"total_entries"`
+	FreshEntries   int   `json:"fresh_entries"`
+	ExpiredEntries int   `json:"expired_entries"`
+	BodyBytes      int64 `json:"body_bytes"`
+}
+
+func runStats(ctx context.Context, args []string, stdout io.Writer) error {
+	auth, err := loadAuth()
+	if err != nil {
+		return err
+	}
+	fs := flag.NewFlagSet("stats", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	baseURL := fs.String("url", defaultAuthURL(auth), "Octopool base URL")
+	pool := fs.String("pool", defaultAuthPool(auth), "pool id")
+	tokenEnv := fs.String("token-env", "OCTOPOOL_TOKEN", "caller token env var")
+	since := fs.String("since", "24h", "stats window, e.g. 30m, 24h, 7d")
+	jsonOutput := fs.Bool("json", false, "print raw JSON")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := validateAuthURLForRequest(auth, *baseURL, *tokenEnv); err != nil {
+		return err
+	}
+	token, err := callerToken(*tokenEnv)
+	if err != nil {
+		return err
+	}
+	query := url.Values{}
+	if strings.TrimSpace(*since) != "" {
+		query.Set("since", strings.TrimSpace(*since))
+	}
+	endpoint := apiURL(*baseURL, "/v1/pools/"+urlPath(*pool)+"/stats")
+	if encoded := query.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+	resp, err := getJSONRaw(ctx, endpoint, token)
+	if err != nil {
+		return err
+	}
+	if *jsonOutput {
+		return writeJSONResponse(stdout, resp)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("%s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	var stats statsResponse
+	if err := json.Unmarshal(body, &stats); err != nil {
+		return err
+	}
+	return renderStats(stdout, stats)
+}
+
+func renderStats(w io.Writer, stats statsResponse) error {
+	lines := []string{
+		"pool: " + stats.Pool,
+		"window: " + firstNonEmpty(stats.Window.Label, "24h"),
+		fmt.Sprintf("operator: %s", firstNonEmpty(stats.Operator.GitHubLogin, "unknown")),
+		fmt.Sprintf("requests: %s (%s errors)", intFmt(stats.PoolUsage.Requests), intFmt(stats.PoolUsage.Errors)),
+		fmt.Sprintf(
+			"cache: %s hit (%s hits, %s misses, %s bypass)",
+			percent(stats.PoolUsage.CacheHitRate),
+			intFmt(stats.PoolUsage.CacheHits),
+			intFmt(stats.PoolUsage.CacheMisses),
+			intFmt(stats.PoolUsage.CacheBypass),
+		),
+		fmt.Sprintf(
+			"caller: %s requests, %s hit",
+			intFmt(stats.CallerUsage.Requests),
+			percent(stats.CallerUsage.CacheHitRate),
+		),
+		fmt.Sprintf(
+			"entries: %s fresh / %s total, %s expired, %s",
+			intFmt(stats.Cache.FreshEntries),
+			intFmt(stats.Cache.TotalEntries),
+			intFmt(stats.Cache.ExpiredEntries),
+			byteFmt(stats.Cache.BodyBytes),
+		),
+	}
+	for _, line := range lines {
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintln(w, "top routes:"); err != nil {
+		return err
+	}
+	if len(stats.Routes) == 0 {
+		_, err := fmt.Fprintln(w, "  none")
+		return err
+	}
+	for _, route := range stats.Routes {
+		if _, err := fmt.Fprintf(
+			w,
+			"  %s: %s req, %s hit, %s errors\n",
+			route.RouteKind,
+			intFmt(route.Requests),
+			percent(route.CacheHitRate),
+			intFmt(route.Errors),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func percent(value *float64) string {
+	if value == nil || math.IsNaN(*value) || math.IsInf(*value, 0) {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.1f%%", *value*100)
+}
+
+func intFmt(value int) string {
+	return fmt.Sprintf("%d", value)
+}
+
+func byteFmt(value int64) string {
+	switch {
+	case value >= 1024*1024:
+		return fmt.Sprintf("%.1f MiB", float64(value)/(1024*1024))
+	case value >= 1024:
+		return fmt.Sprintf("%.1f KiB", float64(value)/1024)
+	default:
+		return fmt.Sprintf("%d B", value)
+	}
+}

--- a/cmd/octopool/stats_test.go
+++ b/cmd/octopool/stats_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRenderStats(t *testing.T) {
+	rate := 0.625
+	stats := statsResponse{
+		Pool:     "maintainers",
+		Window:   statsWindow{Label: "24h", Seconds: 86400},
+		Operator: statsOperator{GitHubLogin: "steipete"},
+		PoolUsage: statsAggregate{
+			Requests:     12,
+			Errors:       1,
+			CacheHits:    5,
+			CacheMisses:  3,
+			CacheBypass:  4,
+			CacheHitRate: &rate,
+		},
+		CallerUsage: statsAggregate{
+			Requests:     8,
+			CacheHitRate: &rate,
+		},
+		Cache: statsCache{
+			TotalEntries:   9,
+			FreshEntries:   7,
+			ExpiredEntries: 2,
+			BodyBytes:      1536,
+		},
+		Routes: []statsRoute{{
+			RouteKind: "pr_view",
+			statsAggregate: statsAggregate{
+				Requests:     6,
+				Errors:       0,
+				CacheHitRate: &rate,
+			},
+		}},
+	}
+	var out bytes.Buffer
+	if err := renderStats(&out, stats); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"pool: maintainers",
+		"operator: steipete",
+		"cache: 62.5% hit (5 hits, 3 misses, 4 bypass)",
+		"entries: 7 fresh / 9 total, 2 expired, 1.5 KiB",
+		"  pr_view: 6 req, 62.5% hit, 0 errors",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderStatsNoRoutes(t *testing.T) {
+	var out bytes.Buffer
+	if err := renderStats(&out, statsResponse{Pool: "maintainers"}); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "cache: n/a hit") {
+		t.Fatalf("missing n/a cache rate:\n%s", got)
+	}
+	if !strings.Contains(got, "top routes:\n  none") {
+		t.Fatalf("missing empty routes:\n%s", got)
+	}
+}

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -42,7 +42,9 @@ A hit is only served if:
 - the repo's public-visibility proof still covers the entry (re-checked, with a small
   historical-proof allowance during GitHub outages / secondary-rate-limit — see below).
 
-Hits are still audited, with the cached identity attributed.
+Hits are still audited, with the cached identity attributed. Each audit row records cache
+status as `hit`, `miss`, `bypass`, or `unknown`, which powers `octopool stats` and the
+dashboard hit-rate/top-route views.
 
 ## Public-repo guard
 
@@ -70,6 +72,8 @@ private-repo block — a hard `404`/private response always denies.
   key/kind, status, response headers JSON, body JSON, body encoding, source identity,
   created/expires timestamps (migration `0002`).
 - `github_public_repos` — `owner`, `repo`, `checked_at`, `expires_at` (migration `0003`).
+- `audit_events.cache_status` / `audit_events.cacheable` — per-request cache metrics
+  (migration `0005`).
 
 Secret values are never written to the cache. R2 is deferred; current routes are bounded
 enough to live in D1, and large Actions logs skip the cache entirely.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -104,6 +104,27 @@ passed straight through to the real GitHub CLI, with its exit code preserved.
 Fetches `GET /v1/pools/<pool>/health` using the stored token. Returns identity counts and
 policy version.
 
+### `octopool stats [--pool <id>] [--since 24h] [--json]`
+
+Fetches `GET /v1/pools/<pool>/stats` using the stored token. The default human output
+shows the pool request count, cache hit rate, caller-specific usage, D1 cache entries,
+and top route kinds. `--since` accepts `30m`, `24h`, or `7d` style windows, capped at 30
+days.
+
+```sh
+octopool stats
+# pool: maintainers
+# cache: 82.4% hit (42 hits, 9 misses, 3 bypass)
+# top routes:
+#   pr_view: 31 req, 86.1% hit, 0 errors
+```
+
+Use `--json` for dashboards or scripts that want the raw aggregate:
+
+```sh
+octopool stats --since 7d --json
+```
+
 ### `octopool request --path <p> [--method GET] [--query k=v] [--header k=v]`
 
 Debug/admin raw wrapper over `POST /v1/github/request`. Prints the full relay envelope.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -23,7 +23,9 @@ non-admin org members cannot load dashboard data.
 - caller and pool identity
 - active/total pooled identities
 - Durable Object rate-limit snapshots, active cooldowns, and live leases
-- D1 cache totals, fresh/expired entries, body byte size, and route-kind breakdown
+- D1 cache totals, fresh/expired entries, body byte size, hit rate, and route-kind
+  breakdown
+- top route kinds for the last 24 hours, with cache hit rate, bypasses, and errors
 - public-repo proof count
 - per-caller usage for the last seven days
 - recent audit traffic with route kind, status, identity, and duration

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -47,6 +47,8 @@ D1 schema lives in `migrations/`:
 - `0003_github_app_public_cache.sql` — `installation_id` column and `github_public_repos`.
 - `0004_web_dashboard_sessions.sql` — dashboard role, OAuth states, and hashed website
   sessions.
+- `0005_audit_cache_metrics.sql` — per-request cache status and cacheability columns,
+  plus stats indexes for route and hit-rate aggregates.
 
 Apply with `wrangler d1 migrations apply octopool` (add `--remote` for production).
 
@@ -77,5 +79,8 @@ Override the host/resolver with `OCTOPOOL_E2E_HOST` / `OCTOPOOL_E2E_RESOLVER`.
 ## Observability
 
 Observability is enabled at full sampling. Every routed request writes an `audit_events`
-row (caller, pool, route key/kind, identity, status, error code, duration); secrets and
-request bodies are never recorded.
+row (caller, pool, route key/kind, identity, status, error code, duration, cache
+hit/miss/bypass status); secrets and request bodies are never recorded.
+
+`GET /v1/pools/<pool>/stats?since=24h` returns pool-wide and caller-specific cache stats.
+The CLI wraps this as `octopool stats`.

--- a/migrations/0005_audit_cache_metrics.sql
+++ b/migrations/0005_audit_cache_metrics.sql
@@ -1,0 +1,11 @@
+ALTER TABLE audit_events ADD COLUMN cache_status TEXT NOT NULL DEFAULT 'unknown'
+  CHECK (cache_status IN ('hit', 'miss', 'bypass', 'unknown'));
+
+ALTER TABLE audit_events ADD COLUMN cacheable INTEGER NOT NULL DEFAULT 0
+  CHECK (cacheable IN (0, 1));
+
+CREATE INDEX IF NOT EXISTS idx_audit_pool_cache_created
+  ON audit_events(pool_id, cache_status, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_audit_pool_route_cache_created
+  ON audit_events(pool_id, route_kind, cache_status, created_at);

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -81,6 +81,10 @@ const DASHBOARD_HTML = `<!doctype html>
         <table><thead><tr><th>Route</th><th>Fresh</th><th>Total</th><th>Latest</th></tr></thead><tbody id="cache-routes"></tbody></table>
       </div>
       <div class="panel">
+        <div class="panel-head"><h2>Top Routes</h2><span class="section-label">24 hours</span></div>
+        <table><thead><tr><th>Route</th><th>Requests</th><th>Hit rate</th><th>Bypass</th><th>Errors</th></tr></thead><tbody id="route-usage"></tbody></table>
+      </div>
+      <div class="panel">
         <div class="panel-head"><h2>Who Uses It</h2><span class="section-label">7 days</span></div>
         <table><thead><tr><th>User</th><th>Requests</th><th>Errors</th><th>Avg ms</th><th>Last seen</th></tr></thead><tbody id="callers"></tbody></table>
       </div>
@@ -128,12 +132,13 @@ function render(data) {
   $("who").replaceChildren(el("strong", data.operator.github_login), el("span", data.pool + " · " + data.generated_at));
   $("tiles").replaceChildren(
     tile("Requests 24h", fmt(data.usage.requests_24h), data.usage.errors_24h + " errors"),
+    tile("Cache Hit 24h", pct(data.usage.cache_hit_rate_24h), data.usage.cache_misses_24h + " misses"),
     tile("Cache Fresh", fmt(data.cache.fresh_entries), fmt(data.cache.total_entries) + " total"),
-    tile("Cache Bytes", bytes(data.cache.body_bytes), data.cache.expired_entries + " expired"),
     tile("Identities", fmt(data.identities.active) + "/" + fmt(data.identities.total), data.coordinator.cooldowns.length + " cooldowns"),
   );
   renderRates(data);
   rows("cache-routes", data.cache.routes, (item) => [item.route_kind, item.fresh_entries, item.entries, rel(item.latest_created_at)]);
+  rows("route-usage", data.route_usage, (item) => [item.route_kind, item.requests, pct(item.cache_hit_rate), item.cache_bypass, item.errors]);
   rows("callers", data.users, (item) => [item.github_login, item.requests, item.errors, Math.round(item.avg_duration_ms || 0), rel(item.last_seen)]);
   rows("recent", data.recent, (item) => [rel(item.created_at), item.github_login, item.route_kind, statusPill(item.status), item.identity_id || "none"]);
 }
@@ -202,7 +207,7 @@ function resetDashboard() {
   $("tiles").replaceChildren();
   $("rates").replaceChildren();
   $("rate-count").textContent = "";
-  for (const id of ["cache-routes", "callers", "recent"]) $(id).replaceChildren();
+  for (const id of ["cache-routes", "route-usage", "callers", "recent"]) $(id).replaceChildren();
   $("error").style.display = "none";
 }
 function el(tag, text, cls) {
@@ -212,6 +217,10 @@ function el(tag, text, cls) {
   return node;
 }
 function fmt(value) { return Number(value || 0).toLocaleString(); }
+function pct(value) {
+  if (value === null || value === undefined) return "n/a";
+  return (Number(value) * 100).toFixed(1) + "%";
+}
 function bytes(value) {
   const n = Number(value || 0);
   if (n > 1024 * 1024) return (n / 1024 / 1024).toFixed(1) + " MiB";

--- a/src/db.ts
+++ b/src/db.ts
@@ -82,12 +82,14 @@ export async function insertAudit(
     status: number;
     errorCode?: string;
     durationMs: number;
+    cacheStatus?: "hit" | "miss" | "bypass" | "unknown";
+    cacheable?: boolean;
   },
 ): Promise<void> {
   await env.DB.prepare(
     `INSERT INTO audit_events
-       (request_id, caller_id, pool_id, route_key, route_kind, identity_id, status, error_code, duration_ms)
-     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)`,
+       (request_id, caller_id, pool_id, route_key, route_kind, identity_id, status, error_code, duration_ms, cache_status, cacheable)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)`,
   )
     .bind(
       event.requestId,
@@ -99,6 +101,8 @@ export async function insertAudit(
       event.status,
       event.errorCode ?? null,
       event.durationMs,
+      event.cacheStatus ?? "unknown",
+      event.cacheable === true ? 1 : 0,
     )
     .run();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import { rootResponse } from "./landing";
 import { classifyRoute, normalizeRouteKey, validateRelayRequest } from "./policy";
 import { PoolCoordinator } from "./pool-coordinator";
 import { ensurePublicGitHubRepo } from "./public-repos";
+import { parseStatsWindow, poolStats } from "./stats";
 import {
   finishGitHubWebLogin,
   logoutWebSession,
@@ -90,6 +91,12 @@ async function routeRequest(
   }
   if (request.method === "POST" && url.pathname === "/v1/login/github-cli") {
     return loginGitHubCLI(request, env);
+  }
+  if (request.method === "GET" && /^\/v1\/pools\/[^/]+\/stats$/.test(url.pathname)) {
+    const pool = routeParam(url.pathname, /^\/v1\/pools\/(?<pool>[^/]+)\/stats$/, "pool");
+    const caller = await authenticateCaller(request, env, pool);
+    const window = parseStatsWindow(url.searchParams.get("since"));
+    return jsonResponse(await poolStats(env, pool, caller, window));
   }
   if (request.method === "GET" && /^\/v1\/pools\/[^/]+\/health$/.test(url.pathname)) {
     const pool = routeParam(url.pathname, /^\/v1\/pools\/(?<pool>[^/]+)\/health$/, "pool");
@@ -173,6 +180,9 @@ async function dashboardUsage(env: Env, pool: string) {
     `SELECT
        COUNT(*) AS requests_24h,
        SUM(CASE WHEN status >= 400 THEN 1 ELSE 0 END) AS errors_24h,
+       SUM(CASE WHEN cache_status = 'hit' THEN 1 ELSE 0 END) AS cache_hits_24h,
+       SUM(CASE WHEN cache_status = 'miss' THEN 1 ELSE 0 END) AS cache_misses_24h,
+       SUM(CASE WHEN cache_status = 'bypass' THEN 1 ELSE 0 END) AS cache_bypass_24h,
        AVG(duration_ms) AS avg_duration_ms_24h,
        MAX(created_at) AS latest_seen_at
      FROM audit_events
@@ -183,12 +193,22 @@ async function dashboardUsage(env: Env, pool: string) {
     .first<{
       requests_24h: number;
       errors_24h: number | null;
+      cache_hits_24h: number | null;
+      cache_misses_24h: number | null;
+      cache_bypass_24h: number | null;
       avg_duration_ms_24h: number | null;
       latest_seen_at: string | null;
     }>();
+  const cacheHits = row?.cache_hits_24h ?? 0;
+  const cacheMisses = row?.cache_misses_24h ?? 0;
+  const cacheDenominator = cacheHits + cacheMisses;
   return {
     requests_24h: row?.requests_24h ?? 0,
     errors_24h: row?.errors_24h ?? 0,
+    cache_hits_24h: cacheHits,
+    cache_misses_24h: cacheMisses,
+    cache_bypass_24h: row?.cache_bypass_24h ?? 0,
+    cache_hit_rate_24h: cacheDenominator === 0 ? null : cacheHits / cacheDenominator,
     avg_duration_ms_24h: row?.avg_duration_ms_24h ?? null,
     latest_seen_at: row?.latest_seen_at ?? null,
   };
@@ -336,7 +356,13 @@ async function dashboardRecent(env: Env, pool: string) {
 
 async function dashboardRouteUsage(env: Env, pool: string) {
   const rows = await env.DB.prepare(
-    `SELECT route_kind, COUNT(*) AS requests, SUM(CASE WHEN status >= 400 THEN 1 ELSE 0 END) AS errors
+    `SELECT
+       route_kind,
+       COUNT(*) AS requests,
+       SUM(CASE WHEN status >= 400 THEN 1 ELSE 0 END) AS errors,
+       SUM(CASE WHEN cache_status = 'hit' THEN 1 ELSE 0 END) AS cache_hits,
+       SUM(CASE WHEN cache_status = 'miss' THEN 1 ELSE 0 END) AS cache_misses,
+       SUM(CASE WHEN cache_status = 'bypass' THEN 1 ELSE 0 END) AS cache_bypass
      FROM audit_events
      WHERE pool_id = ?1
        AND created_at >= datetime('now', '-24 hours')
@@ -345,8 +371,27 @@ async function dashboardRouteUsage(env: Env, pool: string) {
      LIMIT 12`,
   )
     .bind(pool)
-    .all<{ route_kind: string; requests: number; errors: number | null }>();
-  return rows.results.map((row) => ({ ...row, errors: row.errors ?? 0 }));
+    .all<{
+      route_kind: string;
+      requests: number;
+      errors: number | null;
+      cache_hits: number | null;
+      cache_misses: number | null;
+      cache_bypass: number | null;
+    }>();
+  return rows.results.map((row) => {
+    const cacheHits = row.cache_hits ?? 0;
+    const cacheMisses = row.cache_misses ?? 0;
+    const cacheDenominator = cacheHits + cacheMisses;
+    return {
+      ...row,
+      errors: row.errors ?? 0,
+      cache_hits: cacheHits,
+      cache_misses: cacheMisses,
+      cache_bypass: row.cache_bypass ?? 0,
+      cache_hit_rate: cacheDenominator === 0 ? null : cacheHits / cacheDenominator,
+    };
+  });
 }
 
 async function dashboardIdentityUsage(env: Env, pool: string) {
@@ -463,12 +508,16 @@ async function relayGitHub(
   }
   let route: ReturnType<typeof classifyRoute> | undefined;
   let identity: Identity | undefined;
+  let auditCacheStatus: "hit" | "miss" | "bypass" | "unknown" = "unknown";
+  let auditCacheable = false;
   try {
     route = classifyRoute(relayRequest, policy);
     const cacheEnabled = shouldUseGitHubCache(relayRequest, route);
     const cacheKey = cacheEnabled
       ? await githubCacheKey(relayRequest.pool, relayRequest, route)
       : undefined;
+    auditCacheable = cacheKey !== undefined;
+    auditCacheStatus = cacheKey === undefined ? "bypass" : "miss";
     if (cacheKey !== undefined) {
       const cached = await readGitHubCache(env, cacheKey);
       if (cached !== undefined) {
@@ -492,6 +541,8 @@ async function relayGitHub(
               status: cached.status,
               durationMs: Date.now() - started,
               identityId: cached.identity.id,
+              cacheStatus: "hit",
+              cacheable: true,
             }),
           );
           return jsonResponse({
@@ -547,6 +598,8 @@ async function relayGitHub(
           identityId: identity.id,
           status: github.status,
           durationMs: Date.now() - started,
+          cacheStatus: auditCacheStatus,
+          cacheable: auditCacheable,
         }),
         ...(cacheKey === undefined
           ? []
@@ -584,6 +637,8 @@ async function relayGitHub(
         status: audit.status,
         errorCode: audit.code,
         durationMs: Date.now() - started,
+        cacheStatus: auditCacheStatus,
+        cacheable: auditCacheable,
         ...(identity === undefined ? {} : { identityId: identity.id }),
       }),
     );

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,0 +1,203 @@
+import { HttpError } from "./http";
+import type { Caller } from "./types";
+
+const MAX_WINDOW_SECONDS = 30 * 24 * 60 * 60;
+
+export type StatsWindow = {
+  label: string;
+  seconds: number;
+};
+
+export type CacheAggregate = {
+  requests: number;
+  errors: number;
+  avg_duration_ms: number | null;
+  cache_hits: number;
+  cache_misses: number;
+  cache_bypass: number;
+  cache_unknown: number;
+  cacheable_requests: number;
+  cache_hit_rate: number | null;
+};
+
+export type AggregateRow = {
+  requests: number;
+  errors: number | null;
+  avg_duration_ms: number | null;
+  cache_hits: number | null;
+  cache_misses: number | null;
+  cache_bypass: number | null;
+  cache_unknown: number | null;
+  cacheable_requests: number | null;
+};
+
+type RouteRow = AggregateRow & {
+  route_kind: string;
+  latest_seen_at: string | null;
+};
+
+export function parseStatsWindow(raw: string | null): StatsWindow {
+  const fallback = { label: "24h", seconds: 24 * 60 * 60 };
+  if (raw === null || raw.trim() === "") {
+    return fallback;
+  }
+  const trimmed = raw.trim().toLowerCase();
+  const match = /^([1-9][0-9]*)(m|h|d)?$/.exec(trimmed);
+  if (match === null) {
+    throw new HttpError(400, "invalid_window", "since must look like 30m, 24h, or 7d");
+  }
+  const amount = Number.parseInt(match[1] ?? "", 10);
+  const unit = match[2] ?? "h";
+  const seconds = amount * unitSeconds(unit);
+  if (!Number.isFinite(seconds) || seconds <= 0 || seconds > MAX_WINDOW_SECONDS) {
+    throw new HttpError(400, "invalid_window", "since must be between 1 minute and 30 days");
+  }
+  return { label: `${amount}${unit}`, seconds };
+}
+
+export async function poolStats(env: Env, pool: string, caller: Caller, window: StatsWindow) {
+  const [poolUsage, callerUsage, routes, callerRoutes, cache] = await Promise.all([
+    aggregateUsage(env, pool, window.seconds),
+    aggregateUsage(env, pool, window.seconds, caller.id),
+    routeUsage(env, pool, window.seconds),
+    routeUsage(env, pool, window.seconds, caller.id),
+    cacheTotals(env, pool),
+  ]);
+  return {
+    generated_at: new Date().toISOString(),
+    pool,
+    window,
+    operator: {
+      github_login: caller.github_login,
+    },
+    pool_usage: poolUsage,
+    caller_usage: callerUsage,
+    routes,
+    caller_routes: callerRoutes,
+    cache,
+  };
+}
+
+async function aggregateUsage(
+  env: Env,
+  pool: string,
+  windowSeconds: number,
+  callerId?: string,
+): Promise<CacheAggregate> {
+  const callerClause = callerId === undefined ? "" : "AND caller_id = ?3";
+  const statement = env.DB.prepare(
+    `SELECT
+       COUNT(*) AS requests,
+       SUM(CASE WHEN status >= 400 THEN 1 ELSE 0 END) AS errors,
+       AVG(duration_ms) AS avg_duration_ms,
+       SUM(CASE WHEN cache_status = 'hit' THEN 1 ELSE 0 END) AS cache_hits,
+       SUM(CASE WHEN cache_status = 'miss' THEN 1 ELSE 0 END) AS cache_misses,
+       SUM(CASE WHEN cache_status = 'bypass' THEN 1 ELSE 0 END) AS cache_bypass,
+       SUM(CASE WHEN cache_status = 'unknown' THEN 1 ELSE 0 END) AS cache_unknown,
+       SUM(CASE WHEN cacheable = 1 THEN 1 ELSE 0 END) AS cacheable_requests
+     FROM audit_events
+     WHERE pool_id = ?1
+       AND created_at >= datetime('now', ?2)
+       ${callerClause}`,
+  );
+  const bound =
+    callerId === undefined
+      ? statement.bind(pool, `-${windowSeconds} seconds`)
+      : statement.bind(pool, `-${windowSeconds} seconds`, callerId);
+  const row = await bound.first<AggregateRow>();
+  return normalizeAggregate(row);
+}
+
+async function routeUsage(
+  env: Env,
+  pool: string,
+  windowSeconds: number,
+  callerId?: string,
+): Promise<(CacheAggregate & { route_kind: string; latest_seen_at: string | null })[]> {
+  const callerClause = callerId === undefined ? "" : "AND caller_id = ?3";
+  const statement = env.DB.prepare(
+    `SELECT
+       route_kind,
+       COUNT(*) AS requests,
+       SUM(CASE WHEN status >= 400 THEN 1 ELSE 0 END) AS errors,
+       AVG(duration_ms) AS avg_duration_ms,
+       SUM(CASE WHEN cache_status = 'hit' THEN 1 ELSE 0 END) AS cache_hits,
+       SUM(CASE WHEN cache_status = 'miss' THEN 1 ELSE 0 END) AS cache_misses,
+       SUM(CASE WHEN cache_status = 'bypass' THEN 1 ELSE 0 END) AS cache_bypass,
+       SUM(CASE WHEN cache_status = 'unknown' THEN 1 ELSE 0 END) AS cache_unknown,
+       SUM(CASE WHEN cacheable = 1 THEN 1 ELSE 0 END) AS cacheable_requests,
+       MAX(created_at) AS latest_seen_at
+     FROM audit_events
+     WHERE pool_id = ?1
+       AND created_at >= datetime('now', ?2)
+       ${callerClause}
+     GROUP BY route_kind
+     ORDER BY requests DESC, route_kind
+     LIMIT 12`,
+  );
+  const bound =
+    callerId === undefined
+      ? statement.bind(pool, `-${windowSeconds} seconds`)
+      : statement.bind(pool, `-${windowSeconds} seconds`, callerId);
+  const rows = await bound.all<RouteRow>();
+  return rows.results.map((row) => ({
+    route_kind: row.route_kind,
+    latest_seen_at: row.latest_seen_at,
+    ...normalizeAggregate(row),
+  }));
+}
+
+async function cacheTotals(env: Env, pool: string) {
+  const row = await env.DB.prepare(
+    `SELECT
+       COUNT(*) AS total_entries,
+       SUM(CASE WHEN expires_at > CURRENT_TIMESTAMP THEN 1 ELSE 0 END) AS fresh_entries,
+       SUM(CASE WHEN expires_at <= CURRENT_TIMESTAMP THEN 1 ELSE 0 END) AS expired_entries,
+       COALESCE(SUM(length(body_json)), 0) AS body_bytes
+     FROM github_cache_entries
+     WHERE pool_id = ?1`,
+  )
+    .bind(pool)
+    .first<{
+      total_entries: number;
+      fresh_entries: number | null;
+      expired_entries: number | null;
+      body_bytes: number | null;
+    }>();
+  return {
+    total_entries: row?.total_entries ?? 0,
+    fresh_entries: row?.fresh_entries ?? 0,
+    expired_entries: row?.expired_entries ?? 0,
+    body_bytes: row?.body_bytes ?? 0,
+  };
+}
+
+export function normalizeAggregate(row: AggregateRow | null): CacheAggregate {
+  const cacheHits = row?.cache_hits ?? 0;
+  const cacheMisses = row?.cache_misses ?? 0;
+  const denominator = cacheHits + cacheMisses;
+  return {
+    requests: row?.requests ?? 0,
+    errors: row?.errors ?? 0,
+    avg_duration_ms: row?.avg_duration_ms ?? null,
+    cache_hits: cacheHits,
+    cache_misses: cacheMisses,
+    cache_bypass: row?.cache_bypass ?? 0,
+    cache_unknown: row?.cache_unknown ?? 0,
+    cacheable_requests: row?.cacheable_requests ?? 0,
+    cache_hit_rate: denominator === 0 ? null : cacheHits / denominator,
+  };
+}
+
+function unitSeconds(unit: string): number {
+  switch (unit) {
+    case "m":
+      return 60;
+    case "h":
+      return 60 * 60;
+    case "d":
+      return 24 * 60 * 60;
+    default:
+      throw new HttpError(400, "invalid_window", "since unit must be m, h, or d");
+  }
+}

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAggregate, parseStatsWindow } from "../src/stats";
+import { HttpError } from "../src/http";
+
+describe("stats windows", () => {
+  it("defaults to 24h", () => {
+    expect(parseStatsWindow(null)).toEqual({ label: "24h", seconds: 24 * 60 * 60 });
+    expect(parseStatsWindow("")).toEqual({ label: "24h", seconds: 24 * 60 * 60 });
+  });
+
+  it("parses minute, hour, and day windows", () => {
+    expect(parseStatsWindow("30m")).toEqual({ label: "30m", seconds: 30 * 60 });
+    expect(parseStatsWindow("24h")).toEqual({ label: "24h", seconds: 24 * 60 * 60 });
+    expect(parseStatsWindow("7d")).toEqual({ label: "7d", seconds: 7 * 24 * 60 * 60 });
+    expect(parseStatsWindow("2")).toEqual({ label: "2h", seconds: 2 * 60 * 60 });
+  });
+
+  it("rejects invalid or too-large windows", () => {
+    expect(() => parseStatsWindow("0h")).toThrow(HttpError);
+    expect(() => parseStatsWindow("31d")).toThrow(HttpError);
+    expect(() => parseStatsWindow("yesterday")).toThrow(HttpError);
+  });
+});
+
+describe("stats aggregates", () => {
+  it("normalizes null aggregate rows", () => {
+    expect(normalizeAggregate(null)).toEqual({
+      requests: 0,
+      errors: 0,
+      avg_duration_ms: null,
+      cache_hits: 0,
+      cache_misses: 0,
+      cache_bypass: 0,
+      cache_unknown: 0,
+      cacheable_requests: 0,
+      cache_hit_rate: null,
+    });
+  });
+
+  it("computes hit rate from hits and misses only", () => {
+    expect(
+      normalizeAggregate({
+        requests: 13,
+        errors: 1,
+        avg_duration_ms: 12.5,
+        cache_hits: 7,
+        cache_misses: 3,
+        cache_bypass: 2,
+        cache_unknown: 1,
+        cacheable_requests: 10,
+      }),
+    ).toEqual({
+      requests: 13,
+      errors: 1,
+      avg_duration_ms: 12.5,
+      cache_hits: 7,
+      cache_misses: 3,
+      cache_bypass: 2,
+      cache_unknown: 1,
+      cacheable_requests: 10,
+      cache_hit_rate: 0.7,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add D1-backed cache status metrics on audit events
- add authenticated `/v1/pools/:pool/stats` plus `octopool stats`
- show 24h cache hit rate and top routes on the dashboard
- document stats flow and add TS/Go regression coverage

## Proof

- `pnpm check`
- `pnpm docs:site`
- `autoreview --mode local` clean
