### PR TITLE
fix: improve cache hit rate safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Raise cache hit rates with response-aware TTLs for closed PRs/issues, immutable commits, and normalized default GitHub query/header variants while keeping mutable CI reads short-lived.
 - Skip Octopool-backed `gh` wrapper scripts when falling back to the real GitHub CLI, avoiding duplicate fallback attempts and warnings.
 
 ## 0.2.4 - 2026-05-29

--- a/cmd/octopool/stats.go
+++ b/cmd/octopool/stats.go
@@ -115,11 +115,17 @@ func renderStats(w io.Writer, stats statsResponse) error {
 		fmt.Sprintf("operator: %s", firstNonEmpty(stats.Operator.GitHubLogin, "unknown")),
 		fmt.Sprintf("requests: %s (%s errors)", intFmt(stats.PoolUsage.Requests), intFmt(stats.PoolUsage.Errors)),
 		fmt.Sprintf(
-			"cache: %s hit (%s hits, %s misses, %s bypass)",
+			"cache: %s hit (%s hits, %s misses, %s bypass, %s unknown)",
 			percent(stats.PoolUsage.CacheHitRate),
 			intFmt(stats.PoolUsage.CacheHits),
 			intFmt(stats.PoolUsage.CacheMisses),
 			intFmt(stats.PoolUsage.CacheBypass),
+			intFmt(stats.PoolUsage.CacheUnknown),
+		),
+		fmt.Sprintf(
+			"cacheable: %s/%s requests",
+			intFmt(stats.PoolUsage.CacheableRequests),
+			intFmt(stats.PoolUsage.Requests),
 		),
 		fmt.Sprintf(
 			"caller: %s requests, %s hit",

--- a/cmd/octopool/stats_test.go
+++ b/cmd/octopool/stats_test.go
@@ -47,7 +47,8 @@ func TestRenderStats(t *testing.T) {
 	for _, want := range []string{
 		"pool: maintainers",
 		"operator: steipete",
-		"cache: 62.5% hit (5 hits, 3 misses, 4 bypass)",
+		"cache: 62.5% hit (5 hits, 3 misses, 4 bypass, 0 unknown)",
+		"cacheable: 0/12 requests",
 		"entries: 7 fresh / 9 total, 2 expired, 1.5 KiB",
 		"  pr_view: 6 req, 62.5% hit, 0 errors",
 	} {

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -14,8 +14,10 @@ performs the GitHub call and writes the result back.
 
 ### Cache key
 
-SHA-256 (base64url) over a stable, sorted JSON of: pool, method, path, query, the
-vary headers (`accept`, `x-github-api-version`), and the normalized route key. The key is
+SHA-256 (base64url) over a stable, sorted JSON of: pool, method, path, normalized
+query, the vary headers, and the normalized route key. Default pagination
+(`page=1`, `per_page=30`) and default JSON `accept` variants are folded together; custom
+media types and non-default query values still produce distinct entries. The key is
 pool-scoped, so pools never share cache entries.
 
 ### What is cached
@@ -27,11 +29,14 @@ Only `200` responses on cacheable routes are stored. The cache is **bypassed** w
 
 ### TTLs
 
-Per route kind (`cacheTTLSeconds`):
+Per route kind and response state (`cacheTTLSeconds`):
 
-- `pr_view`, `issue_view`, `branch_view` → 30s
-- `run_view`, `run_jobs`, `commit_check_runs`, `commit_status` → 15s
-- everything else → 60s
+- workflow runs, run lists, job lists, checks, and commit statuses → 15s because
+  completed CI can still change after a rerun
+- closed PRs/issues → 1h; open PRs → 2m; open issues → 5m
+- immutable commit objects → 24h; commit lists → 5m
+- repo metadata → 10m; workflow metadata → 1h
+- large logs, explicit log routes, `rate_limit`, and conditional requests still bypass
 
 ### Cache-hit integrity
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -145,7 +145,8 @@ days.
 ```sh
 octopool stats
 # pool: maintainers
-# cache: 82.4% hit (42 hits, 9 misses, 3 bypass)
+# cache: 82.4% hit (42 hits, 9 misses, 3 bypass, 0 unknown)
+# cacheable: 51/54 requests
 # top routes:
 #   pr_view: 31 req, 86.1% hit, 0 errors
 ```

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -26,7 +26,7 @@ export async function githubCacheKey(
     pool,
     method: request.method,
     path: request.path,
-    query: stableRecord(request.query ?? {}),
+    query: normalizedCacheQuery(request.query ?? {}),
     headers: stableRecord(cacheVaryHeaders(request.headers)),
     route_key: route.routeKey,
   };
@@ -72,7 +72,7 @@ export async function writeGitHubCache(
   if (response.status !== 200) {
     return;
   }
-  const ttlSeconds = cacheTTLSeconds(route);
+  const ttlSeconds = cacheTTLSeconds(route, response);
   const expiresAt = sqliteTimestamp(new Date(Date.now() + ttlSeconds * 1000));
   await env.DB.prepare(queries.writeGitHubCache)
     .bind(
@@ -95,20 +95,26 @@ export async function writeGitHubCache(
     .run();
 }
 
-function cacheTTLSeconds(route: RouteInfo): number {
+export function cacheTTLSeconds(route: RouteInfo, response?: GitHubRelayResponse): number {
   switch (route.kind) {
     case "repo_view":
+      return 600;
+    case "commit_list":
+      return 300;
+    case "commit_view":
+      return 86_400;
     case "workflow_list":
     case "workflow_view":
-      return 300;
+      return 3_600;
     case "pr_view":
+      return closedPR(response) ? 3_600 : 120;
     case "pr_list":
+      return 60;
     case "issue_view":
+      return closedIssue(response) ? 3_600 : 300;
     case "issue_list":
+      return 60;
     case "branch_view":
-      return 30;
-    case "commit_list":
-    case "commit_view":
       return 120;
     case "run_view":
     case "run_list":
@@ -116,6 +122,7 @@ function cacheTTLSeconds(route: RouteInfo): number {
     case "run_jobs":
     case "commit_check_runs":
     case "commit_status":
+    case "job_view":
       return 15;
     default:
       return 60;
@@ -126,11 +133,25 @@ function cacheVaryHeaders(headers: RelayRequest["headers"]): Record<string, stri
   const out: Record<string, string> = {};
   const accept = headers?.accept;
   const version = headers?.["x-github-api-version"];
-  if (accept !== undefined) {
-    out.accept = accept;
+  if (accept !== undefined && !defaultJSONAccept(accept)) {
+    out.accept = accept.toLowerCase();
   }
   if (version !== undefined) {
     out["x-github-api-version"] = version;
+  }
+  return out;
+}
+
+function normalizedCacheQuery(
+  input: Record<string, string | string[]>,
+): Record<string, string | string[]> {
+  const out: Record<string, string | string[]> = {};
+  for (const key of Object.keys(input).sort()) {
+    const value = input[key];
+    if (value === undefined || defaultQueryValue(key, value)) {
+      continue;
+    }
+    out[key] = Array.isArray(value) ? [...value] : value;
   }
   return out;
 }
@@ -146,6 +167,37 @@ function stableRecord(
     }
   }
   return out;
+}
+
+function defaultQueryValue(key: string, value: string | string[]): boolean {
+  if (Array.isArray(value)) {
+    return false;
+  }
+  return (key === "page" && value === "1") || (key === "per_page" && value === "30");
+}
+
+function defaultJSONAccept(value: string): boolean {
+  const normalized = value.toLowerCase();
+  return (
+    normalized === "application/vnd.github+json" ||
+    normalized === "application/json" ||
+    normalized === "application/vnd.github.v3+json"
+  );
+}
+
+function closedPR(response?: GitHubRelayResponse): boolean {
+  if (!isRecord(response?.body)) {
+    return false;
+  }
+  return response.body.state === "closed" || typeof response.body.merged_at === "string";
+}
+
+function closedIssue(response?: GitHubRelayResponse): boolean {
+  return isRecord(response?.body) && response.body.state === "closed";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function parseJSONRecord(raw: string): Record<string, string> {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { githubCacheKey, shouldUseGitHubCache } from "../src/cache";
+import { cacheTTLSeconds, githubCacheKey, shouldUseGitHubCache } from "../src/cache";
 import { classifyRoute, defaultPolicy, validateRelayRequest } from "../src/policy";
+import type { GitHubRelayResponse } from "../src/types";
 
 describe("github cache policy", () => {
   const policy = defaultPolicy("openclaw");
@@ -45,6 +46,46 @@ describe("github cache policy", () => {
     );
   });
 
+  it("normalizes default query and JSON accept variants in cache keys", async () => {
+    const left = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/openclaw/actions/runs",
+      query: { page: "1", per_page: "30" },
+      headers: { accept: "application/vnd.github+json" },
+    });
+    const right = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/openclaw/actions/runs",
+      headers: { accept: "application/json" },
+    });
+    const route = classifyRoute(left, policy);
+    await expect(githubCacheKey("maintainers", left, route)).resolves.toBe(
+      await githubCacheKey("maintainers", right, route),
+    );
+  });
+
+  it("keeps non-default pagination and media accepts distinct", async () => {
+    const left = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/openclaw/pulls/85341/files",
+      query: { per_page: "100" },
+      headers: { accept: "application/vnd.github+json" },
+    });
+    const right = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/openclaw/pulls/85341/files",
+      headers: { accept: "application/vnd.github.diff" },
+    });
+    const route = classifyRoute(left, policy);
+    await expect(githubCacheKey("maintainers", left, route)).resolves.not.toBe(
+      await githubCacheKey("maintainers", right, route),
+    );
+  });
+
   it("bypasses conditional and rate-limit reads", () => {
     const pr = validateRelayRequest({
       pool: "maintainers",
@@ -57,4 +98,68 @@ describe("github cache policy", () => {
     const rate = validateRelayRequest({ pool: "maintainers", method: "GET", path: "/rate_limit" });
     expect(shouldUseGitHubCache(rate, classifyRoute(rate, policy))).toBe(false);
   });
+
+  it("keeps mutable CI TTLs short and extends closed items", () => {
+    const run = classifyRoute(
+      validateRelayRequest({
+        pool: "maintainers",
+        method: "GET",
+        path: "/repos/openclaw/openclaw/actions/runs/123",
+      }),
+      policy,
+    );
+    expect(cacheTTLSeconds(run, response({ status: "completed" }))).toBe(15);
+    expect(cacheTTLSeconds(run, response({ status: "in_progress" }))).toBe(15);
+
+    const runList = classifyRoute(
+      validateRelayRequest({
+        pool: "maintainers",
+        method: "GET",
+        path: "/repos/openclaw/openclaw/actions/runs",
+      }),
+      policy,
+    );
+    expect(cacheTTLSeconds(runList, response({ workflow_runs: [{ status: "completed" }] }))).toBe(
+      15,
+    );
+
+    const checks = classifyRoute(
+      validateRelayRequest({
+        pool: "maintainers",
+        method: "GET",
+        path: "/repos/openclaw/openclaw/commits/abc1234/check-runs",
+      }),
+      policy,
+    );
+    expect(cacheTTLSeconds(checks, response({ check_runs: [{ status: "completed" }] }))).toBe(15);
+
+    const files = classifyRoute(
+      validateRelayRequest({
+        pool: "maintainers",
+        method: "GET",
+        path: "/repos/openclaw/openclaw/pulls/42/files",
+      }),
+      policy,
+    );
+    expect(cacheTTLSeconds(files, response([]))).toBe(60);
+
+    const pr = classifyRoute(
+      validateRelayRequest({
+        pool: "maintainers",
+        method: "GET",
+        path: "/repos/openclaw/openclaw/pulls/42",
+      }),
+      policy,
+    );
+    expect(cacheTTLSeconds(pr, response({ state: "closed", merged_at: null }))).toBe(3_600);
+    expect(cacheTTLSeconds(pr, response({ state: "open" }))).toBe(120);
+  });
 });
+
+function response(body: unknown): GitHubRelayResponse {
+  return {
+    status: 200,
+    headers: {},
+    body,
+  };
+}

--- a/test/public-repos.test.ts
+++ b/test/public-repos.test.ts
@@ -25,6 +25,20 @@ describe("public repo guard", () => {
     });
   });
 
+  it("keeps public proofs short by default", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ private: false })),
+    );
+    const run = vi.fn(async () => ({}));
+    const bind = vi.fn(() => ({ run }));
+    const prepare = vi.fn(() => ({ bind }));
+
+    await ensurePublicGitHubRepo({ ...env(), DB: { prepare } } as unknown as Env, route());
+
+    expect(bind).toHaveBeenCalledWith("openclaw", "octopool", "+30 seconds");
+  });
+
   it("retries public checks without the verifier token when the verifier is depleted", async () => {
     const fetchMock = vi
       .fn()


### PR DESCRIPTION
## Summary
- normalize default GitHub pagination and JSON accept variants into the same cache key
- extend safe non-CI cache TTLs for closed PRs/issues, repo/workflow metadata, and immutable commits while keeping mutable CI/PR subresources short-lived
- show unknown/cacheable request counts in `octopool stats`

## Test plan
- `pnpm check`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local`
