### PR TITLE
fix: bound gh pr checks PR lookup freshness instead of bypassing the shared cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Extend the active workflow-run-list cache TTL from 30s to 45s so concurrent CI polling sessions share cache entries.
 - Relay `commits/{ref}` reads (commit view, check-runs, check-suites, status, statuses) for branch and tag names instead of denying non-SHA refs to the personal-token fallback, with short ref-scoped cache TTLs while SHA-shaped paths keep their long immutable TTLs.
 
+### Fixes
+
+- Stop `gh pr checks` from bypassing the shared cache on its PR head-SHA lookup: the relay now honors a `cache-control: max-age=N` request directive that treats fresh entries older than `N` seconds as coalesced misses whose refills write through to the shared cache, and the checks flow uses `max-age=20` so concurrent CI-polling sessions share one upstream PR read instead of each forcing a live fetch.
+
 ## 0.4.2 - 2026-07-04
 
 ### Fixes

--- a/cmd/octopool/gh_top_checks.go
+++ b/cmd/octopool/gh_top_checks.go
@@ -9,16 +9,23 @@ import (
 	"strings"
 )
 
+// prChecksMaxPRAgeSeconds bounds how old a relay-cached PR record may be when
+// resolving the head SHA for `gh pr checks`.
+const prChecksMaxPRAgeSeconds = 20
+
 func relayPRChecks(ctx context.Context, stdout io.Writer, repo string, number string, opts ghTopOptions) error {
 	client, err := newGHRelayClient()
 	if err != nil {
 		return err
 	}
-	liveHeaders := map[string]string{"if-none-match": `"octopool-live"`}
+	// Bound the PR lookup's staleness instead of forcing a live read: concurrent
+	// CI-polling sessions coalesce onto one shared-cache fill while the head SHA
+	// stays at most a few seconds behind a push.
+	freshHeaders := map[string]string{"cache-control": "max-age=" + strconv.Itoa(prChecksMaxPRAgeSeconds)}
 	prEnvelope, err := client.do(ctx, ghAPIRequest{
 		method:  "GET",
 		path:    repoPath(repo, "pulls", number),
-		headers: liveHeaders,
+		headers: freshHeaders,
 	})
 	if err != nil {
 		return err

--- a/cmd/octopool/gh_top_pr_test.go
+++ b/cmd/octopool/gh_top_pr_test.go
@@ -66,8 +66,14 @@ func TestRunGHPRChecksUsesCacheableRequests(t *testing.T) {
 				t.Fatalf("unexpected cache-bypass headers: %#v", body["headers"])
 			}
 		}
-		if body["path"] == "/repos/openclaw/octopool/pulls/7" && body["headers"] == nil {
-			t.Fatal("expected live PR head lookup header")
+		if body["path"] == "/repos/openclaw/octopool/pulls/7" {
+			headers, _ := body["headers"].(map[string]any)
+			if headers["cache-control"] != "max-age=20" {
+				t.Fatalf("expected bounded-freshness PR lookup header, got %#v", body["headers"])
+			}
+			if _, ok := headers["if-none-match"]; ok {
+				t.Fatalf("unexpected cache-bypass header: %#v", headers)
+			}
 		}
 		switch body["path"] {
 		case "/repos/openclaw/octopool/pulls/7":

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -41,6 +41,12 @@ Only `200` responses on cacheable routes are stored. The cache is **bypassed** w
 - the route is a log route, large-payload route, or `rate_limit`, or
 - the request carries a conditional header (`if-none-match` / `if-modified-since`).
 
+Cacheable requests can instead bound acceptable staleness with a
+`cache-control: max-age=N` header. A fresh entry older than `N` seconds is treated as a
+miss and refetched, and the refill writes through to the shared cache, so concurrent
+bounded-freshness readers coalesce onto one upstream request rather than each bypassing
+the cache. The CLI's `gh pr checks` resolves the PR head SHA this way with `max-age=20`.
+
 ### Token-free GitHub reads
 
 Before spending a pooled identity, Octopool can use anonymous GitHub API, public page/raw,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -153,8 +153,11 @@ for the common plain-term `-R owner/repo --state ... --json ...` shape. Cache hi
 zero GitHub Search quota; misses use the pool's search bucket. Qualified search syntax
 such as `author:` or custom sort/match flags falls through to the real `gh`. PR search
 supports the issue-like fields returned by GitHub Search; PR-list-only fields such as
-`headRefName` fall through. `gh pr checks` uses the shared cache by default; ask for raw
-`gh api` conditional requests only when freshness matters more than quota.
+`headRefName` fall through. `gh pr checks` uses the shared cache throughout: its PR
+head-SHA lookup sends `cache-control: max-age=20` so concurrent CI-polling sessions share
+one upstream PR read at most 20 seconds old, and the check/status reads for that SHA use
+the normal cache TTLs. Ask for raw `gh api` conditional requests only when instant
+freshness matters more than quota.
 `--jq` runs after `--json` filtering, matching the usual agent workflow for small
 machine-readable reads.
 

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -32,7 +32,12 @@ Request body:
 - `query` values are strings or string arrays. Keys are rejected if they look
   secret-bearing (`token`, `secret`, `password`, `api_key`, …).
 - `headers` are filtered down to `accept`, `x-github-api-version`, `if-none-match`,
-  `if-modified-since`. Everything else is dropped.
+  `if-modified-since`, `cache-control`. Everything else is dropped.
+- A `cache-control: max-age=N` request directive bounds acceptable cache staleness: a
+  fresh shared-cache entry older than `N` seconds is treated as a miss and refilled, and
+  the refill writes through to the shared cache, unlike conditional headers, which bypass
+  it. Other `cache-control` directives are ignored, and the header never varies the cache
+  key or reaches GitHub.
 - `route_hint.pr_head_sha` and closed/merged `route_hint.pr_state` are validated cache
   discriminators for PR file lists.
 - Legacy `route_hint.owner`, `route_hint.repo`, `route_hint.kind`, `cache_key`, and

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -80,7 +80,9 @@ Durable Object partition key: `pool:<pool_id>`.
 12. Always release an owned cache-fill lease.
 
 Conditional, log, large-payload, `rate_limit`, and otherwise non-cacheable requests bypass
-cache. Route-specific bounded stale entries may be served for quota/depletion/cooldown
+cache. A `cache-control: max-age=N` request directive instead treats fresh entries older
+than `N` seconds as coalesced misses whose refills write through to the shared cache.
+Route-specific bounded stale entries may be served for quota/depletion/cooldown
 failures after the same identity and public-proof checks.
 
 ## Relay API

--- a/src/cache-coalesce.ts
+++ b/src/cache-coalesce.ts
@@ -16,6 +16,7 @@ export async function coalesceGitHubCacheMiss(
   options: {
     waitMs?: number;
     pollMs?: number;
+    maxAgeSeconds?: number;
     sleep?: (ms: number) => Promise<void>;
   } = {},
 ): Promise<{ leaseToken?: string; cached?: CachedGitHubResponse }> {
@@ -29,7 +30,7 @@ export async function coalesceGitHubCacheMiss(
   const deadline = Date.now() + waitMs;
   while (Date.now() < deadline) {
     await wait(pollMs);
-    const cached = await readGitHubCache(env, cacheKey);
+    const cached = await readGitHubCache(env, cacheKey, undefined, options.maxAgeSeconds);
     if (cached !== undefined) {
       return { cached };
     }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -60,24 +60,50 @@ export function shouldUseGitHubCache(request: RelayRequest, route: RouteInfo): b
   return headers["if-none-match"] === undefined && headers["if-modified-since"] === undefined;
 }
 
+export function requestCacheMaxAgeSeconds(request: RelayRequest): number | undefined {
+  const cacheControl = request.headers?.["cache-control"];
+  if (cacheControl === undefined) {
+    return undefined;
+  }
+  const match = /(?:^|[,\s])max-age=(\d{1,9})(?:[,\s]|$)/i.exec(cacheControl);
+  return match?.[1] === undefined ? undefined : Number.parseInt(match[1], 10);
+}
+
 export async function readGitHubCache(
   env: Env,
   cacheKey: string,
   ctx?: ExecutionContext,
+  maxAgeSeconds?: number,
 ): Promise<CachedGitHubResponse | undefined> {
   const edge = await readEdgeJSON<CachedGitHubResponse>(EDGE_CACHE_NAMESPACE, cacheKey);
   if (edge !== undefined) {
     if (freshCachedResponse(edge)) {
-      return edge;
+      if (withinRequestedMaxAge(edge, maxAgeSeconds)) {
+        return edge;
+      }
+      // Keep the still-fresh edge copy; another data center may have refilled
+      // D1 more recently, so fall through instead of evicting.
+    } else {
+      await deleteEdgeJSON(EDGE_CACHE_NAMESPACE, cacheKey);
     }
-    await deleteEdgeJSON(EDGE_CACHE_NAMESPACE, cacheKey);
   }
   const row = await env.DB.prepare(queries.readGitHubCache).bind(cacheKey).first<CacheRow>();
   const cached = cacheRowResponse(row);
-  if (cached !== undefined && ctx !== undefined) {
+  if (cached === undefined || !withinRequestedMaxAge(cached, maxAgeSeconds)) {
+    return undefined;
+  }
+  if (ctx !== undefined) {
     ctx.waitUntil(writeEdgeCachedResponse(cacheKey, cached));
   }
   return cached;
+}
+
+function withinRequestedMaxAge(cached: CachedGitHubResponse, maxAgeSeconds?: number): boolean {
+  if (maxAgeSeconds === undefined) {
+    return true;
+  }
+  const createdAt = parseSQLiteTimestamp(cached.created_at);
+  return Number.isFinite(createdAt) && Date.now() - createdAt <= maxAgeSeconds * 1000;
 }
 
 export async function readStaleGitHubCache(

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -290,6 +290,7 @@ function normalizeHeaders(value: unknown): Record<string, string> | undefined {
     "x-github-api-version",
     "if-none-match",
     "if-modified-since",
+    "cache-control",
     "x-octopool-public-shape",
   ]);
   const out: Record<string, string> = {};

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -4,6 +4,7 @@ import {
   githubCacheKey,
   readGitHubCache,
   readStaleGitHubCache,
+  requestCacheMaxAgeSeconds,
   shouldUseGitHubCache,
   writeGitHubCache,
 } from "./cache";
@@ -47,6 +48,7 @@ type RelayBase = {
 type ActiveRelay = RelayBase & {
   route: RouteInfo;
   cacheEnabled: boolean;
+  maxAgeSeconds: number | undefined;
   sharedCacheKey: string | undefined;
   cacheKey: string | undefined;
   attemptedIdentityCacheKeys: { cacheKey: string; identity: Pick<Identity, "id" | "kind"> }[];
@@ -124,6 +126,7 @@ async function prepareRelay(
     ...base,
     route,
     cacheEnabled,
+    maxAgeSeconds: cacheEnabled ? requestCacheMaxAgeSeconds(base.request) : undefined,
     sharedCacheKey: cacheKey,
     cacheKey,
     attemptedIdentityCacheKeys: [],
@@ -202,7 +205,7 @@ async function readCacheEntry(
   cacheKey: string,
   identity: Identity | undefined,
 ): Promise<CachedGitHubResponse | undefined> {
-  const cached = await readGitHubCache(state.env, cacheKey, state.ctx);
+  const cached = await readGitHubCache(state.env, cacheKey, state.ctx, state.maxAgeSeconds);
   if (
     cached === undefined ||
     !(await cachedResponseAvailable(
@@ -225,7 +228,12 @@ async function coalesceRelayCacheMiss(
   if (state.cacheKey === undefined) {
     return undefined;
   }
-  const fill = await coalesceGitHubCacheMiss(state.env, state.coordinator, state.cacheKey);
+  const fill = await coalesceGitHubCacheMiss(
+    state.env,
+    state.coordinator,
+    state.cacheKey,
+    state.maxAgeSeconds === undefined ? {} : { maxAgeSeconds: state.maxAgeSeconds },
+  );
   state.cacheFillToken = fill.leaseToken;
   if (
     fill.cached === undefined ||

--- a/test/cache-coalesce.test.ts
+++ b/test/cache-coalesce.test.ts
@@ -44,6 +44,36 @@ describe("cache miss coalescing", () => {
     });
   });
 
+  it("ignores published entries older than the requested max-age while waiting", async () => {
+    const coordinator = {
+      claimCacheFill: vi.fn(async () => null),
+      finishCacheFill: vi.fn(async () => undefined),
+    };
+    const aged = {
+      status: 200,
+      response_headers_json: "{}",
+      body_json: '{"head":{"sha":"old"}}',
+      body_encoding: "json",
+      identity_id: null,
+      identity_kind: null,
+      created_at: sqliteUTC(Date.now() - 60_000),
+      expires_at: sqliteUTC(Date.now() + 60_000),
+    };
+    const result = await coalesceGitHubCacheMiss(
+      env([aged, aged, aged]),
+      coordinator as never,
+      "cache-key",
+      {
+        waitMs: 3,
+        pollMs: 1,
+        maxAgeSeconds: 20,
+        sleep: async () => undefined,
+      },
+    );
+
+    expect(result).toEqual({});
+  });
+
   it("only releases fills owned by the current request", async () => {
     const coordinator = {
       claimCacheFill: vi.fn(async () => "leader-token"),
@@ -76,6 +106,13 @@ describe("cache miss coalescing", () => {
     consoleError.mockRestore();
   });
 });
+
+function sqliteUTC(ms: number): string {
+  return new Date(ms)
+    .toISOString()
+    .replace("T", " ")
+    .replace(/\.\d{3}Z$/, "");
+}
 
 function env(rows: unknown[]): Env {
   let index = 0;

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -5,6 +5,7 @@ import {
   pruneExpiredGitHubCache,
   readGitHubCache,
   readStaleGitHubCache,
+  requestCacheMaxAgeSeconds,
   shouldUseGitHubCache,
   staleCacheSeconds,
   writeGitHubCache,
@@ -168,6 +169,115 @@ describe("github cache policy", () => {
     await expect(githubCacheKey("maintainers", request, route)).resolves.not.toBe(
       await githubCacheKey("maintainers", request, route, { id: "primary", kind: "pat" }),
     );
+  });
+
+  it("keeps max-age requests cacheable with an unchanged cache key", async () => {
+    const bounded = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/openclaw/pulls/85341",
+      headers: { "cache-control": "max-age=20" },
+    });
+    const plain = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/openclaw/pulls/85341",
+    });
+    const route = classifyRoute(bounded, policy);
+    expect(shouldUseGitHubCache(bounded, route)).toBe(true);
+    await expect(githubCacheKey("maintainers", bounded, route)).resolves.toBe(
+      await githubCacheKey("maintainers", plain, classifyRoute(plain, policy)),
+    );
+  });
+
+  it("parses the max-age request directive", () => {
+    const request = (headers?: Record<string, string>) =>
+      validateRelayRequest({
+        pool: "maintainers",
+        method: "GET",
+        path: "/repos/openclaw/openclaw/pulls/85341",
+        ...(headers === undefined ? {} : { headers }),
+      });
+    expect(requestCacheMaxAgeSeconds(request())).toBeUndefined();
+    expect(requestCacheMaxAgeSeconds(request({ "cache-control": "max-age=20" }))).toBe(20);
+    expect(requestCacheMaxAgeSeconds(request({ "cache-control": "public, max-age=0" }))).toBe(0);
+    expect(requestCacheMaxAgeSeconds(request({ "cache-control": "no-cache" }))).toBeUndefined();
+    expect(requestCacheMaxAgeSeconds(request({ "cache-control": "max-age=oops" }))).toBeUndefined();
+  });
+
+  it("treats fresh entries beyond the requested max-age as misses", async () => {
+    vi.stubGlobal("caches", {
+      default: {
+        match: vi.fn(async () => undefined),
+        put: vi.fn(async () => undefined),
+        delete: vi.fn(async () => true),
+      },
+    });
+    const env = {
+      DB: {
+        prepare: () => ({
+          bind: () => ({
+            first: async () => ({
+              status: 200,
+              response_headers_json: "{}",
+              body_json: '{"head":{"sha":"abc"}}',
+              body_encoding: "json",
+              identity_id: null,
+              identity_kind: null,
+              created_at: sqliteUTC(Date.now() - 30_000),
+              expires_at: sqliteUTC(Date.now() + 60_000),
+            }),
+          }),
+        }),
+      },
+    } as unknown as Env;
+
+    await expect(readGitHubCache(env, "cache-key", undefined, 60)).resolves.toMatchObject({
+      body: { head: { sha: "abc" } },
+    });
+    await expect(readGitHubCache(env, "cache-key", undefined, 15)).resolves.toBeUndefined();
+  });
+
+  it("falls through a too-old edge entry to a newer D1 fill without evicting it", async () => {
+    const edgeEntry = {
+      status: 200,
+      headers: {},
+      body: { head: { sha: "old" } },
+      body_encoding: "json",
+      created_at: sqliteUTC(Date.now() - 30_000),
+      expires_at: sqliteUTC(Date.now() + 60_000),
+    };
+    const edgeDelete = vi.fn(async () => true);
+    vi.stubGlobal("caches", {
+      default: {
+        match: vi.fn(async () => Response.json(edgeEntry)),
+        put: vi.fn(async () => undefined),
+        delete: edgeDelete,
+      },
+    });
+    const env = {
+      DB: {
+        prepare: () => ({
+          bind: () => ({
+            first: async () => ({
+              status: 200,
+              response_headers_json: "{}",
+              body_json: '{"head":{"sha":"new"}}',
+              body_encoding: "json",
+              identity_id: null,
+              identity_kind: null,
+              created_at: sqliteUTC(Date.now() - 1_000),
+              expires_at: sqliteUTC(Date.now() + 90_000),
+            }),
+          }),
+        }),
+      },
+    } as unknown as Env;
+
+    await expect(readGitHubCache(env, "cache-key", undefined, 15)).resolves.toMatchObject({
+      body: { head: { sha: "new" } },
+    });
+    expect(edgeDelete).not.toHaveBeenCalled();
   });
 
   it("bypasses conditional and rate-limit reads", () => {

--- a/test/e2e/max-age-cache.test.ts
+++ b/test/e2e/max-age-cache.test.ts
@@ -1,0 +1,99 @@
+import { env } from "cloudflare:workers";
+import { describe, expect, it, vi } from "vitest";
+import { deleteEdgeJSON } from "../../src/edge-cache";
+import { jsonResponse, relay, seedPool } from "./harness";
+
+const PR_PATH = "/repos/openclaw/octopool/pulls/42";
+const FIRST_HEAD = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const SECOND_HEAD = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+type RelayEnvelope = {
+  body: { head?: { sha?: string } };
+  relay: { cache: string; route_kind: string };
+};
+
+describe("Worker end-to-end bounded-freshness cache", () => {
+  it("re-fills entries older than the requested max-age through the shared cache", async () => {
+    await seedPool();
+    let prFetches = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        const request = new Request(input, init);
+        const url = new URL(request.url);
+        if (url.pathname === PR_PATH) {
+          prFetches++;
+          return jsonResponse({
+            state: "open",
+            merged_at: null,
+            head: { sha: prFetches === 1 ? FIRST_HEAD : SECOND_HEAD },
+          });
+        }
+        if (url.pathname === "/repos/openclaw/octopool") {
+          return jsonResponse({ private: false });
+        }
+        return jsonResponse({ message: "unexpected upstream request" }, 500);
+      }),
+    );
+    const bounded = { headers: { "cache-control": "max-age=20" } };
+
+    const fill = await relay(PR_PATH, undefined, bounded);
+    expect(await fill.json<RelayEnvelope>()).toMatchObject({
+      body: { head: { sha: FIRST_HEAD } },
+      relay: { cache: "miss", route_kind: "pr_view" },
+    });
+    expect(prFetches).toBe(1);
+
+    const boundedHit = await relay(PR_PATH, undefined, bounded);
+    expect(await boundedHit.json<RelayEnvelope>()).toMatchObject({
+      body: { head: { sha: FIRST_HEAD } },
+      relay: { cache: "hit", route_kind: "pr_view" },
+    });
+    expect(prFetches).toBe(1);
+
+    // Age the shared entry past the freshness bound while its normal TTL stays valid.
+    const cacheRow = await env.DB.prepare(
+      "SELECT cache_key FROM github_cache_entries WHERE route_kind = 'pr_view' LIMIT 1",
+    ).first<{ cache_key: string }>();
+    expect(cacheRow).not.toBeNull();
+    await env.DB.prepare(
+      "UPDATE github_cache_entries SET created_at = datetime('now', '-30 seconds') WHERE cache_key = ?",
+    )
+      .bind(cacheRow!.cache_key)
+      .run();
+    await deleteEdgeJSON("github-v1", cacheRow!.cache_key);
+
+    const unbounded = await relay(PR_PATH);
+    expect(await unbounded.json<RelayEnvelope>()).toMatchObject({
+      body: { head: { sha: FIRST_HEAD } },
+      relay: { cache: "hit", route_kind: "pr_view" },
+    });
+    expect(prFetches).toBe(1);
+
+    const boundedRefill = await relay(PR_PATH, undefined, bounded);
+    expect(await boundedRefill.json<RelayEnvelope>()).toMatchObject({
+      body: { head: { sha: SECOND_HEAD } },
+      relay: { cache: "miss", route_kind: "pr_view" },
+    });
+    expect(prFetches).toBe(2);
+
+    // The bounded refill wrote through, so everyone shares the fresh entry again.
+    const sharedHit = await relay(PR_PATH, undefined, bounded);
+    expect(await sharedHit.json<RelayEnvelope>()).toMatchObject({
+      body: { head: { sha: SECOND_HEAD } },
+      relay: { cache: "hit", route_kind: "pr_view" },
+    });
+    expect(prFetches).toBe(2);
+
+    const audits = await env.DB.prepare(
+      "SELECT cache_status FROM audit_events ORDER BY rowid",
+    ).all<{ cache_status: string }>();
+    expect(audits.results.map(({ cache_status }) => cache_status)).toEqual([
+      "miss",
+      "hit",
+      "hit",
+      "miss",
+      "hit",
+    ]);
+  });
+});

--- a/test/policy.test.ts
+++ b/test/policy.test.ts
@@ -27,6 +27,25 @@ describe("route policy", () => {
     });
   });
 
+  it("keeps cache-control in the filtered request headers", () => {
+    expect(
+      validateRelayRequest({
+        pool: "maintainers",
+        method: "GET",
+        path: "/repos/openclaw/octopool/pulls/1",
+        headers: {
+          "Cache-Control": "max-age=20",
+          "x-unexpected": "dropped",
+        },
+      }),
+    ).toEqual({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/pulls/1",
+      headers: { "cache-control": "max-age=20" },
+    });
+  });
+
   it("allows public user reads", () => {
     for (const path of [
       "/users/openperf",


### PR DESCRIPTION
## Problem

`gh pr checks` is the hottest agent command (heavy 20-150s CI polling loops across up to 9 concurrent sessions), and its PR head-SHA lookup forced a live fetch with `if-none-match: "octopool-live"`. The relay treats conditional headers as a full cache bypass — no shared-cache read *and* no write-back — so every polling session burned an upstream `pr_view` read (live stats: ~299 bypasses/24h on `pr_view`).

## Fix

- The relay now honors a `cache-control: max-age=N` request directive on cacheable routes: a fresh shared-cache entry older than `N` seconds is treated as a **coalesced miss** — the refetch goes through the existing pool-coordinator fill lease and the refill writes through to the shared cache. Unlike a conditional bypass, concurrent bounded-freshness readers share one upstream request and everyone benefits from the refill.
- The directive never varies the cache key and is never forwarded to GitHub; other `cache-control` directives are ignored.
- A too-old-but-still-fresh edge entry falls through to D1 without being evicted, since another data center may hold a newer fill.
- `gh pr checks` sends `cache-control: max-age=20` on the PR lookup. Checks still reflect the head SHA, now at most 20s behind a push — the old bypass showed pending/absent checks right after a push anyway, and polling loops correct within one iteration.
- Version skew degrades gracefully: an older relay drops the header and serves the normal 120s `pr_view` TTL; a newer relay with the old CLI keeps the bypass behavior.

## Tests

- Go: `TestRunGHPRChecksUsesCacheableRequests` now asserts the `cache-control: max-age=20` header and absence of `if-none-match`.
- Unit: directive parsing, unchanged cache key, max-age reads treated as misses, edge fall-through without eviction, coalescing rejects aged fills, header allowlist.
- E2E (`test/e2e/max-age-cache.test.ts`): fill → bounded hit → aged entry served to unbounded readers but refilled for bounded ones → shared hit; audit statuses `miss,hit,hit,miss,hit`.

Docs updated (`cache.md`, `relay.md`, `cli.md`, `spec.md`) plus a 0.4.3 Unreleased changelog entry.

## Proof

- `pnpm test` 186 passed, `pnpm test:e2e` 36 passed, `go test ./...`, `go vet`, tsc build, oxlint, format checks all green.
- Codex autoreview (gpt-5.5, local mode): clean, no actionable findings.
