### PR TITLE
Route gh reads through OctoPool first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Route safe read-shaped `gh` calls through Octopool before local fallback, with an explicit server fallback signal when a route is unsupported, denied by pool policy, private, or the identity pool is depleted.
 - Route browser GitHub OAuth through the registered `octopool.dev` callback, then forward back to `octopool.openclaw.ai` so the authoritative website can log in without GitHub rejecting the redirect URI.
 
 ## 0.2.2 - 2026-05-28

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Octopool moves that traffic off individual machines and onto Cloudflare:
 - **Cache hits cost zero GitHub quota.** Fresh D1 hits return straight from Cloudflare without touching GitHub at all. Repeated maintainer reads stop consuming any pooled identity's budget.
 - **Tokens stay server-side.** Callers authenticate to octopool with a short caller token (issued in exchange for their `gh auth token`). The underlying PATs and App private keys never leave the Worker — not into responses, not into audit rows, not into the cache.
 - **Org-gated, public-repo only.** Only verified members of one GitHub org can mint a caller token, and every repo route is checked against GitHub's public-visibility endpoint before a pooled identity or cache entry is used. Private-repo callers fall back to their own `gh`.
-- **Fails open to real `gh`.** The CLI is a drop-in `gh` shim. Only the supported read shapes go through the relay; everything else (mutations, unusual flags, repos outside the org allowlist) runs your local `gh` with your own token.
+- **Fails open to real `gh`.** The CLI is a drop-in `gh` shim. Safe read-shaped calls try Octopool first, so the server owns cache, app/PAT routing, and pool policy. Mutations and secret-bearing requests stay local; safe reads run your real `gh` only when Octopool explicitly returns `fallback_local`.
 
 If you're not running a maintainer team and you don't care about GitHub rate limits, you don't need this.
 
@@ -67,7 +67,7 @@ octopool login https://octopool.your-org.dev    # self-hosted endpoint
 octopool whoami
 ```
 
-Use it like `gh` for the supported read shapes:
+Use it like `gh` for common read shapes:
 
 ```sh
 octopool gh pr view 85341 -R openclaw/openclaw --json number,title,url
@@ -78,7 +78,7 @@ octopool gh api repos/openclaw/openclaw/pulls/85341 --jq .number
 octopool stats
 ```
 
-Symlink it as `gh` for a transparent shim — supported reads go through octopool, everything else (mutations, unusual flags, repos outside the org allowlist) passes through to your local `gh`:
+Symlink it as `gh` for a transparent shim — safe reads try Octopool first, while mutations, unusual flags, and explicit server fallback signals pass through to your local `gh`:
 
 ```sh
 ln -s "$(command -v octopool)" ~/bin/gh

--- a/cmd/octopool/gh.go
+++ b/cmd/octopool/gh.go
@@ -16,7 +16,7 @@ import (
 	"time"
 )
 
-var relayPathPatterns = []*regexp.Regexp{
+var relayQueryPathPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`^/repos/[^/]+/[^/]+$`),
 	regexp.MustCompile(`^/repos/[^/]+/[^/]+/commits$`),
 	regexp.MustCompile(`^/repos/[^/]+/[^/]+/commits/[0-9A-Fa-f]{7,64}$`),
@@ -47,6 +47,8 @@ type relayEnvelope struct {
 	BodyEncoding string            `json:"body_encoding"`
 }
 
+var errOctopoolNotLoggedIn = errors.New("not logged in; run: octopool login")
+
 func runGH(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) error {
 	if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
 		fmt.Fprintln(stdout, "usage: octopool gh api <GET path> [--jq expr]")
@@ -56,6 +58,9 @@ func runGH(ctx context.Context, args []string, stdout io.Writer, stderr io.Write
 	if args[0] != "api" {
 		handled, err := runGHTopLevel(ctx, args, stdout)
 		if err != nil {
+			if shouldRunRealGH(err) {
+				return execRealGHAfterLocalFallback(ctx, args, stdout, stderr, err)
+			}
 			return err
 		}
 		if handled {
@@ -78,10 +83,16 @@ func runGH(ctx context.Context, args []string, stdout io.Writer, stderr io.Write
 	}
 	client, err := newGHRelayClient()
 	if err != nil {
+		if shouldRunRealGH(err) {
+			return execRealGHAfterLocalFallback(ctx, args, stdout, stderr, err)
+		}
 		return err
 	}
 	envelope, err := client.do(ctx, request)
 	if err != nil {
+		if shouldRunRealGH(err) {
+			return execRealGHAfterLocalFallback(ctx, args, stdout, stderr, err)
+		}
 		return err
 	}
 	return writeGHBody(ctx, stdout, envelope, request.jq)
@@ -103,7 +114,7 @@ func newGHRelayClient() (ghRelayClient, error) {
 		token = auth.Token
 	}
 	if token == "" {
-		return ghRelayClient{}, errors.New("not logged in; run: octopool login")
+		return ghRelayClient{}, errOctopoolNotLoggedIn
 	}
 	baseURL := envDefault("OCTOPOOL_URL", auth.URL)
 	if baseURL == "" {
@@ -136,6 +147,9 @@ func (client ghRelayClient) do(ctx context.Context, request ghAPIRequest) (relay
 		return relayEnvelope{}, err
 	}
 	if status >= 400 {
+		if fallback, ok := parseLocalFallback(out); ok {
+			return relayEnvelope{}, fallback
+		}
 		return relayEnvelope{}, fmt.Errorf("octopool request failed: %s", strings.TrimSpace(string(out)))
 	}
 	var envelope relayEnvelope
@@ -251,10 +265,10 @@ func safeRelayHeader(header string) bool {
 }
 
 func safeRelayRequest(request ghAPIRequest) bool {
-	if !relaySupportedPath(request.path) {
+	if !safeRelayPath(request.path) {
 		return false
 	}
-	if owner, ok := relayPathOwner(request.path); ok && !localAllowedRelayOwner(owner) {
+	if len(request.query) > 0 && !relayQueryPath(request.path) {
 		return false
 	}
 	for key := range request.query {
@@ -263,6 +277,32 @@ func safeRelayRequest(request ghAPIRequest) bool {
 		}
 	}
 	return true
+}
+
+func safeRelayPath(path string) bool {
+	lower := strings.ToLower(path)
+	return strings.HasPrefix(path, "/") &&
+		!strings.Contains(path, "://") &&
+		!strings.Contains(path, "\\") &&
+		!strings.Contains(path, "?") &&
+		!strings.Contains(path, "#") &&
+		!strings.Contains(path, "..") &&
+		!hasDotSegment(path) &&
+		!strings.Contains(lower, "%2e") &&
+		!strings.Contains(lower, "%5c")
+}
+
+func hasDotSegment(path string) bool {
+	return path == "." || strings.Contains(path, "/./") || strings.HasSuffix(path, "/.")
+}
+
+func relayQueryPath(path string) bool {
+	for _, pattern := range relayQueryPathPatterns {
+		if pattern.MatchString(path) {
+			return true
+		}
+	}
+	return false
 }
 
 func sensitiveQueryKey(key string) bool {
@@ -275,33 +315,6 @@ func sensitiveQueryKey(key string) bool {
 		strings.Contains(lower, "apikey") ||
 		strings.Contains(lower, "access_key") ||
 		strings.Contains(lower, "private_key")
-}
-
-func relaySupportedPath(path string) bool {
-	for _, pattern := range relayPathPatterns {
-		if pattern.MatchString(path) {
-			return true
-		}
-	}
-	return false
-}
-
-func relayPathOwner(path string) (string, bool) {
-	parts := strings.Split(path, "/")
-	if len(parts) < 4 || parts[1] != "repos" || parts[2] == "" {
-		return "", false
-	}
-	return strings.ToLower(parts[2]), true
-}
-
-func localAllowedRelayOwner(owner string) bool {
-	allowed := envDefault("OCTOPOOL_ALLOWED_OWNERS", "openclaw")
-	for _, item := range strings.Split(allowed, ",") {
-		if strings.EqualFold(strings.TrimSpace(item), owner) {
-			return true
-		}
-	}
-	return false
 }
 
 func writeGHBody(ctx context.Context, stdout io.Writer, envelope relayEnvelope, jq string) error {
@@ -348,6 +361,57 @@ func writeGHBody(ctx context.Context, stdout io.Writer, envelope relayEnvelope, 
 
 func rawJSONIsNull(value json.RawMessage) bool {
 	return bytes.Equal(bytes.TrimSpace(value), []byte("null"))
+}
+
+type localFallbackError struct {
+	Reason string
+}
+
+func (err localFallbackError) Error() string {
+	if err.Reason == "" {
+		return "octopool requested local gh fallback"
+	}
+	return "octopool requested local gh fallback: " + err.Reason
+}
+
+func isLocalFallback(err error) bool {
+	var fallback localFallbackError
+	return errors.As(err, &fallback)
+}
+
+func shouldRunRealGH(err error) bool {
+	return isLocalFallback(err) || errors.Is(err, errOctopoolNotLoggedIn)
+}
+
+func parseLocalFallback(out []byte) (localFallbackError, bool) {
+	var response apiErrorResponse
+	if err := json.Unmarshal(out, &response); err != nil {
+		return localFallbackError{}, false
+	}
+	if response.Error.Code != "fallback_local" {
+		return localFallbackError{}, false
+	}
+	reason := response.Error.Details.FallbackReason
+	if reason == "" {
+		reason = response.Error.Message
+	}
+	return localFallbackError{Reason: reason}, true
+}
+
+func execRealGHAfterLocalFallback(
+	ctx context.Context,
+	args []string,
+	stdout io.Writer,
+	stderr io.Writer,
+	reason error,
+) error {
+	if envDefault("OCTOPOOL_NO_FALLBACK", "") != "" {
+		return reason
+	}
+	if !errors.Is(reason, errOctopoolNotLoggedIn) {
+		fmt.Fprintf(stderr, "octopool: %v; falling back to real gh\n", reason)
+	}
+	return execRealGH(ctx, args, stdout, stderr)
 }
 
 func runJQ(ctx context.Context, stdout io.Writer, input []byte, expr string) error {

--- a/cmd/octopool/gh_test.go
+++ b/cmd/octopool/gh_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 )
 
@@ -96,20 +97,23 @@ func TestSafeRelayRequest(t *testing.T) {
 		t.Fatalf("parse fallback=%v err=%v", fallback, err)
 	}
 	if safeRelayRequest(request) {
-		t.Fatal("search path should fall back")
+		t.Fatal("unknown query-bearing read should stay local")
+	}
+
+	request, fallback, err = parseGHAPIArgs([]string{"/search/issues"})
+	if err != nil || fallback {
+		t.Fatalf("parse fallback=%v err=%v", fallback, err)
+	}
+	if !safeRelayRequest(request) {
+		t.Fatal("queryless unknown read can ask octopool for a fallback decision")
 	}
 
 	request, fallback, err = parseGHAPIArgs([]string{"/repos/cli/cli/pulls/1"})
 	if err != nil || fallback {
 		t.Fatalf("parse fallback=%v err=%v", fallback, err)
 	}
-	if safeRelayRequest(request) {
-		t.Fatal("owner outside local allowlist should fall back")
-	}
-
-	t.Setenv("OCTOPOOL_ALLOWED_OWNERS", "openclaw,cli")
 	if !safeRelayRequest(request) {
-		t.Fatal("env allowlist owner should relay")
+		t.Fatal("owner policy should be decided by octopool")
 	}
 
 	request, fallback, err = parseGHAPIArgs([]string{"/repos/openclaw/openclaw/pulls/1?access_token=x"})
@@ -127,6 +131,14 @@ func TestSafeRelayRequest(t *testing.T) {
 	if safeRelayRequest(request) {
 		t.Fatal("secret query should fall back")
 	}
+
+	request, fallback, err = parseGHAPIArgs([]string{"/repos/openclaw/openclaw/compare/main...feature"})
+	if err != nil || fallback {
+		t.Fatalf("parse fallback=%v err=%v", fallback, err)
+	}
+	if safeRelayRequest(request) {
+		t.Fatal("canonicalizing path should stay local")
+	}
 }
 
 func TestTopLevelRepoNumber(t *testing.T) {
@@ -143,8 +155,9 @@ func TestTopLevelRepoNumber(t *testing.T) {
 	}
 
 	opts = ghTopOptions{repo: "cli/cli", positionals: []string{"1"}}
-	if _, _, ok = repoNumber(opts); ok {
-		t.Fatal("repo outside local allowlist should fall back")
+	repo, number, ok = repoNumber(opts)
+	if !ok || repo != "cli/cli" || number != "1" {
+		t.Fatalf("repoNumber outside default owner = %q %q %v", repo, number, ok)
 	}
 
 	opts = ghTopOptions{repo: "openclaw", positionals: []string{"1"}}
@@ -229,6 +242,43 @@ func TestWriteGHBodyAllowsNullTextBody(t *testing.T) {
 	if err := writeGHBody(t.Context(), discardWriter{}, envelope, ""); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestParseLocalFallback(t *testing.T) {
+	err, ok := parseLocalFallback([]byte(`{"error":{"code":"fallback_local","message":"Run locally","details":{"reason":"route_denied"}}}`))
+	if !ok {
+		t.Fatal("expected fallback")
+	}
+	if err.Reason != "route_denied" {
+		t.Fatalf("reason = %q", err.Reason)
+	}
+}
+
+func TestShouldRunRealGH(t *testing.T) {
+	if !shouldRunRealGH(localFallbackError{Reason: "route_denied"}) {
+		t.Fatal("fallback_local should run real gh")
+	}
+	if !shouldRunRealGH(errOctopoolNotLoggedIn) {
+		t.Fatal("missing octopool login should run real gh")
+	}
+	if shouldRunRealGH(assertAnError{}) {
+		t.Fatal("ordinary errors should not run real gh")
+	}
+}
+
+func TestNewGHRelayClientMissingLoginUsesFallbackSentinel(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OCTOPOOL_TOKEN", "")
+	_, err := newGHRelayClient()
+	if !errors.Is(err, errOctopoolNotLoggedIn) {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+type assertAnError struct{}
+
+func (assertAnError) Error() string {
+	return "boom"
 }
 
 type discardWriter struct{}

--- a/cmd/octopool/gh_top.go
+++ b/cmd/octopool/gh_top.go
@@ -188,7 +188,7 @@ func runGHRun(ctx context.Context, args []string, stdout io.Writer) (bool, error
 			return false, nil
 		}
 		repo, ok := repoFromOptionOrCurrent(opts.repo)
-		if !ok || !localAllowedRelayOwner(strings.Split(repo, "/")[0]) {
+		if !ok {
 			return false, nil
 		}
 		return true, relayTop(ctx, stdout, ghAPIRequest{method: "GET", path: repoPath(repo, "actions", "runs", opts.positionals[0])}, opts, fieldMapRun)
@@ -787,7 +787,7 @@ func repoNumber(opts ghTopOptions) (string, string, bool) {
 		}
 		repo = currentGitHubRepo()
 	}
-	if repo == "" || number == "" || !localAllowedRelayOwner(strings.Split(repo, "/")[0]) {
+	if repo == "" || number == "" {
 		return "", "", false
 	}
 	return repo, number, true
@@ -801,7 +801,7 @@ func repoOnly(opts ghTopOptions) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	if repo == "" || !localAllowedRelayOwner(strings.Split(repo, "/")[0]) {
+	if repo == "" {
 		return "", false
 	}
 	return repo, true

--- a/cmd/octopool/login.go
+++ b/cmd/octopool/login.go
@@ -35,6 +35,7 @@ type apiErrorResponse struct {
 			GitHubRateLimitRemaining string `json:"github_rate_limit_remaining"`
 			GitHubRateLimitResource  string `json:"github_rate_limit_resource"`
 			GitHubRetryAfter         string `json:"github_retry_after"`
+			FallbackReason           string `json:"reason"`
 		} `json:"details"`
 	} `json:"error"`
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -110,17 +110,22 @@ names, such as `url`, `author`, `headRefName`, `headRefOid`, `baseRefName`,
 `--jq` runs after `--json` filtering, matching the usual agent workflow for small
 machine-readable reads.
 
-The command falls through to the real `gh` (no relay call) when any of these hold:
+The command falls through to the real `gh` without contacting Octopool when any of these
+hold:
 
 - method is not `GET`, or mutating field flags are present (`-f`, `-F`, `--field`,
   `--raw-field`, `--paginate`, `--slurp`).
-- the path is not a relay-supported shape (see [Relay](relay.md#supported-routes)).
-- the repo owner is outside the local allowlist (`OCTOPOOL_ALLOWED_OWNERS`, default
-  `openclaw`). Ordinary non-OpenClaw reads stay on the real `gh`.
 - a query key looks secret-bearing, or a header is outside the safe set
   (`accept`, `x-github-api-version`, `if-none-match`, `if-modified-since`).
 - `--jq` was requested but `jq` is not installed.
 - a top-level subcommand or flag is not one of the supported read-only shapes.
+
+Safe read-shaped requests are sent to Octopool first. Octopool owns the route and pool
+policy decision; on a cache miss it uses the configured app/PAT identity pool, writes
+eligible public responses to the shared cache, and returns the GitHub-shaped body. If the
+server says the read should run locally — unsupported route, owner denied by pool policy,
+private/unverified repository, no usable identity, or identity pool depleted — the CLI
+runs the original command with the real `gh` and your local GitHub token.
 
 Any other `gh` subcommand (`gh pr create`, `gh auth`, unusual formatting flags, …) is
 passed straight through to the real GitHub CLI, with its exit code preserved.
@@ -166,7 +171,8 @@ Admin provisioning. Requires an admin token. See [Admin & provisioning](admin.md
   `octopool login` for that URL. This prevents leaking the token to an attacker-supplied
   endpoint.
 - Once a request reaches Octopool, relay policy denials fail closed; they are not
-  silently retried against the real `gh`.
+  silently retried against the real `gh` unless Octopool returns the explicit
+  `fallback_local` signal for a safe read.
 
 ## Environment variables
 
@@ -176,7 +182,8 @@ These are dev/CI escape hatches, not the everyday UX:
 - `OCTOPOOL_TOKEN` — caller token override (required to use a non-saved URL).
 - `OCTOPOOL_POOL` — pool id (default `maintainers`).
 - `OCTOPOOL_GH_PATH` — path to the real `gh` binary.
-- `OCTOPOOL_ALLOWED_OWNERS` — local owner prefilter for the `gh` shim (default `openclaw`).
+- `OCTOPOOL_NO_FALLBACK=1` — fail instead of running real `gh` after Octopool returns
+  `fallback_local`, useful for proving relay/cache coverage.
 - `OCTOPOOL_ADMIN_TOKEN` — admin token for `octopool admin`.
 - `OCTOPOOL_ALLOW_INSECURE_LOGIN=1` — permit non-HTTPS login for local dev.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -14,7 +14,8 @@ It lets trusted users and agents share an explicitly managed pool of GitHub iden
 - avoid agent stampedes against the same GitHub endpoint
 - keep GitHub tokens out of logs, local config, and SQLite stores
 - expose compact quota, health, and audit state for maintainers
-- fall through to the real GitHub CLI when the local shim sees unsupported commands
+- fall through to the real GitHub CLI for unsafe commands locally, and for safe reads only
+  after the relay returns an explicit local-fallback signal
 
 ## Non-Goals
 
@@ -69,7 +70,8 @@ pool:<pool_id>:route:<owner>/<repo>
 ## Request Flow
 
 1. A caller uses `octopool gh api`, a `gh` symlink, or `POST /v1/github/request`.
-2. The CLI or API client sends a normalized read request to Octopool.
+2. The CLI sends safe read-shaped requests to Octopool before trying the local GitHub
+   token. Mutations and secret-bearing requests stay local.
 3. Worker authenticates caller and validates command policy.
 4. Worker verifies repo routes are public before cache or pooled identity use.
 5. Worker checks D1 for a fresh cache entry.
@@ -79,6 +81,9 @@ pool:<pool_id>:route:<owner>/<repo>
 9. GitHub App identities mint short-lived installation tokens server-side.
 10. Worker records rate-limit headers, status, route class, and redacted audit state.
 11. Worker writes eligible public responses to D1 and returns the GitHub-shaped body.
+12. If the read is safe but Octopool cannot serve it — unsupported route, owner denied,
+    private/unverified repo, no usable identity, or depleted identity pool — Worker
+    returns `fallback_local`; the CLI then runs the original command with real `gh`.
 
 ## API
 
@@ -289,7 +294,7 @@ OCTOPOOL_URL
 OCTOPOOL_TOKEN
 OCTOPOOL_POOL
 OCTOPOOL_GH_PATH
-OCTOPOOL_ALLOWED_OWNERS
+OCTOPOOL_NO_FALLBACK
 ```
 
 Modes:
@@ -300,10 +305,13 @@ Modes:
 
 Fallback:
 
-- unsupported or mutating commands: run the real GitHub CLI
-- non-allowed owners: run the real GitHub CLI before any relay call
-- relay unavailable: run the real GitHub CLI when the local command is safe to pass through
-- relay policy deny: fail closed and explain route/policy, not token identity
+- mutating commands, request bodies, unsafe headers, and secret-bearing queries: run the real
+  GitHub CLI before any relay call
+- safe read-shaped commands: try Octopool first, including owners and route shapes the
+  local CLI does not know about yet
+- relay returns `fallback_local`: run the original command with the real GitHub CLI
+- relay unavailable or misconfigured: fail loudly unless the local shim has no Octopool login
+  yet, in which case it runs the real GitHub CLI
 
 ## Supported v1 Routes
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import {
 import { discoveryResponse } from "./discovery";
 import { isPublicRequest } from "./hosts";
 import { rootResponse } from "./landing";
+import { githubResponseLocalFallbackReason, localFallbackError } from "./local-fallback";
 import { classifyRoute, normalizeRouteKey, validateRelayRequest } from "./policy";
 import { PoolCoordinator } from "./pool-coordinator";
 import { ensurePublicGitHubRepo } from "./public-repos";
@@ -417,65 +418,92 @@ async function relayGitHub(
       throw new HttpError(503, "no_identity", "No active identity can serve this route");
     }
     await ensurePublicGitHubRepo(env, route);
-    const selectionRequest: SelectionRequest = {
-      pool: relayRequest.pool,
-      routeKey: route.routeKey,
-      resource: route.resource,
-      candidates: identities.map((candidate) => ({ id: candidate.id, weight: candidate.weight })),
-    };
     const coordinator = env.POOL_COORDINATOR.getByName(`pool:${relayRequest.pool}`);
-    const selection = await selectIdentity(coordinator, selectionRequest);
-    identity = findIdentity(identities, selection.identityId);
-    const rawGitHub = await callGitHub(env, identity, relayRequest, route);
-    const github = sanitizeGitHubResponse(route, rawGitHub);
-    const rate = rateFromHeaders(github.headers);
-    ctx.waitUntil(
-      Promise.all([
-        coordinator.recordResult({
+    const attemptedIdentityIds = new Set<string>();
+    let fallbackReason = "identity_pool_depleted";
+    for (let attempt = 0; attempt < identities.length; attempt++) {
+      const candidates = identities
+        .filter((candidate) => !attemptedIdentityIds.has(candidate.id))
+        .map((candidate) => ({ id: candidate.id, weight: candidate.weight }));
+      if (candidates.length === 0) {
+        break;
+      }
+      const selectionRequest: SelectionRequest = {
+        pool: relayRequest.pool,
+        routeKey: route.routeKey,
+        resource: route.resource,
+        candidates,
+      };
+      const selection = await selectIdentity(coordinator, selectionRequest);
+      identity = findIdentity(identities, selection.identityId);
+      const rawGitHub = await callGitHub(env, identity, relayRequest, route);
+      const github = sanitizeGitHubResponse(route, rawGitHub);
+      const rate = rateFromHeaders(github.headers);
+      const localFallbackReason = githubResponseLocalFallbackReason(github.status, rate);
+      if (localFallbackReason !== undefined) {
+        attemptedIdentityIds.add(identity.id);
+        fallbackReason = localFallbackReason;
+        await coordinator.recordResult({
           identityId: identity.id,
           routeKey: route.routeKey,
           resource: route.resource,
           status: github.status,
           rate,
-        }),
-        insertAudit(env, {
-          requestId,
-          callerId: caller.id,
+        });
+        continue;
+      }
+      ctx.waitUntil(
+        Promise.all([
+          coordinator.recordResult({
+            identityId: identity.id,
+            routeKey: route.routeKey,
+            resource: route.resource,
+            status: github.status,
+            rate,
+          }),
+          insertAudit(env, {
+            requestId,
+            callerId: caller.id,
+            pool: relayRequest.pool,
+            routeKey: route.routeKey,
+            routeKind: route.kind,
+            identityId: identity.id,
+            status: github.status,
+            durationMs: Date.now() - started,
+            cacheStatus: auditCacheStatus,
+            cacheable: auditCacheable,
+          }),
+          ...(cacheKey === undefined
+            ? []
+            : [writeGitHubCache(env, cacheKey, relayRequest, route, github, identity)]),
+        ]),
+      );
+      return jsonResponse({
+        status: github.status,
+        headers: github.headers,
+        body: github.body,
+        body_encoding: github.body_encoding,
+        identity: {
+          id: identity.id,
+          kind: identity.kind,
+        },
+        relay: {
           pool: relayRequest.pool,
-          routeKey: route.routeKey,
-          routeKind: route.kind,
-          identityId: identity.id,
-          status: github.status,
-          durationMs: Date.now() - started,
-          cacheStatus: auditCacheStatus,
-          cacheable: auditCacheable,
-        }),
-        ...(cacheKey === undefined
-          ? []
-          : [writeGitHubCache(env, cacheKey, relayRequest, route, github, identity)]),
-      ]),
-    );
-    return jsonResponse({
-      status: github.status,
-      headers: github.headers,
-      body: github.body,
-      body_encoding: github.body_encoding,
-      identity: {
-        id: identity.id,
-        kind: identity.kind,
-      },
-      relay: {
-        pool: relayRequest.pool,
-        request_id: requestId,
-        cacheable: route.cacheable,
-        cache: cacheKey === undefined ? "bypass" : "miss",
-        stale_ok: false,
-        route_kind: route.kind,
-        lease_reason: selection.reason,
-      },
+          request_id: requestId,
+          cacheable: route.cacheable,
+          cache: cacheKey === undefined ? "bypass" : "miss",
+          stale_ok: false,
+          route_kind: route.kind,
+          lease_reason: selection.reason,
+        },
+      });
+    }
+    throw new HttpError(424, "fallback_local", "Run this request with local GitHub credentials", {
+      reason: fallbackReason,
     });
   } catch (error) {
-    const audit = auditError(error);
+    const reported = localFallbackError(error) ?? error;
+    const audit = auditError(reported);
     ctx.waitUntil(
       insertAudit(env, {
         requestId,
@@ -491,7 +519,7 @@ async function relayGitHub(
         ...(identity === undefined ? {} : { identityId: identity.id }),
       }),
     );
-    throw error;
+    throw reported;
   }
 }
 

--- a/src/local-fallback.ts
+++ b/src/local-fallback.ts
@@ -1,0 +1,48 @@
+import { rateFromHeaders } from "./github";
+import { HttpError } from "./http";
+
+export function localFallbackError(error: unknown): HttpError | undefined {
+  if (!(error instanceof HttpError) || !localFallbackReasons.has(error.code)) {
+    return undefined;
+  }
+  return new HttpError(424, "fallback_local", "Run this request with local GitHub credentials", {
+    reason: error.code,
+  });
+}
+
+export function githubResponseNeedsLocalFallback(
+  status: number,
+  rate: ReturnType<typeof rateFromHeaders>,
+): boolean {
+  return githubResponseLocalFallbackReason(status, rate) !== undefined;
+}
+
+export function githubResponseLocalFallbackReason(
+  status: number,
+  rate: ReturnType<typeof rateFromHeaders>,
+): string | undefined {
+  if (status === 401) {
+    return "github_identity_unauthorized";
+  }
+  if (status === 429 || rate.retryAfter !== undefined) {
+    return "github_rate_limited";
+  }
+  if (status === 403 && rate.remaining === 0) {
+    return "github_identity_depleted";
+  }
+  if (status === 403) {
+    return "github_identity_forbidden";
+  }
+  return undefined;
+}
+
+const localFallbackReasons = new Set([
+  "identities_cooling_down",
+  "logs_denied",
+  "no_identity",
+  "owner_denied",
+  "repo_not_public",
+  "repo_public_check_failed",
+  "route_denied",
+  "search_denied",
+]);

--- a/test/local-fallback.test.ts
+++ b/test/local-fallback.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { HttpError } from "../src/http";
+import {
+  githubResponseLocalFallbackReason,
+  githubResponseNeedsLocalFallback,
+  localFallbackError,
+} from "../src/local-fallback";
+
+describe("local gh fallback signal", () => {
+  it("converts safe relay denials into an explicit fallback response", () => {
+    const fallback = localFallbackError(new HttpError(403, "route_denied", "Route is not enabled"));
+
+    expect(fallback?.status).toBe(424);
+    expect(fallback?.code).toBe("fallback_local");
+    expect(fallback?.details).toMatchObject({ reason: "route_denied" });
+  });
+
+  it("does not hide auth or malformed-request failures behind local fallback", () => {
+    expect(localFallbackError(new HttpError(401, "missing_auth", "Missing bearer token"))).toBe(
+      undefined,
+    );
+    expect(localFallbackError(new HttpError(400, "invalid_query", "query key token"))).toBe(
+      undefined,
+    );
+  });
+
+  it("falls back when the pooled GitHub identity is unusable", () => {
+    expect(githubResponseLocalFallbackReason(401, {})).toBe("github_identity_unauthorized");
+    expect(githubResponseNeedsLocalFallback(403, { remaining: 0 })).toBe(true);
+    expect(githubResponseNeedsLocalFallback(403, { remaining: 42 })).toBe(true);
+    expect(githubResponseNeedsLocalFallback(429, {})).toBe(true);
+    expect(githubResponseNeedsLocalFallback(500, {})).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- route safe `gh` read calls through OctoPool first, including owner/route shapes the CLI does not know yet
- fall back to the real GitHub CLI only for unsafe calls, missing OctoPool login, or explicit server `fallback_local`
- retry other pooled identities before local fallback when one app/PAT identity is rate-limited, unauthorized, or cooling down

## Proof
- `pnpm check`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local` clean
