### PR TITLE
Add branch-limited Git proxy

### DIFF
--- a/cmd/octopool/gitcmd.go
+++ b/cmd/octopool/gitcmd.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+func runGit(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) error {
+	if len(args) == 0 {
+		return errors.New("missing git subcommand")
+	}
+	switch args[0] {
+	case "clone":
+		return runGitClone(ctx, args[1:], stdout, stderr)
+	case "credential":
+		return runGitCredential(args[1:], os.Stdin, stdout)
+	default:
+		return fmt.Errorf("unknown git subcommand %q", args[0])
+	}
+}
+
+func runGitClone(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) error {
+	auth, err := loadAuth()
+	if err != nil {
+		return err
+	}
+	fs := flag.NewFlagSet("git clone", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	baseURL := fs.String("url", defaultAuthURL(auth), "Octopool base URL")
+	gitPath := fs.String("git-path", envDefault("OCTOPOOL_GIT_PATH", "git"), "Git binary path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() < 1 || fs.NArg() > 2 {
+		return errors.New("usage: octopool git clone owner/repo [dir]")
+	}
+	if auth.Token == "" && strings.TrimSpace(os.Getenv("OCTOPOOL_TOKEN")) == "" {
+		return errors.New("not logged in; run: octopool login")
+	}
+	cloneURL, err := gitCloneURL(*baseURL, fs.Arg(0))
+	if err != nil {
+		return err
+	}
+	targetDir := gitCloneDir(fs.Arg(0), fs.Args()[1:])
+	helper, err := credentialHelperCommand()
+	if err != nil {
+		return err
+	}
+	credentialKey, err := gitCredentialConfigKey(*baseURL)
+	if err != nil {
+		return err
+	}
+	cloneArgs := []string{
+		"-c",
+		credentialKey + ".helper=" + helper,
+		"clone",
+		cloneURL,
+	}
+	if fs.NArg() == 2 {
+		cloneArgs = append(cloneArgs, fs.Arg(1))
+	}
+	cmd := exec.CommandContext(ctx, *gitPath, cloneArgs...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	configCmd := exec.CommandContext(
+		ctx,
+		*gitPath,
+		"-C",
+		targetDir,
+		"config",
+		credentialKey+".helper",
+		helper,
+	)
+	configCmd.Stdout = stdout
+	configCmd.Stderr = stderr
+	return configCmd.Run()
+}
+
+func runGitCredential(args []string, stdin io.Reader, stdout io.Writer) error {
+	if len(args) > 1 {
+		return errors.New("usage: octopool git credential [get|store|erase]")
+	}
+	if len(args) == 1 && args[0] != "get" {
+		return nil
+	}
+	auth, err := loadAuth()
+	if err != nil {
+		return err
+	}
+	token, err := callerToken("OCTOPOOL_TOKEN")
+	if err != nil {
+		return err
+	}
+	values := readCredentialInput(stdin)
+	if !credentialRequestMatches(auth, values) {
+		return nil
+	}
+	fmt.Fprintln(stdout, "username=x-octopool")
+	fmt.Fprintf(stdout, "password=%s\n\n", token)
+	return nil
+}
+
+func runAdminGitPolicy(ctx context.Context, args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("admin git-policy", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	baseURL := fs.String("url", envDefault("OCTOPOOL_URL", defaultURL), "Octopool base URL")
+	pool := fs.String("pool", envDefault("OCTOPOOL_POOL", "maintainers"), "pool id")
+	adminTokenEnv := fs.String("admin-token-env", "OCTOPOOL_ADMIN_TOKEN", "admin token env var")
+	githubLogin := fs.String("github-login", "", "GitHub login to configure")
+	repo := fs.String("repo", "", "GitHub repo owner/repo")
+	fetch := fs.Bool("fetch", false, "allow clone/fetch")
+	push := fs.Bool("push", false, "allow push")
+	expiresAt := fs.String("expires-at", "", "optional ISO expiry timestamp")
+	deletePolicy := fs.Bool("delete", false, "delete policy")
+	pushBranches := multiFlag{}
+	fs.Var(&pushBranches, "push-branch", "allowed push branch glob, repeatable")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *githubLogin == "" || *repo == "" {
+		return errors.New("--github-login and --repo are required")
+	}
+	token, err := requiredEnv(*adminTokenEnv)
+	if err != nil {
+		return err
+	}
+	endpoint := apiURL(*baseURL, "/v1/admin/pools/"+urlPath(*pool)+"/git-policies")
+	if *deletePolicy {
+		separator := "?"
+		if strings.Contains(endpoint, "?") {
+			separator = "&"
+		}
+		endpoint += separator + "github_login=" + url.QueryEscape(*githubLogin) + "&repo=" + url.QueryEscape(*repo)
+		return deleteJSON(ctx, stdout, endpoint, token)
+	}
+	body := map[string]any{
+		"github_login":  *githubLogin,
+		"repo":          *repo,
+		"fetch":         *fetch,
+		"push":          *push,
+		"push_branches": []string(pushBranches),
+	}
+	if *expiresAt != "" {
+		body["expires_at"] = *expiresAt
+	}
+	return putJSON(ctx, stdout, endpoint, token, body)
+}
+
+func gitCloneURL(baseURL string, repo string) (string, error) {
+	parsed, err := url.Parse(strings.TrimRight(baseURL, "/"))
+	if err != nil {
+		return "", err
+	}
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
+		return "", errors.New("git clone URL must use HTTPS unless targeting localhost")
+	}
+	owner, name, ok := strings.Cut(repo, "/")
+	if !ok || owner == "" || name == "" || strings.Contains(name, "/") {
+		return "", errors.New("repo must be owner/repo")
+	}
+	if !safeGitPathPart(owner) || !safeGitPathPart(strings.TrimSuffix(name, ".git")) {
+		return "", errors.New("repo must contain only GitHub owner/repo path characters")
+	}
+	parsed.Path = strings.TrimRight(parsed.Path, "/") + "/git/" + urlPath(owner) + "/" + urlPath(strings.TrimSuffix(name, ".git")) + ".git"
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String(), nil
+}
+
+func gitCloneDir(repo string, extra []string) string {
+	if len(extra) > 0 && extra[0] != "" {
+		return extra[0]
+	}
+	_, name, ok := strings.Cut(repo, "/")
+	if !ok {
+		return repo
+	}
+	return strings.TrimSuffix(name, ".git")
+}
+
+func safeGitPathPart(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, char := range value {
+		if char >= 'a' && char <= 'z' || char >= 'A' && char <= 'Z' || char >= '0' && char <= '9' || char == '_' || char == '.' || char == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func credentialHelperCommand() (string, error) {
+	executable, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	return "!" + shellQuote(executable) + " git credential", nil
+}
+
+func gitCredentialConfigKey(baseURL string) (string, error) {
+	parsed, err := url.Parse(strings.TrimRight(baseURL, "/"))
+	if err != nil {
+		return "", err
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", errors.New("Octopool URL is invalid")
+	}
+	return "credential." + parsed.Scheme + "://" + parsed.Host + "/git/", nil
+}
+
+func credentialRequestMatches(auth authFile, values map[string]string) bool {
+	if values["protocol"] == "" || values["host"] == "" {
+		return false
+	}
+	base := defaultAuthURL(auth)
+	parsed, err := url.Parse(base)
+	if err != nil {
+		return false
+	}
+	return values["protocol"] == parsed.Scheme &&
+		strings.EqualFold(values["host"], parsed.Host) &&
+		strings.HasPrefix(values["path"], "git/")
+}
+
+func readCredentialInput(stdin io.Reader) map[string]string {
+	out := map[string]string{}
+	scanner := bufio.NewScanner(stdin)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			break
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if ok {
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func shellQuote(value string) string {
+	if runtime.GOOS == "windows" {
+		return `"` + strings.ReplaceAll(value, `"`, `\"`) + `"`
+	}
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
+}

--- a/cmd/octopool/gitcmd_test.go
+++ b/cmd/octopool/gitcmd_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGitCloneURL(t *testing.T) {
+	got, err := gitCloneURL("https://octopool.example.com", "openclaw/octopool")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "https://octopool.example.com/git/openclaw/octopool.git" {
+		t.Fatalf("unexpected clone URL: %s", got)
+	}
+}
+
+func TestGitCredentialHelperReturnsTokenForOctopoolGitURL(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+	t.Setenv("OCTOPOOL_URL", "")
+	t.Setenv("OCTOPOOL_TOKEN", "")
+	if err := saveAuth(authFile{
+		URL:   "https://octopool.example.com",
+		Pool:  "maintainers",
+		Token: "op_secret",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	input := strings.NewReader("protocol=https\nhost=octopool.example.com\npath=git/openclaw/octopool.git\n\n")
+	if err := runGitCredential([]string{"get"}, input, &out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "username=x-octopool\n") {
+		t.Fatalf("missing username: %q", out.String())
+	}
+	if !strings.Contains(out.String(), "password=op_secret\n") {
+		t.Fatalf("missing password: %q", out.String())
+	}
+}
+
+func TestAdminGitPolicySendsExpectedJSON(t *testing.T) {
+	t.Setenv("OCTOPOOL_ADMIN_TOKEN", "admin-token")
+	var received map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Fatalf("method = %s", r.Method)
+		}
+		if r.URL.Path != "/v1/admin/pools/maintainers/git-policies" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if r.Header.Get("authorization") != "Bearer admin-token" {
+			t.Fatalf("authorization = %s", r.Header.Get("authorization"))
+		}
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	var out bytes.Buffer
+	err := runAdminGitPolicy(context.Background(), []string{
+		"--url", server.URL,
+		"--pool", "maintainers",
+		"--github-login", "agent",
+		"--repo", "openclaw/octopool",
+		"--fetch",
+		"--push",
+		"--push-branch", "agent/*",
+	}, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if received["github_login"] != "agent" || received["repo"] != "openclaw/octopool" {
+		t.Fatalf("unexpected body: %#v", received)
+	}
+	branches, ok := received["push_branches"].([]any)
+	if !ok || len(branches) != 1 || branches[0] != "agent/*" {
+		t.Fatalf("unexpected branches: %#v", received["push_branches"])
+	}
+}
+
+func TestGitCloneDir(t *testing.T) {
+	if got := gitCloneDir("openclaw/octopool", nil); got != "octopool" {
+		t.Fatalf("clone dir = %s", got)
+	}
+	if got := gitCloneDir("openclaw/octopool", []string{filepath.Join("tmp", "repo")}); got != filepath.Join("tmp", "repo") {
+		t.Fatalf("clone dir override = %s", got)
+	}
+}
+
+func TestGitCredentialIgnoresOtherHosts(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+	if err := os.MkdirAll(filepath.Join(configDir, "octopool"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveAuth(authFile{URL: "https://octopool.example.com", Token: "op_secret"}); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	input := strings.NewReader("protocol=https\nhost=github.com\npath=openclaw/octopool.git\n\n")
+	if err := runGitCredential([]string{"get"}, input, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("expected no credentials, got %q", out.String())
+	}
+}

--- a/cmd/octopool/main.go
+++ b/cmd/octopool/main.go
@@ -76,6 +76,8 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		return runWhoami(args[1:], stdout)
 	case "gh":
 		return runGH(ctx, args[1:], stdout, stderr)
+	case "git":
+		return runGit(ctx, args[1:], stdout, stderr)
 	case "health":
 		return runHealth(ctx, args[1:], stdout)
 	case "stats":
@@ -211,6 +213,8 @@ func runAdmin(ctx context.Context, args []string, stdout io.Writer) error {
 		return runAdminCaller(ctx, args[1:], stdout)
 	case "identity":
 		return runAdminIdentity(ctx, args[1:], stdout)
+	case "git-policy":
+		return runAdminGitPolicy(ctx, args[1:], stdout)
 	default:
 		return fmt.Errorf("unknown admin subcommand %q", args[0])
 	}
@@ -371,6 +375,47 @@ func postJSONRaw(
 	return httpClient.Do(req)
 }
 
+func putJSON(ctx context.Context, stdout io.Writer, url string, token string, body map[string]any) error {
+	resp, err := jsonRaw(ctx, http.MethodPut, url, token, body)
+	if err != nil {
+		return err
+	}
+	return writeJSONResponse(stdout, resp)
+}
+
+func deleteJSON(ctx context.Context, stdout io.Writer, url string, token string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+	if token != "" {
+		req.Header.Set("authorization", "Bearer "+token)
+	}
+	return do(stdout, req)
+}
+
+func jsonRaw(
+	ctx context.Context,
+	method string,
+	url string,
+	token string,
+	body map[string]any,
+) (*http.Response, error) {
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, strings.NewReader(string(encoded)))
+	if err != nil {
+		return nil, err
+	}
+	if token != "" {
+		req.Header.Set("authorization", "Bearer "+token)
+	}
+	req.Header.Set("content-type", "application/json")
+	return httpClient.Do(req)
+}
+
 func do(stdout io.Writer, req *http.Request) error {
 	resp, err := httpClient.Do(req)
 	if err != nil {
@@ -507,5 +552,5 @@ func apiURL(base string, path string) string {
 }
 
 func usage(w io.Writer) {
-	fmt.Fprintln(w, "usage: octopool <login|whoami|gh|health|stats|request|admin> [flags]")
+	fmt.Fprintln(w, "usage: octopool <login|whoami|gh|git|health|stats|request|admin> [flags]")
 }

--- a/internal/dbquery/d1.sql.go
+++ b/internal/dbquery/d1.sql.go
@@ -473,6 +473,31 @@ func (q *Queries) DashboardUsers(ctx context.Context, poolID string) ([]Dashboar
 	return items, nil
 }
 
+const deleteCallerGitPolicy = `-- name: DeleteCallerGitPolicy :exec
+DELETE FROM caller_git_policies
+WHERE caller_id = ?1
+  AND pool_id = ?2
+  AND lower(owner) = lower(?3)
+  AND lower(repo) = lower(?4)
+`
+
+type DeleteCallerGitPolicyParams struct {
+	CallerID string `json:"caller_id"`
+	PoolID   string `json:"pool_id"`
+	LOWER    string `json:"LOWER"`
+	LOWER_2  string `json:"LOWER_2"`
+}
+
+func (q *Queries) DeleteCallerGitPolicy(ctx context.Context, arg DeleteCallerGitPolicyParams) error {
+	_, err := q.db.ExecContext(ctx, deleteCallerGitPolicy,
+		arg.CallerID,
+		arg.PoolID,
+		arg.LOWER,
+		arg.LOWER_2,
+	)
+	return err
+}
+
 const deleteIdentityScopes = `-- name: DeleteIdentityScopes :exec
 DELETE FROM identity_scopes
 WHERE identity_id = ?1
@@ -507,6 +532,35 @@ type EnsurePoolParams struct {
 func (q *Queries) EnsurePool(ctx context.Context, arg EnsurePoolParams) error {
 	_, err := q.db.ExecContext(ctx, ensurePool, arg.ID, arg.PolicyJson)
 	return err
+}
+
+const findCallerForGitPolicy = `-- name: FindCallerForGitPolicy :one
+SELECT callers.id, callers.github_login
+FROM callers
+JOIN caller_pools ON caller_pools.caller_id = callers.id
+WHERE lower(callers.github_login) = lower(?1)
+  AND callers.org_login = ?2
+  AND callers.status = 'active'
+  AND caller_pools.pool_id = ?3
+LIMIT 1
+`
+
+type FindCallerForGitPolicyParams struct {
+	LOWER    string `json:"LOWER"`
+	OrgLogin string `json:"org_login"`
+	PoolID   string `json:"pool_id"`
+}
+
+type FindCallerForGitPolicyRow struct {
+	ID          string `json:"id"`
+	GithubLogin string `json:"github_login"`
+}
+
+func (q *Queries) FindCallerForGitPolicy(ctx context.Context, arg FindCallerForGitPolicyParams) (FindCallerForGitPolicyRow, error) {
+	row := q.db.QueryRowContext(ctx, findCallerForGitPolicy, arg.LOWER, arg.OrgLogin, arg.PoolID)
+	var i FindCallerForGitPolicyRow
+	err := row.Scan(&i.ID, &i.GithubLogin)
+	return i, err
 }
 
 const freshCoveringPublicRepoProof = `-- name: FreshCoveringPublicRepoProof :one
@@ -551,6 +605,48 @@ func (q *Queries) FreshPublicRepoProof(ctx context.Context, arg FreshPublicRepoP
 	var column_1 int64
 	err := row.Scan(&column_1)
 	return column_1, err
+}
+
+const getCallerGitPolicy = `-- name: GetCallerGitPolicy :one
+SELECT allow_fetch, allow_push, push_branch_globs_json, expires_at
+FROM caller_git_policies
+WHERE caller_id = ?1
+  AND pool_id = ?2
+  AND lower(owner) = lower(?3)
+  AND lower(repo) = lower(?4)
+  AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)
+LIMIT 1
+`
+
+type GetCallerGitPolicyParams struct {
+	CallerID string `json:"caller_id"`
+	PoolID   string `json:"pool_id"`
+	LOWER    string `json:"LOWER"`
+	LOWER_2  string `json:"LOWER_2"`
+}
+
+type GetCallerGitPolicyRow struct {
+	AllowFetch          int64          `json:"allow_fetch"`
+	AllowPush           int64          `json:"allow_push"`
+	PushBranchGlobsJson string         `json:"push_branch_globs_json"`
+	ExpiresAt           sql.NullString `json:"expires_at"`
+}
+
+func (q *Queries) GetCallerGitPolicy(ctx context.Context, arg GetCallerGitPolicyParams) (GetCallerGitPolicyRow, error) {
+	row := q.db.QueryRowContext(ctx, getCallerGitPolicy,
+		arg.CallerID,
+		arg.PoolID,
+		arg.LOWER,
+		arg.LOWER_2,
+	)
+	var i GetCallerGitPolicyRow
+	err := row.Scan(
+		&i.AllowFetch,
+		&i.AllowPush,
+		&i.PushBranchGlobsJson,
+		&i.ExpiresAt,
+	)
+	return i, err
 }
 
 const getCallerPoolGrant = `-- name: GetCallerPoolGrant :one
@@ -1305,6 +1401,43 @@ func (q *Queries) UpdateCallerWebLogin(ctx context.Context, arg UpdateCallerWebL
 		arg.GithubUserID,
 		arg.OrgVerifiedAt,
 		arg.ID,
+	)
+	return err
+}
+
+const upsertCallerGitPolicy = `-- name: UpsertCallerGitPolicy :exec
+INSERT INTO caller_git_policies
+  (caller_id, pool_id, owner, repo, allow_fetch, allow_push, push_branch_globs_json, expires_at)
+VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+ON CONFLICT(caller_id, pool_id, owner, repo) DO UPDATE SET
+  allow_fetch = excluded.allow_fetch,
+  allow_push = excluded.allow_push,
+  push_branch_globs_json = excluded.push_branch_globs_json,
+  expires_at = excluded.expires_at,
+  updated_at = CURRENT_TIMESTAMP
+`
+
+type UpsertCallerGitPolicyParams struct {
+	CallerID            string         `json:"caller_id"`
+	PoolID              string         `json:"pool_id"`
+	Owner               string         `json:"owner"`
+	Repo                string         `json:"repo"`
+	AllowFetch          int64          `json:"allow_fetch"`
+	AllowPush           int64          `json:"allow_push"`
+	PushBranchGlobsJson string         `json:"push_branch_globs_json"`
+	ExpiresAt           sql.NullString `json:"expires_at"`
+}
+
+func (q *Queries) UpsertCallerGitPolicy(ctx context.Context, arg UpsertCallerGitPolicyParams) error {
+	_, err := q.db.ExecContext(ctx, upsertCallerGitPolicy,
+		arg.CallerID,
+		arg.PoolID,
+		arg.Owner,
+		arg.Repo,
+		arg.AllowFetch,
+		arg.AllowPush,
+		arg.PushBranchGlobsJson,
+		arg.ExpiresAt,
 	)
 	return err
 }

--- a/internal/dbquery/models.go
+++ b/internal/dbquery/models.go
@@ -37,6 +37,19 @@ type Caller struct {
 	DashboardRole string         `json:"dashboard_role"`
 }
 
+type CallerGitPolicy struct {
+	CallerID            string         `json:"caller_id"`
+	PoolID              string         `json:"pool_id"`
+	Owner               string         `json:"owner"`
+	Repo                string         `json:"repo"`
+	AllowFetch          int64          `json:"allow_fetch"`
+	AllowPush           int64          `json:"allow_push"`
+	PushBranchGlobsJson string         `json:"push_branch_globs_json"`
+	ExpiresAt           sql.NullString `json:"expires_at"`
+	CreatedAt           string         `json:"created_at"`
+	UpdatedAt           string         `json:"updated_at"`
+}
+
 type CallerPool struct {
 	CallerID  string `json:"caller_id"`
 	PoolID    string `json:"pool_id"`

--- a/migrations/0006_git_policies.sql
+++ b/migrations/0006_git_policies.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS caller_git_policies (
+  caller_id TEXT NOT NULL REFERENCES callers(id) ON DELETE CASCADE,
+  pool_id TEXT NOT NULL REFERENCES pools(id) ON DELETE CASCADE,
+  owner TEXT NOT NULL,
+  repo TEXT NOT NULL,
+  allow_fetch INTEGER NOT NULL DEFAULT 0 CHECK (allow_fetch IN (0, 1)),
+  allow_push INTEGER NOT NULL DEFAULT 0 CHECK (allow_push IN (0, 1)),
+  push_branch_globs_json TEXT NOT NULL DEFAULT '[]',
+  expires_at TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (caller_id, pool_id, owner, repo)
+);
+
+CREATE INDEX IF NOT EXISTS idx_caller_git_policies_repo
+  ON caller_git_policies(pool_id, owner, repo);

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  esbuild: true
+  sharp: true
+  workerd: true

--- a/sql/queries/d1.sql
+++ b/sql/queries/d1.sql
@@ -209,6 +209,44 @@ VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'active');
 INSERT INTO caller_pools (caller_id, pool_id)
 VALUES (?1, ?2);
 
+-- name: FindCallerForGitPolicy :one
+SELECT callers.id, callers.github_login
+FROM callers
+JOIN caller_pools ON caller_pools.caller_id = callers.id
+WHERE lower(callers.github_login) = lower(?1)
+  AND callers.org_login = ?2
+  AND callers.status = 'active'
+  AND caller_pools.pool_id = ?3
+LIMIT 1;
+
+-- name: UpsertCallerGitPolicy :exec
+INSERT INTO caller_git_policies
+  (caller_id, pool_id, owner, repo, allow_fetch, allow_push, push_branch_globs_json, expires_at)
+VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+ON CONFLICT(caller_id, pool_id, owner, repo) DO UPDATE SET
+  allow_fetch = excluded.allow_fetch,
+  allow_push = excluded.allow_push,
+  push_branch_globs_json = excluded.push_branch_globs_json,
+  expires_at = excluded.expires_at,
+  updated_at = CURRENT_TIMESTAMP;
+
+-- name: DeleteCallerGitPolicy :exec
+DELETE FROM caller_git_policies
+WHERE caller_id = ?1
+  AND pool_id = ?2
+  AND lower(owner) = lower(?3)
+  AND lower(repo) = lower(?4);
+
+-- name: GetCallerGitPolicy :one
+SELECT allow_fetch, allow_push, push_branch_globs_json, expires_at
+FROM caller_git_policies
+WHERE caller_id = ?1
+  AND pool_id = ?2
+  AND lower(owner) = lower(?3)
+  AND lower(repo) = lower(?4)
+  AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)
+LIMIT 1;
+
 -- name: GetIdentityPoolKind :one
 SELECT pool_id, kind
 FROM identities

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -16,6 +16,14 @@ export async function authenticateCaller(
   pool: string,
 ): Promise<Caller> {
   const token = requestBearer(request);
+  return authenticateCallerToken(token, env, pool);
+}
+
+export async function authenticateCallerToken(
+  token: string,
+  env: Env,
+  pool: string,
+): Promise<Caller> {
   const tokenHash = await hashToken(token);
   const row = await env.DB.prepare(queries.authenticateCaller)
     .bind(tokenHash, pool)

--- a/src/generated/sql.ts
+++ b/src/generated/sql.ts
@@ -68,6 +68,14 @@ export const queries = {
   insertCaller:
     "INSERT INTO callers (id, name, token_hash, github_login, github_user_id, org_login, org_verified_at, status)\nVALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'active')",
   insertCallerPool: "INSERT INTO caller_pools (caller_id, pool_id)\nVALUES (?1, ?2)",
+  findCallerForGitPolicy:
+    "SELECT callers.id, callers.github_login\nFROM callers\nJOIN caller_pools ON caller_pools.caller_id = callers.id\nWHERE lower(callers.github_login) = lower(?1)\n  AND callers.org_login = ?2\n  AND callers.status = 'active'\n  AND caller_pools.pool_id = ?3\nLIMIT 1",
+  upsertCallerGitPolicy:
+    "INSERT INTO caller_git_policies\n  (caller_id, pool_id, owner, repo, allow_fetch, allow_push, push_branch_globs_json, expires_at)\nVALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)\nON CONFLICT(caller_id, pool_id, owner, repo) DO UPDATE SET\n  allow_fetch = excluded.allow_fetch,\n  allow_push = excluded.allow_push,\n  push_branch_globs_json = excluded.push_branch_globs_json,\n  expires_at = excluded.expires_at,\n  updated_at = CURRENT_TIMESTAMP",
+  deleteCallerGitPolicy:
+    "DELETE FROM caller_git_policies\nWHERE caller_id = ?1\n  AND pool_id = ?2\n  AND lower(owner) = lower(?3)\n  AND lower(repo) = lower(?4)",
+  getCallerGitPolicy:
+    "SELECT allow_fetch, allow_push, push_branch_globs_json, expires_at\nFROM caller_git_policies\nWHERE caller_id = ?1\n  AND pool_id = ?2\n  AND lower(owner) = lower(?3)\n  AND lower(repo) = lower(?4)\n  AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)\nLIMIT 1",
   getIdentityPoolKind: "SELECT pool_id, kind\nFROM identities\nWHERE id = ?1",
   upsertIdentity:
     "INSERT INTO identities (id, pool_id, kind, login, secret_ref, installation_id, status, weight)\nVALUES (?1, ?2, ?3, ?4, ?5, ?6, 'active', ?7)\nON CONFLICT(id) DO UPDATE SET\n  login = excluded.login,\n  secret_ref = excluded.secret_ref,\n  installation_id = excluded.installation_id,\n  status = 'active',\n  weight = excluded.weight,\n  updated_at = CURRENT_TIMESTAMP",

--- a/src/git-proxy.ts
+++ b/src/git-proxy.ts
@@ -1,0 +1,508 @@
+import { authenticateCallerToken, envSecret } from "./auth";
+import { loadIdentities } from "./db";
+import { githubToken } from "./github";
+import { HttpError, isObject, jsonResponse, requireString } from "./http";
+import { queries } from "./generated/sql";
+import type { Caller, Identity, RouteInfo } from "./types";
+
+type GitOperation = "fetch" | "push";
+
+type GitRoute = {
+  owner: string;
+  repo: string;
+  upstreamPath: string;
+  operation: GitOperation;
+};
+
+type GitPolicy = {
+  allowFetch: boolean;
+  allowPush: boolean;
+  pushBranchGlobs: string[];
+};
+
+type ReceivePackCommand = {
+  oldOid: string;
+  newOid: string;
+  ref: string;
+};
+
+const ZERO_OID = "0000000000000000000000000000000000000000";
+const MAX_RECEIVE_PACK_COMMAND_BYTES = 65_536;
+
+export async function handleGitRequest(request: Request, env: Env): Promise<Response> {
+  const url = new URL(request.url);
+  const route = parseGitRoute(url, request.method);
+  if (route === undefined) {
+    throw new HttpError(404, "not_found", "Route not found");
+  }
+  const token = gitAuthToken(request);
+  if (token === undefined) {
+    return gitAuthChallenge();
+  }
+  const pool = gitPool(env);
+  const caller = await authenticateCallerToken(token, env, pool);
+  const policy = await loadGitPolicy(env, caller, pool, route.owner, route.repo);
+  authorizeGitOperation(policy, route.operation);
+
+  const identity = await selectGitHubAppIdentity(env, pool, route);
+  const upstreamRequest = await buildUpstreamGitRequest(request, env, identity, route, policy);
+  const response = await fetch(upstreamRequest);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: gitResponseHeaders(response.headers),
+  });
+}
+
+export async function upsertGitPolicy(request: Request, env: Env, pool: string): Promise<Response> {
+  const body = await request.json().catch(() => undefined);
+  if (!isObject(body)) {
+    throw new HttpError(400, "invalid_json", "Expected a JSON object");
+  }
+  const githubLogin = requireString(body.github_login, "github_login");
+  const repo = parseRepoName(requireString(body.repo, "repo"));
+  const caller = await env.DB.prepare(queries.findCallerForGitPolicy)
+    .bind(githubLogin, env.ALLOWED_GITHUB_ORG, pool)
+    .first<{ id: string; github_login: string }>();
+  if (caller === null) {
+    throw new HttpError(404, "caller_not_found", "Caller is not provisioned for this pool");
+  }
+  const allowFetch = body.fetch === true ? 1 : 0;
+  const allowPush = body.push === true ? 1 : 0;
+  const pushBranches = parseBranchGlobs(body.push_branches);
+  const expiresAt =
+    typeof body.expires_at === "string" && body.expires_at.trim() !== ""
+      ? body.expires_at.trim()
+      : null;
+  if (expiresAt !== null && !Number.isFinite(Date.parse(expiresAt))) {
+    throw new HttpError(400, "expires_at_invalid", "expires_at must be an ISO timestamp");
+  }
+  await env.DB.prepare(queries.upsertCallerGitPolicy)
+    .bind(
+      caller.id,
+      pool,
+      repo.owner,
+      repo.repo,
+      allowFetch,
+      allowPush,
+      JSON.stringify(pushBranches),
+      expiresAt,
+    )
+    .run();
+  return jsonResponse(
+    {
+      git_policy: {
+        github_login: caller.github_login,
+        pool,
+        repo: `${repo.owner}/${repo.repo}`,
+        fetch: allowFetch === 1,
+        push: allowPush === 1,
+        push_branches: pushBranches,
+        expires_at: expiresAt,
+      },
+    },
+    201,
+  );
+}
+
+export async function deleteGitPolicy(request: Request, env: Env, pool: string): Promise<Response> {
+  const url = new URL(request.url);
+  const githubLogin = url.searchParams.get("github_login")?.trim();
+  const repoParam = url.searchParams.get("repo")?.trim();
+  if (githubLogin === undefined || githubLogin === "") {
+    throw new HttpError(400, "invalid_request", "github_login query parameter is required");
+  }
+  if (repoParam === undefined || repoParam === "") {
+    throw new HttpError(400, "invalid_request", "repo query parameter is required");
+  }
+  const repo = parseRepoName(repoParam);
+  const caller = await env.DB.prepare(queries.findCallerForGitPolicy)
+    .bind(githubLogin, env.ALLOWED_GITHUB_ORG, pool)
+    .first<{ id: string }>();
+  if (caller === null) {
+    throw new HttpError(404, "caller_not_found", "Caller is not provisioned for this pool");
+  }
+  await env.DB.prepare(queries.deleteCallerGitPolicy)
+    .bind(caller.id, pool, repo.owner, repo.repo)
+    .run();
+  return jsonResponse({ deleted: true });
+}
+
+export function parseGitRoute(url: URL, method: string): GitRoute | undefined {
+  const match =
+    /^\/git\/(?<owner>[A-Za-z0-9_.-]+)\/(?<repo>[A-Za-z0-9_.-]+)\.git\/(?<tail>.+)$/.exec(
+      url.pathname,
+    );
+  if (match?.groups === undefined) {
+    return undefined;
+  }
+  const { owner, repo, tail } = match.groups;
+  if (owner === undefined || repo === undefined || tail === undefined) {
+    return undefined;
+  }
+  if (method === "GET" && tail === "info/refs") {
+    const service = url.searchParams.get("service");
+    if (service === "git-upload-pack") {
+      return { owner, repo, upstreamPath: `${owner}/${repo}.git/info/refs`, operation: "fetch" };
+    }
+    if (service === "git-receive-pack") {
+      return { owner, repo, upstreamPath: `${owner}/${repo}.git/info/refs`, operation: "push" };
+    }
+    return undefined;
+  }
+  if (method === "POST" && tail === "git-upload-pack") {
+    return {
+      owner,
+      repo,
+      upstreamPath: `${owner}/${repo}.git/git-upload-pack`,
+      operation: "fetch",
+    };
+  }
+  if (method === "POST" && tail === "git-receive-pack") {
+    return {
+      owner,
+      repo,
+      upstreamPath: `${owner}/${repo}.git/git-receive-pack`,
+      operation: "push",
+    };
+  }
+  return undefined;
+}
+
+export function gitAuthToken(request: Request): string | undefined {
+  const authorization = request.headers.get("authorization") ?? "";
+  const bearer = /^Bearer\s+(.+)$/i.exec(authorization);
+  if (bearer?.[1] !== undefined && bearer[1].trim() !== "") {
+    return bearer[1].trim();
+  }
+  const basic = /^Basic\s+(.+)$/i.exec(authorization);
+  if (basic?.[1] === undefined) {
+    return undefined;
+  }
+  let decoded = "";
+  try {
+    decoded = atob(basic[1]);
+  } catch {
+    return undefined;
+  }
+  const separator = decoded.indexOf(":");
+  if (separator < 0) {
+    return undefined;
+  }
+  const password = decoded.slice(separator + 1).trim();
+  return password === "" ? undefined : password;
+}
+
+export function branchMatchesGlob(branch: string, glob: string): boolean {
+  if (glob === "") {
+    return false;
+  }
+  const escaped = glob.replace(/[.+^${}()|[\]\\]/g, "\\$&").replaceAll("*", ".*");
+  return new RegExp(`^${escaped}$`).test(branch);
+}
+
+export function parseReceivePackCommands(input: Uint8Array): {
+  commands: ReceivePackCommand[];
+  prefixLength: number;
+} {
+  const commands: ReceivePackCommand[] = [];
+  let offset = 0;
+  for (;;) {
+    if (offset + 4 > input.length) {
+      throw new HttpError(
+        400,
+        "git_receive_pack_invalid",
+        "Receive-pack command list is incomplete",
+      );
+    }
+    const lengthText = ascii(input.subarray(offset, offset + 4));
+    if (lengthText === "0000") {
+      return { commands, prefixLength: offset + 4 };
+    }
+    const length = Number.parseInt(lengthText, 16);
+    if (!Number.isFinite(length) || length < 4) {
+      throw new HttpError(
+        400,
+        "git_receive_pack_invalid",
+        "Receive-pack pkt-line length is invalid",
+      );
+    }
+    if (offset + length > input.length) {
+      throw new HttpError(
+        400,
+        "git_receive_pack_invalid",
+        "Receive-pack command pkt-line is incomplete",
+      );
+    }
+    const payload = ascii(input.subarray(offset + 4, offset + length));
+    const commandText = commands.length === 0 ? (payload.split("\0", 1)[0] ?? "") : payload;
+    const fields = commandText.trimEnd().split(" ");
+    if (fields.length < 3) {
+      throw new HttpError(400, "git_receive_pack_invalid", "Receive-pack command is invalid");
+    }
+    const [oldOid, newOid, ref] = fields;
+    if (!validOid(oldOid) || !validOid(newOid) || ref === undefined || ref === "") {
+      throw new HttpError(400, "git_receive_pack_invalid", "Receive-pack command is invalid");
+    }
+    commands.push({ oldOid, newOid, ref });
+    offset += length;
+  }
+}
+
+export function validatePushCommands(commands: ReceivePackCommand[], policy: GitPolicy): void {
+  for (const command of commands) {
+    if (command.newOid === ZERO_OID) {
+      throw new HttpError(403, "git_push_denied", "Branch deletes are not enabled");
+    }
+    if (!command.ref.startsWith("refs/heads/")) {
+      throw new HttpError(403, "git_push_denied", "Only branch pushes are enabled");
+    }
+    const branch = command.ref.slice("refs/heads/".length);
+    if (!policy.pushBranchGlobs.some((glob) => branchMatchesGlob(branch, glob))) {
+      throw new HttpError(403, "git_push_denied", `Branch ${branch} is not allowed`);
+    }
+  }
+}
+
+async function buildUpstreamGitRequest(
+  request: Request,
+  env: Env,
+  identity: Identity,
+  route: GitRoute,
+  policy: GitPolicy,
+): Promise<Request> {
+  const upstreamUrl = new URL(`https://github.com/${route.upstreamPath}`);
+  const inputUrl = new URL(request.url);
+  if (route.upstreamPath.endsWith("/info/refs")) {
+    upstreamUrl.search = inputUrl.search;
+  }
+  const headers = new Headers();
+  for (const key of ["accept", "content-type", "git-protocol", "user-agent"]) {
+    const value = request.headers.get(key);
+    if (value !== null) {
+      headers.set(key, value);
+    }
+  }
+  const body =
+    route.operation === "push" && request.method === "POST"
+      ? await validatedReceivePackBody(request, policy)
+      : request.body;
+  const appToken = await githubToken(env, identity);
+  headers.set("authorization", `Basic ${btoa(`x-access-token:${appToken}`)}`);
+  return new Request(upstreamUrl.toString(), {
+    method: request.method,
+    headers,
+    body,
+    redirect: "manual",
+  });
+}
+
+async function validatedReceivePackBody(
+  request: Request,
+  policy: GitPolicy,
+): Promise<ReadableStream<Uint8Array> | null> {
+  if (request.body === null) {
+    throw new HttpError(400, "git_receive_pack_invalid", "Receive-pack body is required");
+  }
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      throw new HttpError(
+        400,
+        "git_receive_pack_invalid",
+        "Receive-pack command list is incomplete",
+      );
+    }
+    if (value !== undefined) {
+      total += value.byteLength;
+      chunks.push(value);
+      const buffered = concat(chunks, total);
+      try {
+        const parsed = parseReceivePackCommands(buffered);
+        validatePushCommands(parsed.commands, policy);
+        return streamBufferedThenReader(chunks, reader);
+      } catch (error) {
+        if (
+          error instanceof HttpError &&
+          error.code === "git_receive_pack_invalid" &&
+          error.message.includes("incomplete")
+        ) {
+          if (total > MAX_RECEIVE_PACK_COMMAND_BYTES) {
+            await reader.cancel();
+            throw new HttpError(
+              400,
+              "git_receive_pack_invalid",
+              "Receive-pack command list is too large",
+            );
+          }
+          continue;
+        }
+        await reader.cancel();
+        throw error;
+      }
+    }
+  }
+}
+
+function streamBufferedThenReader(
+  chunks: Uint8Array[],
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) {
+            controller.close();
+            return;
+          }
+          if (value !== undefined) {
+            controller.enqueue(value);
+          }
+        }
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+    async cancel() {
+      await reader.cancel();
+    },
+  });
+}
+
+async function loadGitPolicy(
+  env: Env,
+  caller: Caller,
+  pool: string,
+  owner: string,
+  repo: string,
+): Promise<GitPolicy> {
+  const row = await env.DB.prepare(queries.getCallerGitPolicy)
+    .bind(caller.id, pool, owner, repo)
+    .first<{
+      allow_fetch: number;
+      allow_push: number;
+      push_branch_globs_json: string;
+      expires_at: string | null;
+    }>();
+  if (row === null) {
+    throw new HttpError(403, "git_policy_denied", "Git access is not enabled for this caller");
+  }
+  return {
+    allowFetch: row.allow_fetch === 1,
+    allowPush: row.allow_push === 1,
+    pushBranchGlobs: parseStoredBranchGlobs(row.push_branch_globs_json),
+  };
+}
+
+function authorizeGitOperation(policy: GitPolicy, operation: GitOperation): void {
+  if (operation === "fetch" && !policy.allowFetch) {
+    throw new HttpError(403, "git_fetch_denied", "Git fetch is not enabled for this caller");
+  }
+  if (operation === "push" && !policy.allowPush) {
+    throw new HttpError(403, "git_push_denied", "Git push is not enabled for this caller");
+  }
+}
+
+async function selectGitHubAppIdentity(env: Env, pool: string, route: GitRoute): Promise<Identity> {
+  const candidates = await loadIdentities(env, pool, {
+    kind: "git",
+    owner: route.owner.toLowerCase(),
+    repo: route.repo,
+    resource: "core",
+    routeKey: `GIT ${route.owner}/${route.repo}`,
+    cacheable: false,
+    largePayload: true,
+    logs: false,
+  } satisfies RouteInfo);
+  const app = candidates
+    .filter((identity) => identity.kind === "github_app")
+    .sort((left, right) => right.weight - left.weight || left.id.localeCompare(right.id))[0];
+  if (app === undefined) {
+    throw new HttpError(
+      503,
+      "no_git_identity",
+      "No active GitHub App identity can serve this repo",
+    );
+  }
+  return app;
+}
+
+function gitResponseHeaders(input: Headers): Headers {
+  const headers = new Headers();
+  for (const [key, value] of input) {
+    const lower = key.toLowerCase();
+    if (lower === "set-cookie" || lower === "www-authenticate") {
+      continue;
+    }
+    headers.set(key, value);
+  }
+  headers.set("cache-control", "no-store");
+  return headers;
+}
+
+function gitAuthChallenge(): Response {
+  return new Response("Git authentication required\n", {
+    status: 401,
+    headers: {
+      "cache-control": "no-store",
+      "www-authenticate": 'Basic realm="octopool"',
+    },
+  });
+}
+
+function gitPool(env: Env): string {
+  const configured = envSecret(env, "DEFAULT_LOGIN_POOL");
+  return configured === undefined || configured.trim() === "" ? "maintainers" : configured.trim();
+}
+
+function parseRepoName(value: string): { owner: string; repo: string } {
+  const match = /^(?<owner>[A-Za-z0-9_.-]+)\/(?<repo>[A-Za-z0-9_.-]+)$/.exec(value);
+  if (match?.groups?.owner === undefined || match.groups.repo === undefined) {
+    throw new HttpError(400, "repo_invalid", "repo must be owner/repo");
+  }
+  return { owner: match.groups.owner.toLowerCase(), repo: match.groups.repo };
+}
+
+function parseBranchGlobs(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter((item) => item !== "" && !item.startsWith("/") && !item.includes(".."));
+}
+
+function parseStoredBranchGlobs(value: string): string[] {
+  try {
+    return parseBranchGlobs(JSON.parse(value));
+  } catch {
+    return [];
+  }
+}
+
+function validOid(value: string | undefined): value is string {
+  return typeof value === "string" && /^[0-9a-fA-F]{40,64}$/.test(value);
+}
+
+function ascii(bytes: Uint8Array): string {
+  return new TextDecoder("utf-8", { fatal: false, ignoreBOM: false }).decode(bytes);
+}
+
+function concat(chunks: Uint8Array[], total: number): Uint8Array {
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}

--- a/src/github.ts
+++ b/src/github.ts
@@ -35,7 +35,7 @@ export async function callGitHub(
   };
 }
 
-async function githubToken(env: Env, identity: Identity): Promise<string> {
+export async function githubToken(env: Env, identity: Identity): Promise<string> {
   switch (identity.kind) {
     case "pat":
       return githubSecret(env, identity.secret_ref);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { githubCacheKey, readGitHubCache, shouldUseGitHubCache, writeGitHubCache
 import { dashboardResponse } from "./dashboard";
 import { ensurePool, insertAudit, loadIdentities, loadPoolPolicy } from "./db";
 import { callGitHub, rateFromHeaders } from "./github";
+import { deleteGitPolicy, handleGitRequest, upsertGitPolicy } from "./git-proxy";
 import { sanitizeGitHubResponse } from "./github-sanitize";
 import { queries } from "./generated/sql";
 import {
@@ -130,9 +131,33 @@ async function routeRequest(
   if (request.method === "POST" && url.pathname === "/v1/github/request") {
     return relayGitHub(request, env, ctx, requestId);
   }
+  if (url.pathname.startsWith("/git/")) {
+    return handleGitRequest(request, env);
+  }
   if (request.method === "POST" && url.pathname === "/v1/admin/callers") {
     await authenticateAdmin(request, env);
     return createCaller(request, env);
+  }
+  if (request.method === "PUT" && /^\/v1\/admin\/pools\/[^/]+\/git-policies$/.test(url.pathname)) {
+    await authenticateAdmin(request, env);
+    const pool = routeParam(
+      url.pathname,
+      /^\/v1\/admin\/pools\/(?<pool>[^/]+)\/git-policies$/,
+      "pool",
+    );
+    return upsertGitPolicy(request, env, pool);
+  }
+  if (
+    request.method === "DELETE" &&
+    /^\/v1\/admin\/pools\/[^/]+\/git-policies$/.test(url.pathname)
+  ) {
+    await authenticateAdmin(request, env);
+    const pool = routeParam(
+      url.pathname,
+      /^\/v1\/admin\/pools\/(?<pool>[^/]+)\/git-policies$/,
+      "pool",
+    );
+    return deleteGitPolicy(request, env, pool);
   }
   if (request.method === "POST" && /^\/v1\/admin\/pools\/[^/]+\/identities$/.test(url.pathname)) {
     await authenticateAdmin(request, env);

--- a/test/git-proxy.test.ts
+++ b/test/git-proxy.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  branchMatchesGlob,
+  gitAuthToken,
+  handleGitRequest,
+  parseGitRoute,
+  parseReceivePackCommands,
+  validatePushCommands,
+} from "../src/git-proxy";
+import { queries } from "../src/generated/sql";
+
+const OLD = "1".repeat(40);
+const NEW = "2".repeat(40);
+const ZERO = "0".repeat(40);
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("git proxy policy helpers", () => {
+  it("challenges unauthenticated git clients with Basic auth", async () => {
+    const response = await handleGitRequest(
+      new Request(
+        "https://octopool.dev/git/openclaw/octopool.git/info/refs?service=git-upload-pack",
+      ),
+      {} as Env,
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("www-authenticate")).toBe('Basic realm="octopool"');
+  });
+
+  it("extracts bearer and basic octopool tokens", () => {
+    expect(
+      gitAuthToken(
+        new Request("https://octopool.dev/git/o/r.git/info/refs", {
+          headers: { authorization: "Bearer op_token" },
+        }),
+      ),
+    ).toBe("op_token");
+    expect(
+      gitAuthToken(
+        new Request("https://octopool.dev/git/o/r.git/info/refs", {
+          headers: { authorization: `Basic ${btoa("agent:op_basic")}` },
+        }),
+      ),
+    ).toBe("op_basic");
+  });
+
+  it("classifies supported git smart-http routes", () => {
+    expect(
+      parseGitRoute(
+        new URL("https://octopool.dev/git/openclaw/octopool.git/info/refs?service=git-upload-pack"),
+        "GET",
+      ),
+    ).toMatchObject({ owner: "openclaw", repo: "octopool", operation: "fetch" });
+    expect(
+      parseGitRoute(
+        new URL("https://octopool.dev/git/openclaw/octopool.git/git-receive-pack"),
+        "POST",
+      ),
+    ).toMatchObject({ owner: "openclaw", repo: "octopool", operation: "push" });
+    expect(
+      parseGitRoute(new URL("https://octopool.dev/openclaw/octopool.git"), "GET"),
+    ).toBeUndefined();
+  });
+
+  it("matches branch globs as anchored branch-name patterns", () => {
+    expect(branchMatchesGlob("agent/task", "agent/*")).toBe(true);
+    expect(branchMatchesGlob("nested/agent/task", "agent/*")).toBe(false);
+    expect(branchMatchesGlob("main", "main")).toBe(true);
+    expect(branchMatchesGlob("main-old", "main")).toBe(false);
+  });
+
+  it("parses receive-pack commands before the pack body", () => {
+    const bytes = receivePack([
+      `${OLD} ${NEW} refs/heads/agent/task\0 report-status side-band-64k\n`,
+      `${OLD} ${NEW} refs/heads/agent/other\n`,
+    ]);
+    const parsed = parseReceivePackCommands(bytes);
+
+    expect(parsed.commands).toEqual([
+      { oldOid: OLD, newOid: NEW, ref: "refs/heads/agent/task" },
+      { oldOid: OLD, newOid: NEW, ref: "refs/heads/agent/other" },
+    ]);
+    expect(parsed.prefixLength).toBeLessThan(bytes.byteLength);
+  });
+
+  it("denies disallowed push refs", () => {
+    const policy = { allowFetch: true, allowPush: true, pushBranchGlobs: ["agent/*"] };
+    expect(() =>
+      validatePushCommands([{ oldOid: OLD, newOid: NEW, ref: "refs/heads/agent/task" }], policy),
+    ).not.toThrow();
+    expect(() =>
+      validatePushCommands([{ oldOid: OLD, newOid: NEW, ref: "refs/heads/main" }], policy),
+    ).toThrow(/not allowed/);
+    expect(() =>
+      validatePushCommands([{ oldOid: OLD, newOid: NEW, ref: "refs/tags/v1" }], policy),
+    ).toThrow(/Only branch/);
+    expect(() =>
+      validatePushCommands([{ oldOid: OLD, newOid: ZERO, ref: "refs/heads/agent/task" }], policy),
+    ).toThrow(/deletes/);
+  });
+
+  it("proxies allowed fetches with GitHub App credentials", async () => {
+    const secretRef = "APP_KEY_FETCH";
+    const env = await gitEnv({
+      secretRef,
+      fetch: true,
+      push: false,
+      branches: [],
+    });
+    const fetchMock = vi.fn(async (input: Request | string, init?: RequestInit) => {
+      const request = typeof input === "string" ? new Request(input, init) : input;
+      if (request.url.includes("/app/installations/123/access_tokens")) {
+        expect(request.headers.get("authorization")).not.toContain("op_agent");
+        return Response.json({
+          token: "ghs_app_fetch",
+          expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+        });
+      }
+      expect(request.url).toBe(
+        "https://github.com/openclaw/octopool.git/info/refs?service=git-upload-pack",
+      );
+      expect(atob(request.headers.get("authorization")?.replace(/^Basic\s+/i, "") ?? "")).toBe(
+        "x-access-token:ghs_app_fetch",
+      );
+      return new Response("refs", {
+        status: 200,
+        headers: { "content-type": "application/x-git-upload-pack-advertisement" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await handleGitRequest(
+      gitRequest(
+        "https://octopool.dev/git/openclaw/octopool.git/info/refs?service=git-upload-pack",
+      ),
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("refs");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects disallowed branch pushes before forwarding to GitHub", async () => {
+    const env = await gitEnv({
+      secretRef: "APP_KEY_PUSH_DENIED",
+      fetch: true,
+      push: true,
+      branches: ["agent/*"],
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      handleGitRequest(
+        gitRequest("https://octopool.dev/git/openclaw/octopool.git/git-receive-pack", {
+          method: "POST",
+          body: receivePack([`${OLD} ${NEW} refs/heads/main\0 report-status\n`]),
+        }),
+        env,
+      ),
+    ).rejects.toMatchObject({ status: 403, code: "git_push_denied" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+function receivePack(lines: string[]): Uint8Array {
+  const encoded = new TextEncoder();
+  const parts = [
+    ...lines.map((line) => {
+      const payload = encoded.encode(line);
+      const length = (payload.byteLength + 4).toString(16).padStart(4, "0");
+      const out = new Uint8Array(4 + payload.byteLength);
+      out.set(encoded.encode(length), 0);
+      out.set(payload, 4);
+      return out;
+    }),
+    encoded.encode("0000PACK"),
+  ];
+  const total = parts.reduce((sum, part) => sum + part.byteLength, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.byteLength;
+  }
+  return out;
+}
+
+function gitRequest(url: string, init: RequestInit = {}): Request {
+  const headers = new Headers(init.headers);
+  headers.set("authorization", `Basic ${btoa("agent:op_agent")}`);
+  return new Request(url, { ...init, headers });
+}
+
+async function gitEnv(input: {
+  secretRef: string;
+  fetch: boolean;
+  push: boolean;
+  branches: string[];
+}): Promise<Env> {
+  const privateKey = await testPrivateKeyPEM();
+  const prepare = vi.fn((sql: string) => {
+    const statement = {
+      bind: vi.fn(() => statement),
+      first: vi.fn(async () => {
+        if (sql === queries.authenticateCaller) {
+          return {
+            id: "caller_1",
+            name: "Agent",
+            github_login: "agent",
+            org_login: "openclaw",
+            org_verified_at: new Date(Date.now() + 3_600_000).toISOString(),
+          };
+        }
+        if (sql === queries.getCallerGitPolicy) {
+          return {
+            allow_fetch: input.fetch ? 1 : 0,
+            allow_push: input.push ? 1 : 0,
+            push_branch_globs_json: JSON.stringify(input.branches),
+            expires_at: null,
+          };
+        }
+        return null;
+      }),
+      all: vi.fn(async () => {
+        if (sql === queries.listActiveIdentitiesForRoute) {
+          return {
+            results: [
+              {
+                id: "ghapp_1",
+                kind: "github_app",
+                login: "octopool-app",
+                secret_ref: input.secretRef,
+                installation_id: 123,
+                weight: 100,
+              },
+            ],
+          };
+        }
+        return { results: [] };
+      }),
+      run: vi.fn(async () => undefined),
+    };
+    return statement;
+  });
+  return {
+    DB: { prepare },
+    ALLOWED_GITHUB_ORG: "openclaw",
+    DEFAULT_ALLOWED_OWNERS: "openclaw",
+    DEFAULT_LOGIN_POOL: "maintainers",
+    REQUEST_TIMEOUT_MS: "15000",
+    OCTOPOOL_GITHUB_APP_ID: "12345",
+    [input.secretRef]: privateKey,
+  } as unknown as Env;
+}
+
+async function testPrivateKeyPEM(): Promise<string> {
+  const pair = (await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  )) as CryptoKeyPair;
+  const exported = await crypto.subtle.exportKey("pkcs8", pair.privateKey);
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(exported as ArrayBuffer)));
+  return `-----BEGIN PRIVATE KEY-----\n${base64.match(/.{1,64}/g)?.join("\n") ?? base64}\n-----END PRIVATE KEY-----`;
+}


### PR DESCRIPTION
Introduce a Git smart-HTTP proxy under /git/:owner/:repo.git so agents can clone, fetch, and push through Octopool using existing caller tokens. The proxy accepts Git Basic auth with the Octopool token as the password, falls back to Bearer auth for test/debug clients, selects GitHub App identities for upstream GitHub access, and forwards Git traffic without caching.

Add per-caller Git policy storage and admin APIs for repo-scoped fetch/push grants. Push policies store allowed branch globs, optional expiry, and default-deny behavior; receive-pack command parsing validates branch updates before any push is forwarded, while rejecting deletes, tags, and non-branch refs in v1.

Add CLI support for octopool git clone, an Octopool credential helper for plain git push after clone, and octopool admin git-policy for provisioning policies. Cover the new behavior with Worker helper/proxy tests, CLI tests, generated SQL bindings, and pnpm build-script approvals.