### PR TITLE
feat: add state-aware PR file cache hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Add validated PR state discriminators for PR subresource cache keys and richer stats that show saved GitHub calls plus backend request counts.
 - Raise cache hit rates with response-aware TTLs for closed PRs/issues, immutable commits, and normalized default GitHub query/header variants while keeping mutable CI reads short-lived.
 - Skip Octopool-backed `gh` wrapper scripts when falling back to the real GitHub CLI, avoiding duplicate fallback attempts and warnings.
 

--- a/cmd/octopool/main.go
+++ b/cmd/octopool/main.go
@@ -173,8 +173,10 @@ func runRequest(ctx context.Context, args []string, stdout io.Writer) error {
 	path := fs.String("path", "", "GitHub API path")
 	queryValues := multiFlag{}
 	headerValues := multiFlag{}
+	routeHintValues := multiFlag{}
 	fs.Var(&queryValues, "query", "query key=value, repeatable")
 	fs.Var(&headerValues, "header", "header key=value, repeatable")
+	fs.Var(&routeHintValues, "route-hint", "route hint key=value, repeatable")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -198,6 +200,9 @@ func runRequest(ctx context.Context, args []string, stdout io.Writer) error {
 	}
 	if len(headerValues) > 0 {
 		body["headers"] = valuesMap(headerValues)
+	}
+	if len(routeHintValues) > 0 {
+		body["route_hint"] = valuesMap(routeHintValues)
 	}
 	return postJSON(ctx, stdout, apiURL(*url, "/v1/github/request"), token, body)
 }

--- a/cmd/octopool/stats.go
+++ b/cmd/octopool/stats.go
@@ -41,6 +41,10 @@ type statsAggregate struct {
 	CacheUnknown      int      `json:"cache_unknown"`
 	CacheableRequests int      `json:"cacheable_requests"`
 	CacheHitRate      *float64 `json:"cache_hit_rate"`
+	CacheableHitRate  *float64 `json:"cacheable_hit_rate"`
+	BypassRate        *float64 `json:"bypass_rate"`
+	SavedGitHubCalls  int      `json:"saved_github_requests"`
+	BackendRequests   int      `json:"backend_requests"`
 }
 
 type statsRoute struct {
@@ -128,6 +132,11 @@ func renderStats(w io.Writer, stats statsResponse) error {
 			intFmt(stats.PoolUsage.Requests),
 		),
 		fmt.Sprintf(
+			"github: %s saved, %s backend",
+			intFmt(stats.PoolUsage.SavedGitHubCalls),
+			intFmt(stats.PoolUsage.BackendRequests),
+		),
+		fmt.Sprintf(
 			"caller: %s requests, %s hit",
 			intFmt(stats.CallerUsage.Requests),
 			percent(stats.CallerUsage.CacheHitRate),
@@ -155,10 +164,12 @@ func renderStats(w io.Writer, stats statsResponse) error {
 	for _, route := range stats.Routes {
 		if _, err := fmt.Fprintf(
 			w,
-			"  %s: %s req, %s hit, %s errors\n",
+			"  %s: %s req, %s hit, %s miss, %s bypass, %s errors\n",
 			route.RouteKind,
 			intFmt(route.Requests),
 			percent(route.CacheHitRate),
+			intFmt(route.CacheMisses),
+			intFmt(route.CacheBypass),
 			intFmt(route.Errors),
 		); err != nil {
 			return err

--- a/cmd/octopool/stats_test.go
+++ b/cmd/octopool/stats_test.go
@@ -13,12 +13,14 @@ func TestRenderStats(t *testing.T) {
 		Window:   statsWindow{Label: "24h", Seconds: 86400},
 		Operator: statsOperator{GitHubLogin: "steipete"},
 		PoolUsage: statsAggregate{
-			Requests:     12,
-			Errors:       1,
-			CacheHits:    5,
-			CacheMisses:  3,
-			CacheBypass:  4,
-			CacheHitRate: &rate,
+			Requests:         12,
+			Errors:           1,
+			CacheHits:        5,
+			CacheMisses:      3,
+			CacheBypass:      4,
+			CacheHitRate:     &rate,
+			SavedGitHubCalls: 5,
+			BackendRequests:  7,
 		},
 		CallerUsage: statsAggregate{
 			Requests:     8,
@@ -35,6 +37,8 @@ func TestRenderStats(t *testing.T) {
 			statsAggregate: statsAggregate{
 				Requests:     6,
 				Errors:       0,
+				CacheMisses:  1,
+				CacheBypass:  2,
 				CacheHitRate: &rate,
 			},
 		}},
@@ -49,8 +53,9 @@ func TestRenderStats(t *testing.T) {
 		"operator: steipete",
 		"cache: 62.5% hit (5 hits, 3 misses, 4 bypass, 0 unknown)",
 		"cacheable: 0/12 requests",
+		"github: 5 saved, 7 backend",
 		"entries: 7 fresh / 9 total, 2 expired, 1.5 KiB",
-		"  pr_view: 6 req, 62.5% hit, 0 errors",
+		"  pr_view: 6 req, 62.5% hit, 1 miss, 2 bypass, 0 errors",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("expected %q in:\n%s", want, got)

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -15,10 +15,18 @@ performs the GitHub call and writes the result back.
 ### Cache key
 
 SHA-256 (base64url) over a stable, sorted JSON of: pool, method, path, normalized
-query, the vary headers, and the normalized route key. Default pagination
+query, the vary headers, the normalized route key, and any validated state discriminator.
+Default pagination
 (`page=1`, `per_page=30`) and default JSON `accept` variants are folded together; custom
 media types and non-default query values still produce distinct entries. The key is
 pool-scoped, so pools never share cache entries.
+
+PR file-list routes may include a validated
+`route_hint.pr_head_sha` or closed/merged `route_hint.pr_state` discriminator. Clients
+that already know the current PR state can use that to avoid mixing entries across head
+SHAs while letting Octopool keep `files` warm longer. Hints are first checked against
+GitHub and then cached briefly in `github_pr_state_proofs`, so repeated cache hits do not
+need to re-contact GitHub just to validate the hint.
 
 ### What is cached
 
@@ -33,6 +41,8 @@ Per route kind and response state (`cacheTTLSeconds`):
 
 - workflow runs, run lists, job lists, checks, and commit statuses → 15s because
   completed CI can still change after a rerun
+- PR files with a validated state discriminator → 5m; PR reviews/comments and
+  undiscriminated PR files → 1m
 - closed PRs/issues → 1h; open PRs → 2m; open issues → 5m
 - immutable commit objects → 24h; commit lists → 5m
 - repo metadata → 10m; workflow metadata → 1h
@@ -80,6 +90,8 @@ private-repo block — a hard `404`/private response always denies.
   key/kind, status, response headers JSON, body JSON, body encoding, source identity,
   created/expires timestamps (migration `0002`).
 - `github_public_repos` — `owner`, `repo`, `checked_at`, `expires_at` (migration `0003`).
+- `github_pr_state_proofs` — short-lived validated PR head/state discriminators for
+  state-scoped PR subresource cache keys (migration `0006`).
 - `audit_events.cache_status` / `audit_events.cacheable` — per-request cache metrics
   (migration `0005`).
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -147,8 +147,9 @@ octopool stats
 # pool: maintainers
 # cache: 82.4% hit (42 hits, 9 misses, 3 bypass, 0 unknown)
 # cacheable: 51/54 requests
+# github: 42 saved, 12 backend
 # top routes:
-#   pr_view: 31 req, 86.1% hit, 0 errors
+#   pr_view: 31 req, 86.1% hit, 5 miss, 0 bypass, 0 errors
 ```
 
 Use `--json` for dashboards or scripts that want the raw aggregate:
@@ -157,9 +158,11 @@ Use `--json` for dashboards or scripts that want the raw aggregate:
 octopool stats --since 7d --json
 ```
 
-### `octopool request --path <p> [--method GET] [--query k=v] [--header k=v]`
+### `octopool request --path <p> [--method GET] [--query k=v] [--header k=v] [--route-hint k=v]`
 
 Debug/admin raw wrapper over `POST /v1/github/request`. Prints the full relay envelope.
+`--route-hint pr_head_sha=<sha>` or `--route-hint pr_state=closed` can be used for
+state-aware PR subresource cache probes.
 
 ### `octopool admin caller|identity ...`
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -168,6 +168,8 @@ D1 schema lives in `migrations/`:
   sessions.
 - `0005_audit_cache_metrics.sql` — per-request cache status and cacheability columns,
   plus stats indexes for route and hit-rate aggregates.
+- `0006_pr_state_proofs.sql` — short-lived validated PR state discriminators for
+  state-aware PR subresource cache keys.
 
 Apply with `wrangler d1 migrations apply octopool` (add `--remote` for production).
 

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -20,7 +20,12 @@ Request body:
   "path": "/repos/openclaw/openclaw/pulls/123",
   "query": { "per_page": "100" },
   "headers": { "accept": "application/vnd.github+json" },
-  "route_hint": { "owner": "openclaw", "repo": "openclaw", "kind": "pr_view" },
+  "route_hint": {
+    "owner": "openclaw",
+    "repo": "openclaw",
+    "kind": "pr_files",
+    "pr_head_sha": "0123456789abcdef0123456789abcdef01234567"
+  },
   "cache_key": "...",
   "idempotency_key": "..."
 }
@@ -32,7 +37,10 @@ Request body:
   secret-bearing (`token`, `secret`, `password`, `api_key`, …).
 - `headers` are filtered down to `accept`, `x-github-api-version`, `if-none-match`,
   `if-modified-since`. Everything else is dropped.
-- `route_hint`, `cache_key`, `idempotency_key` are accepted and currently advisory.
+- `route_hint.owner`, `route_hint.repo`, and `route_hint.kind` are currently advisory.
+  `route_hint.pr_head_sha` and closed/merged `route_hint.pr_state` are validated cache
+  discriminators for PR file lists.
+- `cache_key` and `idempotency_key` are accepted and currently advisory.
 
 ### Path validation
 
@@ -108,6 +116,11 @@ gated by the pool's `allow_logs` policy.
 
 Every repo route additionally passes a public-visibility check before a pooled identity
 or cache entry is used — see [Cache & public-repo guard](cache.md).
+
+`route_hint.pr_head_sha` and `route_hint.pr_state` are validated, optional cache
+discriminators for PR file lists. They do not bypass policy or visibility checks; they
+only let clients that already know current PR state keep `/files` cache entries separate
+across head SHAs or closed/merged state.
 
 ## Safety limits
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -113,7 +113,8 @@ Request:
   "route_hint": {
     "owner": "openclaw",
     "repo": "openclaw",
-    "kind": "pr_view"
+    "kind": "pr_files",
+    "pr_head_sha": "0123456789abcdef0123456789abcdef01234567"
   },
   "cache_key": "github-rest:...",
   "idempotency_key": "..."

--- a/internal/dbquery/d1.sql.go
+++ b/internal/dbquery/d1.sql.go
@@ -532,6 +532,36 @@ func (q *Queries) FreshCoveringPublicRepoProof(ctx context.Context, arg FreshCov
 	return column_1, err
 }
 
+const freshPRStateProof = `-- name: FreshPRStateProof :one
+SELECT 1
+FROM github_pr_state_proofs
+WHERE lower(owner) = ?1
+  AND lower(repo) = ?2
+  AND number = ?3
+  AND state_hint = ?4
+  AND expires_at > CURRENT_TIMESTAMP
+LIMIT 1
+`
+
+type FreshPRStateProofParams struct {
+	Owner     string `json:"owner"`
+	Repo      string `json:"repo"`
+	Number    int64  `json:"number"`
+	StateHint string `json:"state_hint"`
+}
+
+func (q *Queries) FreshPRStateProof(ctx context.Context, arg FreshPRStateProofParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, freshPRStateProof,
+		arg.Owner,
+		arg.Repo,
+		arg.Number,
+		arg.StateHint,
+	)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const freshPublicRepoProof = `-- name: FreshPublicRepoProof :one
 SELECT 1
 FROM github_public_repos
@@ -1340,6 +1370,33 @@ func (q *Queries) UpsertIdentity(ctx context.Context, arg UpsertIdentityParams) 
 		arg.SecretRef,
 		arg.InstallationID,
 		arg.Weight,
+	)
+	return err
+}
+
+const upsertPRStateProof = `-- name: UpsertPRStateProof :exec
+INSERT INTO github_pr_state_proofs (owner, repo, number, state_hint, checked_at, expires_at)
+VALUES (?1, ?2, ?3, ?4, CURRENT_TIMESTAMP, datetime(CURRENT_TIMESTAMP, ?5))
+ON CONFLICT(owner, repo, number, state_hint) DO UPDATE SET
+  checked_at = excluded.checked_at,
+  expires_at = excluded.expires_at
+`
+
+type UpsertPRStateProofParams struct {
+	Owner     string      `json:"owner"`
+	Repo      string      `json:"repo"`
+	Number    int64       `json:"number"`
+	StateHint string      `json:"state_hint"`
+	Datetime  interface{} `json:"datetime"`
+}
+
+func (q *Queries) UpsertPRStateProof(ctx context.Context, arg UpsertPRStateProofParams) error {
+	_, err := q.db.ExecContext(ctx, upsertPRStateProof,
+		arg.Owner,
+		arg.Repo,
+		arg.Number,
+		arg.StateHint,
+		arg.Datetime,
 	)
 	return err
 }

--- a/internal/dbquery/models.go
+++ b/internal/dbquery/models.go
@@ -70,6 +70,15 @@ type GithubCacheEntry struct {
 	ExpiresAt           string         `json:"expires_at"`
 }
 
+type GithubPrStateProof struct {
+	Owner     string `json:"owner"`
+	Repo      string `json:"repo"`
+	Number    int64  `json:"number"`
+	StateHint string `json:"state_hint"`
+	CheckedAt string `json:"checked_at"`
+	ExpiresAt string `json:"expires_at"`
+}
+
 type GithubPublicRepo struct {
 	Owner     string `json:"owner"`
 	Repo      string `json:"repo"`

--- a/migrations/0006_pr_state_proofs.sql
+++ b/migrations/0006_pr_state_proofs.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS github_pr_state_proofs (
+  owner TEXT NOT NULL,
+  repo TEXT NOT NULL,
+  number INTEGER NOT NULL,
+  state_hint TEXT NOT NULL,
+  checked_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  expires_at TEXT NOT NULL,
+  PRIMARY KEY (owner, repo, number, state_hint)
+);
+
+CREATE INDEX IF NOT EXISTS idx_github_pr_state_proofs_expires
+  ON github_pr_state_proofs (expires_at);

--- a/sql/queries/d1.sql
+++ b/sql/queries/d1.sql
@@ -320,6 +320,23 @@ WHERE lower(owner) = ?1
   AND expires_at > CURRENT_TIMESTAMP
 LIMIT 1;
 
+-- name: FreshPRStateProof :one
+SELECT 1
+FROM github_pr_state_proofs
+WHERE lower(owner) = ?1
+  AND lower(repo) = ?2
+  AND number = ?3
+  AND state_hint = ?4
+  AND expires_at > CURRENT_TIMESTAMP
+LIMIT 1;
+
+-- name: UpsertPRStateProof :exec
+INSERT INTO github_pr_state_proofs (owner, repo, number, state_hint, checked_at, expires_at)
+VALUES (?1, ?2, ?3, ?4, CURRENT_TIMESTAMP, datetime(CURRENT_TIMESTAMP, ?5))
+ON CONFLICT(owner, repo, number, state_hint) DO UPDATE SET
+  checked_at = excluded.checked_at,
+  expires_at = excluded.expires_at;
+
 -- name: StatsAggregatePool :one
 SELECT
   COUNT(*) AS requests,

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -29,6 +29,7 @@ export async function githubCacheKey(
     query: normalizedCacheQuery(request.query ?? {}),
     headers: stableRecord(cacheVaryHeaders(request.headers)),
     route_key: route.routeKey,
+    state: cacheStateDiscriminator(route),
   };
   return hashToken(JSON.stringify(stable));
 }
@@ -124,6 +125,8 @@ export function cacheTTLSeconds(route: RouteInfo, response?: GitHubRelayResponse
     case "commit_status":
     case "job_view":
       return 15;
+    case "pr_files":
+      return stateAwarePRSubresource(route, response) ? 300 : 60;
     default:
       return 60;
   }
@@ -194,6 +197,28 @@ function closedPR(response?: GitHubRelayResponse): boolean {
 
 function closedIssue(response?: GitHubRelayResponse): boolean {
   return isRecord(response?.body) && response.body.state === "closed";
+}
+
+function stateAwarePRSubresource(route: RouteInfo, response?: GitHubRelayResponse): boolean {
+  if (!isRecord(response?.body) && !Array.isArray(response?.body)) {
+    return false;
+  }
+  return routeStateHint(route) !== undefined && route.state_hint_source === "live";
+}
+
+function cacheStateDiscriminator(route: RouteInfo): string | undefined {
+  if (!stateAwarePRRoute(route)) {
+    return undefined;
+  }
+  return routeStateHint(route);
+}
+
+function routeStateHint(route: RouteInfo): string | undefined {
+  return route.state_hint;
+}
+
+function stateAwarePRRoute(route: RouteInfo): boolean {
+  return route.kind === "pr_files";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/generated/sql.ts
+++ b/src/generated/sql.ts
@@ -95,6 +95,10 @@ export const queries = {
     "SELECT 1\nFROM github_public_repos\nWHERE lower(owner) = ?1\n  AND lower(repo) = ?2\n  AND checked_at >= datetime(?3, '-5 seconds')\nLIMIT 1",
   freshCoveringPublicRepoProof:
     "SELECT 1\nFROM github_public_repos\nWHERE lower(owner) = ?1\n  AND lower(repo) = ?2\n  AND checked_at >= datetime(?3, '-5 seconds')\n  AND expires_at > CURRENT_TIMESTAMP\nLIMIT 1",
+  freshPRStateProof:
+    "SELECT 1\nFROM github_pr_state_proofs\nWHERE lower(owner) = ?1\n  AND lower(repo) = ?2\n  AND number = ?3\n  AND state_hint = ?4\n  AND expires_at > CURRENT_TIMESTAMP\nLIMIT 1",
+  upsertPRStateProof:
+    "INSERT INTO github_pr_state_proofs (owner, repo, number, state_hint, checked_at, expires_at)\nVALUES (?1, ?2, ?3, ?4, CURRENT_TIMESTAMP, datetime(CURRENT_TIMESTAMP, ?5))\nON CONFLICT(owner, repo, number, state_hint) DO UPDATE SET\n  checked_at = excluded.checked_at,\n  expires_at = excluded.expires_at",
   statsAggregatePool:
     "SELECT\n  COUNT(*) AS requests,\n  SUM(CASE WHEN status >= 400 THEN 1 ELSE 0 END) AS errors,\n  AVG(duration_ms) AS avg_duration_ms,\n  SUM(CASE WHEN cache_status = 'hit' THEN 1 ELSE 0 END) AS cache_hits,\n  SUM(CASE WHEN cache_status = 'miss' THEN 1 ELSE 0 END) AS cache_misses,\n  SUM(CASE WHEN cache_status = 'bypass' THEN 1 ELSE 0 END) AS cache_bypass,\n  SUM(CASE WHEN cache_status = 'unknown' THEN 1 ELSE 0 END) AS cache_unknown,\n  SUM(CASE WHEN cacheable = 1 THEN 1 ELSE 0 END) AS cacheable_requests\nFROM audit_events\nWHERE pool_id = ?1\n  AND created_at >= datetime('now', ?2)",
   statsAggregateCaller:

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { rootResponse } from "./landing";
 import { githubResponseLocalFallbackReason, localFallbackError } from "./local-fallback";
 import { classifyRoute, normalizeRouteKey, validateRelayRequest } from "./policy";
 import { PoolCoordinator } from "./pool-coordinator";
+import { verifyPRStateHint, verifyPRStateHintLive } from "./pr-state";
 import { ensurePublicGitHubRepo } from "./public-repos";
 import { httpsRedirect, secureResponse } from "./security";
 import { parseStatsWindow, poolStats } from "./stats";
@@ -360,9 +361,9 @@ async function relayGitHub(
   let auditCacheStatus: "hit" | "miss" | "bypass" | "unknown" = "unknown";
   let auditCacheable = false;
   try {
-    route = classifyRoute(relayRequest, policy);
+    route = await verifyPRStateHint(env, relayRequest, classifyRoute(relayRequest, policy));
     const cacheEnabled = shouldUseGitHubCache(relayRequest, route);
-    const cacheKey = cacheEnabled
+    let cacheKey = cacheEnabled
       ? await githubCacheKey(relayRequest.pool, relayRequest, route)
       : undefined;
     auditCacheable = cacheKey !== undefined;
@@ -410,6 +411,60 @@ async function relayGitHub(
               route_kind: route.kind,
             },
           });
+        }
+      }
+    }
+    if (cacheKey !== undefined && route.state_hint_source === "cached") {
+      route = await verifyPRStateHintLive(env, relayRequest, route);
+      cacheKey = cacheEnabled
+        ? await githubCacheKey(relayRequest.pool, relayRequest, route)
+        : undefined;
+      auditCacheable = cacheKey !== undefined;
+      auditCacheStatus = cacheKey === undefined ? "bypass" : "miss";
+      if (cacheKey !== undefined) {
+        const cached = await readGitHubCache(env, cacheKey);
+        if (cached !== undefined) {
+          const activeIdentities = await loadIdentities(env, relayRequest.pool, route);
+          if (activeIdentities.length === 0) {
+            throw new HttpError(503, "no_identity", "No active identity can serve this route");
+          }
+          const cachedIdentity =
+            cached.identity === undefined
+              ? undefined
+              : activeIdentities.find((candidate) => candidate.id === cached.identity?.id);
+          if (cached.identity !== undefined && cachedIdentity !== undefined) {
+            await ensurePublicGitHubRepo(env, route, cached.created_at);
+            const sanitizedCached = sanitizeGitHubResponse(route, cached);
+            ctx.waitUntil(
+              insertAudit(env, {
+                requestId,
+                callerId: caller.id,
+                pool: relayRequest.pool,
+                routeKey: route.routeKey,
+                routeKind: route.kind,
+                status: cached.status,
+                durationMs: Date.now() - started,
+                identityId: cached.identity.id,
+                cacheStatus: "hit",
+                cacheable: true,
+              }),
+            );
+            return jsonResponse({
+              status: sanitizedCached.status,
+              headers: sanitizedCached.headers,
+              body: sanitizedCached.body,
+              body_encoding: sanitizedCached.body_encoding,
+              identity: cached.identity,
+              relay: {
+                pool: relayRequest.pool,
+                request_id: requestId,
+                cacheable: route.cacheable,
+                cache: "hit",
+                stale_ok: false,
+                route_kind: route.kind,
+              },
+            });
+          }
         }
       }
     }

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -258,6 +258,12 @@ function normalizeRouteHint(
   if (typeof value.kind === "string") {
     hint.kind = value.kind;
   }
+  if (typeof value.pr_head_sha === "string" && /^[0-9a-fA-F]{40}$/.test(value.pr_head_sha)) {
+    hint.pr_head_sha = value.pr_head_sha.toLowerCase();
+  }
+  if (typeof value.pr_state === "string" && /^(open|closed|merged)$/i.test(value.pr_state)) {
+    hint.pr_state = value.pr_state.toLowerCase();
+  }
   return hint;
 }
 

--- a/src/pr-state.ts
+++ b/src/pr-state.ts
@@ -1,0 +1,130 @@
+import { queries } from "./generated/sql";
+import { parsePositiveInt } from "./http";
+import type { RelayRequest, RouteInfo } from "./types";
+
+type PullResponse = {
+  state?: unknown;
+  merged_at?: unknown;
+  head?: {
+    sha?: unknown;
+  };
+};
+
+export async function verifyPRStateHint(
+  env: Env,
+  request: RelayRequest,
+  route: RouteInfo,
+): Promise<RouteInfo> {
+  return verifyPRStateHintInternal(env, request, route, true);
+}
+
+export async function verifyPRStateHintLive(
+  env: Env,
+  request: RelayRequest,
+  route: RouteInfo,
+): Promise<RouteInfo> {
+  return verifyPRStateHintInternal(env, request, withoutStateHint(route), false);
+}
+
+export function withoutStateHint(route: RouteInfo): RouteInfo {
+  const { state_hint: _stateHint, state_hint_source: _stateHintSource, ...rest } = route;
+  return rest;
+}
+
+async function verifyPRStateHintInternal(
+  env: Env,
+  request: RelayRequest,
+  route: RouteInfo,
+  allowCachedProof: boolean,
+): Promise<RouteInfo> {
+  const stateHint = stateHintFromRequest(request);
+  if (stateHint === undefined || !stateAwarePRRoute(route)) {
+    return route;
+  }
+  const number = pullNumber(request.path);
+  if (route.owner === undefined || route.repo === undefined || number === undefined) {
+    return route;
+  }
+  try {
+    if (allowCachedProof && (await freshPRStateProof(env, route, number, stateHint))) {
+      return { ...route, state_hint: stateHint, state_hint_source: "cached" };
+    }
+    const response = await fetch(
+      `https://api.github.com/repos/${encodeURIComponent(route.owner)}/${encodeURIComponent(route.repo)}/pulls/${number}`,
+      {
+        headers: {
+          accept: "application/vnd.github+json",
+          "user-agent": "octopool",
+          "x-github-api-version": "2022-11-28",
+        },
+        signal: AbortSignal.timeout(parsePositiveInt(env.REQUEST_TIMEOUT_MS, 15_000)),
+      },
+    );
+    if (!response.ok) {
+      return route;
+    }
+    const body = (await response.json()) as PullResponse;
+    if (hintMatchesPR(stateHint, body)) {
+      await upsertPRStateProof(env, route, number, stateHint);
+      return { ...route, state_hint: stateHint, state_hint_source: "live" };
+    }
+    return route;
+  } catch {
+    return route;
+  }
+}
+
+async function freshPRStateProof(
+  env: Env,
+  route: RouteInfo,
+  number: string,
+  stateHint: string,
+): Promise<boolean> {
+  const row = await env.DB.prepare(queries.freshPRStateProof)
+    .bind(route.owner?.toLowerCase(), route.repo?.toLowerCase(), number, stateHint)
+    .first<{ "1": number }>();
+  return row !== null;
+}
+
+async function upsertPRStateProof(
+  env: Env,
+  route: RouteInfo,
+  number: string,
+  stateHint: string,
+): Promise<void> {
+  await env.DB.prepare(queries.upsertPRStateProof)
+    .bind(route.owner?.toLowerCase(), route.repo?.toLowerCase(), number, stateHint, "+300 seconds")
+    .run();
+}
+
+function hintMatchesPR(hint: string, body: PullResponse): boolean {
+  if (hint.startsWith("pr-head:")) {
+    return body.head?.sha === hint.slice("pr-head:".length);
+  }
+  if (hint === "pr-state:closed") {
+    return body.state === "closed";
+  }
+  if (hint === "pr-state:merged") {
+    return typeof body.merged_at === "string";
+  }
+  return false;
+}
+
+function pullNumber(path: string): string | undefined {
+  return /^\/repos\/[^/]+\/[^/]+\/pulls\/([0-9]+)\//.exec(path)?.[1];
+}
+
+function stateAwarePRRoute(route: RouteInfo): boolean {
+  return route.kind === "pr_files";
+}
+
+function stateHintFromRequest(request: RelayRequest): string | undefined {
+  const hint = request.route_hint;
+  if (hint?.pr_head_sha !== undefined) {
+    return `pr-head:${hint.pr_head_sha}`;
+  }
+  if (hint?.pr_state === "closed" || hint?.pr_state === "merged") {
+    return `pr-state:${hint.pr_state}`;
+  }
+  return undefined;
+}

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -19,6 +19,10 @@ export type CacheAggregate = {
   cache_unknown: number;
   cacheable_requests: number;
   cache_hit_rate: number | null;
+  cacheable_hit_rate: number | null;
+  bypass_rate: number | null;
+  saved_github_requests: number;
+  backend_requests: number;
 };
 
 export type AggregateRow = {
@@ -136,16 +140,24 @@ export function normalizeAggregate(row: AggregateRow | null): CacheAggregate {
   const cacheHits = row?.cache_hits ?? 0;
   const cacheMisses = row?.cache_misses ?? 0;
   const denominator = cacheHits + cacheMisses;
+  const requests = row?.requests ?? 0;
+  const cacheBypass = row?.cache_bypass ?? 0;
+  const cacheUnknown = row?.cache_unknown ?? 0;
+  const cacheableRequests = row?.cacheable_requests ?? 0;
   return {
-    requests: row?.requests ?? 0,
+    requests,
     errors: row?.errors ?? 0,
     avg_duration_ms: row?.avg_duration_ms ?? null,
     cache_hits: cacheHits,
     cache_misses: cacheMisses,
-    cache_bypass: row?.cache_bypass ?? 0,
-    cache_unknown: row?.cache_unknown ?? 0,
-    cacheable_requests: row?.cacheable_requests ?? 0,
+    cache_bypass: cacheBypass,
+    cache_unknown: cacheUnknown,
+    cacheable_requests: cacheableRequests,
     cache_hit_rate: denominator === 0 ? null : cacheHits / denominator,
+    cacheable_hit_rate: cacheableRequests === 0 ? null : cacheHits / cacheableRequests,
+    bypass_rate: requests === 0 ? null : cacheBypass / requests,
+    saved_github_requests: cacheHits,
+    backend_requests: cacheMisses + cacheBypass,
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,8 @@ export type RelayRequest = {
     owner?: string;
     repo?: string;
     kind?: string;
+    pr_head_sha?: string;
+    pr_state?: string;
   };
   cache_key?: string;
   idempotency_key?: string;
@@ -49,6 +51,8 @@ export type RouteInfo = {
   repo?: string;
   resource: string;
   routeKey: string;
+  state_hint?: string;
+  state_hint_source?: "cached" | "live";
   cacheable: boolean;
   largePayload: boolean;
   logs: boolean;

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -86,6 +86,40 @@ describe("github cache policy", () => {
     );
   });
 
+  it("uses verified PR state hints as cache-key discriminators", async () => {
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/openclaw/pulls/85341/files",
+    });
+    const plain = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/openclaw/pulls/85341/files",
+    });
+    const route = {
+      ...classifyRoute(request, policy),
+      state_hint: "pr-head:0123456789abcdef0123456789abcdef01234567",
+      state_hint_source: "live" as const,
+    };
+    await expect(githubCacheKey("maintainers", request, route)).resolves.not.toBe(
+      await githubCacheKey("maintainers", plain, classifyRoute(plain, policy)),
+    );
+  });
+
+  it("ignores malformed PR state hints", () => {
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/openclaw/pulls/85341/files",
+      route_hint: {
+        pr_head_sha: "not-a-sha",
+        pr_state: "surprise",
+      },
+    });
+    expect(classifyRoute(request, policy).state_hint).toBeUndefined();
+  });
+
   it("bypasses conditional and rate-limit reads", () => {
     const pr = validateRelayRequest({
       pool: "maintainers",
@@ -142,6 +176,19 @@ describe("github cache policy", () => {
       policy,
     );
     expect(cacheTTLSeconds(files, response([]))).toBe(60);
+    const stateAwareFiles = {
+      ...classifyRoute(
+        validateRelayRequest({
+          pool: "maintainers",
+          method: "GET",
+          path: "/repos/openclaw/openclaw/pulls/42/files",
+        }),
+        policy,
+      ),
+      state_hint: "pr-head:0123456789abcdef0123456789abcdef01234567",
+      state_hint_source: "live" as const,
+    };
+    expect(cacheTTLSeconds(stateAwareFiles, response([]))).toBe(300);
 
     const pr = classifyRoute(
       validateRelayRequest({

--- a/test/pr-state.test.ts
+++ b/test/pr-state.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { classifyRoute, defaultPolicy, validateRelayRequest } from "../src/policy";
+import { verifyPRStateHint } from "../src/pr-state";
+
+describe("PR state hint verification", () => {
+  const policy = defaultPolicy("openclaw");
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps a matching PR head discriminator", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          state: "open",
+          merged_at: null,
+          head: { sha: "0123456789abcdef0123456789abcdef01234567" },
+        }),
+      ),
+    );
+    const request = requestWithHint({ pr_head_sha: "0123456789abcdef0123456789abcdef01234567" });
+    const database = databaseWithFreshProof(null);
+    const route = await verifyPRStateHint(env(database), request, classifyRoute(request, policy));
+
+    expect(route.state_hint).toBe("pr-head:0123456789abcdef0123456789abcdef01234567");
+    expect(route.state_hint_source).toBe("live");
+    expect(database.run).toHaveBeenCalledOnce();
+  });
+
+  it("reuses a fresh proof without touching GitHub", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const request = requestWithHint({ pr_head_sha: "0123456789abcdef0123456789abcdef01234567" });
+    const route = await verifyPRStateHint(
+      env(databaseWithFreshProof({ "1": 1 })),
+      request,
+      classifyRoute(request, policy),
+    );
+
+    expect(route.state_hint).toBe("pr-head:0123456789abcdef0123456789abcdef01234567");
+    expect(route.state_hint_source).toBe("cached");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("drops a stale or forged PR head discriminator", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          state: "open",
+          merged_at: null,
+          head: { sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+        }),
+      ),
+    );
+    const request = requestWithHint({ pr_head_sha: "0123456789abcdef0123456789abcdef01234567" });
+    const route = await verifyPRStateHint(
+      env(databaseWithFreshProof(null)),
+      request,
+      classifyRoute(request, policy),
+    );
+
+    expect(route.state_hint).toBeUndefined();
+  });
+
+  it("drops the discriminator when verification fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    );
+    const request = requestWithHint({ pr_head_sha: "0123456789abcdef0123456789abcdef01234567" });
+    const route = await verifyPRStateHint(
+      env(databaseWithFreshProof(null)),
+      request,
+      classifyRoute(request, policy),
+    );
+
+    expect(route.state_hint).toBeUndefined();
+  });
+
+  it("drops the discriminator when proof storage fails", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const first = vi.fn(async () => {
+      throw new Error("table missing");
+    });
+    const bind = vi.fn(() => ({ first, run: vi.fn() }));
+    const database = { prepare: vi.fn(() => ({ bind })) };
+    const request = requestWithHint({ pr_head_sha: "0123456789abcdef0123456789abcdef01234567" });
+    const route = await verifyPRStateHint(
+      env(database as unknown as TestDB),
+      request,
+      classifyRoute(request, policy),
+    );
+
+    expect(route.state_hint).toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps a matching merged discriminator", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          state: "closed",
+          merged_at: "2026-05-29T00:00:00Z",
+          head: { sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+        }),
+      ),
+    );
+    const request = requestWithHint({ pr_state: "merged" });
+    const route = await verifyPRStateHint(
+      env(databaseWithFreshProof(null)),
+      request,
+      classifyRoute(request, policy),
+    );
+
+    expect(route.state_hint).toBe("pr-state:merged");
+    expect(route.state_hint_source).toBe("live");
+  });
+});
+
+function requestWithHint(route_hint: Record<string, string>) {
+  return validateRelayRequest({
+    pool: "maintainers",
+    method: "GET",
+    path: "/repos/openclaw/openclaw/pulls/42/files",
+    route_hint,
+  });
+}
+
+type TestDB = {
+  run: ReturnType<typeof vi.fn>;
+  prepare: ReturnType<typeof vi.fn>;
+};
+
+function env(database: TestDB): Env {
+  return {
+    REQUEST_TIMEOUT_MS: "15000",
+    DB: database,
+  } as unknown as Env;
+}
+
+function databaseWithFreshProof(row: { "1": number } | null): TestDB {
+  const first = vi.fn(async () => row);
+  const run = vi.fn(async () => ({}));
+  const bind = vi.fn(() => ({ first, run }));
+  const prepare = vi.fn(() => ({ bind }));
+  return { prepare, run };
+}

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -34,6 +34,10 @@ describe("stats aggregates", () => {
       cache_unknown: 0,
       cacheable_requests: 0,
       cache_hit_rate: null,
+      cacheable_hit_rate: null,
+      bypass_rate: null,
+      saved_github_requests: 0,
+      backend_requests: 0,
     });
   });
 
@@ -59,6 +63,10 @@ describe("stats aggregates", () => {
       cache_unknown: 1,
       cacheable_requests: 10,
       cache_hit_rate: 0.7,
+      cacheable_hit_rate: 0.7,
+      bypass_rate: 2 / 13,
+      saved_github_requests: 7,
+      backend_requests: 5,
     });
   });
 });


### PR DESCRIPTION
## Summary
- add validated PR file cache discriminators for `pr_head_sha` / closed or merged `pr_state`
- keep state-scoped cache hits GitHub-free with short-lived D1 PR state proofs, while revalidating before state-scoped writes
- expose richer stats for saved GitHub calls and backend request counts
- add `octopool request --route-hint` for live/debug cache probes

## Test plan
- `pnpm check`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local`
