### PR TITLE
chore: move OpenClaw deployment to the OpenClaw Cloudflare account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changes
 
+- Move the OpenClaw deployment to the OpenClaw Foundation Cloudflare account (new D1 database and Worker); temporarily served from workers.dev until the `octopool.dev` zone moves accounts.
+
 - Relay `GET /user` as the caller's public profile served token-free, so `gh api user` identity probes stop bouncing to local tokens as `route_denied`.
 - Retry transient pool-exhaustion fallbacks (`identities_cooling_down`, `identity_pool_depleted`, `github_identity_depleted`, `github_rate_limited`) against the relay with short backoff before running real `gh`; tune with `OCTOPOOL_RELAY_RETRIES`.
 - Serve bounded stale cache entries for token-free-only routes when their public backend is unavailable (`web_only_unavailable`) instead of forcing a local fallback.

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "octopool",
-  "account_id": "de09342a728de2c25c85cc6b34d68739",
+  "account_id": "91b59577e757131d68d55a471fe32aca",
   "main": "src/index.ts",
   "compatibility_date": "2026-05-26",
   "compatibility_flags": ["nodejs_compat"],
@@ -18,12 +18,10 @@
     "GITHUB_OAUTH_CLIENT_ID": "Iv23lilUVXPNTPhNhUmZ",
     "GITHUB_OAUTH_CALLBACK_ORIGIN": "https://octopool.dev",
   },
-  "routes": [
-    {
-      "pattern": "octopool.dev",
-      "custom_domain": true,
-    },
-  ],
+  "workers_dev": true,
+  // TODO(octopool.dev cutover): restore the custom-domain route once the zone
+  // moves to this account:
+  // "routes": [{ "pattern": "octopool.dev", "custom_domain": true }],
   "triggers": {
     "crons": ["17 * * * *"],
   },
@@ -31,7 +29,7 @@
     {
       "binding": "DB",
       "database_name": "octopool",
-      "database_id": "15066240-b0c6-4f25-bcfb-136dc6ce1bff",
+      "database_id": "28122808-8a3c-4524-a1c0-70b5984744b7",
     },
   ],
   "durable_objects": {


### PR DESCRIPTION
## What

Moves the OpenClaw production deployment of the `octopool` Worker from the personal Cloudflare account to the OpenClaw Foundation account (`91b59577`), where the `octopool-openclaw-proxy` Worker already lives.

- `account_id` → OpenClaw Foundation account
- `database_id` → new D1 `octopool` on that account (all 11 migrations applied remotely)
- Custom-domain route temporarily replaced with `workers_dev` until the `octopool.dev` zone moves accounts; the route is preserved in a comment and will be restored at DNS cutover

## Deployment state (already live)

- Worker deployed: https://octopool.services-91b.workers.dev (version 87201c12)
- All secrets set from 1Password: admin token (new, stored as "Octopool Admin Token (OpenClaw account)"), GitHub App id + PKCS#8 key, OAuth client secret, org verifier token, proxy secret
- GitHub App identity `ghapp_openclaw` (installation 135990630) registered, scope `openclaw`
- Live-verified with the 0.4.3 CLI: `gh api user` served via the new caller-profile relay (no fallback), `gh pr view`, `gh run list`, `octopool stats` all green with `OCTOPOOL_NO_FALLBACK=1`

## Remaining cutover (tracked separately)

1. Add `octopool.dev` as a zone on the OpenClaw account (needs dashboard/API access with zone create)
2. Flip nameservers at Namecheap to the assigned pair
3. Restore the custom-domain route in `wrangler.jsonc` and redeploy
4. Tear down the old Worker + D1 on the personal account
