### PR TITLE
fix: authenticate public repo proof checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixes
 
+- Use the configured GitHub verifier token for public-repository checks while still rejecting token-visible private repositories.
 - Serve the landing page by default at `/` and render browser login failures as HTML instead of raw JSON.
 
 ## 0.1.0 - 2026-05-27

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -53,6 +53,9 @@ route uses a pooled identity or a cache entry, `ensurePublicGitHubRepo` confirms
 is public.
 
 - An unauthenticated `GET /repos/{owner}/{repo}` is made against GitHub.
+- If `OCTOPOOL_GITHUB_ORG_TOKEN` is configured, that server-side token is used for the
+  check to avoid shared unauthenticated GitHub quota; Octopool still requires the
+  response body to say `private: false`.
 - `404` or `private !== false` → `403 repo_not_public`.
 - A successful public check is recorded in `github_public_repos` with a TTL
   (`PUBLIC_REPO_TTL_SECONDS`, default 30s); subsequent requests reuse the fresh proof

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -31,7 +31,8 @@ Secrets (via `wrangler secret put`, never in D1/KV/logs):
 
 - `OCTOPOOL_ADMIN_TOKEN` — admin API auth.
 - `GITHUB_OAUTH_CLIENT_SECRET` — website GitHub login.
-- `OCTOPOOL_GITHUB_ORG_TOKEN` — background org-membership verifier.
+- `OCTOPOOL_GITHUB_ORG_TOKEN` — background org-membership verifier and public-repo
+  proof fetcher.
 - `OCTOPOOL_GITHUB_APP_ID` — GitHub App id (for App identities).
 - One secret per identity `secret_ref` — PAT value, or the App private key as **PKCS#8**
   (`BEGIN PRIVATE KEY`) PEM. Keep a copy in 1Password.

--- a/src/public-repos.ts
+++ b/src/public-repos.ts
@@ -1,3 +1,4 @@
+import { envSecret } from "./auth";
 import { HttpError, parsePositiveInt } from "./http";
 import type { RouteInfo } from "./types";
 
@@ -25,11 +26,7 @@ export async function ensurePublicGitHubRepo(
   const response = await fetch(
     `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`,
     {
-      headers: {
-        accept: "application/vnd.github+json",
-        "user-agent": "octopool",
-        "x-github-api-version": "2022-11-28",
-      },
+      headers: publicRepoCheckHeaders(env),
       signal: AbortSignal.timeout(parsePositiveInt(env.REQUEST_TIMEOUT_MS, 15_000)),
     },
   );
@@ -67,6 +64,19 @@ export async function ensurePublicGitHubRepo(
   )
     .bind(owner, repo, `+${ttlSeconds} seconds`)
     .run();
+}
+
+function publicRepoCheckHeaders(env: Env): Record<string, string> {
+  const headers: Record<string, string> = {
+    accept: "application/vnd.github+json",
+    "user-agent": "octopool",
+    "x-github-api-version": "2022-11-28",
+  };
+  const token = envSecret(env, "OCTOPOOL_GITHUB_ORG_TOKEN");
+  if (token !== undefined && token.trim() !== "") {
+    headers.authorization = `Bearer ${token}`;
+  }
+  return headers;
 }
 
 function publicCheckMayUseHistoricalProof(response: Response): boolean {

--- a/test/public-repos.test.ts
+++ b/test/public-repos.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ensurePublicGitHubRepo } from "../src/public-repos";
+import type { RouteInfo } from "../src/types";
+
+describe("public repo guard", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the org verifier token for public checks when configured", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        private: false,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await ensurePublicGitHubRepo(env(), route());
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(init.headers).toMatchObject({
+      authorization: "Bearer verifier-token",
+      "user-agent": "octopool",
+    });
+  });
+
+  it("does not cache token-visible private repositories", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          private: true,
+        }),
+      ),
+    );
+
+    await expect(ensurePublicGitHubRepo(env(), route())).rejects.toMatchObject({
+      status: 403,
+      code: "repo_not_public",
+    });
+  });
+});
+
+function env(): Env {
+  const first = vi.fn(async () => null);
+  const run = vi.fn(async () => ({}));
+  const bind = vi.fn(() => ({ first, run }));
+  const prepare = vi.fn(() => ({ bind }));
+  return {
+    REQUEST_TIMEOUT_MS: "15000",
+    OCTOPOOL_GITHUB_ORG_TOKEN: "verifier-token",
+    DB: { prepare },
+  } as unknown as Env;
+}
+
+function route(): RouteInfo {
+  return {
+    kind: "repo_view",
+    routeKey: "repo:openclaw/octopool",
+    resource: "repo:openclaw/octopool",
+    owner: "openclaw",
+    repo: "octopool",
+    cacheable: true,
+    logs: false,
+    largePayload: false,
+  };
+}


### PR DESCRIPTION
## Summary

- use the configured GitHub verifier token for public-repo proof requests
- keep the hard public-only boundary by rejecting any response where `private !== false`
- add regression coverage for token use and private repo denial

## Proof

- `pnpm check`
- `pnpm docs:site`
- `autoreview --mode local` clean
