### PR TITLE
ci: update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
           cache: false
@@ -72,7 +72,7 @@ jobs:
         run: pnpm docs:site
 
       - name: Snapshot release build
-        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: "v2.16.0"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,7 +30,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Check out
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,12 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
           cache: false
@@ -68,7 +68,7 @@ jobs:
         run: cp .goreleaser.yaml /tmp/.goreleaser.yaml
 
       - name: GoReleaser
-        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: "v2.16.0"


### PR DESCRIPTION
## Summary

- pin `actions/checkout` v7.0.0 across CI, Pages, and release workflows
- pin `actions/setup-go` v6.5.0 across CI and release workflows
- pin `goreleaser/goreleaser-action` v7.2.3 across snapshot and release builds

These releases include upstream dependency, audit, and checkout-hardening updates. Every action remains pinned to the exact release commit.

## Validation

- structured Codex autoreview: clean, no actionable findings
- `pnpm check`
- workflow YAML parse
- `actionlint` (only the pre-existing SC2129 style note in the unchanged release script)
- `pnpm audit --json` (0 vulnerabilities)
- `govulncheck ./...` (no vulnerabilities)
- `pnpm e2e` (live `octopool.dev` smoke passed)

`pnpm test:e2e:cli-worker` reached the expected local Worker but could not prove its anonymous GitHub API cache miss because the local egress quota was exhausted (`0/60`); GitHub HTML and raw transports remained healthy. PR CI provides the exact action-run and snapshot-release proof.
