### PR TITLE
feat: keep repository search token-free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.4.6 - Unreleased
 
+### Changes
+
+- Keep common repo-scoped `gh search issues|prs` reads on the token-free anonymous API and shared cache even when pooled search is disabled, and key hydrated PR file lists by the verified head SHA for longer cache reuse.
+
 ## 0.4.5 - 2026-07-13
 
 ### Changes

--- a/cmd/octopool/gh_api.go
+++ b/cmd/octopool/gh_api.go
@@ -7,11 +7,12 @@ import (
 )
 
 type ghAPIRequest struct {
-	method  string
-	path    string
-	query   map[string]any
-	headers map[string]string
-	jq      string
+	method    string
+	path      string
+	query     map[string]any
+	headers   map[string]string
+	routeHint map[string]string
+	jq        string
 }
 
 func parseGHAPIArgs(args []string) (ghAPIRequest, bool, error) {

--- a/cmd/octopool/gh_relay.go
+++ b/cmd/octopool/gh_relay.go
@@ -120,6 +120,9 @@ func (client ghRelayClient) doOnce(ctx context.Context, request ghAPIRequest) (r
 	if len(request.headers) > 0 {
 		body["headers"] = request.headers
 	}
+	if len(request.routeHint) > 0 {
+		body["route_hint"] = request.routeHint
+	}
 	out, status, err := doRaw(ctx, apiURL(client.baseURL, "/v1/github/request"), client.token, body)
 	if err != nil {
 		return relayEnvelope{}, err

--- a/cmd/octopool/gh_top_pr.go
+++ b/cmd/octopool/gh_top_pr.go
@@ -110,25 +110,29 @@ func relayHydratedPRView(ctx context.Context, stdout io.Writer, repo string, num
 	for _, field := range opts.json {
 		switch field {
 		case "files":
-			files, err := relayPagedArray(ctx, client, repoPath(repo, "pulls", number, "files"))
+			routeHint := map[string]string{}
+			if sha := nestedStringValue(pr, "head", "sha"); sha != "" {
+				routeHint["pr_head_sha"] = sha
+			}
+			files, err := relayPagedArray(ctx, client, repoPath(repo, "pulls", number, "files"), routeHint)
 			if err != nil {
 				return err
 			}
 			pr["files"] = mapPRFiles(files)
 		case "commits":
-			commits, err := relayPagedArray(ctx, client, repoPath(repo, "pulls", number, "commits"))
+			commits, err := relayPagedArray(ctx, client, repoPath(repo, "pulls", number, "commits"), nil)
 			if err != nil {
 				return err
 			}
 			pr["commits"] = mapPRCommits(commits)
 		case "comments":
-			comments, err := relayPagedArray(ctx, client, repoPath(repo, "issues", number, "comments"))
+			comments, err := relayPagedArray(ctx, client, repoPath(repo, "issues", number, "comments"), nil)
 			if err != nil {
 				return err
 			}
 			pr["comments"] = mapPRComments(comments)
 		case "reviews":
-			reviews, err := relayPagedArray(ctx, client, repoPath(repo, "pulls", number, "reviews"))
+			reviews, err := relayPagedArray(ctx, client, repoPath(repo, "pulls", number, "reviews"), nil)
 			if err != nil {
 				return err
 			}
@@ -146,14 +150,15 @@ func relayHydratedPRView(ctx context.Context, stdout io.Writer, repo string, num
 	return writeBytes(ctx, stdout, filtered, opts.jq)
 }
 
-func relayPagedArray(ctx context.Context, client ghRelayClient, path string) ([]any, error) {
+func relayPagedArray(ctx context.Context, client ghRelayClient, path string, routeHint map[string]string) ([]any, error) {
 	items := []any{}
 	complete := false
 	for page := 1; page <= maxRelayPages; page++ {
 		envelope, err := client.do(ctx, ghAPIRequest{
-			method: "GET",
-			path:   path,
-			query:  map[string]any{"per_page": strconv.Itoa(relayPageSize), "page": strconv.Itoa(page)},
+			method:    "GET",
+			path:      path,
+			query:     map[string]any{"per_page": strconv.Itoa(relayPageSize), "page": strconv.Itoa(page)},
+			routeHint: routeHint,
 		})
 		if err != nil {
 			return nil, err

--- a/cmd/octopool/gh_top_pr_test.go
+++ b/cmd/octopool/gh_top_pr_test.go
@@ -14,8 +14,13 @@ func TestRunGHPRViewHydratesDetails(t *testing.T) {
 				"number":   7,
 				"title":    "hydrate pr",
 				"html_url": "https://github.com/openclaw/octopool/pull/7",
+				"head":     map[string]any{"sha": "0123456789abcdef0123456789abcdef01234567"},
 			}
 		case "/repos/openclaw/octopool/pulls/7/files":
+			hint := body["route_hint"].(map[string]any)
+			if hint["pr_head_sha"] != "0123456789abcdef0123456789abcdef01234567" {
+				t.Fatalf("route hint = %#v", hint)
+			}
 			return []map[string]any{{"filename": "cmd/octopool/gh.go"}}
 		case "/repos/openclaw/octopool/pulls/7/commits":
 			return []map[string]any{{"sha": "abc1234"}}

--- a/cmd/octopool/gh_top_search.go
+++ b/cmd/octopool/gh_top_search.go
@@ -150,9 +150,10 @@ func relayGitHubSearch(
 		q += " " + strings.Join(terms, " ")
 	}
 	envelope, err := client.do(ctx, ghAPIRequest{
-		method: "GET",
-		path:   "/search/issues",
-		query:  map[string]any{"q": q, "per_page": strconv.Itoa(desiredLimit(opts))},
+		method:  "GET",
+		path:    "/search/issues",
+		query:   map[string]any{"q": q, "per_page": strconv.Itoa(desiredLimit(opts))},
+		headers: map[string]string{"x-octopool-public-shape": publicShapeIssueSearch},
 	})
 	if err != nil {
 		return err

--- a/cmd/octopool/gh_top_search_test.go
+++ b/cmd/octopool/gh_top_search_test.go
@@ -15,6 +15,10 @@ func TestRunGHSearchIssuesUsesScopedSearchRoute(t *testing.T) {
 		if query["per_page"] != "10" || query["q"] != "repo:openclaw/octopool type:issue cache regression" {
 			t.Fatalf("query = %#v", query)
 		}
+		headers := body["headers"].(map[string]any)
+		if headers["x-octopool-public-shape"] != "issue-search-v1" {
+			t.Fatalf("headers = %#v", headers)
+		}
 		return map[string]any{
 			"items": []map[string]any{{
 				"number":   1,
@@ -39,6 +43,26 @@ func TestRunGHSearchIssuesUsesScopedSearchRoute(t *testing.T) {
 	got := out.String()
 	if !strings.Contains(got, `"number":1`) {
 		t.Fatalf("out = %s", got)
+	}
+}
+
+func TestRunGHSearchUsesTokenFreeShapeForExactRESTFields(t *testing.T) {
+	relayTestServer(t, func(body map[string]any) any {
+		headers := body["headers"].(map[string]any)
+		if headers["x-octopool-public-shape"] != "issue-search-v1" {
+			t.Fatalf("headers = %#v", headers)
+		}
+		return map[string]any{"items": []map[string]any{}}
+	})
+	var out bytes.Buffer
+	result := handleGHSearch(t.Context(), []string{
+		"issues",
+		"cache",
+		"-R", "openclaw/octopool",
+		"--json", "number,title,body",
+	}, &out)
+	if result.err != nil || result.action != ghComplete {
+		t.Fatalf("action=%v err=%v", result.action, result.err)
 	}
 }
 

--- a/cmd/octopool/routes_generated.go
+++ b/cmd/octopool/routes_generated.go
@@ -9,6 +9,7 @@ const (
 	publicShapeActionsJobs        = "actions-jobs-v1"
 	publicShapeIssueSummary       = "issue-summary-v1"
 	publicShapeIssueList          = "issue-list-v1"
+	publicShapeIssueSearch        = "issue-search-v1"
 	publicShapePullRequestList    = "pr-list-v1"
 	publicShapePullRequestSummary = "pr-summary-v1"
 	publicShapeLabelList          = "label-list-v1"

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -51,8 +51,10 @@ the cache. The CLI's `gh pr checks` resolves the PR head SHA this way with `max-
 
 Before spending a pooled identity, Octopool can use anonymous GitHub API, public page/raw,
 and Git smart HTTP endpoints. Successful direct repository-resource responses are themselves
-a public visibility proof; ambiguous search responses still require the explicit repository
-guard. The canonical route-by-route inventory is
+a public visibility proof; ambiguous search responses still require an explicit repository
+guard. Token-free-only shaped repo search uses the public repository page marker for that
+proof, avoiding both pooled identities and the configured verification token. The canonical
+route-by-route inventory is
 [Token-Free GitHub Endpoints](token-free.md).
 
 The main transport classes are:
@@ -103,8 +105,8 @@ Per route kind and response state (`cacheTTLSeconds`):
   remain mutable because new runs can appear
 - PR files with a validated state discriminator → 5m; PR commits, reviews,
   comments, issue comments/events/timeline, and undiscriminated PR files → 1m..5m
-- repository-scoped `gh search issues|prs` shim calls use cacheable GitHub Search
-  requests, with misses accounted against the search bucket
+- supported repository-scoped `gh search issues|prs` shim calls use anonymous API before
+  any allowed search-bucket identity
 - closed PRs/issues → 1h; open PRs → 2m; open issues → 5m
 - release lists/latest → 5m; release by tag/id → 1h
 - immutable commit objects → 24h; commit lists → 5m; contents → 1h
@@ -158,8 +160,9 @@ is public.
   can prove visibility from GitHub's public repository page marker without an API token.
 - A successful anonymous request for a direct repository resource is also accepted as the
   live public proof, so a cache miss does not need a second GitHub metadata request. Search
-  responses still run the explicit visibility check because an empty result does not prove
-  that a `repo:` qualifier names a public repository.
+  responses still run an explicit visibility check because an empty result does not prove
+  that a `repo:` qualifier names a public repository; token-free-only shaped search uses
+  the public repository page marker directly.
 - A successful public check is recorded in `github_public_repos` with a TTL
   (`PUBLIC_REPO_TTL_SECONDS`, default 30s) and the edge cache; subsequent cache hits reuse
   the fresh proof instead of re-hitting GitHub.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -157,10 +157,14 @@ Run views also support the nested `jobs` field; Octopool composes its job/step m
 the cache, exact API responses, or bounded public GitHub pages.
 `gh search issues|prs` is translated to a repo-scoped, cacheable GitHub Search request
 for the common plain-term `-R owner/repo --state ... --json ...` shape. Cache hits cost
-zero GitHub Search quota; misses use the pool's search bucket. Qualified search syntax
+zero GitHub Search quota. All supported search fields use the anonymous GitHub Search API;
+this path remains available when pooled search is disabled and never uses a pooled identity
+or local token. Qualified search syntax
 such as `author:` or custom sort/match flags falls through to the real `gh`. PR search
 supports the issue-like fields returned by GitHub Search; PR-list-only fields such as
-`headRefName` fall through. `gh pr checks` uses the shared cache throughout: its PR
+`headRefName` fall through. Hydrated `gh pr view --json files,...` requests send the
+verified PR head SHA, allowing file pages to share a five-minute state-scoped cache.
+`gh pr checks` uses the shared cache throughout: its PR
 head-SHA lookup sends `cache-control: max-age=60` so concurrent CI-polling sessions share
 one upstream PR read at most 60 seconds old, and the check/status reads for that SHA use
 the normal cache TTLs. Ask for raw `gh api` conditional requests only when instant

--- a/docs/token-free.md
+++ b/docs/token-free.md
@@ -28,6 +28,10 @@ Cache hits are separate: a fresh D1 cache hit contacts no GitHub endpoint.
 - Shaped page fallbacks require an internal `x-octopool-public-shape` header generated
   by supported top-level CLI commands. Raw `gh api` requests do not opt into these
   reduced page shapes.
+- Supported repo-scoped `gh search issues|prs` shapes stay token-free-only when pooled
+  search is disabled: Octopool uses anonymous API and the shared cache, but never a
+  pooled identity or the caller's local token. If anonymous API and bounded stale cache
+  are unavailable, the read fails closed.
 - Only `GET` with the default JSON accept variants is eligible for anonymous API JSON
   fallback.
 
@@ -113,6 +117,10 @@ The guard normally checks `GET https://api.github.com/repos/{owner}/{repo}`. If 
 proof is rate-limited or unavailable, Octopool can inspect
 `https://github.com/{owner}/{repo}` for GitHub's public-repository marker. This proves
 visibility only; it does not provide a relay response.
+Token-free-only shaped search always uses this page-marker proof and never a configured
+verification token.
+Its `issue-search-v1` CLI shape gates an exact first-page anonymous API request; it is not
+a reduced public-page response shape.
 
 ## Anonymous API routes
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -7,6 +7,7 @@ import {
 import { deleteEdgeJSON, readEdgeJSON, writeEdgeJSON } from "./edge-cache";
 import { queries } from "./generated/sql";
 import { defaultGitHubJSONAccept } from "./github-response";
+import { PUBLIC_SHAPES } from "./github-public-shapes";
 import { isRecord } from "./object";
 import { parseSQLiteTimestamp, sqliteTimestamp } from "./sqlite-time";
 import type { GitHubRelayResponse, Identity, RelayRequest, RouteInfo } from "./types";
@@ -285,7 +286,7 @@ function cacheVaryHeaders(headers: RelayRequest["headers"]): Record<string, stri
   if (version !== undefined) {
     out["x-github-api-version"] = version;
   }
-  if (publicShape !== undefined) {
+  if (publicShape !== undefined && publicShape !== PUBLIC_SHAPES.issueSearch) {
     out["x-octopool-public-shape"] = publicShape;
   }
   return out;

--- a/src/github-public-shapes.ts
+++ b/src/github-public-shapes.ts
@@ -3,6 +3,7 @@ export const PUBLIC_SHAPES = {
   actionsJobs: "actions-jobs-v1",
   issueSummary: "issue-summary-v1",
   issueList: "issue-list-v1",
+  issueSearch: "issue-search-v1",
   pullRequestList: "pr-list-v1",
   pullRequestSummary: "pr-summary-v1",
   labelList: "label-list-v1",
@@ -10,3 +11,61 @@ export const PUBLIC_SHAPES = {
   workflowView: "workflow-view-v1",
   releaseSummary: "release-summary-v1",
 } as const;
+
+export function isPublicIssueSearchQuery(
+  query: Record<string, string | string[]> | undefined,
+  owner: string,
+  repo: string,
+): boolean {
+  const allowedKeys = new Set(["q", "per_page", "page"]);
+  if (
+    query === undefined ||
+    Object.entries(query).some(
+      ([key, value]) => !allowedKeys.has(key) || Array.isArray(value) || value === "",
+    ) ||
+    (query.page !== undefined && query.page !== "1")
+  ) {
+    return false;
+  }
+  const perPageText = query.per_page ?? "30";
+  const perPage = Number(perPageText);
+  const raw = query.q;
+  if (
+    typeof perPageText !== "string" ||
+    !/^(?:[1-9]|[1-9][0-9]|100)$/.test(perPageText) ||
+    !Number.isInteger(perPage) ||
+    typeof raw !== "string"
+  ) {
+    return false;
+  }
+  let repoMatches = 0;
+  let typeMatches = 0;
+  let stateMatches = 0;
+  let terms = 0;
+  for (const token of raw.trim().split(/\s+/).filter(Boolean)) {
+    const repoMatch = /^repo:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/i.exec(token);
+    if (repoMatch !== null) {
+      if (
+        repoMatch[1]?.toLowerCase() !== owner.toLowerCase() ||
+        repoMatch[2]?.toLowerCase() !== repo.toLowerCase()
+      ) {
+        return false;
+      }
+      repoMatches++;
+      continue;
+    }
+    if (/^type:(issue|pr)$/i.test(token)) {
+      typeMatches++;
+      continue;
+    }
+    if (/^state:(open|closed)$/i.test(token)) {
+      stateMatches++;
+      continue;
+    }
+    if (!/^[A-Za-z0-9_.-]+$/.test(token) || token.toUpperCase() === "OR") {
+      return false;
+    }
+    terms++;
+  }
+  return repoMatches === 1 && typeMatches === 1 && stateMatches <= 1 && terms >= 1;
+}

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -1,4 +1,5 @@
 import { HttpError } from "./http";
+import { isPublicIssueSearchQuery, PUBLIC_SHAPES } from "./github-public-shapes";
 import { isRecord } from "./object";
 import { ROUTES, routeKeyForMatch, type RouteManifestEntry } from "./route-manifest";
 import type { PoolPolicy, RelayRequest, RouteInfo } from "./types";
@@ -86,9 +87,6 @@ export function classifyRoute(request: RelayRequest, policy: PoolPolicy): RouteI
     if (match === null) {
       continue;
     }
-    if (rule.search === true && !policy.allow_search) {
-      throw new HttpError(403, "search_denied", "Search routes are disabled for this pool");
-    }
     if (rule.logs === true && !policy.allow_logs) {
       throw new HttpError(403, "logs_denied", "Log routes are disabled for this pool");
     }
@@ -105,6 +103,10 @@ export function classifyRoute(request: RelayRequest, policy: PoolPolicy): RouteI
       }
     }
     const searchRepo = searchRepoForRule(rule, request.query);
+    const tokenFreeOnly = !policy.allow_search && tokenFreeSearchRequest(rule, request, searchRepo);
+    if (rule.search === true && !policy.allow_search && !tokenFreeOnly) {
+      throw new HttpError(403, "search_denied", "Search routes are disabled for this pool");
+    }
     if (rule.kind === "search_repositories" && !policy.allow_public_repos) {
       throw new HttpError(
         403,
@@ -132,6 +134,7 @@ export function classifyRoute(request: RelayRequest, policy: PoolPolicy): RouteI
       kind: rule.kind,
       resource: rule.resource,
       routeKey: routeKeyForMatch(request.method, rule, match),
+      ...(tokenFreeOnly ? { tokenFreeOnly: true } : {}),
       publicOnly: !allowedOwner,
       cacheable: rule.cacheable,
       largePayload: rule.largePayload === true,
@@ -147,6 +150,19 @@ export function classifyRoute(request: RelayRequest, policy: PoolPolicy): RouteI
     return info;
   }
   throw new HttpError(403, "route_denied", "Route is not enabled");
+}
+
+function tokenFreeSearchRequest(
+  rule: RouteRule,
+  request: RelayRequest,
+  searchRepo: { owner: string; repo: string } | undefined,
+): boolean {
+  return (
+    rule.kind === "search_issues" &&
+    request.headers?.["x-octopool-public-shape"] === PUBLIC_SHAPES.issueSearch &&
+    searchRepo !== undefined &&
+    isPublicIssueSearchQuery(request.query, searchRepo.owner, searchRepo.repo)
+  );
 }
 
 function repoFromSearchQuery(query: Record<string, string | string[]> | undefined): {

--- a/src/public-repos.ts
+++ b/src/public-repos.ts
@@ -96,6 +96,21 @@ async function refreshPublicGitHubRepoProof(
   route: RouteInfo,
   cacheCreatedAt?: string,
 ): Promise<void> {
+  if (route.tokenFreeOnly) {
+    const pageProof = await fetchPublicRepoPageProof(env, owner, repo);
+    if (pageProof === false) {
+      throw new HttpError(403, "repo_not_public", "Octopool only relays public repositories");
+    }
+    if (pageProof === undefined) {
+      throw new HttpError(
+        502,
+        "repo_public_check_failed",
+        "GitHub public repository page check failed",
+      );
+    }
+    await storePublicRepoProof(env, owner, repo);
+    return;
+  }
   let response = await fetchPublicRepoProof(env, owner, repo, true);
   let historicalProofEligibleResponse: Response | undefined;
   if (!response.ok && publicCheckMayRetryUnauthenticated(response)) {

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -165,6 +165,14 @@ async function executeRelay(state: ActiveRelay): Promise<Response> {
     return web;
   }
 
+  if (state.route.tokenFreeOnly) {
+    const stale = await serveStaleRelayCache(state, "web_only_unavailable");
+    if (stale !== undefined) {
+      return stale;
+    }
+    throw new HttpError(503, "token_free_unavailable", "Token-free GitHub search is unavailable");
+  }
+
   await ensurePublicGitHubRepo(state.env, state.route, undefined, state.coordinator);
   const fallback = capabilitiesForRouteKind(state.route.kind).fallback;
   if (fallback === "local") {

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export type RouteInfo = {
   publicOnly: boolean;
   resource: string;
   routeKey: string;
+  tokenFreeOnly?: boolean;
   state_hint?: string;
   state_hint_source?: "cached" | "live";
   cacheable: boolean;

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -119,6 +119,32 @@ describe("github cache policy", () => {
     );
   });
 
+  it("shares exact search cache entries across the token-free policy shape", async () => {
+    const shaped = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/search/issues",
+      query: { q: "repo:openclaw/openclaw type:issue cache", per_page: "10" },
+      headers: { "x-octopool-public-shape": "issue-search-v1" },
+    });
+    const exact = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/search/issues",
+      query: { q: "repo:openclaw/openclaw type:issue cache", per_page: "10" },
+    });
+
+    await expect(
+      githubCacheKey("maintainers", shaped, classifyRoute(shaped, policy)),
+    ).resolves.toBe(
+      await githubCacheKey(
+        "maintainers",
+        exact,
+        classifyRoute(exact, { ...policy, allow_search: true }),
+      ),
+    );
+  });
+
   it("uses verified PR state hints as cache-key discriminators", async () => {
     const request = validateRelayRequest({
       pool: "maintainers",

--- a/test/e2e/relay-backends.test.ts
+++ b/test/e2e/relay-backends.test.ts
@@ -184,6 +184,107 @@ describe("Worker end-to-end relay backends", () => {
     });
   });
 
+  it("serves policy-disabled repo search from anonymous API and shared cache", async () => {
+    await seedPool();
+    await env.DB.prepare("UPDATE pools SET policy_json = ? WHERE id = 'maintainers'")
+      .bind(
+        JSON.stringify({
+          allowed_owners: ["openclaw"],
+          allow_public_repos: true,
+          allow_search: false,
+          allow_logs: true,
+        }),
+      )
+      .run();
+    const upstream = vi.fn<typeof fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      expect(bearer(request)).toBeUndefined();
+      if (request.url.startsWith("https://api.github.com/search/issues?")) {
+        return jsonResponse(
+          {
+            total_count: 1,
+            incomplete_results: false,
+            items: [{ number: 5, title: "Cache regression", state: "open" }],
+          },
+          200,
+          publicRateHeaders(),
+        );
+      }
+      if (request.url === "https://github.com/openclaw/octopool") {
+        return new Response(
+          '<meta name="octolytics-dimension-repository_public" content="true" />',
+        );
+      }
+      throw new Error(`unexpected upstream ${request.url}`);
+    });
+    vi.stubGlobal("fetch", upstream);
+    const options = {
+      query: {
+        q: "repo:openclaw/octopool type:issue state:open cache",
+        per_page: "10",
+      },
+      headers: { "x-octopool-public-shape": "issue-search-v1" },
+    };
+
+    const first = await relay("/search/issues", undefined, options);
+    expect(await first.json<RelayEnvelope>()).toMatchObject({
+      body: { total_count: 1, items: [{ number: 5, title: "Cache regression" }] },
+      relay: { backend: "web", cache: "miss", route_kind: "search_issues" },
+    });
+    const second = await relay("/search/issues", undefined, options);
+    expect(await second.json<RelayEnvelope>()).toMatchObject({
+      relay: { backend: "web", cache: "hit", route_kind: "search_issues" },
+    });
+    expect(upstream).toHaveBeenCalledTimes(2);
+    expect(
+      await env.DB.prepare(
+        "SELECT COUNT(*) AS count FROM audit_events WHERE identity_id IS NOT NULL",
+      ).first(),
+    ).toEqual({ count: 0 });
+  });
+
+  it("never spends a pooled identity when token-free repo search is unavailable", async () => {
+    await seedPool();
+    await env.DB.prepare("UPDATE pools SET policy_json = ? WHERE id = 'maintainers'")
+      .bind(
+        JSON.stringify({
+          allowed_owners: ["openclaw"],
+          allow_public_repos: true,
+          allow_search: false,
+          allow_logs: true,
+        }),
+      )
+      .run();
+    const upstream = vi.fn<typeof fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      expect(bearer(request)).toBeUndefined();
+      return jsonResponse({ message: "unavailable" }, 503);
+    });
+    vi.stubGlobal("fetch", upstream);
+
+    const response = await relay("/search/issues", undefined, {
+      query: {
+        q: "repo:openclaw/octopool type:issue state:open cache",
+        per_page: "10",
+      },
+      headers: { "x-octopool-public-shape": "issue-search-v1" },
+    });
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      error: { code: "token_free_unavailable" },
+    });
+    expect(upstream).toHaveBeenCalledTimes(1);
+    expect(
+      await env.DB.prepare(
+        "SELECT COUNT(*) AS count FROM audit_events WHERE identity_id IS NOT NULL",
+      ).first(),
+    ).toEqual({ count: 0 });
+    expect(
+      await env.DB.prepare("SELECT status, error_code, fallback_reason FROM audit_events").first(),
+    ).toEqual({ status: 503, error_code: "token_free_unavailable", fallback_reason: null });
+  });
+
   it("normalizes policy denial to local fallback and records a denied audit", async () => {
     await seedPool();
     await env.DB.prepare("UPDATE pools SET policy_json = ? WHERE id = 'maintainers'")

--- a/test/policy.test.ts
+++ b/test/policy.test.ts
@@ -437,6 +437,42 @@ describe("route policy", () => {
     });
   });
 
+  it("allows shaped repo search only through token-free backends", () => {
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/search/issues",
+      query: { q: "repo:openclaw/openclaw type:issue state:open cache" },
+      headers: { "x-octopool-public-shape": "issue-search-v1" },
+    });
+    expect(classifyRoute(request, policy)).toMatchObject({
+      kind: "search_issues",
+      owner: "openclaw",
+      repo: "openclaw",
+      tokenFreeOnly: true,
+    });
+    expect(classifyRoute(request, { ...policy, allow_search: true })).not.toHaveProperty(
+      "tokenFreeOnly",
+    );
+
+    for (const query of [
+      { q: "repo:openclaw/openclaw cache" },
+      { q: "repo:openclaw/openclaw type:issue cache", page: "2" },
+      { q: "repo:openclaw/openclaw type:issue cache", per_page: "1e2" },
+      { q: "repo:openclaw/openclaw type:issue cache", sort: "updated" },
+      { q: "repo:openclaw/openclaw type:issue author:octocat cache" },
+    ]) {
+      const invalid = validateRelayRequest({
+        pool: "maintainers",
+        method: "GET",
+        path: "/search/issues",
+        query,
+        headers: { "x-octopool-public-shape": "issue-search-v1" },
+      });
+      expect(() => classifyRoute(invalid, policy)).toThrow();
+    }
+  });
+
   it("allows plain repository search when search is enabled", () => {
     const request = validateRelayRequest({
       pool: "maintainers",


### PR DESCRIPTION
## What Problem This Solves

Supported repository-scoped `gh search issues|prs` reads fell back to the caller's GitHub token whenever pooled search was disabled. Hydrated PR file reads also omitted the available PR head SHA, keeping those cache entries on the shorter undiscriminated lifetime.

## Why This Change Was Made

Exact first-page CLI search shapes now use anonymous GitHub Search plus the shared cache even when pooled search is disabled. The worker validates the complete query shape, proves repository visibility without a verification token, shares exact REST cache entries with policy-enabled searches, and fails closed instead of invoking a pooled or local identity when token-free backends and stale cache are unavailable. Hydrated PR file pagination now carries the verified head SHA into the existing state-scoped cache path.

Public GitHub issue pages were tested as a possible search backend and deliberately excluded: they could not guarantee the Search API's result ordering and exact output contract.

## User Impact

Common agent search reads no longer spend personal or pooled GitHub tokens under the default disabled-search policy. Repeated searches share exact cached responses, and repeated hydrated PR file reads can reuse a five-minute head-scoped entry.

## Evidence

- `pnpm check` — 188 unit tests, 40 Worker E2E tests, generated checks, lint, TypeScript build, Go tests, and Go vet passed.
- `pnpm test:e2e:cli-worker` — compiled CLI to local Worker token-free miss plus D1/edge hit passed.
- Source-blind behavior validation — repeated live public searches produced a miss then hit with no identity, changed terms changed results, token-free failure did not invoke the configured real-`gh` fixture, and PR files produced a miss then hit with a 300-second cache lifetime.
- Autoreview — clean after query validation, exact-output, and fail-closed corrections.
