### PR TITLE
feat: expand GitHub cache coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fetch public PR diffs, commit/compare diff and patch media, and explicit-ref content files through token-free GitHub web/raw endpoints before spending pooled GitHub API budget, while still writing the shared D1 cache.
 - Serve bounded stale cache entries when pooled identities are depleted, cooling down, or rate-limited, and count those responses as saved GitHub requests in stats and dashboard aggregates.
 - Route GitHub release list/view reads through Octopool for REST paths and top-level `gh release` JSON commands.
+- Raise `gh` shim cache coverage with repo-scoped cached `gh search issues|prs`, hydrated PR detail fields (`files`, `commits`, `comments`, `reviews`), cacheable default `gh pr checks`, and extra PR/issue subresource routes.
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Use it like `gh` for common read shapes:
 
 ```sh
 octopool gh pr view 85341 -R openclaw/openclaw --json number,title,url
+octopool gh search issues cache regression -R openclaw/openclaw --state open --json number,title,url
 octopool gh pr checks 85341 -R openclaw/openclaw --json name,state,bucket
 octopool gh issue list -R openclaw/openclaw --state open --json number,title,url
 octopool gh run list -R openclaw/openclaw --branch main --limit 10 --json databaseId,status

--- a/cmd/octopool/gh.go
+++ b/cmd/octopool/gh.go
@@ -24,7 +24,7 @@ var relayQueryPathPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`^/repos/[^/]+/[^/]+/contents/.+$`),
 	regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls/[0-9]+$`),
 	regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls$`),
-	regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls/[0-9]+/(files|comments|reviews)$`),
+	regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls/[0-9]+/(files|commits|comments|reviews)$`),
 	regexp.MustCompile(`^/repos/[^/]+/[^/]+/commits/[0-9A-Fa-f]{7,64}/(check-runs|status)$`),
 	regexp.MustCompile(`^/repos/[^/]+/[^/]+/actions/runs$`),
 	regexp.MustCompile(`^/repos/[^/]+/[^/]+/actions/runs/[0-9]+$`),
@@ -34,7 +34,7 @@ var relayQueryPathPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`^/repos/[^/]+/[^/]+/check-runs/[0-9]+/annotations$`),
 	regexp.MustCompile(`^/repos/[^/]+/[^/]+/issues/[0-9]+$`),
 	regexp.MustCompile(`^/repos/[^/]+/[^/]+/issues$`),
-	regexp.MustCompile(`^/repos/[^/]+/[^/]+/issues/[0-9]+/(comments|timeline)$`),
+	regexp.MustCompile(`^/repos/[^/]+/[^/]+/issues/[0-9]+/(comments|events|timeline)$`),
 	regexp.MustCompile(`^/repos/[^/]+/[^/]+/branches/[^/?#]+$`),
 	regexp.MustCompile(`^/repos/[^/]+/[^/]+/actions/workflows$`),
 	regexp.MustCompile(`^/repos/[^/]+/[^/]+/actions/workflows/[^/?#]+$`),
@@ -43,6 +43,7 @@ var relayQueryPathPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`^/repos/[^/]+/[^/]+/releases/latest$`),
 	regexp.MustCompile(`^/repos/[^/]+/[^/]+/releases/tags/[^/?#]+$`),
 	regexp.MustCompile(`^/repos/[^/]+/[^/]+/releases/[0-9]+$`),
+	regexp.MustCompile(`^/search/(issues|code|commits)$`),
 	regexp.MustCompile(`^/rate_limit$`),
 }
 

--- a/cmd/octopool/gh_test.go
+++ b/cmd/octopool/gh_test.go
@@ -83,7 +83,9 @@ func TestSafeRelayRequest(t *testing.T) {
 	for _, path := range []string{
 		"/repos/openclaw/octopool",
 		"/repos/openclaw/octopool/pulls?state=open",
+		"/repos/openclaw/octopool/pulls/1/commits",
 		"/repos/openclaw/octopool/issues?state=open",
+		"/repos/openclaw/octopool/issues/1/events",
 		"/repos/openclaw/octopool/contents/README.md?ref=main",
 		"/repos/openclaw/octopool/compare/main...feature",
 		"/repos/openclaw/octopool/actions/workflows/ci.yml",
@@ -106,8 +108,8 @@ func TestSafeRelayRequest(t *testing.T) {
 	if err != nil || fallback {
 		t.Fatalf("parse fallback=%v err=%v", fallback, err)
 	}
-	if safeRelayRequest(request) {
-		t.Fatal("unknown query-bearing read should stay local")
+	if !safeRelayRequest(request) {
+		t.Fatal("search read can ask octopool for a policy decision")
 	}
 
 	request, fallback, err = parseGHAPIArgs([]string{"/search/issues"})
@@ -298,6 +300,264 @@ func TestRunGHReleaseViewEscapesSlashTagsOnce(t *testing.T) {
 		t.Fatalf("handled=%v err=%v", handled, err)
 	}
 	if got := out.String(); !strings.Contains(got, `"tagName":"release/1.0"`) {
+		t.Fatalf("out = %s", got)
+	}
+}
+
+func TestRunGHSearchIssuesUsesScopedSearchRoute(t *testing.T) {
+	relayTestServer(t, func(body map[string]any) any {
+		if body["path"] != "/search/issues" {
+			t.Fatalf("path = %v", body["path"])
+		}
+		query := body["query"].(map[string]any)
+		if query["per_page"] != "10" || query["q"] != "repo:openclaw/octopool type:issue cache regression" {
+			t.Fatalf("query = %#v", query)
+		}
+		return map[string]any{
+			"items": []map[string]any{{
+				"number":   1,
+				"title":    "cache hit regression",
+				"body":     "octopool should pool this",
+				"html_url": "https://github.com/openclaw/octopool/issues/1",
+			}},
+		}
+	})
+	var out bytes.Buffer
+	handled, err := runGHSearch(t.Context(), []string{
+		"issues",
+		"-R", "openclaw/octopool",
+		"cache",
+		"regression",
+		"--json", "number,title,url",
+		"--limit", "10",
+	}, &out)
+	if err != nil || !handled {
+		t.Fatalf("handled=%v err=%v", handled, err)
+	}
+	got := out.String()
+	if !strings.Contains(got, `"number":1`) {
+		t.Fatalf("out = %s", got)
+	}
+}
+
+func TestRunGHSearchUsesExplicitStateOnly(t *testing.T) {
+	relayTestServer(t, func(body map[string]any) any {
+		query := body["query"].(map[string]any)
+		if query["q"] != "repo:openclaw/octopool type:issue state:open cache" {
+			t.Fatalf("query = %#v", query)
+		}
+		return map[string]any{"items": []map[string]any{}}
+	})
+	var out bytes.Buffer
+	handled, err := runGHSearch(t.Context(), []string{
+		"issues",
+		"cache",
+		"-R", "openclaw/octopool",
+		"--state", "open",
+		"--json", "number,title,url",
+	}, &out)
+	if err != nil || !handled {
+		t.Fatalf("handled=%v err=%v", handled, err)
+	}
+}
+
+func TestRunGHSearchFallsBackForInvalidStateAll(t *testing.T) {
+	var out bytes.Buffer
+	handled, err := runGHSearch(t.Context(), []string{
+		"issues",
+		"cache",
+		"-R", "openclaw/octopool",
+		"--state", "all",
+		"--json", "number,title,url",
+	}, &out)
+	if err != nil || handled {
+		t.Fatalf("handled=%v err=%v", handled, err)
+	}
+}
+
+func TestRunGHSearchFallsBackForUnimplementedSort(t *testing.T) {
+	var out bytes.Buffer
+	handled, err := runGHSearch(t.Context(), []string{
+		"issues",
+		"cache",
+		"-R", "openclaw/octopool",
+		"--sort", "created",
+		"--json", "number,title,url",
+	}, &out)
+	if err != nil || handled {
+		t.Fatalf("handled=%v err=%v", handled, err)
+	}
+}
+
+func TestRunGHSearchFallsBackForQualifiedQuery(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	var out bytes.Buffer
+	handled, err := runGHSearch(t.Context(), []string{
+		"issues",
+		"author:alice",
+		"cache",
+		"-R", "openclaw/octopool",
+		"--json", "number,title,url",
+	}, &out)
+	if !handled || !isLocalFallback(err) {
+		t.Fatalf("handled=%v err=%v", handled, err)
+	}
+}
+
+func TestRunGHSearchFallsBackForUnsupportedTerm(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	var out bytes.Buffer
+	handled, err := runGHSearch(t.Context(), []string{
+		"issues",
+		"C++",
+		"-R", "openclaw/octopool",
+		"--json", "number,title,url",
+	}, &out)
+	if !handled || !isLocalFallback(err) {
+		t.Fatalf("handled=%v err=%v", handled, err)
+	}
+}
+
+func TestRunGHSearchFallsBackForQuotedPhrase(t *testing.T) {
+	var out bytes.Buffer
+	handled, err := runGHSearch(t.Context(), []string{
+		"issues",
+		"cache regression",
+		"-R", "openclaw/octopool",
+		"--json", "number,title,url",
+	}, &out)
+	if err != nil || handled {
+		t.Fatalf("handled=%v err=%v", handled, err)
+	}
+}
+
+func TestRunGHSearchPRsFallsBackForUnavailableFields(t *testing.T) {
+	var out bytes.Buffer
+	handled, err := runGHSearch(t.Context(), []string{
+		"prs",
+		"cache",
+		"-R", "openclaw/octopool",
+		"--json", "number,headRefName,isDraft",
+	}, &out)
+	if err != nil || handled {
+		t.Fatalf("handled=%v err=%v", handled, err)
+	}
+}
+
+func TestRunGHSearchFallsBackForMultipleRepos(t *testing.T) {
+	var out bytes.Buffer
+	handled, err := runGHSearch(t.Context(), []string{
+		"issues",
+		"cache",
+		"-R", "openclaw/octopool",
+		"-R", "openclaw/openclaw",
+		"--json", "number,title,url",
+	}, &out)
+	if err != nil || handled {
+		t.Fatalf("handled=%v err=%v", handled, err)
+	}
+}
+
+func TestRunGHSearchFallsBackForNonSearchModifiers(t *testing.T) {
+	var out bytes.Buffer
+	handled, err := runGHSearch(t.Context(), []string{
+		"prs",
+		"cache",
+		"-R", "openclaw/octopool",
+		"--branch", "feature",
+		"--json", "number,title,url",
+	}, &out)
+	if err != nil || handled {
+		t.Fatalf("handled=%v err=%v", handled, err)
+	}
+}
+
+func TestRunGHPRViewHydratesDetails(t *testing.T) {
+	relayTestServer(t, func(body map[string]any) any {
+		switch body["path"] {
+		case "/repos/openclaw/octopool/pulls/7":
+			return map[string]any{
+				"number":   7,
+				"title":    "hydrate pr",
+				"html_url": "https://github.com/openclaw/octopool/pull/7",
+			}
+		case "/repos/openclaw/octopool/pulls/7/files":
+			return []map[string]any{{"filename": "cmd/octopool/gh.go"}}
+		case "/repos/openclaw/octopool/pulls/7/commits":
+			return []map[string]any{{"sha": "abc1234"}}
+		case "/repos/openclaw/octopool/issues/7/comments":
+			return []map[string]any{{"body": "looks good"}}
+		case "/repos/openclaw/octopool/pulls/7/reviews":
+			return []map[string]any{{"state": "APPROVED"}}
+		default:
+			t.Fatalf("path = %v", body["path"])
+			return nil
+		}
+	})
+	var out bytes.Buffer
+	handled, err := runGHPR(t.Context(), []string{
+		"view",
+		"7",
+		"-R", "openclaw/octopool",
+		"--json", "number,files,commits,comments,reviews",
+	}, &out)
+	if err != nil || !handled {
+		t.Fatalf("handled=%v err=%v", handled, err)
+	}
+	got := out.String()
+	for _, want := range []string{"cmd/octopool/gh.go", "abc1234", "looks good", "APPROVED"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("out missing %q: %s", want, got)
+		}
+	}
+}
+
+func TestRunGHPRViewFallsBackForStatusCheckRollup(t *testing.T) {
+	var out bytes.Buffer
+	handled, err := runGHPR(t.Context(), []string{
+		"view",
+		"7",
+		"-R", "openclaw/octopool",
+		"--json", "number,statusCheckRollup",
+	}, &out)
+	if err != nil || handled {
+		t.Fatalf("handled=%v err=%v", handled, err)
+	}
+}
+
+func TestRunGHPRChecksUsesCacheableRequests(t *testing.T) {
+	relayTestServer(t, func(body map[string]any) any {
+		if body["path"] != "/repos/openclaw/octopool/pulls/7" {
+			if _, ok := body["headers"]; ok {
+				t.Fatalf("unexpected cache-bypass headers: %#v", body["headers"])
+			}
+		}
+		if body["path"] == "/repos/openclaw/octopool/pulls/7" && body["headers"] == nil {
+			t.Fatal("expected live PR head lookup header")
+		}
+		switch body["path"] {
+		case "/repos/openclaw/octopool/pulls/7":
+			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+		case "/repos/openclaw/octopool/commits/abc1234/check-runs":
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"name": "CI", "status": "completed", "conclusion": "success"}}}
+		case "/repos/openclaw/octopool/commits/abc1234/status":
+			return map[string]any{"statuses": []map[string]any{}}
+		default:
+			t.Fatalf("path = %v", body["path"])
+			return nil
+		}
+	})
+	var out bytes.Buffer
+	handled, err := runGHPR(t.Context(), []string{
+		"checks",
+		"7",
+		"-R", "openclaw/octopool",
+		"--json", "name,state",
+	}, &out)
+	if err != nil || !handled {
+		t.Fatalf("handled=%v err=%v", handled, err)
+	}
+	if got := out.String(); !strings.Contains(got, `"name":"CI"`) {
 		t.Fatalf("out = %s", got)
 	}
 }

--- a/cmd/octopool/gh_top.go
+++ b/cmd/octopool/gh_top.go
@@ -17,6 +17,7 @@ import (
 
 type ghTopOptions struct {
 	repo        string
+	repoCount   int
 	json        []string
 	jq          string
 	patch       bool
@@ -47,6 +48,8 @@ func runGHTopLevel(ctx context.Context, args []string, stdout io.Writer) (bool, 
 		return runGHRepo(ctx, args[1:], stdout)
 	case "release":
 		return runGHRelease(ctx, args[1:], stdout)
+	case "search":
+		return runGHSearch(ctx, args[1:], stdout)
 	default:
 		return false, nil
 	}
@@ -68,6 +71,9 @@ func runGHPR(ctx context.Context, args []string, stdout io.Writer) (bool, error)
 		repo, number, ok := repoNumber(opts)
 		if !ok || hasTopModifiers(opts) || !machineReadable(opts) || !supportedJSONFields(opts, supportedPRFields) {
 			return false, nil
+		}
+		if needsHydratedPR(opts.json) {
+			return true, relayHydratedPRView(ctx, stdout, repo, number, opts)
 		}
 		return true, relayTop(ctx, stdout, ghAPIRequest{method: "GET", path: repoPath(repo, "pulls", number)}, opts, fieldMapPR)
 	case "list":
@@ -101,6 +107,58 @@ func runGHPR(ctx context.Context, args []string, stdout io.Writer) (bool, error)
 			return false, nil
 		}
 		return true, relayPRChecks(ctx, stdout, repo, number, opts)
+	default:
+		return false, nil
+	}
+}
+
+func runGHSearch(ctx context.Context, args []string, stdout io.Writer) (bool, error) {
+	if len(args) < 2 {
+		return false, nil
+	}
+	kind := args[0]
+	if kind != "issues" && kind != "prs" {
+		return false, nil
+	}
+	opts, fallback, err := parseGHTopOptions(args[1:])
+	if err != nil || fallback {
+		return !fallback, err
+	}
+	if topJQFallback(opts) {
+		return false, nil
+	}
+	repo, ok := repoFromOptionOrCurrent(opts.repo)
+	if !ok || repo == "" || opts.repoCount > 1 || !machineReadable(opts) || limitOverOnePage(opts) {
+		return false, nil
+	}
+	if opts.patch || opts.branch != "" || opts.workflow != "" || opts.status != "" {
+		return false, nil
+	}
+	if opts.state != "" && opts.state != "open" && opts.state != "closed" {
+		return false, nil
+	}
+	queryParts := opts.positionals
+	for _, part := range queryParts {
+		if strings.ContainsAny(part, " \t\r\n") {
+			return false, nil
+		}
+	}
+	query := strings.TrimSpace(strings.Join(queryParts, " "))
+	if query == "" {
+		return false, nil
+	}
+	opts.positionals = nil
+	switch kind {
+	case "issues":
+		if !supportedJSONFields(opts, supportedIssueFields) {
+			return false, nil
+		}
+		return true, relaySearchIssues(ctx, stdout, repo, query, opts)
+	case "prs":
+		if !supportedJSONFields(opts, supportedPRSearchFields) {
+			return false, nil
+		}
+		return true, relaySearchPRs(ctx, stdout, repo, query, opts)
 	default:
 		return false, nil
 	}
@@ -278,8 +336,8 @@ func parseGHTopOptions(args []string) (ghTopOptions, bool, error) {
 			name string
 			set  func(string)
 		}{
-			{"-R", func(value string) { opts.repo = value }},
-			{"--repo", func(value string) { opts.repo = value }},
+			{"-R", func(value string) { opts.repo = value; opts.repoCount++ }},
+			{"--repo", func(value string) { opts.repo = value; opts.repoCount++ }},
 			{"--json", func(value string) { opts.json = splitFields(value) }},
 			{"--jq", func(value string) { opts.jq = value }},
 			{"-q", func(value string) { opts.jq = value }},
@@ -379,44 +437,10 @@ func relayPRChecks(ctx context.Context, stdout io.Writer, repo string, number st
 	if !ok || sha == "" {
 		return errors.New("pull request response did not include head.sha")
 	}
-	checkRuns := []any{}
-	totalCheckRuns := 0
-	for page := 1; page <= 10; page++ {
-		request := ghAPIRequest{
-			method:  "GET",
-			path:    repoPath(repo, "commits", sha, "check-runs"),
-			query:   map[string]any{"per_page": "100", "page": strconv.Itoa(page)},
-			headers: liveHeaders,
-		}
-		checkRunsEnvelope, err := client.do(ctx, request)
-		if err != nil {
-			return err
-		}
-		items, total, err := checkRunItems(checkRunsEnvelope)
-		if err != nil {
-			return err
-		}
-		if page == 1 {
-			totalCheckRuns = total
-		}
-		checkRuns = append(checkRuns, items...)
-		if len(checkRuns) >= totalCheckRuns || len(items) < 100 {
-			break
-		}
-	}
-	statusEnvelope, err := client.do(ctx, ghAPIRequest{
-		method:  "GET",
-		path:    repoPath(repo, "commits", sha, "status"),
-		headers: liveHeaders,
-	})
+	items, err := prCheckItemsForSHA(ctx, client, repo, sha)
 	if err != nil {
 		return err
 	}
-	statuses, err := statusItems(statusEnvelope)
-	if err != nil {
-		return err
-	}
-	items := ghCheckItems(append(checkRuns, statuses...))
 	raw, err := json.Marshal(items)
 	if err != nil {
 		return err
@@ -431,6 +455,101 @@ func relayPRChecks(ctx context.Context, stdout io.Writer, repo string, number st
 		return err
 	}
 	return checkExitCode(items)
+}
+
+func relayHydratedPRView(ctx context.Context, stdout io.Writer, repo string, number string, opts ghTopOptions) error {
+	client, err := newGHRelayClient()
+	if err != nil {
+		return err
+	}
+	prEnvelope, err := client.do(ctx, ghAPIRequest{method: "GET", path: repoPath(repo, "pulls", number)})
+	if err != nil {
+		return err
+	}
+	body, err := envelopeBodyBytes(prEnvelope)
+	if err != nil {
+		return err
+	}
+	var pr map[string]any
+	if err := json.Unmarshal(body, &pr); err != nil {
+		return err
+	}
+	for _, field := range opts.json {
+		switch field {
+		case "files":
+			files, err := relayPagedArray(ctx, client, repoPath(repo, "pulls", number, "files"))
+			if err != nil {
+				return err
+			}
+			pr["files"] = mapPRFiles(files)
+		case "commits":
+			commits, err := relayPagedArray(ctx, client, repoPath(repo, "pulls", number, "commits"))
+			if err != nil {
+				return err
+			}
+			pr["commits"] = mapPRCommits(commits)
+		case "comments":
+			comments, err := relayPagedArray(ctx, client, repoPath(repo, "issues", number, "comments"))
+			if err != nil {
+				return err
+			}
+			pr["comments"] = mapPRComments(comments)
+		case "reviews":
+			reviews, err := relayPagedArray(ctx, client, repoPath(repo, "pulls", number, "reviews"))
+			if err != nil {
+				return err
+			}
+			pr["reviews"] = mapPRReviews(reviews)
+		}
+	}
+	raw, err := json.Marshal(pr)
+	if err != nil {
+		return err
+	}
+	filtered, err := filterJSONFields(raw, opts.json, fieldMapPR)
+	if err != nil {
+		return err
+	}
+	return writeBytes(ctx, stdout, filtered, opts.jq)
+}
+
+func prCheckItemsForSHA(ctx context.Context, client ghRelayClient, repo string, sha string) ([]any, error) {
+	checkRuns := []any{}
+	totalCheckRuns := 0
+	for page := 1; page <= 10; page++ {
+		request := ghAPIRequest{
+			method: "GET",
+			path:   repoPath(repo, "commits", sha, "check-runs"),
+			query:  map[string]any{"per_page": "100", "page": strconv.Itoa(page)},
+		}
+		checkRunsEnvelope, err := client.do(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+		items, total, err := checkRunItems(checkRunsEnvelope)
+		if err != nil {
+			return nil, err
+		}
+		if page == 1 {
+			totalCheckRuns = total
+		}
+		checkRuns = append(checkRuns, items...)
+		if len(checkRuns) >= totalCheckRuns || len(items) < 100 {
+			break
+		}
+	}
+	statusEnvelope, err := client.do(ctx, ghAPIRequest{
+		method: "GET",
+		path:   repoPath(repo, "commits", sha, "status"),
+	})
+	if err != nil {
+		return nil, err
+	}
+	statuses, err := statusItems(statusEnvelope)
+	if err != nil {
+		return nil, err
+	}
+	return ghCheckItems(append(checkRuns, statuses...)), nil
 }
 
 func relayIssueList(ctx context.Context, stdout io.Writer, request ghAPIRequest, opts ghTopOptions) error {
@@ -481,6 +600,199 @@ func relayIssueList(ctx context.Context, stdout io.Writer, request ghAPIRequest,
 		}
 	}
 	return writeBytes(ctx, stdout, raw, opts.jq)
+}
+
+func relaySearchIssues(ctx context.Context, stdout io.Writer, repo string, rawQuery string, opts ghTopOptions) error {
+	if opts.author != "" || opts.assignee != "" || len(opts.labels) > 0 {
+		return localFallbackError{Reason: "unsupported_search_filter"}
+	}
+	return relayGitHubSearch(ctx, stdout, repo, rawQuery, "issue", opts, fieldMapIssue)
+}
+
+func relaySearchPRs(ctx context.Context, stdout io.Writer, repo string, rawQuery string, opts ghTopOptions) error {
+	if opts.author != "" || opts.assignee != "" || len(opts.labels) > 0 {
+		return localFallbackError{Reason: "unsupported_pr_search_filter"}
+	}
+	return relayGitHubSearch(ctx, stdout, repo, rawQuery, "pr", opts, fieldMapPR)
+}
+
+func relayGitHubSearch(
+	ctx context.Context,
+	stdout io.Writer,
+	repo string,
+	rawQuery string,
+	searchType string,
+	opts ghTopOptions,
+	fieldMap map[string][]string,
+) error {
+	terms, ok := searchTerms(rawQuery)
+	if !ok {
+		return localFallbackError{Reason: "unsupported_search_query"}
+	}
+	client, err := newGHRelayClient()
+	if err != nil {
+		return err
+	}
+	q := fmt.Sprintf("repo:%s type:%s", repo, searchType)
+	if opts.state != "" {
+		q += " state:" + opts.state
+	}
+	if len(terms) > 0 {
+		q += " " + strings.Join(terms, " ")
+	}
+	envelope, err := client.do(ctx, ghAPIRequest{
+		method: "GET",
+		path:   "/search/issues",
+		query:  map[string]any{"q": q, "per_page": strconv.Itoa(desiredLimit(opts))},
+	})
+	if err != nil {
+		return err
+	}
+	body, err := envelopeBodyBytes(envelope)
+	if err != nil {
+		return err
+	}
+	var response map[string]any
+	if err := json.Unmarshal(body, &response); err != nil {
+		return err
+	}
+	items, _ := response["items"].([]any)
+	raw, err := json.Marshal(items)
+	if err != nil {
+		return err
+	}
+	if len(opts.json) > 0 {
+		raw, err = filterJSONFields(raw, opts.json, fieldMap)
+		if err != nil {
+			return err
+		}
+	}
+	return writeBytes(ctx, stdout, raw, opts.jq)
+}
+
+func relayPagedArray(ctx context.Context, client ghRelayClient, path string) ([]any, error) {
+	items := []any{}
+	for page := 1; page <= 10; page++ {
+		envelope, err := client.do(ctx, ghAPIRequest{
+			method: "GET",
+			path:   path,
+			query:  map[string]any{"per_page": "100", "page": strconv.Itoa(page)},
+		})
+		if err != nil {
+			return nil, err
+		}
+		body, err := envelopeBodyBytes(envelope)
+		if err != nil {
+			return nil, err
+		}
+		var pageItems []any
+		if err := json.Unmarshal(body, &pageItems); err != nil {
+			return nil, err
+		}
+		items = append(items, pageItems...)
+		if len(pageItems) < 100 {
+			break
+		}
+	}
+	return items, nil
+}
+
+func mapPRFiles(items []any) []any {
+	return mapObjects(items, func(item map[string]any) map[string]any {
+		return map[string]any{
+			"path":         firstString(item, "filename"),
+			"additions":    item["additions"],
+			"deletions":    item["deletions"],
+			"changeType":   item["status"],
+			"originalPath": firstString(item, "previous_filename"),
+		}
+	})
+}
+
+func mapPRCommits(items []any) []any {
+	return mapObjects(items, func(item map[string]any) map[string]any {
+		commit, _ := item["commit"].(map[string]any)
+		message := firstString(commit, "message")
+		headline, body, _ := strings.Cut(message, "\n\n")
+		if headline == "" {
+			headline = message
+		}
+		return map[string]any{
+			"oid":             firstString(item, "sha"),
+			"messageHeadline": headline,
+			"messageBody":     body,
+			"committedDate":   nestedStringValue(item, "commit", "committer", "date"),
+			"authoredDate":    nestedStringValue(item, "commit", "author", "date"),
+			"url":             firstString(item, "html_url"),
+			"authors":         commitAuthors(item),
+		}
+	})
+}
+
+func mapPRComments(items []any) []any {
+	return mapObjects(items, func(item map[string]any) map[string]any {
+		return map[string]any{
+			"author":    item["user"],
+			"body":      item["body"],
+			"createdAt": item["created_at"],
+			"updatedAt": item["updated_at"],
+			"url":       item["html_url"],
+		}
+	})
+}
+
+func mapPRReviews(items []any) []any {
+	return mapObjects(items, func(item map[string]any) map[string]any {
+		return map[string]any{
+			"author":      item["user"],
+			"body":        item["body"],
+			"state":       item["state"],
+			"submittedAt": item["submitted_at"],
+			"url":         item["html_url"],
+		}
+	})
+}
+
+func mapObjects(items []any, mapper func(map[string]any) map[string]any) []any {
+	out := make([]any, 0, len(items))
+	for _, raw := range items {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		out = append(out, mapper(item))
+	}
+	return out
+}
+
+func commitAuthors(item map[string]any) []any {
+	login := nestedStringValue(item, "author", "login")
+	if login == "" {
+		login = nestedStringValue(item, "commit", "author", "name")
+	}
+	if login == "" {
+		return []any{}
+	}
+	return []any{map[string]any{"login": login}}
+}
+
+func searchTerms(raw string) ([]string, bool) {
+	fields := strings.Fields(strings.ToLower(raw))
+	terms := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if strings.Contains(field, ":") || strings.HasPrefix(field, "-") || field == "or" {
+			return nil, false
+		}
+		term := strings.Trim(field, `"'`)
+		if term == "" {
+			continue
+		}
+		if !allowedSearchTerm.MatchString(term) {
+			return nil, false
+		}
+		terms = append(terms, term)
+	}
+	return terms, true
 }
 
 func checkRunItems(envelope relayEnvelope) ([]any, int, error) {
@@ -711,6 +1023,16 @@ func supportedJSONFields(opts ghTopOptions, supported map[string]bool) bool {
 		}
 	}
 	return true
+}
+
+func needsHydratedPR(fields []string) bool {
+	for _, field := range fields {
+		switch field {
+		case "files", "commits", "comments", "reviews":
+			return true
+		}
+	}
+	return false
 }
 
 func envelopeBodyBytes(envelope relayEnvelope) ([]byte, error) {
@@ -1040,12 +1362,18 @@ var fieldMapCheckRun = map[string][]string{
 var supportedPRFields = supportedFields(
 	"number", "title", "body", "state", "url", "author", "createdAt", "updatedAt", "closedAt",
 	"mergedAt", "headRefName", "headRefOid", "baseRefName", "baseRefOid", "isDraft", "labels",
-	"additions", "deletions", "changedFiles", "mergeable", "merged",
+	"additions", "deletions", "changedFiles", "mergeable", "merged", "files", "commits", "comments",
+	"reviews",
 )
 
 var supportedPRListFields = supportedFields(
 	"number", "title", "body", "state", "url", "author", "createdAt", "updatedAt", "closedAt",
 	"mergedAt", "headRefName", "headRefOid", "baseRefName", "baseRefOid", "isDraft", "labels",
+)
+
+var supportedPRSearchFields = supportedFields(
+	"number", "title", "body", "state", "url", "author", "createdAt", "updatedAt", "closedAt",
+	"labels",
 )
 
 var supportedIssueFields = supportedFields(
@@ -1071,6 +1399,8 @@ var supportedReleaseFields = supportedFields(
 var supportedCheckRunFields = supportedFields(
 	"bucket", "completedAt", "description", "event", "link", "name", "startedAt", "state", "workflow",
 )
+
+var allowedSearchTerm = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
 
 func supportedFields(fields ...string) map[string]bool {
 	out := make(map[string]bool, len(fields))

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -59,8 +59,10 @@ Per route kind and response state (`cacheTTLSeconds`):
 
 - workflow runs, run lists, job lists, checks, and commit statuses → 15s while active;
   completed runs/checks get short extended TTLs
-- PR files with a validated state discriminator → 5m; PR reviews/comments and
-  undiscriminated PR files → 1m
+- PR files with a validated state discriminator → 5m; PR commits, reviews,
+  comments, issue comments/events/timeline, and undiscriminated PR files → 1m..5m
+- repository-scoped `gh search issues|prs` shim calls use cacheable GitHub Search
+  requests, with misses accounted against the search bucket
 - closed PRs/issues → 1h; open PRs → 2m; open issues → 5m
 - release lists/latest → 5m; release by tag/id → 1h
 - immutable commit objects → 24h; commit lists → 5m; contents → 1h

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -92,9 +92,12 @@ safe relay routes:
 
 ```sh
 octopool gh pr view 85341 -R openclaw/openclaw --json number,title,url
+octopool gh pr view 85341 -R openclaw/openclaw --json number,files,commits,comments,reviews
 octopool gh pr list -R openclaw/openclaw --state open --limit 20 --json number,title,url
 octopool gh pr diff 85341 -R openclaw/openclaw --patch
 octopool gh pr checks 85341 -R openclaw/openclaw --json name,state,bucket,link,workflow
+octopool gh search issues cache regression -R openclaw/openclaw --state open --json number,title,url
+octopool gh search prs rate limit -R openclaw/openclaw --state open --json number,title,url
 octopool gh issue view 80490 -R openclaw/openclaw --json number,title,state,url
 octopool gh issue list -R openclaw/openclaw --state open --label bug --limit 20 --json number,title,url
 octopool gh run list -R openclaw/openclaw --branch main --limit 10 --json databaseId,workflowName,status,conclusion,url
@@ -110,6 +113,13 @@ formatted commands stay on the real `gh`. Supported `--json` fields are intentio
 conservative. Common `gh` field names are mapped where the REST API uses different
 names, such as `url`, `author`, `headRefName`, `headRefOid`, `baseRefName`,
 `baseRefOid`, `isDraft`, `databaseId`, `workflowName`, and `nameWithOwner`.
+`gh search issues|prs` is translated to a repo-scoped, cacheable GitHub Search request
+for the common plain-term `-R owner/repo --state ... --json ...` shape. Cache hits cost
+zero GitHub Search quota; misses use the pool's search bucket. Qualified search syntax
+such as `author:` or custom sort/match flags falls through to the real `gh`. PR search
+supports the issue-like fields returned by GitHub Search; PR-list-only fields such as
+`headRefName` fall through. `gh pr checks` uses the shared cache by default; ask for raw
+`gh api` conditional requests only when freshness matters more than quota.
 `--jq` runs after `--json` filtering, matching the usual agent workflow for small
 machine-readable reads.
 

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -96,16 +96,18 @@ traversal (`%2e`, `%5c`). The relay only ever talks to `api.github.com`.
 Routes are classified in `src/policy.ts`. Only the following read-only shapes are
 enabled; anything else returns `403 route_denied`:
 
-- `pr_view`, `pr_files`, `pr_review_comments`, `pr_reviews`
+- `pr_view`, `pr_files`, `pr_commits`, `pr_review_comments`, `pr_reviews`
 - `pr_list`
 - `commit_list`, `commit_view`, `compare`, `contents`, `commit_check_runs`, `commit_status`
 - `run_list`, `run_view`, `run_jobs`, `run_artifacts`
 - `job_view`, `job_logs`, `check_run_annotations`
-- `issue_list`, `issue_view`, `issue_comments`, `issue_timeline`
+- `issue_list`, `issue_view`, `issue_comments`, `issue_events`, `issue_timeline`
 - `branch_view`
 - `repo_view`
 - `release_list`, `release_latest`, `release_view`
 - `workflow_list`, `workflow_view`
+- `search_issues`, `search_code`, `search_commits` when `allow_search` is enabled
+  and `q` contains exactly one `repo:owner/name` qualifier plus plain terms only
 - `rate_limit`
 
 `job_logs` is a large-payload, log-class route: it follows GitHub's signed redirect to
@@ -122,7 +124,9 @@ gated by the pool's `allow_logs` policy.
   public-repo guard proves `private: false` (default `true`). These routes use broad PAT
   identities from the pool rather than repo-scoped GitHub App installation tokens.
 - `allow_logs` — log routes require it (default `true`), else `403 logs_denied`.
-- `allow_search` — search routes require it (default `false`), else `403 search_denied`.
+- `allow_search` — search routes require it (default `false`) and must be scoped by
+  exactly one `repo:owner/name` qualifier plus plain terms and optional
+  `type:issue|pr` / `state:open|closed`, else `403 search_denied`.
 
 Every repo route additionally passes a public-visibility check before a pooled identity
 or cache entry is used — see [Cache & public-repo guard](cache.md).

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -86,6 +86,9 @@ export function staleCacheSeconds(route: RouteInfo): number {
     case "pr_commits":
     case "pr_review_comments":
     case "pr_reviews":
+    case "issue_comments":
+    case "issue_events":
+    case "issue_timeline":
       return 3_600;
     case "repo_view":
     case "commit_list":
@@ -207,6 +210,18 @@ export function cacheTTLSeconds(route: RouteInfo, response?: GitHubRelayResponse
       return 15;
     case "pr_files":
       return stateAwarePRSubresource(route, response) ? 300 : 60;
+    case "pr_commits":
+    case "pr_review_comments":
+    case "pr_reviews":
+    case "issue_comments":
+    case "issue_events":
+    case "issue_timeline":
+      return 300;
+    case "search_issues":
+    case "search_code":
+    case "search_commits":
+    case "search_repositories":
+      return 120;
     default:
       return 60;
   }

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -27,6 +27,7 @@ const rules: RouteRule[] = [
   route(`/repos/${owner}/${repo}/pulls/${number}`, "pr_view", "core"),
   route(`/repos/${owner}/${repo}/pulls`, "pr_list", "core"),
   route(`/repos/${owner}/${repo}/pulls/${number}/files`, "pr_files", "core"),
+  route(`/repos/${owner}/${repo}/pulls/${number}/commits`, "pr_commits", "core"),
   route(`/repos/${owner}/${repo}/pulls/${number}/comments`, "pr_review_comments", "core"),
   route(`/repos/${owner}/${repo}/pulls/${number}/reviews`, "pr_reviews", "core"),
   route(`/repos/${owner}/${repo}/commits/${sha}/check-runs`, "commit_check_runs", "core"),
@@ -44,6 +45,7 @@ const rules: RouteRule[] = [
   route(`/repos/${owner}/${repo}/issues/${number}`, "issue_view", "core"),
   route(`/repos/${owner}/${repo}/issues`, "issue_list", "core"),
   route(`/repos/${owner}/${repo}/issues/${number}/comments`, "issue_comments", "core"),
+  route(`/repos/${owner}/${repo}/issues/${number}/events`, "issue_events", "core"),
   route(`/repos/${owner}/${repo}/issues/${number}/timeline`, "issue_timeline", "core"),
   route(`/repos/${owner}/${repo}/branches/(?<branch>[^/?#]+)`, "branch_view", "core"),
   route(`/repos/${owner}/${repo}/actions/workflows`, "workflow_list", "core"),
@@ -57,6 +59,9 @@ const rules: RouteRule[] = [
   route(`/repos/${owner}/${repo}/releases/latest`, "release_latest", "core"),
   route(`/repos/${owner}/${repo}/releases/tags/${tag}`, "release_view", "core"),
   route(`/repos/${owner}/${repo}/releases/${id}`, "release_view", "core"),
+  route("/search/issues", "search_issues", "search", { search: true }),
+  route("/search/code", "search_code", "search", { search: true }),
+  route("/search/commits", "search_commits", "search", { search: true }),
   route("/rate_limit", "rate_limit", "core"),
 ];
 
@@ -176,12 +181,13 @@ export function classifyRoute(request: RelayRequest, policy: PoolPolicy): RouteI
         throw new HttpError(403, "route_denied", "Cross-repository compare routes are not enabled");
       }
     }
-    const routeOwner = match.groups?.owner?.toLowerCase();
+    const searchRepo = rule.search === true ? repoFromSearchQuery(request.query) : undefined;
+    const routeOwner = (match.groups?.owner ?? searchRepo?.owner)?.toLowerCase();
     const allowedOwner = routeOwner === undefined || policy.allowed_owners.includes(routeOwner);
     if (routeOwner !== undefined && !allowedOwner && !policy.allow_public_repos) {
       throw new HttpError(403, "owner_denied", `Owner ${routeOwner} is not allowed for this pool`);
     }
-    const routeRepo = match.groups?.repo;
+    const routeRepo = match.groups?.repo ?? searchRepo?.repo;
     const info: RouteInfo = {
       kind: rule.kind,
       resource: rule.resource,
@@ -200,6 +206,35 @@ export function classifyRoute(request: RelayRequest, policy: PoolPolicy): RouteI
     return info;
   }
   throw new HttpError(403, "route_denied", "Route is not enabled");
+}
+
+function repoFromSearchQuery(query: Record<string, string | string[]> | undefined): {
+  owner: string;
+  repo: string;
+} {
+  const q = query?.q;
+  if (typeof q !== "string") {
+    throw new HttpError(403, "search_denied", "Search routes require a repo-scoped q query");
+  }
+  const tokens = q.trim().split(/\s+/).filter(Boolean);
+  const matches = tokens
+    .map((token) => /^repo:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/.exec(token))
+    .filter((match): match is RegExpExecArray => match !== null);
+  if (matches.length !== 1 || matches[0]?.[1] === undefined || matches[0]?.[2] === undefined) {
+    throw new HttpError(403, "search_denied", "Search routes require exactly one repo qualifier");
+  }
+  for (const token of tokens) {
+    if (token.startsWith("repo:")) {
+      continue;
+    }
+    if (/^type:(issue|pr)$/.test(token) || /^state:(open|closed)$/.test(token)) {
+      continue;
+    }
+    if (!/^[A-Za-z0-9_.-]+$/.test(token) || token.toUpperCase() === "OR") {
+      throw new HttpError(403, "search_denied", "Search routes only allow plain repo-scoped terms");
+    }
+  }
+  return { owner: matches[0][1], repo: matches[0][2] };
 }
 
 export function normalizeRouteKey(method: string, path: string): string {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -184,6 +184,15 @@ describe("github cache policy", () => {
       policy,
     );
     expect(cacheTTLSeconds(files, response([]))).toBe(60);
+    const commits = classifyRoute(
+      validateRelayRequest({
+        pool: "maintainers",
+        method: "GET",
+        path: "/repos/openclaw/openclaw/pulls/42/commits",
+      }),
+      policy,
+    );
+    expect(cacheTTLSeconds(commits, response([]))).toBe(300);
     const stateAwareFiles = {
       ...classifyRoute(
         validateRelayRequest({

--- a/test/policy.test.ts
+++ b/test/policy.test.ts
@@ -12,10 +12,12 @@ describe("route policy", () => {
       "/repos/openclaw/openclaw/pulls?state=open",
       "/repos/openclaw/openclaw/issues?state=open",
       "/repos/openclaw/openclaw/pulls/85341",
+      "/repos/openclaw/openclaw/pulls/85341/commits",
       "/repos/openclaw/openclaw/commits/ac49d8e2295a093f168baa45312e1e29238c0351/check-runs",
       "/repos/openclaw/openclaw/actions/runs/26360397003/jobs",
       "/repos/openclaw/openclaw/actions/jobs/77594668516/logs",
       "/repos/openclaw/openclaw/issues/80490/comments",
+      "/repos/openclaw/openclaw/issues/80490/events",
       "/repos/openclaw/openclaw/actions/workflows/ci.yml",
       "/repos/openclaw/openclaw/actions/workflows/ci.yml/runs",
     ];
@@ -123,14 +125,43 @@ describe("route policy", () => {
     }
   });
 
-  it("denies search routes until query scope parsing exists", () => {
+  it("gates search routes behind pool policy", () => {
     const request = validateRelayRequest({
       pool: "maintainers",
       method: "GET",
       path: "/search/issues",
+      query: { q: "repo:openclaw/openclaw type:issue state:open cache" },
+    });
+    expect(() => classifyRoute(request, policy)).toThrow(/Search routes are disabled/);
+    expect(classifyRoute(request, { ...policy, allow_search: true })).toMatchObject({
+      kind: "search_issues",
+      owner: "openclaw",
+      repo: "openclaw",
+      resource: "search",
+    });
+  });
+
+  it("denies unscoped search routes even when search is enabled", () => {
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/search/issues",
+      query: { q: "cache regression" },
     });
     expect(() => classifyRoute(request, { ...policy, allow_search: true })).toThrow(
-      /Route is not enabled/,
+      /repo qualifier/,
+    );
+  });
+
+  it("denies broad search syntax outside the repo qualifier", () => {
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/search/issues",
+      query: { q: "repo:openclaw/openclaw cache OR org:other" },
+    });
+    expect(() => classifyRoute(request, { ...policy, allow_search: true })).toThrow(
+      /plain repo-scoped terms/,
     );
   });
 


### PR DESCRIPTION
## Summary
- add repo-scoped cached `octopool gh search issues|prs` for conservative plain-term searches
- hydrate cacheable PR detail fields: `files`, `commits`, `comments`, `reviews`
- make `gh pr checks` use cached check/status subroutes after a live PR-head lookup
- add server policy/cache TTL coverage for PR commits, issue events/timeline/comments, and search routes

## Proof
- `pnpm check`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local`
