### PR TITLE
feat: retry transient pool fallbacks, relay GET /user, widen stale serving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 0.4.3 - Unreleased
 
+### Changes
+
+- Relay `GET /user` as the caller's public profile served token-free, so `gh api user` identity probes stop bouncing to local tokens as `route_denied`.
+- Retry transient pool-exhaustion fallbacks (`identities_cooling_down`, `identity_pool_depleted`, `github_identity_depleted`, `github_rate_limited`) against the relay with short backoff before running real `gh`; tune with `OCTOPOOL_RELAY_RETRIES`.
+- Serve bounded stale cache entries for token-free-only routes when their public backend is unavailable (`web_only_unavailable`) instead of forcing a local fallback.
+- Extend the active workflow-run-list cache TTL from 30s to 45s so concurrent CI polling sessions share cache entries.
+
 ## 0.4.2 - 2026-07-04
 
 ### Fixes

--- a/cmd/octopool/gh_relay.go
+++ b/cmd/octopool/gh_relay.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
+	"time"
 )
 
 type relayEnvelope struct {
@@ -52,7 +54,61 @@ func newGHRelayClient() (ghRelayClient, error) {
 	return ghRelayClient{token: token, baseURL: baseURL, pool: pool}, nil
 }
 
+// Transient pool-exhaustion fallbacks are retried against the relay before the
+// CLI gives up and burns the caller's local token: a concurrent session often
+// fills the shared cache (or an identity cooldown resets) within seconds.
+var relayRetryDelays = []time.Duration{time.Second, 3 * time.Second}
+
+func transientFallbackReason(reason string) bool {
+	switch reason {
+	case "identities_cooling_down", "identity_pool_depleted",
+		"github_identity_depleted", "github_rate_limited":
+		return true
+	default:
+		return false
+	}
+}
+
+func relayRetryAttempts() int {
+	raw := strings.TrimSpace(os.Getenv("OCTOPOOL_RELAY_RETRIES"))
+	if raw == "" {
+		return len(relayRetryDelays)
+	}
+	parsed, err := strconv.Atoi(raw)
+	if err != nil || parsed < 0 {
+		return len(relayRetryDelays)
+	}
+	return parsed
+}
+
 func (client ghRelayClient) do(ctx context.Context, request ghAPIRequest) (relayEnvelope, error) {
+	retries := relayRetryAttempts()
+	for attempt := 0; ; attempt++ {
+		envelope, err := client.doOnce(ctx, request)
+		var fallback localFallbackError
+		if err == nil || attempt >= retries ||
+			!errors.As(err, &fallback) || !transientFallbackReason(fallback.Reason) {
+			return envelope, err
+		}
+		delay := relayRetryDelays[min(attempt, len(relayRetryDelays)-1)]
+		if !sleepContext(ctx, delay) {
+			return envelope, err
+		}
+	}
+}
+
+func sleepContext(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func (client ghRelayClient) doOnce(ctx context.Context, request ghAPIRequest) (relayEnvelope, error) {
 	body := map[string]any{
 		"pool":   client.pool,
 		"method": request.method,

--- a/cmd/octopool/gh_relay_client_test.go
+++ b/cmd/octopool/gh_relay_client_test.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestWriteGHBodyAllowsNullTextBody(t *testing.T) {
@@ -35,6 +37,74 @@ func TestGHRelayClientInvalidAuthUsesLocalFallback(t *testing.T) {
 	_, err := client.do(t.Context(), ghAPIRequest{method: "GET", path: "/repos/openclaw/openclaw"})
 	if !isLocalFallback(err) {
 		t.Fatalf("expected local fallback, got %v", err)
+	}
+}
+
+func TestGHRelayClientRetriesTransientFallback(t *testing.T) {
+	restoreDelays := relayRetryDelays
+	relayRetryDelays = []time.Duration{time.Millisecond, time.Millisecond}
+	t.Cleanup(func() { relayRetryDelays = restoreDelays })
+
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) < 3 {
+			w.WriteHeader(http.StatusFailedDependency)
+			_, _ = w.Write([]byte(`{"error":{"code":"fallback_local","message":"Run locally","details":{"reason":"identities_cooling_down"}}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"status":200,"body":{"ok":true},"body_encoding":"json"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := ghRelayClient{token: "token", baseURL: server.URL, pool: "maintainers"}
+	envelope, err := client.do(t.Context(), ghAPIRequest{method: "GET", path: "/repos/openclaw/openclaw"})
+	if err != nil {
+		t.Fatalf("expected retry success, got %v", err)
+	}
+	if envelope.Status != 200 {
+		t.Fatalf("status = %d", envelope.Status)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("calls = %d", got)
+	}
+}
+
+func TestGHRelayClientDoesNotRetryStructuralFallback(t *testing.T) {
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusFailedDependency)
+		_, _ = w.Write([]byte(`{"error":{"code":"fallback_local","message":"Run locally","details":{"reason":"route_denied"}}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := ghRelayClient{token: "token", baseURL: server.URL, pool: "maintainers"}
+	_, err := client.do(t.Context(), ghAPIRequest{method: "GET", path: "/repos/openclaw/openclaw"})
+	if !isLocalFallback(err) {
+		t.Fatalf("expected local fallback, got %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("calls = %d", got)
+	}
+}
+
+func TestGHRelayClientRetriesDisabledByEnv(t *testing.T) {
+	t.Setenv("OCTOPOOL_RELAY_RETRIES", "0")
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusFailedDependency)
+		_, _ = w.Write([]byte(`{"error":{"code":"fallback_local","message":"Run locally","details":{"reason":"identities_cooling_down"}}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := ghRelayClient{token: "token", baseURL: server.URL, pool: "maintainers"}
+	_, err := client.do(t.Context(), ghAPIRequest{method: "GET", path: "/repos/openclaw/openclaw"})
+	if !isLocalFallback(err) {
+		t.Fatalf("expected local fallback, got %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("calls = %d", got)
 	}
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -255,6 +255,10 @@ These are dev/CI escape hatches, not the everyday UX:
 - `OCTOPOOL_GH_PATH` — path to the real `gh` binary.
 - `OCTOPOOL_NO_FALLBACK=1` — fail instead of running real `gh` after Octopool returns
   `fallback_local`, useful for proving relay/cache coverage.
+- `OCTOPOOL_RELAY_RETRIES` — how many times transient pool-exhaustion fallbacks
+  (`identities_cooling_down`, `identity_pool_depleted`, `github_identity_depleted`,
+  `github_rate_limited`) are retried against the relay (1s, then 3s backoff) before the CLI
+  falls back to real `gh`. Default `2`; `0` disables retries.
 - `OCTOPOOL_ADMIN_TOKEN` — admin token for `octopool admin`.
 - `OCTOPOOL_ALLOW_INSECURE_LOGIN=1` — permit non-HTTPS login for local dev.
 

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -88,6 +88,10 @@ and patch hosts.
 - Public org repository/member/event reads, user/gist collection reads, global metadata reads,
   and public repository metadata collections can be served from unauthenticated GitHub API
   responses before spending pooled identity quota.
+- `GET /user` is relayed as the caller's public profile: Octopool rewrites it to
+  `GET /users/:login` for the authenticated caller and serves it token-free, so identity
+  probes never spend pooled or local quota. Private `/user` fields (plan, private repo
+  counts, email visibility) are not included; callers that need them fall back to real `gh`.
 - `GET /orgs/:org` is intentionally not relayed because authenticated GitHub responses can
   include additional org fields that are not present in unauthenticated public API responses.
 - `GET /users/:login/starred` and `/subscriptions` are intentionally not relayed because
@@ -95,7 +99,8 @@ and patch hosts.
 - `cache` is `hit`, `stale`, `miss`, or `bypass` (conditional, log, large-payload, or
   otherwise non-cacheable request).
 - `stale_ok: true` means an expired public cache entry was served because all eligible
-  identities were depleted, cooling down, missing, or rate-limited. `stale_reason` and
+  identities were depleted, cooling down, missing, or rate-limited, or because a token-free-only
+  route lost its public backend (`web_only_unavailable`). `stale_reason` and
   `cache_expires_at` are included on those responses.
 - `backend` is present as `web` or `github_public` when a cache miss or identity-less cache hit
   was served without a pooled API identity.

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -217,7 +217,9 @@ export function cacheTTLSeconds(route: RouteInfo, response?: GitHubRelayResponse
     case "run":
       return completedRun(response) ? TERMINAL_CI_TTL_SECONDS : 30;
     case "run_list":
-      return completedRunList(response) ? 120 : 30;
+      // 45s active TTL: concurrent sessions poll run lists every 20-30s;
+      // at 30s those polls almost never overlap a fresh entry.
+      return completedRunList(response) ? 120 : 45;
     case "jobs":
       return completedJobs(response) ? TERMINAL_CI_TTL_SECONDS : 30;
     case "checks":

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -80,6 +80,11 @@ export async function relayGitHub(
   if (policy === null) {
     throw new HttpError(404, "pool_not_found", "Pool not found");
   }
+  // `GET /user` is served as the caller's public profile so identity probes
+  // (`gh api user -q .login`) stop bouncing as route_denied onto local tokens.
+  if (relayRequest.path === "/user") {
+    relayRequest.path = `/users/${encodeURIComponent(caller.github_login)}`;
+  }
   const base: RelayBase = {
     env,
     ctx,
@@ -645,6 +650,7 @@ function staleFallbackReason(reason: string): boolean {
     case "identities_cooling_down":
     case "identity_pool_depleted":
     case "no_identity":
+    case "web_only_unavailable":
       return true;
     default:
       return false;

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -206,7 +206,7 @@ describe("github cache policy", () => {
     expect(cacheTTLSeconds(runList, response({ workflow_runs: [{ status: "completed" }] }))).toBe(
       120,
     );
-    expect(cacheTTLSeconds(runList, response({ workflow_runs: [] }))).toBe(30);
+    expect(cacheTTLSeconds(runList, response({ workflow_runs: [] }))).toBe(45);
 
     const checks = classifyRoute(
       validateRelayRequest({

--- a/test/e2e/relay-backends.test.ts
+++ b/test/e2e/relay-backends.test.ts
@@ -1,5 +1,6 @@
 import { env } from "cloudflare:workers";
 import { describe, expect, it, vi } from "vitest";
+import { deleteEdgeJSON } from "../../src/edge-cache";
 import { bearer, jsonResponse, relay, seedPool } from "./harness";
 
 type RelayEnvelope = {
@@ -81,6 +82,78 @@ describe("Worker end-to-end relay backends", () => {
       relay: { backend: "github_public", cache: "hit", route_kind: "user_view" },
     });
     expect(upstream).toHaveBeenCalledTimes(1);
+  });
+
+  it("serves GET /user as the caller's public profile", async () => {
+    await seedPool();
+    const upstream = vi.fn<typeof fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      expect(request.url).toBe("https://api.github.com/users/caller");
+      expect(bearer(request)).toBeUndefined();
+      return jsonResponse({ id: 42, login: "caller" });
+    });
+    vi.stubGlobal("fetch", upstream);
+
+    const response = await relay("/user");
+    expect(await response.json<RelayEnvelope>()).toMatchObject({
+      status: 200,
+      body: { id: 42, login: "caller" },
+      relay: { backend: "github_public", cache: "miss", route_kind: "user_view" },
+    });
+    const cached = await relay("/user");
+    expect(await cached.json<RelayEnvelope>()).toMatchObject({
+      status: 200,
+      relay: { backend: "github_public", cache: "hit", route_kind: "user_view" },
+    });
+    expect(upstream).toHaveBeenCalledTimes(1);
+  });
+
+  it("serves stale cache when a local-only route loses its token-free backend", async () => {
+    await seedPool();
+    const upstream = vi.fn<typeof fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      expect(request.url).toBe("https://api.github.com/users/octocat/repos?type=owner");
+      expect(bearer(request)).toBeUndefined();
+      return jsonResponse([{ id: 1, full_name: "octocat/hello" }], 200, publicRateHeaders());
+    });
+    vi.stubGlobal("fetch", upstream);
+    const primed = await relay("/users/octocat/repos", undefined, {
+      query: { type: "owner" },
+    });
+    expect(primed.status).toBe(200);
+
+    const cacheRow = await env.DB.prepare(
+      "SELECT cache_key FROM github_cache_entries LIMIT 1",
+    ).first<{ cache_key: string }>();
+    expect(cacheRow).not.toBeNull();
+    await env.DB.prepare(
+      `UPDATE github_cache_entries
+       SET expires_at = datetime('now', '-1 second'),
+           stale_expires_at = datetime('now', '+1 hour')
+       WHERE cache_key = ?`,
+    )
+      .bind(cacheRow!.cache_key)
+      .run();
+    await deleteEdgeJSON("github-v1", cacheRow!.cache_key);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => jsonResponse({ message: "unavailable" }, 503)),
+    );
+
+    const response = await relay("/users/octocat/repos", undefined, {
+      query: { type: "owner" },
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json<RelayEnvelope>()).toMatchObject({
+      status: 200,
+      body: [{ id: 1, full_name: "octocat/hello" }],
+      relay: {
+        cache: "stale",
+        route_kind: "user_repo_list",
+        stale_ok: true,
+        stale_reason: "web_only_unavailable",
+      },
+    });
   });
 
   it("returns local fallback when a local-only route has no token-free result", async () => {


### PR DESCRIPTION
## Why

Session-log analysis (Codex + Claude Code, June-July 2026) showed every observed GitHub 403 was a primary rate limit on the caller's personal token, reached through octopool's local-fallback path. Fallback-reason counts from those logs: no_identity 706, route_denied 290, identities_cooling_down 48, web_only_unavailable 18. Live stats showed an 18.9% cache hit rate dominated by concurrent CI polling sessions.

## What

- Relay `GET /user` as the caller's public profile (rewritten to `GET /users/:login`, served token-free). Identity probes (`gh api user -q .login`) stop bouncing as `route_denied` onto local tokens. Private `/user` fields are not included; callers needing them still fall back to real `gh`.
- CLI: retry transient pool-exhaustion fallbacks (`identities_cooling_down`, `identity_pool_depleted`, `github_identity_depleted`, `github_rate_limited`) against the relay with 1s/3s backoff before running real `gh`. A concurrent session often fills the shared cache within seconds, so retrying the relay is cheaper than burning the local token at the worst moment. Tunable via `OCTOPOOL_RELAY_RETRIES` (default 2, 0 disables).
- Serve bounded stale cache for token-free-only routes when their public backend is unavailable (`web_only_unavailable`) instead of forcing local fallback.
- Extend the active workflow-run-list cache TTL from 30s to 45s so 20-30s polling loops from concurrent sessions can share entries (observed 3.6% hit rate on run_list).

## Proof

- `pnpm test` 175 passed, `pnpm test:e2e` 37 passed (new: `/user` rewrite + cached, stale `web_only_unavailable` serving)
- `go test ./...` incl. new retry tests (transient retried, structural not, env disable), `go vet`, `pnpm build`, lint/format/sql/routes checks green
- Codex structured review clean (no actionable findings)
