### PR TITLE
Clarify login access provisioning failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ octopool login https://octopool.your-org.dev    # self-hosted endpoint
 octopool whoami
 ```
 
+Your GitHub account must already be provisioned for that pool by an Octopool admin. If
+login says `caller_not_provisioned`, ask an admin to run:
+
+```sh
+OCTOPOOL_ADMIN_TOKEN=... octopool admin caller \
+  --url https://octopool.your-org.dev \
+  --pool <pool-name> \
+  --github-login your-github-login
+```
+
 Use it like `gh` for common read shapes:
 
 ```sh

--- a/cmd/octopool/login.go
+++ b/cmd/octopool/login.go
@@ -73,7 +73,7 @@ func runLogin(ctx context.Context, args []string, stdout io.Writer) error {
 		return err
 	}
 	if status >= 400 {
-		return formatLoginFailure(status, out, *ghPath)
+		return formatLoginFailure(status, out, *ghPath, server.APIBase, server.Pool)
 	}
 	var response loginResponse
 	if err := json.Unmarshal(out, &response); err != nil {
@@ -156,7 +156,7 @@ func loginServerArgument(fs *flag.FlagSet, urlFlag string, serverFlag string) (s
 	return firstNonEmpty(positional, serverFlag, urlFlag, envDefault("OCTOPOOL_URL", defaultURL)), nil
 }
 
-func formatLoginFailure(status int, body []byte, ghPath string) error {
+func formatLoginFailure(status int, body []byte, ghPath string, serverURL string, pool string) error {
 	trimmed := strings.TrimSpace(string(body))
 	var response apiErrorResponse
 	if err := json.Unmarshal(body, &response); err != nil || response.Error.Code == "" {
@@ -180,7 +180,16 @@ func formatLoginFailure(status int, body []byte, ghPath string) error {
 		}
 		return fmt.Errorf("login failed: GitHub rejected the local gh token while Octopool verified it (%s).\nRefresh GitHub CLI auth: %s auth login\nThen retry: octopool login --gh-path %s%s", message, resolvedGHPath, resolvedGHPath, requestID)
 	}
+	if response.Error.Code == "caller_not_provisioned" {
+		quotedServerURL := shellQuoteArg(serverURL)
+		quotedPool := shellQuoteArg(pool)
+		return fmt.Errorf("login failed: your GitHub account is not provisioned for Octopool pool %q.\nAsk an Octopool admin to grant access with:\nOCTOPOOL_ADMIN_TOKEN=... octopool admin caller --url %s --pool %s --github-login your-github-login\nThen retry: octopool login %s%s", pool, quotedServerURL, quotedPool, quotedServerURL, requestID)
+	}
 	return fmt.Errorf("login failed: %s: %s%s", response.Error.Code, message, requestID)
+}
+
+func shellQuoteArg(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
 func isRateLimitedLoginFailure(message string, response apiErrorResponse) bool {

--- a/cmd/octopool/login_test.go
+++ b/cmd/octopool/login_test.go
@@ -28,7 +28,7 @@ func TestValidateLoginURLRequiresHTTPS(t *testing.T) {
 
 func TestFormatLoginFailureExplainsGitHub403(t *testing.T) {
 	t.Setenv("TZ", "UTC")
-	err := formatLoginFailure(401, []byte(`{"error":{"code":"github_auth_failed","message":"GitHub token check failed with 403","request_id":"req-123","details":{"github_rate_limit_reset":"1779928316","github_rate_limit_remaining":"0","github_rate_limit_resource":"core"}}}`), "/bin/gh")
+	err := formatLoginFailure(401, []byte(`{"error":{"code":"github_auth_failed","message":"GitHub token check failed with 403","request_id":"req-123","details":{"github_rate_limit_reset":"1779928316","github_rate_limit_remaining":"0","github_rate_limit_resource":"core"}}}`), "/bin/gh", "https://octopool.dev", "core")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -50,7 +50,7 @@ func TestFormatLoginFailureExplainsGitHub403(t *testing.T) {
 
 func TestFormatLoginFailureExplainsGitHub429(t *testing.T) {
 	t.Setenv("TZ", "UTC")
-	err := formatLoginFailure(401, []byte(`{"error":{"code":"github_auth_failed","message":"GitHub token check failed with 429","details":{"github_rate_limit_reset":"1779928316","github_retry_after":"60"}}}`), "/bin/gh")
+	err := formatLoginFailure(401, []byte(`{"error":{"code":"github_auth_failed","message":"GitHub token check failed with 429","details":{"github_rate_limit_reset":"1779928316","github_retry_after":"60"}}}`), "/bin/gh", "https://octopool.dev", "core")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -69,7 +69,7 @@ func TestFormatLoginFailureExplainsGitHub429(t *testing.T) {
 
 func TestFormatLoginFailureDoesNotTreatResetHeaderAsRateLimit(t *testing.T) {
 	t.Setenv("TZ", "UTC")
-	err := formatLoginFailure(401, []byte(`{"error":{"code":"github_auth_failed","message":"GitHub token check failed with 401","details":{"github_rate_limit_reset":"1779928316","github_rate_limit_remaining":"4999"}}}`), "/bin/gh")
+	err := formatLoginFailure(401, []byte(`{"error":{"code":"github_auth_failed","message":"GitHub token check failed with 401","details":{"github_rate_limit_reset":"1779928316","github_rate_limit_remaining":"4999"}}}`), "/bin/gh", "https://octopool.dev", "core")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -79,6 +79,41 @@ func TestFormatLoginFailureDoesNotTreatResetHeaderAsRateLimit(t *testing.T) {
 	}
 	if strings.Contains(got, "Retry after reset") {
 		t.Fatalf("did not expect rate-limit guidance:\n%s", got)
+	}
+}
+
+func TestFormatLoginFailureExplainsCallerProvisioning(t *testing.T) {
+	err := formatLoginFailure(403, []byte(`{"error":{"code":"caller_not_provisioned","message":"Caller is not provisioned for this pool","request_id":"req-123"}}`), "/bin/gh", "https://octopool.dev", "maintainers")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	got := err.Error()
+	for _, want := range []string{
+		`not provisioned for Octopool pool "maintainers"`,
+		"octopool admin caller --url 'https://octopool.dev' --pool 'maintainers' --github-login your-github-login",
+		"Then retry: octopool login 'https://octopool.dev'",
+		"req-123",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in error:\n%s", want, got)
+		}
+	}
+}
+
+func TestFormatLoginFailureQuotesProvisioningCommandArguments(t *testing.T) {
+	err := formatLoginFailure(403, []byte(`{"error":{"code":"caller_not_provisioned","message":"Caller is not provisioned for this pool"}}`), "/bin/gh", "https://octopool.dev/path;echo pwned", "maintainers'$(touch /tmp/pwned)")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	got := err.Error()
+	for _, want := range []string{
+		"--url 'https://octopool.dev/path;echo pwned'",
+		"--pool 'maintainers'\"'\"'$(touch /tmp/pwned)'",
+		"Then retry: octopool login 'https://octopool.dev/path;echo pwned'",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in error:\n%s", want, got)
+		}
 	}
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -56,6 +56,15 @@ octopool login --server https://octopool.your-org.dev
   login, timestamp).
 - Octopool validates the GitHub identity and OpenClaw org membership during login, and
   binds the caller by immutable GitHub user id. See [Auth](auth.md).
+- Login does not self-provision access. If the CLI reports `caller_not_provisioned`, ask
+  an Octopool admin to grant your GitHub account to that pool:
+
+```sh
+OCTOPOOL_ADMIN_TOKEN=... octopool admin caller \
+  --url https://octopool.your-org.dev \
+  --pool <pool-name> \
+  --github-login your-github-login
+```
 
 ```sh
 octopool login


### PR DESCRIPTION
## Motivation

On a first install, `octopool login` can fail with an internal provisioning error and no actionable next step:

```sh
dallin@Dallins-MacBook-Pro-3 ~ % octopool login
error: login failed: caller_not_provisioned: Caller is not provisioned for this pool
Octopool request id: 3b297c6b-ab19-4570-91e3-a233ba912405
```

## Summary
- Show actionable admin provisioning guidance for caller_not_provisioned login failures
- Include the discovered server URL and pool in the retry/admin command
- Shell-quote dynamic command arguments and cover metacharacters in regression tests
- Document that login requires an existing caller grant
- Use `<pool-name>` in docs snippets where the caller grant depends on the deployment
- Keep release-note context in this PR body instead of editing `CHANGELOG.md`

## Behavior proof

Built the CLI from this branch and ran it against a local Octopool-compatible endpoint that returns `caller_not_provisioned` from `/v1/login/github-cli`:

```sh
$ GH_TOKEN=*** octopool login http://127.0.0.1:18787
error: login failed: your GitHub account is not provisioned for Octopool pool "maintainers".
Ask an Octopool admin to grant access with:
OCTOPOOL_ADMIN_TOKEN=... octopool admin caller --url 'http://127.0.0.1:18787' --pool 'maintainers' --github-login your-github-login
Then retry: octopool login 'http://127.0.0.1:18787'
Octopool request id: proof-request-id
```

Exit status: `1`, as expected for a failed login.

## Tests
- go test ./cmd/octopool
- pnpm format:check
