### PR TITLE
feat: relay-backed watch and pagination to stop personal-quota drain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ worker-configuration.d.ts
 dist/
 bin/
 *.test
+/octopool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.4.7 - Unreleased
 
+### Changes
+
+- Keep bounded `gh api --paginate` and `--slurp` GET reads on the shared relay cache, falling back to real `gh` after 10 pages.
+
 ### Fixes
 
 - Make every Octopool subcommand help flag exit successfully with command-specific usage and flag details instead of reporting `flag: help requested`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Make every Octopool subcommand help flag exit successfully with command-specific usage and flag details instead of reporting `flag: help requested`.
+- Keep `gh run watch` and `gh pr checks --watch` on relay-cached polling with a 30-second interval floor and backoff to 120 seconds instead of draining personal GitHub API quota.
 
 ## 0.4.6 - 2026-07-13
 

--- a/cmd/octopool/gh.go
+++ b/cmd/octopool/gh.go
@@ -10,7 +10,7 @@ import (
 
 func runGH(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) error {
 	if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
-		fmt.Fprintln(stdout, "usage: octopool gh api <GET path> [--jq expr]")
+		fmt.Fprintln(stdout, "usage: octopool gh api <GET path> [--paginate] [--slurp] [--jq expr]")
 		fmt.Fprintln(stdout, "       octopool gh pr|issue|run|repo|release|workflow|label|gist|search ...")
 		return nil
 	}
@@ -40,12 +40,22 @@ func runGH(ctx context.Context, args []string, stdout io.Writer, stderr io.Write
 	if err != nil {
 		return err
 	}
-	if fallback || !safeRelayRequest(request) || request.jq != "" && !jqAvailable() {
+	if request.paginate {
+		request = prepareGHAPIPagination(request)
+	}
+	if fallback || request.method != "GET" || !safeRelayRequest(request) || request.jq != "" && !jqAvailable() {
 		return execRealGH(ctx, args, stdout, stderr)
 	}
 	client, err := newGHRelayClient()
 	if err != nil {
 		if shouldRunRealGH(err) {
+			return execRealGHAfterLocalFallback(ctx, args, stdout, stderr, err)
+		}
+		return err
+	}
+	if request.paginate {
+		err = relayPaginatedGHAPI(ctx, client, request, stdout)
+		if err != nil && shouldRunRealGH(err) {
 			return execRealGHAfterLocalFallback(ctx, args, stdout, stderr, err)
 		}
 		return err

--- a/cmd/octopool/gh.go
+++ b/cmd/octopool/gh.go
@@ -27,11 +27,11 @@ func runGH(ctx context.Context, args []string, stdout io.Writer, stderr io.Write
 			return nil
 		case ghFail:
 			if shouldRunRealGH(result.err) {
-				return execRealGHAfterLocalFallback(ctx, args, stdout, stderr, result.err)
+				return execRealGHAfterLocalFallback(ctx, floorGHWatchDelegateArgs(args), stdout, stderr, result.err)
 			}
 			return result.err
 		case ghDelegate:
-			return execRealGH(ctx, args, stdout, stderr)
+			return execRealGH(ctx, floorGHWatchDelegateArgs(args), stdout, stderr)
 		default:
 			return errors.New("invalid gh dispatch outcome")
 		}

--- a/cmd/octopool/gh_api.go
+++ b/cmd/octopool/gh_api.go
@@ -100,6 +100,9 @@ func parseGHAPIArgs(args []string) (ghAPIRequest, bool, error) {
 	if request.slurp && !request.paginate {
 		return request, false, errors.New("--slurp requires --paginate")
 	}
+	if request.slurp && request.jq != "" {
+		return request, false, errors.New("the `--slurp` option is not supported with `--jq` or `--template`")
+	}
 	if request.path == "" {
 		return request, false, errors.New("gh api path is required")
 	}

--- a/cmd/octopool/gh_api.go
+++ b/cmd/octopool/gh_api.go
@@ -13,6 +13,8 @@ type ghAPIRequest struct {
 	headers   map[string]string
 	routeHint map[string]string
 	jq        string
+	paginate  bool
+	slurp     bool
 }
 
 func parseGHAPIArgs(args []string) (ghAPIRequest, bool, error) {
@@ -49,7 +51,11 @@ func parseGHAPIArgs(args []string) (ghAPIRequest, bool, error) {
 				}
 				request.headers[header] = strings.TrimSpace(value)
 			}
-		case "-f", "-F", "--field", "--raw-field", "--paginate", "--slurp":
+		case "--paginate":
+			request.paginate = true
+		case "--slurp":
+			request.slurp = true
+		case "-f", "-F", "--field", "--raw-field":
 			return request, true, nil
 		default:
 			if strings.HasPrefix(arg, "--method=") {
@@ -90,6 +96,9 @@ func parseGHAPIArgs(args []string) (ghAPIRequest, bool, error) {
 				}
 			}
 		}
+	}
+	if request.slurp && !request.paginate {
+		return request, false, errors.New("--slurp requires --paginate")
 	}
 	if request.path == "" {
 		return request, false, errors.New("gh api path is required")

--- a/cmd/octopool/gh_api_pagination.go
+++ b/cmd/octopool/gh_api_pagination.go
@@ -34,6 +34,11 @@ func relayPaginatedGHAPI(
 	perPage, validPerPage := positiveQueryInt(request.query["per_page"])
 	page, validPage := positiveQueryInt(request.query["page"])
 	state := ghAPIPaginationState{}
+	if validPerPage && validPage {
+		// total_count covers the whole collection; count the pages a
+		// caller-supplied start page skipped so has-next stays accurate.
+		state.objectItems = (page - 1) * perPage
+	}
 	pages := make([]relayEnvelope, 0, maxRelayPages)
 
 	for pageIndex := 0; pageIndex < maxRelayPages; pageIndex++ {
@@ -44,15 +49,20 @@ func relayPaginatedGHAPI(
 		if envelope.Status >= 400 {
 			return writeGHBody(ctx, stdout, envelope, request.jq)
 		}
-		pages = append(pages, envelope)
 
 		hasNext := false
+		empty := false
 		if envelope.BodyEncoding == "json" && validPerPage && validPage {
 			body, decodeErr := decodeRelayBody(envelope)
 			if decodeErr != nil {
 				return decodeErr
 			}
-			hasNext = relayPageHasNext(body, perPage, &state)
+			hasNext, empty = relayPageHasNext(body, perPage, &state)
+		}
+		// A full previous page forces one probe fetch; when the probe comes
+		// back empty it carries no data and must not appear in the output.
+		if !empty || pageIndex == 0 {
+			pages = append(pages, envelope)
 		}
 		if !hasNext {
 			return writeGHAPIPages(ctx, stdout, pages, request.jq, request.slurp)
@@ -76,18 +86,18 @@ func positiveQueryInt(value any) (int, bool) {
 	return parsed, err == nil && parsed > 0
 }
 
-func relayPageHasNext(body []byte, perPage int, state *ghAPIPaginationState) bool {
+func relayPageHasNext(body []byte, perPage int, state *ghAPIPaginationState) (hasNext bool, empty bool) {
 	var value any
 	if err := json.Unmarshal(body, &value); err != nil {
-		return false
+		return false, false
 	}
 	switch typed := value.(type) {
 	case []any:
-		return len(typed) == perPage
+		return len(typed) == perPage, len(typed) == 0
 	case map[string]any:
 		totalCount, ok := jsonNumericInt(typed["total_count"])
 		if !ok {
-			return false
+			return false, false
 		}
 		arrayKey := ""
 		pageItems := 0
@@ -100,23 +110,23 @@ func relayPageHasNext(body []byte, perPage int, state *ghAPIPaginationState) boo
 				continue
 			}
 			if arrayKey != "" {
-				return false
+				return false, false
 			}
 			arrayKey = key
 			pageItems = len(items)
 		}
 		if arrayKey == "" {
-			return false
+			return false, false
 		}
 		if state.objectArrayKey == "" {
 			state.objectArrayKey = arrayKey
 		} else if state.objectArrayKey != arrayKey {
-			return false
+			return false, false
 		}
 		state.objectItems += pageItems
-		return state.objectItems < totalCount && pageItems > 0
+		return state.objectItems < totalCount && pageItems > 0, pageItems == 0
 	default:
-		return false
+		return false, false
 	}
 }
 
@@ -139,27 +149,59 @@ func writeGHAPIPages(
 	jq string,
 	slurp bool,
 ) error {
-	var output bytes.Buffer
-	if slurp {
-		output.WriteByte('[')
-	}
-	for index, envelope := range pages {
+	bodies := make([][]byte, 0, len(pages))
+	for _, envelope := range pages {
 		body, err := decodeRelayBody(envelope)
 		if err != nil {
 			return err
 		}
-		if slurp {
-			if !json.Valid(body) {
-				return errors.New("cannot slurp a non-JSON response")
-			}
+		if slurp && !json.Valid(body) {
+			return errors.New("cannot slurp a non-JSON response")
+		}
+		bodies = append(bodies, body)
+	}
+	var output bytes.Buffer
+	switch {
+	case slurp:
+		output.WriteByte('[')
+		for index, body := range bodies {
 			if index > 0 {
 				output.WriteByte(',')
 			}
+			output.Write(body)
 		}
-		output.Write(body)
-	}
-	if slurp {
 		output.WriteByte(']')
+	case mergedArrayPages(bodies, &output):
+		// real gh coalesces paginated REST array pages into one JSON array.
+	default:
+		for _, body := range bodies {
+			output.Write(body)
+		}
 	}
 	return writeBytes(ctx, stdout, output.Bytes(), jq)
+}
+
+// mergedArrayPages writes one combined JSON array when every page is a
+// top-level array, matching real gh's --paginate output for REST lists.
+func mergedArrayPages(bodies [][]byte, output *bytes.Buffer) bool {
+	interiors := make([][]byte, 0, len(bodies))
+	for _, body := range bodies {
+		trimmed := bytes.TrimSpace(body)
+		if len(trimmed) < 2 || trimmed[0] != '[' || trimmed[len(trimmed)-1] != ']' {
+			return false
+		}
+		interior := bytes.TrimSpace(trimmed[1 : len(trimmed)-1])
+		if len(interior) > 0 {
+			interiors = append(interiors, interior)
+		}
+	}
+	output.WriteByte('[')
+	for index, interior := range interiors {
+		if index > 0 {
+			output.WriteByte(',')
+		}
+		output.Write(interior)
+	}
+	output.WriteByte(']')
+	return true
 }

--- a/cmd/octopool/gh_api_pagination.go
+++ b/cmd/octopool/gh_api_pagination.go
@@ -160,6 +160,16 @@ func writeGHAPIPages(
 		}
 		bodies = append(bodies, body)
 	}
+	// real gh evaluates --jq once per response page; only --slurp collapses
+	// the pages into a single jq input.
+	if jq != "" && !slurp {
+		for _, body := range bodies {
+			if err := writeBytes(ctx, stdout, body, jq); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
 	var output bytes.Buffer
 	switch {
 	case slurp:

--- a/cmd/octopool/gh_api_pagination.go
+++ b/cmd/octopool/gh_api_pagination.go
@@ -201,7 +201,10 @@ func writeGHAPIPages(
 }
 
 // mergedArrayPages writes one combined JSON array when every page is a
-// top-level array, matching real gh's --paginate output for REST lists.
+// top-level array. This matches real gh, verified empirically: `gh api
+// 'repos/o/r/labels?per_page=4' --paginate` over 3 pages emits ONE array
+// (`jq -s length` == 1) — gh coalesces REST array pages unless --slurp asks
+// for an array of pages.
 func mergedArrayPages(bodies [][]byte, output *bytes.Buffer) bool {
 	interiors := make([][]byte, 0, len(bodies))
 	for _, body := range bodies {

--- a/cmd/octopool/gh_api_pagination.go
+++ b/cmd/octopool/gh_api_pagination.go
@@ -16,7 +16,11 @@ type ghAPIPaginationState struct {
 }
 
 func prepareGHAPIPagination(request ghAPIRequest) ghAPIRequest {
-	if _, ok := request.query["per_page"]; !ok {
+	if raw, ok := request.query["per_page"]; !ok {
+		request.query["per_page"] = strconv.Itoa(relayPageSize)
+	} else if perPage, valid := positiveQueryInt(raw); valid && perPage > relayPageSize {
+		// GitHub caps per_page at 100; clamping keeps the short-page has-next
+		// inference sound instead of stopping after one silently capped page.
 		request.query["per_page"] = strconv.Itoa(relayPageSize)
 	}
 	if _, ok := request.query["page"]; !ok {

--- a/cmd/octopool/gh_api_pagination.go
+++ b/cmd/octopool/gh_api_pagination.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"math"
+	"strconv"
+)
+
+type ghAPIPaginationState struct {
+	objectArrayKey string
+	objectItems    int
+}
+
+func prepareGHAPIPagination(request ghAPIRequest) ghAPIRequest {
+	if _, ok := request.query["per_page"]; !ok {
+		request.query["per_page"] = strconv.Itoa(relayPageSize)
+	}
+	if _, ok := request.query["page"]; !ok {
+		request.query["page"] = "1"
+	}
+	return request
+}
+
+func relayPaginatedGHAPI(
+	ctx context.Context,
+	client ghRelayClient,
+	request ghAPIRequest,
+	stdout io.Writer,
+) error {
+	perPage, validPerPage := positiveQueryInt(request.query["per_page"])
+	page, validPage := positiveQueryInt(request.query["page"])
+	state := ghAPIPaginationState{}
+	pages := make([]relayEnvelope, 0, maxRelayPages)
+
+	for pageIndex := 0; pageIndex < maxRelayPages; pageIndex++ {
+		envelope, err := client.do(ctx, request)
+		if err != nil {
+			return err
+		}
+		if envelope.Status >= 400 {
+			return writeGHBody(ctx, stdout, envelope, request.jq)
+		}
+		pages = append(pages, envelope)
+
+		hasNext := false
+		if envelope.BodyEncoding == "json" && validPerPage && validPage {
+			body, decodeErr := decodeRelayBody(envelope)
+			if decodeErr != nil {
+				return decodeErr
+			}
+			hasNext = relayPageHasNext(body, perPage, &state)
+		}
+		if !hasNext {
+			return writeGHAPIPages(ctx, stdout, pages, request.jq, request.slurp)
+		}
+		if pageIndex == maxRelayPages-1 {
+			return localFallbackError{Reason: "pagination_exhausted"}
+		}
+		page++
+		request.query["page"] = strconv.Itoa(page)
+	}
+
+	return localFallbackError{Reason: "pagination_exhausted"}
+}
+
+func positiveQueryInt(value any) (int, bool) {
+	raw, ok := value.(string)
+	if !ok {
+		return 0, false
+	}
+	parsed, err := strconv.Atoi(raw)
+	return parsed, err == nil && parsed > 0
+}
+
+func relayPageHasNext(body []byte, perPage int, state *ghAPIPaginationState) bool {
+	var value any
+	if err := json.Unmarshal(body, &value); err != nil {
+		return false
+	}
+	switch typed := value.(type) {
+	case []any:
+		return len(typed) == perPage
+	case map[string]any:
+		totalCount, ok := jsonNumericInt(typed["total_count"])
+		if !ok {
+			return false
+		}
+		arrayKey := ""
+		pageItems := 0
+		for key, candidate := range typed {
+			if key == "incomplete_results" {
+				continue
+			}
+			items, isArray := candidate.([]any)
+			if !isArray {
+				continue
+			}
+			if arrayKey != "" {
+				return false
+			}
+			arrayKey = key
+			pageItems = len(items)
+		}
+		if arrayKey == "" {
+			return false
+		}
+		if state.objectArrayKey == "" {
+			state.objectArrayKey = arrayKey
+		} else if state.objectArrayKey != arrayKey {
+			return false
+		}
+		state.objectItems += pageItems
+		return state.objectItems < totalCount && pageItems > 0
+	default:
+		return false
+	}
+}
+
+func jsonNumericInt(value any) (int, bool) {
+	number, ok := value.(float64)
+	if !ok || number < 0 || math.Trunc(number) != number {
+		return 0, false
+	}
+	parsed := int(number)
+	if parsed < 0 || float64(parsed) != number {
+		return 0, false
+	}
+	return parsed, true
+}
+
+func writeGHAPIPages(
+	ctx context.Context,
+	stdout io.Writer,
+	pages []relayEnvelope,
+	jq string,
+	slurp bool,
+) error {
+	var output bytes.Buffer
+	if slurp {
+		output.WriteByte('[')
+	}
+	for index, envelope := range pages {
+		body, err := decodeRelayBody(envelope)
+		if err != nil {
+			return err
+		}
+		if slurp {
+			if !json.Valid(body) {
+				return errors.New("cannot slurp a non-JSON response")
+			}
+			if index > 0 {
+				output.WriteByte(',')
+			}
+		}
+		output.Write(body)
+	}
+	if slurp {
+		output.WriteByte(']')
+	}
+	return writeBytes(ctx, stdout, output.Bytes(), jq)
+}

--- a/cmd/octopool/gh_api_pagination.go
+++ b/cmd/octopool/gh_api_pagination.go
@@ -54,14 +54,19 @@ func relayPaginatedGHAPI(
 			return writeGHBody(ctx, stdout, envelope, request.jq)
 		}
 
-		hasNext := false
-		empty := false
-		if envelope.BodyEncoding == "json" && validPerPage && validPage {
-			body, decodeErr := decodeRelayBody(envelope)
-			if decodeErr != nil {
-				return decodeErr
-			}
-			hasNext, empty = relayPageHasNext(body, perPage, &state)
+		if envelope.BodyEncoding != "json" || !validPerPage || !validPage {
+			return localFallbackError{Reason: "pagination_shape_unsupported"}
+		}
+		body, decodeErr := decodeRelayBody(envelope)
+		if decodeErr != nil {
+			return decodeErr
+		}
+		hasNext, empty, inferable := relayPageHasNext(body, perPage, &state)
+		if !inferable {
+			// Without Link headers the relay can only prove completion for
+			// plain arrays and total_count object lists; anything else (e.g.
+			// compare's total_commits shape) must keep real gh's semantics.
+			return localFallbackError{Reason: "pagination_shape_unsupported"}
 		}
 		// A full previous page forces one probe fetch; when the probe comes
 		// back empty it carries no data and must not appear in the output.
@@ -90,18 +95,18 @@ func positiveQueryInt(value any) (int, bool) {
 	return parsed, err == nil && parsed > 0
 }
 
-func relayPageHasNext(body []byte, perPage int, state *ghAPIPaginationState) (hasNext bool, empty bool) {
+func relayPageHasNext(body []byte, perPage int, state *ghAPIPaginationState) (hasNext bool, empty bool, inferable bool) {
 	var value any
 	if err := json.Unmarshal(body, &value); err != nil {
-		return false, false
+		return false, false, false
 	}
 	switch typed := value.(type) {
 	case []any:
-		return len(typed) == perPage, len(typed) == 0
+		return len(typed) == perPage, len(typed) == 0, true
 	case map[string]any:
 		totalCount, ok := jsonNumericInt(typed["total_count"])
 		if !ok {
-			return false, false
+			return false, false, false
 		}
 		arrayKey := ""
 		pageItems := 0
@@ -114,23 +119,23 @@ func relayPageHasNext(body []byte, perPage int, state *ghAPIPaginationState) (ha
 				continue
 			}
 			if arrayKey != "" {
-				return false, false
+				return false, false, false
 			}
 			arrayKey = key
 			pageItems = len(items)
 		}
 		if arrayKey == "" {
-			return false, false
+			return false, false, false
 		}
 		if state.objectArrayKey == "" {
 			state.objectArrayKey = arrayKey
 		} else if state.objectArrayKey != arrayKey {
-			return false, false
+			return false, false, false
 		}
 		state.objectItems += pageItems
-		return state.objectItems < totalCount && pageItems > 0, pageItems == 0
+		return state.objectItems < totalCount && pageItems > 0, pageItems == 0, true
 	default:
-		return false, false
+		return false, false, false
 	}
 }
 

--- a/cmd/octopool/gh_pagination_test.go
+++ b/cmd/octopool/gh_pagination_test.go
@@ -2,9 +2,307 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
+	"io"
 	"strconv"
+	"strings"
 	"testing"
 )
+
+func TestRunGHAPIPaginatesArrayResponse(t *testing.T) {
+	var queries []map[string]any
+	relayTestServer(t, func(body map[string]any) any {
+		query := body["query"].(map[string]any)
+		queries = append(queries, query)
+		switch query["page"] {
+		case "1":
+			return paginationItems(0, relayPageSize)
+		case "2":
+			return paginationItems(relayPageSize, relayPageSize)
+		default:
+			return paginationItems(2*relayPageSize, 1)
+		}
+	})
+
+	var out bytes.Buffer
+	if err := runGH(t.Context(), []string{
+		"api", "repos/openclaw/octopool/issues", "--paginate",
+	}, &out, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	pages := decodeArrayPageStream(t, out.Bytes())
+	if len(pages) != 3 || len(pages[0]) != 100 || len(pages[1]) != 100 || len(pages[2]) != 1 {
+		t.Fatalf("page lengths = %v", pageLengths(pages))
+	}
+	for index, query := range queries {
+		if query["page"] != strconv.Itoa(index+1) || query["per_page"] != "100" {
+			t.Fatalf("query %d = %#v", index, query)
+		}
+	}
+}
+
+func TestRunGHAPIPaginatesExactMultipleThroughEmptyPage(t *testing.T) {
+	requests := 0
+	relayTestServer(t, func(body map[string]any) any {
+		requests++
+		if body["query"].(map[string]any)["page"] == "1" {
+			return paginationItems(0, relayPageSize)
+		}
+		return []int{}
+	})
+
+	var out bytes.Buffer
+	if err := runGH(t.Context(), []string{
+		"api", "repos/openclaw/octopool/issues", "--paginate",
+	}, &out, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	pages := decodeArrayPageStream(t, out.Bytes())
+	if requests != 2 || len(pages) != 2 || len(pages[0]) != 100 || len(pages[1]) != 0 {
+		t.Fatalf("requests=%d page lengths=%v", requests, pageLengths(pages))
+	}
+}
+
+func TestRunGHAPIPaginatesObjectTotalCountResponse(t *testing.T) {
+	requests := 0
+	relayTestServer(t, func(map[string]any) any {
+		requests++
+		if requests == 1 {
+			return map[string]any{
+				"total_count": 3, "incomplete_results": false,
+				"check_runs": []map[string]any{{"id": 1}, {"id": 2}},
+			}
+		}
+		return map[string]any{
+			"total_count": 3, "incomplete_results": false,
+			"check_runs": []map[string]any{{"id": 3}},
+		}
+	})
+
+	var out bytes.Buffer
+	if err := runGH(t.Context(), []string{
+		"api", "repos/openclaw/octopool/commits/abc1234/check-runs", "--paginate",
+	}, &out, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(out.Bytes()))
+	for expected := 2; expected >= 1; expected-- {
+		var page struct {
+			CheckRuns []map[string]any `json:"check_runs"`
+		}
+		if err := decoder.Decode(&page); err != nil {
+			t.Fatal(err)
+		}
+		if len(page.CheckRuns) != expected {
+			t.Fatalf("check runs = %d, want %d", len(page.CheckRuns), expected)
+		}
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d", requests)
+	}
+}
+
+func TestRunGHAPISlurpWrapsArrayPages(t *testing.T) {
+	relayTestServer(t, func(body map[string]any) any {
+		if body["query"].(map[string]any)["page"] == "1" {
+			return []int{1, 2}
+		}
+		return []int{3}
+	})
+
+	var out bytes.Buffer
+	if err := runGH(t.Context(), []string{
+		"api", "repos/openclaw/octopool/issues?per_page=2", "--paginate", "--slurp",
+	}, &out, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	var pages [][]int
+	if err := json.Unmarshal(out.Bytes(), &pages); err != nil {
+		t.Fatal(err)
+	}
+	if len(pages) != 2 || len(pages[0]) != 2 || len(pages[1]) != 1 {
+		t.Fatalf("pages = %#v", pages)
+	}
+}
+
+func TestRunGHAPISlurpWrapsObjectPages(t *testing.T) {
+	requests := 0
+	relayTestServer(t, func(map[string]any) any {
+		requests++
+		return map[string]any{
+			"total_count": 2,
+			"check_runs":  []map[string]any{{"id": requests}},
+		}
+	})
+
+	var out bytes.Buffer
+	if err := runGH(t.Context(), []string{
+		"api", "repos/openclaw/octopool/commits/abc1234/check-runs", "--paginate", "--slurp",
+	}, &out, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	var pages []struct {
+		CheckRuns []map[string]any `json:"check_runs"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &pages); err != nil {
+		t.Fatal(err)
+	}
+	if len(pages) != 2 || len(pages[0].CheckRuns) != 1 || len(pages[1].CheckRuns) != 1 {
+		t.Fatalf("pages = %#v", pages)
+	}
+}
+
+func TestRunGHAPIJQFiltersPaginatedStream(t *testing.T) {
+	if !jqAvailable() {
+		t.Skip("jq is required")
+	}
+	relayTestServer(t, func(body map[string]any) any {
+		if body["query"].(map[string]any)["page"] == "1" {
+			return []map[string]any{{"id": 1}, {"id": 2}}
+		}
+		return []map[string]any{{"id": 3}}
+	})
+
+	var out bytes.Buffer
+	if err := runGH(t.Context(), []string{
+		"api", "repos/openclaw/octopool/issues?per_page=2", "--paginate", "--jq", ".[] | .id",
+	}, &out, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if out.String() != "1\n2\n3\n" {
+		t.Fatalf("output = %q", out.String())
+	}
+}
+
+func TestRunGHAPIPaginationHonorsPageAndPerPage(t *testing.T) {
+	var perPages []any
+	var pages []any
+	relayTestServer(t, func(body map[string]any) any {
+		query := body["query"].(map[string]any)
+		perPages = append(perPages, query["per_page"])
+		pages = append(pages, query["page"])
+		if query["page"] == "4" {
+			return paginationItems(0, 7)
+		}
+		return paginationItems(7, 1)
+	})
+
+	if err := runGH(t.Context(), []string{
+		"api", "repos/openclaw/octopool/issues?per_page=7&page=4", "--paginate",
+	}, io.Discard, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if len(perPages) != 2 || perPages[0] != "7" || perPages[1] != "7" {
+		t.Fatalf("per_page values = %#v", perPages)
+	}
+	if len(pages) != 2 || pages[0] != "4" || pages[1] != "5" {
+		t.Fatalf("page values = %#v", pages)
+	}
+}
+
+func TestRunGHAPIPaginationExhaustionFallsBackToRealGH(t *testing.T) {
+	requests := 0
+	relayTestServer(t, func(map[string]any) any {
+		requests++
+		return paginationItems(requests*relayPageSize, relayPageSize)
+	})
+	t.Setenv("OCTOPOOL_GH_PATH", fakeGH(t))
+
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	if err := runGH(t.Context(), []string{
+		"api", "repos/openclaw/octopool/issues", "--paginate",
+	}, &out, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	if requests != maxRelayPages {
+		t.Fatalf("relay requests = %d", requests)
+	}
+	if out.String() != "real-gh:api repos/openclaw/octopool/issues --paginate\n" {
+		t.Fatalf("output = %q", out.String())
+	}
+	if !strings.Contains(stderr.String(), "pagination_exhausted") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestParseGHAPISlurpRequiresPaginate(t *testing.T) {
+	_, _, err := parseGHAPIArgs([]string{"repos/openclaw/octopool/issues", "--slurp"})
+	if err == nil || err.Error() != "--slurp requires --paginate" {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestRunGHAPIPostPaginateFallsBack(t *testing.T) {
+	requests := 0
+	relayTestServer(t, func(map[string]any) any {
+		requests++
+		return nil
+	})
+	t.Setenv("OCTOPOOL_GH_PATH", fakeGH(t))
+
+	var out bytes.Buffer
+	if err := runGH(t.Context(), []string{
+		"api", "--method", "POST", "repos/openclaw/octopool/issues", "--paginate",
+	}, &out, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 0 || !strings.HasPrefix(out.String(), "real-gh:") {
+		t.Fatalf("relay requests=%d output=%q", requests, out.String())
+	}
+}
+
+func TestRunGHAPIPaginateNonQueryPathFallsBack(t *testing.T) {
+	requests := 0
+	relayTestServer(t, func(map[string]any) any {
+		requests++
+		return nil
+	})
+	t.Setenv("OCTOPOOL_GH_PATH", fakeGH(t))
+
+	var out bytes.Buffer
+	if err := runGH(t.Context(), []string{
+		"api", "unsupported/queryless/path", "--paginate",
+	}, &out, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 0 || !strings.HasPrefix(out.String(), "real-gh:") {
+		t.Fatalf("relay requests=%d output=%q", requests, out.String())
+	}
+}
+
+func paginationItems(start int, count int) []int {
+	items := make([]int, count)
+	for index := range items {
+		items[index] = start + index
+	}
+	return items
+}
+
+func decodeArrayPageStream(t *testing.T, raw []byte) [][]int {
+	t.Helper()
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	var pages [][]int
+	for {
+		var page []int
+		err := decoder.Decode(&page)
+		if err == io.EOF {
+			return pages
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		pages = append(pages, page)
+	}
+}
+
+func pageLengths(pages [][]int) []int {
+	lengths := make([]int, len(pages))
+	for index, page := range pages {
+		lengths[index] = len(page)
+	}
+	return lengths
+}
 
 func TestRunGHPRChecksFallsBackWhenPaginationIsExhausted(t *testing.T) {
 	checkRuns := make([]map[string]any, relayPageSize)

--- a/cmd/octopool/gh_pagination_test.go
+++ b/cmd/octopool/gh_pagination_test.go
@@ -30,9 +30,12 @@ func TestRunGHAPIPaginatesArrayResponse(t *testing.T) {
 	}, &out, io.Discard); err != nil {
 		t.Fatal(err)
 	}
-	pages := decodeArrayPageStream(t, out.Bytes())
-	if len(pages) != 3 || len(pages[0]) != 100 || len(pages[1]) != 100 || len(pages[2]) != 1 {
-		t.Fatalf("page lengths = %v", pageLengths(pages))
+	var merged []any
+	if err := json.Unmarshal(out.Bytes(), &merged); err != nil {
+		t.Fatalf("output is not one merged JSON array: %v\n%s", err, out.Bytes())
+	}
+	if len(merged) != 2*relayPageSize+1 {
+		t.Fatalf("merged length = %d", len(merged))
 	}
 	for index, query := range queries {
 		if query["page"] != strconv.Itoa(index+1) || query["per_page"] != "100" {
@@ -57,9 +60,12 @@ func TestRunGHAPIPaginatesExactMultipleThroughEmptyPage(t *testing.T) {
 	}, &out, io.Discard); err != nil {
 		t.Fatal(err)
 	}
-	pages := decodeArrayPageStream(t, out.Bytes())
-	if requests != 2 || len(pages) != 2 || len(pages[0]) != 100 || len(pages[1]) != 0 {
-		t.Fatalf("requests=%d page lengths=%v", requests, pageLengths(pages))
+	var merged []any
+	if err := json.Unmarshal(out.Bytes(), &merged); err != nil {
+		t.Fatalf("output is not one merged JSON array: %v\n%s", err, out.Bytes())
+	}
+	if requests != 2 || len(merged) != relayPageSize {
+		t.Fatalf("requests=%d merged length=%d", requests, len(merged))
 	}
 }
 
@@ -226,6 +232,25 @@ func TestRunGHAPIPaginationExhaustionFallsBackToRealGH(t *testing.T) {
 	}
 }
 
+func TestRunGHAPIPaginationSeedsCallerStartPage(t *testing.T) {
+	requests := []string{}
+	relayTestServer(t, func(body map[string]any) any {
+		page := body["query"].(map[string]any)["page"].(string)
+		requests = append(requests, page)
+		return map[string]any{"total_count": 6, "check_runs": []map[string]any{{"id": page + "a"}, {"id": page + "b"}}}
+	})
+
+	var out bytes.Buffer
+	if err := runGH(t.Context(), []string{
+		"api", "repos/openclaw/octopool/commits/abc1234/check-runs?per_page=2&page=2", "--paginate",
+	}, &out, io.Discard); err != nil {
+		t.Fatalf("start page beyond 1 must not exhaust pagination: %v", err)
+	}
+	if len(requests) != 2 || requests[0] != "2" || requests[1] != "3" {
+		t.Fatalf("requests = %v", requests)
+	}
+}
+
 func TestParseGHAPISlurpRequiresPaginate(t *testing.T) {
 	_, _, err := parseGHAPIArgs([]string{"repos/openclaw/octopool/issues", "--slurp"})
 	if err == nil || err.Error() != "--slurp requires --paginate" {
@@ -277,31 +302,6 @@ func paginationItems(start int, count int) []int {
 		items[index] = start + index
 	}
 	return items
-}
-
-func decodeArrayPageStream(t *testing.T, raw []byte) [][]int {
-	t.Helper()
-	decoder := json.NewDecoder(bytes.NewReader(raw))
-	var pages [][]int
-	for {
-		var page []int
-		err := decoder.Decode(&page)
-		if err == io.EOF {
-			return pages
-		}
-		if err != nil {
-			t.Fatal(err)
-		}
-		pages = append(pages, page)
-	}
-}
-
-func pageLengths(pages [][]int) []int {
-	lengths := make([]int, len(pages))
-	for index, page := range pages {
-		lengths[index] = len(page)
-	}
-	return lengths
 }
 
 func TestRunGHPRChecksFallsBackWhenPaginationIsExhausted(t *testing.T) {

--- a/cmd/octopool/gh_pagination_test.go
+++ b/cmd/octopool/gh_pagination_test.go
@@ -299,6 +299,29 @@ func TestRunGHAPIPaginationSeedsCallerStartPage(t *testing.T) {
 	}
 }
 
+func TestRunGHAPIPaginateUninferableObjectFallsBackToRealGH(t *testing.T) {
+	relayTestServer(t, func(map[string]any) any {
+		// compare-like shape: multiple arrays, no total_count — completion
+		// cannot be proven without Link headers.
+		return map[string]any{"total_commits": 250, "commits": []any{}, "files": []any{}}
+	})
+	t.Setenv("OCTOPOOL_GH_PATH", fakeGH(t))
+
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	if err := runGH(t.Context(), []string{
+		"api", "repos/openclaw/octopool/compare/a...b", "--paginate",
+	}, &out, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	if out.String() != "real-gh:api repos/openclaw/octopool/compare/a...b --paginate\n" {
+		t.Fatalf("output = %q", out.String())
+	}
+	if !strings.Contains(stderr.String(), "pagination_shape_unsupported") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
 func TestParseGHAPISlurpRejectsJQ(t *testing.T) {
 	_, _, err := parseGHAPIArgs([]string{"repos/openclaw/octopool/issues", "--paginate", "--slurp", "--jq", ".x"})
 	if err == nil || !strings.Contains(err.Error(), "not supported with") {

--- a/cmd/octopool/gh_pagination_test.go
+++ b/cmd/octopool/gh_pagination_test.go
@@ -232,6 +232,32 @@ func TestRunGHAPIPaginationExhaustionFallsBackToRealGH(t *testing.T) {
 	}
 }
 
+func TestRunGHAPIPaginationClampsOversizedPerPage(t *testing.T) {
+	perPages := []string{}
+	relayTestServer(t, func(body map[string]any) any {
+		query := body["query"].(map[string]any)
+		perPages = append(perPages, query["per_page"].(string))
+		if query["page"] == "1" {
+			return paginationItems(0, relayPageSize)
+		}
+		return paginationItems(relayPageSize, 1)
+	})
+
+	var out bytes.Buffer
+	if err := runGH(t.Context(), []string{
+		"api", "repos/openclaw/octopool/issues?per_page=200", "--paginate",
+	}, &out, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	var merged []any
+	if err := json.Unmarshal(out.Bytes(), &merged); err != nil {
+		t.Fatal(err)
+	}
+	if len(perPages) != 2 || perPages[0] != "100" || perPages[1] != "100" || len(merged) != relayPageSize+1 {
+		t.Fatalf("per_page sent = %v merged=%d; oversized per_page must clamp to GitHub's cap", perPages, len(merged))
+	}
+}
+
 func TestRunGHAPIJQAppliesPerPage(t *testing.T) {
 	if !jqAvailable() {
 		t.Skip("jq is required")

--- a/cmd/octopool/gh_pagination_test.go
+++ b/cmd/octopool/gh_pagination_test.go
@@ -232,6 +232,28 @@ func TestRunGHAPIPaginationExhaustionFallsBackToRealGH(t *testing.T) {
 	}
 }
 
+func TestRunGHAPIJQAppliesPerPage(t *testing.T) {
+	if !jqAvailable() {
+		t.Skip("jq is required")
+	}
+	relayTestServer(t, func(body map[string]any) any {
+		if body["query"].(map[string]any)["page"] == "1" {
+			return []map[string]any{{"id": 1}, {"id": 2}}
+		}
+		return []map[string]any{{"id": 3}}
+	})
+
+	var out bytes.Buffer
+	if err := runGH(t.Context(), []string{
+		"api", "repos/openclaw/octopool/issues?per_page=2", "--paginate", "--jq", "length",
+	}, &out, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if out.String() != "2\n1\n" {
+		t.Fatalf("jq must run once per page like real gh, got %q", out.String())
+	}
+}
+
 func TestRunGHAPIPaginationSeedsCallerStartPage(t *testing.T) {
 	requests := []string{}
 	relayTestServer(t, func(body map[string]any) any {

--- a/cmd/octopool/gh_pagination_test.go
+++ b/cmd/octopool/gh_pagination_test.go
@@ -299,6 +299,13 @@ func TestRunGHAPIPaginationSeedsCallerStartPage(t *testing.T) {
 	}
 }
 
+func TestParseGHAPISlurpRejectsJQ(t *testing.T) {
+	_, _, err := parseGHAPIArgs([]string{"repos/openclaw/octopool/issues", "--paginate", "--slurp", "--jq", ".x"})
+	if err == nil || !strings.Contains(err.Error(), "not supported with") {
+		t.Fatalf("err = %v, want real gh's slurp/jq rejection", err)
+	}
+}
+
 func TestParseGHAPISlurpRequiresPaginate(t *testing.T) {
 	_, _, err := parseGHAPIArgs([]string{"repos/openclaw/octopool/issues", "--slurp"})
 	if err == nil || err.Error() != "--slurp requires --paginate" {

--- a/cmd/octopool/gh_top_checks.go
+++ b/cmd/octopool/gh_top_checks.go
@@ -39,35 +39,47 @@ func relayPRChecks(ctx context.Context, stdout io.Writer, repo string, number st
 }
 
 func relayPRCheckItems(ctx context.Context, client ghRelayClient, repo string, number string) ([]any, error) {
-	// Bound the PR lookup's staleness instead of forcing a live read: concurrent
-	// CI-polling sessions coalesce onto one shared-cache fill while the head SHA
-	// stays at most a few seconds behind a push.
-	freshHeaders := map[string]string{"cache-control": "max-age=" + strconv.Itoa(prChecksMaxPRAgeSeconds)}
+	items, _, err := relayPRCheckItemsWithSHA(ctx, client, repo, number)
+	return items, err
+}
+
+func relayPRHeadSHA(ctx context.Context, client ghRelayClient, repo string, number string, maxAgeSeconds int) (string, error) {
 	prEnvelope, err := client.do(ctx, ghAPIRequest{
 		method:  "GET",
 		path:    repoPath(repo, "pulls", number),
-		headers: freshHeaders,
+		headers: map[string]string{"cache-control": "max-age=" + strconv.Itoa(maxAgeSeconds)},
 	})
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	prBody, err := envelopeBodyBytes(prEnvelope)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	var pr map[string]any
 	if err := json.Unmarshal(prBody, &pr); err != nil {
-		return nil, err
+		return "", err
 	}
 	sha, ok := nestedString(pr, "head", "sha")
 	if !ok || sha == "" {
-		return nil, errors.New("pull request response did not include head.sha")
+		return "", errors.New("pull request response did not include head.sha")
+	}
+	return sha, nil
+}
+
+func relayPRCheckItemsWithSHA(ctx context.Context, client ghRelayClient, repo string, number string) ([]any, string, error) {
+	// Bound the PR lookup's staleness instead of forcing a live read: concurrent
+	// CI-polling sessions coalesce onto one shared-cache fill while the head SHA
+	// stays at most a few seconds behind a push.
+	sha, err := relayPRHeadSHA(ctx, client, repo, number, prChecksMaxPRAgeSeconds)
+	if err != nil {
+		return nil, "", err
 	}
 	items, err := prCheckItemsForSHA(ctx, client, repo, sha)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	return items, nil
+	return items, sha, nil
 }
 
 func prCheckItemsForSHA(ctx context.Context, client ghRelayClient, repo string, sha string) ([]any, error) {

--- a/cmd/octopool/gh_top_checks.go
+++ b/cmd/octopool/gh_top_checks.go
@@ -127,17 +127,32 @@ func prCheckItemsForSHAWithHeaders(
 	if len(checkRuns) < totalCheckRuns {
 		return nil, localFallbackError{Reason: "pagination_exhausted"}
 	}
-	statusEnvelope, err := client.do(ctx, ghAPIRequest{
-		method:  "GET",
-		path:    repoPath(repo, "commits", sha, "status"),
-		headers: headers,
-	})
-	if err != nil {
-		return nil, err
+	statuses := []any{}
+	totalStatuses := 0
+	for page := 1; page <= maxRelayPages; page++ {
+		statusEnvelope, err := client.do(ctx, ghAPIRequest{
+			method:  "GET",
+			path:    repoPath(repo, "commits", sha, "status"),
+			query:   map[string]any{"per_page": strconv.Itoa(relayPageSize), "page": strconv.Itoa(page)},
+			headers: headers,
+		})
+		if err != nil {
+			return nil, err
+		}
+		items, total, err := statusItems(statusEnvelope)
+		if err != nil {
+			return nil, err
+		}
+		if page == 1 {
+			totalStatuses = total
+		}
+		statuses = append(statuses, items...)
+		if len(statuses) >= totalStatuses || len(items) < relayPageSize {
+			break
+		}
 	}
-	statuses, err := statusItems(statusEnvelope)
-	if err != nil {
-		return nil, err
+	if len(statuses) < totalStatuses {
+		return nil, localFallbackError{Reason: "pagination_exhausted"}
 	}
 	return ghCheckItems(append(checkRuns, statuses...)), nil
 }
@@ -162,18 +177,22 @@ func checkRunItems(envelope relayEnvelope) ([]any, int, error) {
 	return items, total, nil
 }
 
-func statusItems(envelope relayEnvelope) ([]any, error) {
+func statusItems(envelope relayEnvelope) ([]any, int, error) {
 	body, err := envelopeBodyBytes(envelope)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	var response map[string]any
 	if err := json.Unmarshal(body, &response); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	rawItems, ok := response["statuses"].([]any)
 	if !ok {
-		return nil, errors.New("status response did not include statuses")
+		return nil, 0, errors.New("status response did not include statuses")
+	}
+	total := len(rawItems)
+	if value, ok := response["total_count"].(float64); ok {
+		total = int(value)
 	}
 	items := make([]any, 0, len(rawItems))
 	for _, raw := range rawItems {
@@ -197,7 +216,7 @@ func statusItems(envelope relayEnvelope) ([]any, error) {
 		}
 		items = append(items, item)
 	}
-	return items, nil
+	return items, total, nil
 }
 
 func ghCheckItems(items []any) []any {
@@ -274,8 +293,11 @@ func checkExitCode(items []any) error {
 		bucket, _ := item["bucket"].(string)
 		state, _ := item["state"].(string)
 		switch strings.ToLower(bucket) {
-		case "fail", "cancel":
+		case "fail":
 			exitCode = 1
+		case "cancel":
+			// real gh exits by Failed then Pending counts only; cancelled
+			// checks are terminal and do not fail the command.
 		case "pending":
 			if exitCode == 0 {
 				exitCode = 8

--- a/cmd/octopool/gh_top_checks.go
+++ b/cmd/octopool/gh_top_checks.go
@@ -18,31 +18,7 @@ func relayPRChecks(ctx context.Context, stdout io.Writer, repo string, number st
 	if err != nil {
 		return err
 	}
-	// Bound the PR lookup's staleness instead of forcing a live read: concurrent
-	// CI-polling sessions coalesce onto one shared-cache fill while the head SHA
-	// stays at most a few seconds behind a push.
-	freshHeaders := map[string]string{"cache-control": "max-age=" + strconv.Itoa(prChecksMaxPRAgeSeconds)}
-	prEnvelope, err := client.do(ctx, ghAPIRequest{
-		method:  "GET",
-		path:    repoPath(repo, "pulls", number),
-		headers: freshHeaders,
-	})
-	if err != nil {
-		return err
-	}
-	prBody, err := envelopeBodyBytes(prEnvelope)
-	if err != nil {
-		return err
-	}
-	var pr map[string]any
-	if err := json.Unmarshal(prBody, &pr); err != nil {
-		return err
-	}
-	sha, ok := nestedString(pr, "head", "sha")
-	if !ok || sha == "" {
-		return errors.New("pull request response did not include head.sha")
-	}
-	items, err := prCheckItemsForSHA(ctx, client, repo, sha)
+	items, err := relayPRCheckItems(ctx, client, repo, number)
 	if err != nil {
 		return err
 	}
@@ -60,6 +36,38 @@ func relayPRChecks(ctx context.Context, stdout io.Writer, repo string, number st
 		return err
 	}
 	return checkExitCode(items)
+}
+
+func relayPRCheckItems(ctx context.Context, client ghRelayClient, repo string, number string) ([]any, error) {
+	// Bound the PR lookup's staleness instead of forcing a live read: concurrent
+	// CI-polling sessions coalesce onto one shared-cache fill while the head SHA
+	// stays at most a few seconds behind a push.
+	freshHeaders := map[string]string{"cache-control": "max-age=" + strconv.Itoa(prChecksMaxPRAgeSeconds)}
+	prEnvelope, err := client.do(ctx, ghAPIRequest{
+		method:  "GET",
+		path:    repoPath(repo, "pulls", number),
+		headers: freshHeaders,
+	})
+	if err != nil {
+		return nil, err
+	}
+	prBody, err := envelopeBodyBytes(prEnvelope)
+	if err != nil {
+		return nil, err
+	}
+	var pr map[string]any
+	if err := json.Unmarshal(prBody, &pr); err != nil {
+		return nil, err
+	}
+	sha, ok := nestedString(pr, "head", "sha")
+	if !ok || sha == "" {
+		return nil, errors.New("pull request response did not include head.sha")
+	}
+	items, err := prCheckItemsForSHA(ctx, client, repo, sha)
+	if err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 func prCheckItemsForSHA(ctx context.Context, client ghRelayClient, repo string, sha string) ([]any, error) {

--- a/cmd/octopool/gh_top_checks.go
+++ b/cmd/octopool/gh_top_checks.go
@@ -83,13 +83,30 @@ func relayPRCheckItemsWithSHA(ctx context.Context, client ghRelayClient, repo st
 }
 
 func prCheckItemsForSHA(ctx context.Context, client ghRelayClient, repo string, sha string) ([]any, error) {
+	return prCheckItemsForSHAWithHeaders(ctx, client, repo, sha, nil)
+}
+
+// prCheckItemsForSHAFresh bypasses cached staleness so a terminal watch
+// snapshot cannot be confirmed by an obsolete cached payload after a rerun.
+func prCheckItemsForSHAFresh(ctx context.Context, client ghRelayClient, repo string, sha string) ([]any, error) {
+	return prCheckItemsForSHAWithHeaders(ctx, client, repo, sha, map[string]string{"cache-control": "max-age=0"})
+}
+
+func prCheckItemsForSHAWithHeaders(
+	ctx context.Context,
+	client ghRelayClient,
+	repo string,
+	sha string,
+	headers map[string]string,
+) ([]any, error) {
 	checkRuns := []any{}
 	totalCheckRuns := 0
 	for page := 1; page <= maxRelayPages; page++ {
 		request := ghAPIRequest{
-			method: "GET",
-			path:   repoPath(repo, "commits", sha, "check-runs"),
-			query:  map[string]any{"per_page": strconv.Itoa(relayPageSize), "page": strconv.Itoa(page)},
+			method:  "GET",
+			path:    repoPath(repo, "commits", sha, "check-runs"),
+			query:   map[string]any{"per_page": strconv.Itoa(relayPageSize), "page": strconv.Itoa(page)},
+			headers: headers,
 		}
 		checkRunsEnvelope, err := client.do(ctx, request)
 		if err != nil {
@@ -111,8 +128,9 @@ func prCheckItemsForSHA(ctx context.Context, client ghRelayClient, repo string, 
 		return nil, localFallbackError{Reason: "pagination_exhausted"}
 	}
 	statusEnvelope, err := client.do(ctx, ghAPIRequest{
-		method: "GET",
-		path:   repoPath(repo, "commits", sha, "status"),
+		method:  "GET",
+		path:    repoPath(repo, "commits", sha, "status"),
+		headers: headers,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/octopool/gh_top_pr.go
+++ b/cmd/octopool/gh_top_pr.go
@@ -31,6 +31,9 @@ func handleGHPR(ctx context.Context, args []string, stdout io.Writer) ghResult {
 	if len(args) == 0 {
 		return ghDelegated()
 	}
+	if args[0] == "checks" && hasWatchFlag(args[1:]) {
+		return handleGHPRChecksWatch(ctx, args[1:], stdout)
+	}
 	opts, early, ok := prepareGHTopOptions(args[1:])
 	if !ok {
 		return early

--- a/cmd/octopool/gh_top_pr_test.go
+++ b/cmd/octopool/gh_top_pr_test.go
@@ -113,12 +113,12 @@ func TestStatusItemsMapLegacyContexts(t *testing.T) {
 		BodyEncoding: "json",
 		Body:         []byte(`{"statuses":[{"context":"ci/external","state":"success","target_url":"https://example.test","created_at":"2026-05-27T00:00:00Z","updated_at":"2026-05-27T00:01:00Z"}]}`),
 	}
-	items, err := statusItems(envelope)
+	items, total, err := statusItems(envelope)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(items) != 1 {
-		t.Fatalf("items = %#v", items)
+	if len(items) != 1 || total != 1 {
+		t.Fatalf("items = %#v total=%d", items, total)
 	}
 	item := items[0].(map[string]any)
 	if item["name"] != "ci/external" || item["conclusion"] != "success" || item["details_url"] != "https://example.test" {

--- a/cmd/octopool/gh_top_run.go
+++ b/cmd/octopool/gh_top_run.go
@@ -11,6 +11,9 @@ func handleGHRun(ctx context.Context, args []string, stdout io.Writer) ghResult 
 	if len(args) == 0 {
 		return ghDelegated()
 	}
+	if args[0] == "watch" {
+		return handleGHRunWatch(ctx, args[1:], stdout)
+	}
 	opts, early, ok := prepareGHTopOptions(args[1:])
 	if !ok {
 		return early

--- a/cmd/octopool/gh_top_run.go
+++ b/cmd/octopool/gh_top_run.go
@@ -114,26 +114,38 @@ func relayRunView(ctx context.Context, stdout io.Writer, repo string, id string,
 }
 
 func runJobs(envelope relayEnvelope) ([]any, error) {
-	body, err := envelopeBodyBytes(envelope)
+	jobs, total, err := runJobsPage(envelope)
 	if err != nil {
 		return nil, err
 	}
+	if total > len(jobs) {
+		return nil, localFallbackError{Reason: "workflow jobs response requires pagination"}
+	}
+	return jobs, nil
+}
+
+func runJobsPage(envelope relayEnvelope) ([]any, int, error) {
+	body, err := envelopeBodyBytes(envelope)
+	if err != nil {
+		return nil, 0, err
+	}
 	var response map[string]any
 	if err := json.Unmarshal(body, &response); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	rawJobs, ok := response["jobs"].([]any)
 	if !ok {
-		return nil, errors.New("workflow jobs response did not include jobs")
+		return nil, 0, errors.New("workflow jobs response did not include jobs")
 	}
-	if total, ok := response["total_count"].(float64); ok && total > float64(len(rawJobs)) {
-		return nil, localFallbackError{Reason: "workflow jobs response requires pagination"}
+	total := len(rawJobs)
+	if value, ok := response["total_count"].(float64); ok {
+		total = int(value)
 	}
 	jobs := make([]any, 0, len(rawJobs))
 	for _, rawJob := range rawJobs {
 		job, ok := rawJob.(map[string]any)
 		if !ok {
-			return nil, errors.New("workflow jobs response included an invalid job")
+			return nil, 0, errors.New("workflow jobs response included an invalid job")
 		}
 		mapped := map[string]any{}
 		for field, path := range map[string][]string{
@@ -154,7 +166,7 @@ func runJobs(envelope relayEnvelope) ([]any, error) {
 			for _, rawStep := range rawSteps {
 				step, ok := rawStep.(map[string]any)
 				if !ok {
-					return nil, errors.New("workflow jobs response included an invalid step")
+					return nil, 0, errors.New("workflow jobs response included an invalid step")
 				}
 				mappedStep := map[string]any{}
 				for field, path := range map[string][]string{
@@ -175,7 +187,7 @@ func runJobs(envelope relayEnvelope) ([]any, error) {
 		}
 		jobs = append(jobs, mapped)
 	}
-	return jobs, nil
+	return jobs, total, nil
 }
 
 func hasJSONField(fields []string, expected string) bool {

--- a/cmd/octopool/gh_top_watch.go
+++ b/cmd/octopool/gh_top_watch.go
@@ -208,19 +208,33 @@ func relayWatchRun(ctx context.Context, client ghRelayClient, repo string, id st
 func relayWatchRunJobs(ctx context.Context, client ghRelayClient, repo string, id string, backoff *watchBackoff) ([]any, error) {
 	var jobs []any
 	err := retryWatchTick(ctx, backoff, func() error {
-		envelope, err := client.do(ctx, ghAPIRequest{
-			method: "GET",
-			path:   repoPath(repo, "actions", "runs", id, "jobs"),
-			query:  map[string]any{"per_page": "100"},
-			headers: map[string]string{
-				"x-octopool-public-shape": publicShapeActionsJobs,
-			},
-		})
-		if err != nil {
-			return err
+		jobs = jobs[:0]
+		total := 0
+		for page := 1; page <= maxRelayPages; page++ {
+			envelope, err := client.do(ctx, ghAPIRequest{
+				method: "GET",
+				path:   repoPath(repo, "actions", "runs", id, "jobs"),
+				query:  map[string]any{"per_page": strconv.Itoa(relayPageSize), "page": strconv.Itoa(page)},
+				headers: map[string]string{
+					"x-octopool-public-shape": publicShapeActionsJobs,
+				},
+			})
+			if err != nil {
+				return err
+			}
+			pageJobs, pageTotal, err := runJobsPage(envelope)
+			if err != nil {
+				return err
+			}
+			if page == 1 {
+				total = pageTotal
+			}
+			jobs = append(jobs, pageJobs...)
+			if len(jobs) >= total || len(pageJobs) < relayPageSize {
+				return nil
+			}
 		}
-		jobs, err = runJobs(envelope)
-		return err
+		return localFallbackError{Reason: "workflow jobs pagination exhausted"}
 	})
 	return jobs, err
 }
@@ -272,7 +286,7 @@ func parseGHPRChecksWatchOptions(args []string) (ghPRChecksWatchOptions, bool) {
 	for index := 0; index < len(args); index++ {
 		arg := args[index]
 		switch {
-		case arg == "--watch":
+		case arg == "--watch" || arg == "--watch=true":
 			watch = true
 		case arg == "--fail-fast":
 			opts.failFast = true
@@ -342,13 +356,16 @@ func relayPRChecksWatch(ctx context.Context, stdout io.Writer, opts ghPRChecksWa
 		}
 		pending, passing, failing := checkWatchCounts(items)
 		counts := fmt.Sprintf("%d/%d/%d", pending, passing, failing)
-		if counts != previousCounts {
+		// Structured output must stay pure: no progress lines ahead of the
+		// final --json/--jq payload.
+		structured := len(opts.json) > 0 || opts.jq != ""
+		if counts != previousCounts && !structured {
 			if _, err := fmt.Fprintf(stdout, "checks: %d pending, %d pass, %d fail\n", pending, passing, failing); err != nil {
 				return err
 			}
 			progressPrinted = true
-			previousCounts = counts
 		}
+		previousCounts = counts
 		if pending == 0 || opts.failFast && failing > 0 {
 			if err := printPRChecksWatchFinal(ctx, stdout, items, opts); err != nil {
 				return err
@@ -424,7 +441,8 @@ func watchError(err error, progressPrinted bool) error {
 
 func hasWatchFlag(args []string) bool {
 	for _, arg := range args {
-		if arg == "--watch" {
+		// Cobra bools also accept the explicit form; --watch=false stays unwatched.
+		if arg == "--watch" || arg == "--watch=true" {
 			return true
 		}
 	}

--- a/cmd/octopool/gh_top_watch.go
+++ b/cmd/octopool/gh_top_watch.go
@@ -406,7 +406,13 @@ func relayPRChecksWatch(ctx context.Context, stdout io.Writer, opts ghPRChecksWa
 			// before the watch (new head SHA) or a check rerun (same SHA, cached
 			// terminal payloads) could otherwise finalize on obsolete results.
 			// One fresh sweep per exit attempt.
-			final, confirmed, err := confirmPRChecksTerminal(ctx, client, opts, sha)
+			var final []any
+			var confirmed bool
+			err := retryWatchTick(ctx, &backoff, func() error {
+				var confirmErr error
+				final, confirmed, confirmErr = confirmPRChecksTerminal(ctx, client, opts, sha)
+				return confirmErr
+			})
 			if err != nil {
 				return watchError(err, progressPrinted)
 			}

--- a/cmd/octopool/gh_top_watch.go
+++ b/cmd/octopool/gh_top_watch.go
@@ -1,0 +1,518 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	watchMinInterval = 30 * time.Second
+	watchMaxInterval = 120 * time.Second
+	watchMaxErrors   = 3
+)
+
+var watchSleep = func(ctx context.Context, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+type ghRunWatchOptions struct {
+	repo       string
+	id         string
+	interval   time.Duration
+	exitStatus bool
+}
+
+type ghPRChecksWatchOptions struct {
+	repo     string
+	number   string
+	interval time.Duration
+	failFast bool
+	json     []string
+	jq       string
+}
+
+type watchBackoff struct {
+	current time.Duration
+	limit   time.Duration
+}
+
+func newWatchBackoff(requested time.Duration) watchBackoff {
+	start := max(requested, watchMinInterval)
+	return watchBackoff{current: start, limit: max(watchMaxInterval, start)}
+}
+
+func (backoff *watchBackoff) sleep(ctx context.Context) error {
+	if err := watchSleep(ctx, backoff.current); err != nil {
+		return err
+	}
+	backoff.current = min(backoff.current*2, backoff.limit)
+	return nil
+}
+
+func retryWatchTick(ctx context.Context, backoff *watchBackoff, poll func() error) error {
+	var err error
+	for attempt := 0; attempt < watchMaxErrors; attempt++ {
+		if err = poll(); err == nil {
+			return nil
+		}
+		// Deterministic relay refusals (unsupported route, not logged in) never
+		// heal on retry; surface them immediately so first-tick fallback stays fast.
+		if shouldRunRealGH(err) {
+			return err
+		}
+		if attempt+1 < watchMaxErrors {
+			if sleepErr := backoff.sleep(ctx); sleepErr != nil {
+				return sleepErr
+			}
+		}
+	}
+	return err
+}
+
+func handleGHRunWatch(ctx context.Context, args []string, stdout io.Writer) ghResult {
+	opts, ok := parseGHRunWatchOptions(args)
+	if !ok {
+		return ghDelegated()
+	}
+	repo, ok := repoFromOptionOrCurrent(opts.repo)
+	if !ok {
+		return ghDelegated()
+	}
+	opts.repo = repo
+	return ghCompleted(relayRunWatch(ctx, stdout, opts))
+}
+
+func parseGHRunWatchOptions(args []string) (ghRunWatchOptions, bool) {
+	opts := ghRunWatchOptions{interval: watchMinInterval}
+	positionals := []string{}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "--exit-status":
+			opts.exitStatus = true
+		case arg == "--compact":
+		case watchFlagValue(args, &index, arg, "-R", &opts.repo):
+		case watchFlagValue(args, &index, arg, "--repo", &opts.repo):
+		case isWatchValueFlag(arg, "-i"):
+			value, valueOK := takeWatchFlagValue(args, &index, arg, "-i")
+			if !valueOK || !setWatchInterval(value, &opts.interval) {
+				return opts, false
+			}
+		case isWatchValueFlag(arg, "--interval"):
+			value, valueOK := takeWatchFlagValue(args, &index, arg, "--interval")
+			if !valueOK || !setWatchInterval(value, &opts.interval) {
+				return opts, false
+			}
+		case strings.HasPrefix(arg, "-"):
+			return opts, false
+		default:
+			positionals = append(positionals, arg)
+		}
+	}
+	if len(positionals) != 1 || !isDigits(positionals[0]) {
+		return opts, false
+	}
+	opts.id = positionals[0]
+	return opts, true
+}
+
+func relayRunWatch(ctx context.Context, stdout io.Writer, opts ghRunWatchOptions) error {
+	client, err := newGHRelayClient()
+	if err != nil {
+		return err
+	}
+	backoff := newWatchBackoff(opts.interval)
+	previousStatus := ""
+	progressPrinted := false
+	for {
+		var run map[string]any
+		err := retryWatchTick(ctx, &backoff, func() error {
+			var pollErr error
+			run, pollErr = relayWatchRun(ctx, client, opts.repo, opts.id)
+			return pollErr
+		})
+		if err != nil {
+			return watchError(err, progressPrinted)
+		}
+		status := firstString(run, "status")
+		if status == "" {
+			return watchError(errors.New("workflow run response did not include status"), progressPrinted)
+		}
+		if !progressPrinted {
+			if _, err := fmt.Fprintf(stdout, "Watching run %s in %s (status: %s)\n", opts.id, opts.repo, status); err != nil {
+				return err
+			}
+			progressPrinted = true
+		} else if status != previousStatus {
+			if _, err := fmt.Fprintf(stdout, "run %s: %s -> %s\n", opts.id, previousStatus, status); err != nil {
+				return err
+			}
+		}
+		previousStatus = status
+		if status == "completed" {
+			jobs, err := relayWatchRunJobs(ctx, client, opts.repo, opts.id, &backoff)
+			if err != nil {
+				return watchError(err, true)
+			}
+			if err := printWatchRunJobs(stdout, jobs); err != nil {
+				return err
+			}
+			conclusion := firstString(run, "conclusion")
+			if _, err := fmt.Fprintf(stdout, "Run %s completed with '%s'\n", opts.id, conclusion); err != nil {
+				return err
+			}
+			if opts.exitStatus && !strings.EqualFold(conclusion, "success") {
+				return exitCodeError{Code: 1}
+			}
+			return nil
+		}
+		if err := backoff.sleep(ctx); err != nil {
+			return err
+		}
+	}
+}
+
+func relayWatchRun(ctx context.Context, client ghRelayClient, repo string, id string) (map[string]any, error) {
+	envelope, err := client.do(ctx, ghAPIRequest{
+		method:  "GET",
+		path:    repoPath(repo, "actions", "runs", id),
+		headers: map[string]string{"x-octopool-public-shape": publicShapeActionsSummary},
+	})
+	if err != nil {
+		return nil, err
+	}
+	body, err := envelopeBodyBytes(envelope)
+	if err != nil {
+		return nil, err
+	}
+	var run map[string]any
+	if err := json.Unmarshal(body, &run); err != nil {
+		return nil, err
+	}
+	return run, nil
+}
+
+func relayWatchRunJobs(ctx context.Context, client ghRelayClient, repo string, id string, backoff *watchBackoff) ([]any, error) {
+	var jobs []any
+	err := retryWatchTick(ctx, backoff, func() error {
+		envelope, err := client.do(ctx, ghAPIRequest{
+			method: "GET",
+			path:   repoPath(repo, "actions", "runs", id, "jobs"),
+			query:  map[string]any{"per_page": "100"},
+			headers: map[string]string{
+				"x-octopool-public-shape": publicShapeActionsJobs,
+			},
+		})
+		if err != nil {
+			return err
+		}
+		jobs, err = runJobs(envelope)
+		return err
+	})
+	return jobs, err
+}
+
+func printWatchRunJobs(stdout io.Writer, jobs []any) error {
+	for _, rawJob := range jobs {
+		job, ok := rawJob.(map[string]any)
+		if !ok {
+			continue
+		}
+		conclusion := firstString(job, "conclusion")
+		if _, err := fmt.Fprintf(stdout, "job %s: %s\n", firstString(job, "name"), conclusion); err != nil {
+			return err
+		}
+		if !strings.EqualFold(conclusion, "failure") {
+			continue
+		}
+		steps, _ := job["steps"].([]any)
+		for _, rawStep := range steps {
+			step, ok := rawStep.(map[string]any)
+			if !ok || !strings.EqualFold(firstString(step, "conclusion"), "failure") {
+				continue
+			}
+			if _, err := fmt.Fprintf(stdout, "  step %s: %s\n", firstString(step, "name"), firstString(step, "conclusion")); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func handleGHPRChecksWatch(ctx context.Context, args []string, stdout io.Writer) ghResult {
+	opts, ok := parseGHPRChecksWatchOptions(args)
+	if !ok || opts.jq != "" && !jqAvailable() {
+		return ghDelegated()
+	}
+	repo, ok := repoFromOptionOrCurrent(opts.repo)
+	if !ok {
+		return ghDelegated()
+	}
+	opts.repo = repo
+	return ghCompleted(relayPRChecksWatch(ctx, stdout, opts))
+}
+
+func parseGHPRChecksWatchOptions(args []string) (ghPRChecksWatchOptions, bool) {
+	opts := ghPRChecksWatchOptions{interval: watchMinInterval}
+	positionals := []string{}
+	watch := false
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "--watch":
+			watch = true
+		case arg == "--fail-fast":
+			opts.failFast = true
+		case watchFlagValue(args, &index, arg, "-R", &opts.repo):
+		case watchFlagValue(args, &index, arg, "--repo", &opts.repo):
+		case isWatchValueFlag(arg, "-i"):
+			value, valueOK := takeWatchFlagValue(args, &index, arg, "-i")
+			if !valueOK || !setWatchInterval(value, &opts.interval) {
+				return opts, false
+			}
+		case isWatchValueFlag(arg, "--interval"):
+			value, valueOK := takeWatchFlagValue(args, &index, arg, "--interval")
+			if !valueOK || !setWatchInterval(value, &opts.interval) {
+				return opts, false
+			}
+		case isWatchValueFlag(arg, "--json"):
+			value, valueOK := takeWatchFlagValue(args, &index, arg, "--json")
+			if !valueOK {
+				return opts, false
+			}
+			opts.json = splitFields(value)
+			if len(opts.json) == 0 || !supportedJSONFields(ghTopOptions{json: opts.json}, supportedCheckRunFields) {
+				return opts, false
+			}
+		case isWatchValueFlag(arg, "--jq"):
+			value, valueOK := takeWatchFlagValue(args, &index, arg, "--jq")
+			if !valueOK {
+				return opts, false
+			}
+			opts.jq = value
+		case isWatchValueFlag(arg, "-q"):
+			value, valueOK := takeWatchFlagValue(args, &index, arg, "-q")
+			if !valueOK {
+				return opts, false
+			}
+			opts.jq = value
+		case strings.HasPrefix(arg, "-"):
+			return opts, false
+		default:
+			positionals = append(positionals, arg)
+		}
+	}
+	if !watch || len(positionals) != 1 || !isDigits(positionals[0]) {
+		return opts, false
+	}
+	opts.number = positionals[0]
+	return opts, true
+}
+
+func relayPRChecksWatch(ctx context.Context, stdout io.Writer, opts ghPRChecksWatchOptions) error {
+	client, err := newGHRelayClient()
+	if err != nil {
+		return err
+	}
+	backoff := newWatchBackoff(opts.interval)
+	previousCounts := ""
+	progressPrinted := false
+	for {
+		var items []any
+		err := retryWatchTick(ctx, &backoff, func() error {
+			var pollErr error
+			items, pollErr = relayPRCheckItems(ctx, client, opts.repo, opts.number)
+			return pollErr
+		})
+		if err != nil {
+			return watchError(err, progressPrinted)
+		}
+		pending, passing, failing := checkWatchCounts(items)
+		counts := fmt.Sprintf("%d/%d/%d", pending, passing, failing)
+		if counts != previousCounts {
+			if _, err := fmt.Fprintf(stdout, "checks: %d pending, %d pass, %d fail\n", pending, passing, failing); err != nil {
+				return err
+			}
+			progressPrinted = true
+			previousCounts = counts
+		}
+		if pending == 0 || opts.failFast && failing > 0 {
+			if err := printPRChecksWatchFinal(ctx, stdout, items, opts); err != nil {
+				return err
+			}
+			return checkExitCode(items)
+		}
+		if err := backoff.sleep(ctx); err != nil {
+			return err
+		}
+	}
+}
+
+func checkWatchCounts(items []any) (pending int, passing int, failing int) {
+	for _, raw := range items {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		switch watchCheckBucket(item) {
+		case "pass", "skipping":
+			passing++
+		case "fail", "cancel":
+			failing++
+		default:
+			pending++
+		}
+	}
+	return pending, passing, failing
+}
+
+func watchCheckBucket(item map[string]any) string {
+	bucket := strings.ToLower(firstString(item, "bucket"))
+	if bucket != "" {
+		return bucket
+	}
+	state := strings.ToLower(firstString(item, "state"))
+	if state == "success" || state == "neutral" {
+		return "pass"
+	}
+	return "pending"
+}
+
+func printPRChecksWatchFinal(ctx context.Context, stdout io.Writer, items []any, opts ghPRChecksWatchOptions) error {
+	if len(opts.json) > 0 {
+		raw, err := json.Marshal(items)
+		if err != nil {
+			return err
+		}
+		raw, err = filterJSONFields(raw, opts.json, fieldMapCheckRun)
+		if err != nil {
+			return err
+		}
+		return writeBytes(ctx, stdout, raw, opts.jq)
+	}
+	for _, raw := range items {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, err := fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\n", firstString(item, "name"), firstString(item, "bucket"), firstString(item, "state"), firstString(item, "link")); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func watchError(err error, progressPrinted bool) error {
+	if progressPrinted && shouldRunRealGH(err) {
+		return errors.New(err.Error())
+	}
+	return err
+}
+
+func hasWatchFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--watch" {
+			return true
+		}
+	}
+	return false
+}
+
+func watchFlagValue(args []string, index *int, arg string, name string, target *string) bool {
+	if !isWatchValueFlag(arg, name) {
+		return false
+	}
+	value, ok := takeWatchFlagValue(args, index, arg, name)
+	if !ok {
+		return false
+	}
+	*target = value
+	return true
+}
+
+func isWatchValueFlag(arg string, name string) bool {
+	return arg == name || strings.HasPrefix(arg, name+"=")
+}
+
+func takeWatchFlagValue(args []string, index *int, arg string, name string) (string, bool) {
+	if strings.HasPrefix(arg, name+"=") {
+		value := strings.TrimPrefix(arg, name+"=")
+		return value, value != ""
+	}
+	*index = *index + 1
+	if *index >= len(args) {
+		return "", false
+	}
+	return args[*index], true
+}
+
+func setWatchInterval(raw string, interval *time.Duration) bool {
+	seconds, err := strconv.Atoi(raw)
+	if err != nil {
+		return false
+	}
+	*interval = max(time.Duration(seconds)*time.Second, watchMinInterval)
+	return true
+}
+
+func floorGHWatchDelegateArgs(args []string) []string {
+	if !isGHWatchShape(args) {
+		return args
+	}
+	out := append([]string(nil), args...)
+	found := false
+	for index := 2; index < len(out); index++ {
+		arg := out[index]
+		for _, name := range []string{"-i", "--interval"} {
+			if arg == name {
+				found = true
+				if index+1 < len(out) {
+					out[index+1] = floorWatchIntervalValue(out[index+1])
+					index++
+				}
+				break
+			}
+			if strings.HasPrefix(arg, name+"=") {
+				found = true
+				value := strings.TrimPrefix(arg, name+"=")
+				out[index] = name + "=" + floorWatchIntervalValue(value)
+				break
+			}
+		}
+	}
+	if !found {
+		out = append(out, "--interval", "30")
+	}
+	return out
+}
+
+func isGHWatchShape(args []string) bool {
+	if len(args) < 2 {
+		return false
+	}
+	if args[0] == "run" && args[1] == "watch" {
+		return true
+	}
+	return args[0] == "pr" && args[1] == "checks" && hasWatchFlag(args[2:])
+}
+
+func floorWatchIntervalValue(raw string) string {
+	seconds, err := strconv.Atoi(raw)
+	if err == nil && seconds < int(watchMinInterval/time.Second) {
+		return strconv.Itoa(int(watchMinInterval / time.Second))
+	}
+	return raw
+}

--- a/cmd/octopool/gh_top_watch.go
+++ b/cmd/octopool/gh_top_watch.go
@@ -521,12 +521,22 @@ func watchError(err error, progressPrinted bool) error {
 }
 
 func hasWatchFlag(args []string) bool {
+	// pflag applies last-value-wins to repeated boolean flags; mirror that so
+	// `--watch --watch=false` is not treated as a watch shape.
+	watch := false
 	for _, arg := range args {
+		if arg == "--" {
+			break
+		}
 		if watchFlagTrue(arg) {
-			return true
+			watch = true
+		} else if value, ok := strings.CutPrefix(arg, "--watch="); ok {
+			if parsed, err := strconv.ParseBool(value); err == nil && !parsed {
+				watch = false
+			}
 		}
 	}
-	return false
+	return watch
 }
 
 // watchFlagTrue mirrors pflag bool parsing: bare --watch or any ParseBool
@@ -588,6 +598,10 @@ func floorGHWatchDelegateArgs(args []string) []string {
 	found := false
 	for index := 2; index < len(out); index++ {
 		arg := out[index]
+		// Everything after the terminator is positional, never an interval flag.
+		if arg == "--" {
+			break
+		}
 		if value := attachedWatchInterval(arg); value != "" {
 			found = true
 			out[index] = "-i" + floorWatchIntervalValue(value)

--- a/cmd/octopool/gh_top_watch.go
+++ b/cmd/octopool/gh_top_watch.go
@@ -392,15 +392,17 @@ func relayPRChecksWatch(ctx context.Context, stdout io.Writer, opts ghPRChecksWa
 		if err != nil {
 			return watchError(err, progressPrinted)
 		}
-		pending, passing, failing := checkWatchCounts(items)
-		counts := fmt.Sprintf("%d/%d/%d", pending, passing, failing)
+		pending, passing, failing, cancelled := checkWatchCounts(items)
+		counts := fmt.Sprintf("%d/%d/%d/%d", pending, passing, failing, cancelled)
 		if counts != previousCounts {
-			if _, err := fmt.Fprintf(stdout, "checks: %d pending, %d pass, %d fail\n", pending, passing, failing); err != nil {
+			if _, err := fmt.Fprintf(stdout, "checks: %d pending, %d pass, %d fail, %d cancel\n", pending, passing, failing, cancelled); err != nil {
 				return err
 			}
 			progressPrinted = true
 		}
 		previousCounts = counts
+		// real gh's --fail-fast stops on failed checks only; cancellation is
+		// terminal but not a failure.
 		if pending == 0 || opts.failFast && failing > 0 {
 			// The snapshot came from bounded-staleness cache reads; a push right
 			// before the watch (new head SHA) or a check rerun (same SHA, cached
@@ -446,14 +448,14 @@ func confirmPRChecksTerminal(
 	if err != nil {
 		return nil, false, err
 	}
-	pending, _, failing := checkWatchCounts(items)
+	pending, _, failing, _ := checkWatchCounts(items)
 	if pending == 0 || opts.failFast && failing > 0 {
 		return items, true, nil
 	}
 	return nil, false, nil
 }
 
-func checkWatchCounts(items []any) (pending int, passing int, failing int) {
+func checkWatchCounts(items []any) (pending int, passing int, failing int, cancelled int) {
 	for _, raw := range items {
 		item, ok := raw.(map[string]any)
 		if !ok {
@@ -462,13 +464,15 @@ func checkWatchCounts(items []any) (pending int, passing int, failing int) {
 		switch watchCheckBucket(item) {
 		case "pass", "skipping":
 			passing++
-		case "fail", "cancel":
+		case "fail":
 			failing++
+		case "cancel":
+			cancelled++
 		default:
 			pending++
 		}
 	}
-	return pending, passing, failing
+	return pending, passing, failing, cancelled
 }
 
 func watchCheckBucket(item map[string]any) string {

--- a/cmd/octopool/gh_top_watch.go
+++ b/cmd/octopool/gh_top_watch.go
@@ -392,6 +392,11 @@ func relayPRChecksWatch(ctx context.Context, stdout io.Writer, opts ghPRChecksWa
 		if err != nil {
 			return watchError(err, progressPrinted)
 		}
+		// Zero registered checks must not read as green: real gh errors out
+		// instead of watching (push-then-watch races land here).
+		if len(items) == 0 {
+			return fmt.Errorf("no checks reported on pull request #%s", opts.number)
+		}
 		pending, passing, failing, cancelled := checkWatchCounts(items)
 		counts := fmt.Sprintf("%d/%d/%d/%d", pending, passing, failing, cancelled)
 		if counts != previousCounts {

--- a/cmd/octopool/gh_top_watch.go
+++ b/cmd/octopool/gh_top_watch.go
@@ -372,9 +372,10 @@ func relayPRChecksWatch(ctx context.Context, stdout io.Writer, opts ghPRChecksWa
 	progressPrinted := false
 	for {
 		var items []any
+		var sha string
 		err := retryWatchTick(ctx, &backoff, func() error {
 			var pollErr error
-			items, pollErr = relayPRCheckItems(ctx, client, opts.repo, opts.number)
+			items, sha, pollErr = relayPRCheckItemsWithSHA(ctx, client, opts.repo, opts.number)
 			return pollErr
 		})
 		if err != nil {
@@ -393,10 +394,19 @@ func relayPRChecksWatch(ctx context.Context, stdout io.Writer, opts ghPRChecksWa
 		}
 		previousCounts = counts
 		if pending == 0 || opts.failFast && failing > 0 {
-			if err := printPRChecksWatchFinal(ctx, stdout, items, opts); err != nil {
-				return err
+			// The snapshot's head came from a bounded-staleness lookup; a push
+			// right before the watch could otherwise turn a stale SHA's finished
+			// checks into a false terminal result. One fresh read per exit.
+			current, err := relayPRHeadSHA(ctx, client, opts.repo, opts.number, 0)
+			if err != nil {
+				return watchError(err, progressPrinted)
 			}
-			return checkExitCode(items)
+			if current == sha {
+				if err := printPRChecksWatchFinal(ctx, stdout, items, opts); err != nil {
+					return err
+				}
+				return checkExitCode(items)
+			}
 		}
 		if err := backoff.sleep(ctx); err != nil {
 			return err
@@ -569,7 +579,15 @@ func floorGHWatchDelegateArgs(args []string) []string {
 		}
 	}
 	if !found {
-		out = append(out, "--interval", "30")
+		floor := []string{"--interval", "30"}
+		// Keep the injected flag ahead of any `--` terminator; after it,
+		// real gh would treat the flag as a positional and reject the command.
+		for index, arg := range out {
+			if arg == "--" {
+				return append(out[:index:index], append(floor, out[index:]...)...)
+			}
+		}
+		out = append(out, floor...)
 	}
 	return out
 }

--- a/cmd/octopool/gh_top_watch.go
+++ b/cmd/octopool/gh_top_watch.go
@@ -41,8 +41,6 @@ type ghPRChecksWatchOptions struct {
 	number   string
 	interval time.Duration
 	failFast bool
-	json     []string
-	jq       string
 }
 
 type watchBackoff struct {
@@ -157,7 +155,7 @@ func relayRunWatch(ctx context.Context, stdout io.Writer, opts ghRunWatchOptions
 		var run map[string]any
 		err := retryWatchTick(ctx, &backoff, func() error {
 			var pollErr error
-			run, pollErr = relayWatchRun(ctx, client, opts.repo, opts.id)
+			run, pollErr = relayWatchRun(ctx, client, opts.repo, opts.id, nil)
 			return pollErr
 		})
 		if err != nil {
@@ -179,6 +177,31 @@ func relayRunWatch(ctx context.Context, stdout io.Writer, opts ghRunWatchOptions
 		}
 		previousStatus = status
 		if status == "completed" {
+			// Reruns reuse the run ID, so a cached terminal payload from a
+			// previous attempt could finalize the watch instantly with stale
+			// results. Confirm completion with one uncached read per exit.
+			var confirmed map[string]any
+			err := retryWatchTick(ctx, &backoff, func() error {
+				var pollErr error
+				confirmed, pollErr = relayWatchRun(ctx, client, opts.repo, opts.id, watchFreshHeaders())
+				return pollErr
+			})
+			if err != nil {
+				return watchError(err, progressPrinted)
+			}
+			confirmedStatus := watchSafeText(firstString(confirmed, "status"))
+			if confirmedStatus != "completed" {
+				if confirmedStatus != "" && confirmedStatus != status {
+					if _, err := fmt.Fprintf(stdout, "run %s: %s -> %s\n", opts.id, status, confirmedStatus); err != nil {
+						return err
+					}
+					previousStatus = confirmedStatus
+				}
+				if err := backoff.sleep(ctx); err != nil {
+					return err
+				}
+				continue
+			}
 			jobs, err := relayWatchRunJobs(ctx, client, opts.repo, opts.id, &backoff)
 			if err != nil {
 				return watchError(err, true)
@@ -186,7 +209,7 @@ func relayRunWatch(ctx context.Context, stdout io.Writer, opts ghRunWatchOptions
 			if err := printWatchRunJobs(stdout, jobs); err != nil {
 				return err
 			}
-			conclusion := watchSafeText(firstString(run, "conclusion"))
+			conclusion := watchSafeText(firstString(confirmed, "conclusion"))
 			if _, err := fmt.Fprintf(stdout, "Run %s completed with '%s'\n", opts.id, conclusion); err != nil {
 				return err
 			}
@@ -201,11 +224,19 @@ func relayRunWatch(ctx context.Context, stdout io.Writer, opts ghRunWatchOptions
 	}
 }
 
-func relayWatchRun(ctx context.Context, client ghRelayClient, repo string, id string) (map[string]any, error) {
+func watchFreshHeaders() map[string]string {
+	return map[string]string{"cache-control": "max-age=0"}
+}
+
+func relayWatchRun(ctx context.Context, client ghRelayClient, repo string, id string, extraHeaders map[string]string) (map[string]any, error) {
+	headers := map[string]string{"x-octopool-public-shape": publicShapeActionsSummary}
+	for key, value := range extraHeaders {
+		headers[key] = value
+	}
 	envelope, err := client.do(ctx, ghAPIRequest{
 		method:  "GET",
 		path:    repoPath(repo, "actions", "runs", id),
-		headers: map[string]string{"x-octopool-public-shape": publicShapeActionsSummary},
+		headers: headers,
 	})
 	if err != nil {
 		return nil, err
@@ -233,6 +264,9 @@ func relayWatchRunJobs(ctx context.Context, client ghRelayClient, repo string, i
 				query:  map[string]any{"per_page": strconv.Itoa(relayPageSize), "page": strconv.Itoa(page)},
 				headers: map[string]string{
 					"x-octopool-public-shape": publicShapeActionsJobs,
+					// The run just confirmed terminal; stale cached jobs from a
+					// previous attempt must not leak into the final summary.
+					"cache-control": "max-age=0",
 				},
 			})
 			if err != nil {
@@ -284,7 +318,7 @@ func printWatchRunJobs(stdout io.Writer, jobs []any) error {
 
 func handleGHPRChecksWatch(ctx context.Context, args []string, stdout io.Writer) ghResult {
 	opts, ok := parseGHPRChecksWatchOptions(args)
-	if !ok || opts.jq != "" && !jqAvailable() {
+	if !ok {
 		return ghDelegated()
 	}
 	repo, ok := repoFromOptionOrCurrent(opts.repo)
@@ -324,38 +358,15 @@ func parseGHPRChecksWatchOptions(args []string) (ghPRChecksWatchOptions, bool) {
 			if !setWatchInterval(attachedWatchInterval(arg), &opts.interval) {
 				return opts, false
 			}
-		case isWatchValueFlag(arg, "--json"):
-			value, valueOK := takeWatchFlagValue(args, &index, arg, "--json")
-			if !valueOK {
-				return opts, false
-			}
-			opts.json = splitFields(value)
-			if len(opts.json) == 0 || !supportedJSONFields(ghTopOptions{json: opts.json}, supportedCheckRunFields) {
-				return opts, false
-			}
-		case isWatchValueFlag(arg, "--jq"):
-			value, valueOK := takeWatchFlagValue(args, &index, arg, "--jq")
-			if !valueOK {
-				return opts, false
-			}
-			opts.jq = value
-		case isWatchValueFlag(arg, "-q"):
-			value, valueOK := takeWatchFlagValue(args, &index, arg, "-q")
-			if !valueOK {
-				return opts, false
-			}
-			opts.jq = value
 		case strings.HasPrefix(arg, "-"):
+			// real gh rejects --watch with --json/--jq/--template; delegating
+			// unknown flags lets it report those combinations itself.
 			return opts, false
 		default:
 			positionals = append(positionals, arg)
 		}
 	}
 	if !watch || len(positionals) != 1 || !isDigits(positionals[0]) {
-		return opts, false
-	}
-	// real gh rejects --jq without --json; delegate so it reports that itself.
-	if opts.jq != "" && len(opts.json) == 0 {
 		return opts, false
 	}
 	opts.number = positionals[0]
@@ -383,10 +394,7 @@ func relayPRChecksWatch(ctx context.Context, stdout io.Writer, opts ghPRChecksWa
 		}
 		pending, passing, failing := checkWatchCounts(items)
 		counts := fmt.Sprintf("%d/%d/%d", pending, passing, failing)
-		// Structured output must stay pure: no progress lines ahead of the
-		// final --json/--jq payload.
-		structured := len(opts.json) > 0 || opts.jq != ""
-		if counts != previousCounts && !structured {
+		if counts != previousCounts {
 			if _, err := fmt.Fprintf(stdout, "checks: %d pending, %d pass, %d fail\n", pending, passing, failing); err != nil {
 				return err
 			}
@@ -394,24 +402,49 @@ func relayPRChecksWatch(ctx context.Context, stdout io.Writer, opts ghPRChecksWa
 		}
 		previousCounts = counts
 		if pending == 0 || opts.failFast && failing > 0 {
-			// The snapshot's head came from a bounded-staleness lookup; a push
-			// right before the watch could otherwise turn a stale SHA's finished
-			// checks into a false terminal result. One fresh read per exit.
-			current, err := relayPRHeadSHA(ctx, client, opts.repo, opts.number, 0)
+			// The snapshot came from bounded-staleness cache reads; a push right
+			// before the watch (new head SHA) or a check rerun (same SHA, cached
+			// terminal payloads) could otherwise finalize on obsolete results.
+			// One fresh sweep per exit attempt.
+			final, confirmed, err := confirmPRChecksTerminal(ctx, client, opts, sha)
 			if err != nil {
 				return watchError(err, progressPrinted)
 			}
-			if current == sha {
-				if err := printPRChecksWatchFinal(ctx, stdout, items, opts); err != nil {
+			if confirmed {
+				if err := printPRChecksWatchFinal(stdout, final); err != nil {
 					return err
 				}
-				return checkExitCode(items)
+				return checkExitCode(final)
 			}
 		}
 		if err := backoff.sleep(ctx); err != nil {
 			return err
 		}
 	}
+}
+
+func confirmPRChecksTerminal(
+	ctx context.Context,
+	client ghRelayClient,
+	opts ghPRChecksWatchOptions,
+	sha string,
+) ([]any, bool, error) {
+	current, err := relayPRHeadSHA(ctx, client, opts.repo, opts.number, 0)
+	if err != nil {
+		return nil, false, err
+	}
+	if current != sha {
+		return nil, false, nil
+	}
+	items, err := prCheckItemsForSHAFresh(ctx, client, opts.repo, current)
+	if err != nil {
+		return nil, false, err
+	}
+	pending, _, failing := checkWatchCounts(items)
+	if pending == 0 || opts.failFast && failing > 0 {
+		return items, true, nil
+	}
+	return nil, false, nil
 }
 
 func checkWatchCounts(items []any) (pending int, passing int, failing int) {
@@ -444,18 +477,7 @@ func watchCheckBucket(item map[string]any) string {
 	return "pending"
 }
 
-func printPRChecksWatchFinal(ctx context.Context, stdout io.Writer, items []any, opts ghPRChecksWatchOptions) error {
-	if len(opts.json) > 0 {
-		raw, err := json.Marshal(items)
-		if err != nil {
-			return err
-		}
-		raw, err = filterJSONFields(raw, opts.json, fieldMapCheckRun)
-		if err != nil {
-			return err
-		}
-		return writeBytes(ctx, stdout, raw, opts.jq)
-	}
+func printPRChecksWatchFinal(stdout io.Writer, items []any) error {
 	for _, raw := range items {
 		item, ok := raw.(map[string]any)
 		if !ok {

--- a/cmd/octopool/gh_top_watch.go
+++ b/cmd/octopool/gh_top_watch.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 const (
@@ -104,6 +105,8 @@ func parseGHRunWatchOptions(args []string) (ghRunWatchOptions, bool) {
 		case arg == "--exit-status":
 			opts.exitStatus = true
 		case arg == "--compact":
+			// Accepted without effect: the shim's terse transition/summary output
+			// is already compact by design and does not render real gh's live table.
 		case watchFlagValue(args, &index, arg, "-R", &opts.repo):
 		case watchFlagValue(args, &index, arg, "--repo", &opts.repo):
 		case isWatchValueFlag(arg, "-i"):
@@ -114,6 +117,10 @@ func parseGHRunWatchOptions(args []string) (ghRunWatchOptions, bool) {
 		case isWatchValueFlag(arg, "--interval"):
 			value, valueOK := takeWatchFlagValue(args, &index, arg, "--interval")
 			if !valueOK || !setWatchInterval(value, &opts.interval) {
+				return opts, false
+			}
+		case attachedWatchInterval(arg) != "":
+			if !setWatchInterval(attachedWatchInterval(arg), &opts.interval) {
 				return opts, false
 			}
 		case strings.HasPrefix(arg, "-"):
@@ -127,6 +134,15 @@ func parseGHRunWatchOptions(args []string) (ghRunWatchOptions, bool) {
 	}
 	opts.id = positionals[0]
 	return opts, true
+}
+
+// attachedWatchInterval handles pflag's attached shorthand form -i45.
+func attachedWatchInterval(arg string) string {
+	value, ok := strings.CutPrefix(arg, "-i")
+	if !ok || value == "" || !isDigits(value) {
+		return ""
+	}
+	return value
 }
 
 func relayRunWatch(ctx context.Context, stdout io.Writer, opts ghRunWatchOptions) error {
@@ -147,7 +163,7 @@ func relayRunWatch(ctx context.Context, stdout io.Writer, opts ghRunWatchOptions
 		if err != nil {
 			return watchError(err, progressPrinted)
 		}
-		status := firstString(run, "status")
+		status := watchSafeText(firstString(run, "status"))
 		if status == "" {
 			return watchError(errors.New("workflow run response did not include status"), progressPrinted)
 		}
@@ -170,7 +186,7 @@ func relayRunWatch(ctx context.Context, stdout io.Writer, opts ghRunWatchOptions
 			if err := printWatchRunJobs(stdout, jobs); err != nil {
 				return err
 			}
-			conclusion := firstString(run, "conclusion")
+			conclusion := watchSafeText(firstString(run, "conclusion"))
 			if _, err := fmt.Fprintf(stdout, "Run %s completed with '%s'\n", opts.id, conclusion); err != nil {
 				return err
 			}
@@ -245,8 +261,8 @@ func printWatchRunJobs(stdout io.Writer, jobs []any) error {
 		if !ok {
 			continue
 		}
-		conclusion := firstString(job, "conclusion")
-		if _, err := fmt.Fprintf(stdout, "job %s: %s\n", firstString(job, "name"), conclusion); err != nil {
+		conclusion := watchSafeText(firstString(job, "conclusion"))
+		if _, err := fmt.Fprintf(stdout, "job %s: %s\n", watchSafeText(firstString(job, "name")), conclusion); err != nil {
 			return err
 		}
 		if !strings.EqualFold(conclusion, "failure") {
@@ -258,7 +274,7 @@ func printWatchRunJobs(stdout io.Writer, jobs []any) error {
 			if !ok || !strings.EqualFold(firstString(step, "conclusion"), "failure") {
 				continue
 			}
-			if _, err := fmt.Fprintf(stdout, "  step %s: %s\n", firstString(step, "name"), firstString(step, "conclusion")); err != nil {
+			if _, err := fmt.Fprintf(stdout, "  step %s: %s\n", watchSafeText(firstString(step, "name")), watchSafeText(firstString(step, "conclusion"))); err != nil {
 				return err
 			}
 		}
@@ -286,8 +302,10 @@ func parseGHPRChecksWatchOptions(args []string) (ghPRChecksWatchOptions, bool) {
 	for index := 0; index < len(args); index++ {
 		arg := args[index]
 		switch {
-		case arg == "--watch" || arg == "--watch=true":
+		case watchFlagTrue(arg):
 			watch = true
+		case strings.HasPrefix(arg, "--watch="):
+			return opts, false
 		case arg == "--fail-fast":
 			opts.failFast = true
 		case watchFlagValue(args, &index, arg, "-R", &opts.repo):
@@ -300,6 +318,10 @@ func parseGHPRChecksWatchOptions(args []string) (ghPRChecksWatchOptions, bool) {
 		case isWatchValueFlag(arg, "--interval"):
 			value, valueOK := takeWatchFlagValue(args, &index, arg, "--interval")
 			if !valueOK || !setWatchInterval(value, &opts.interval) {
+				return opts, false
+			}
+		case attachedWatchInterval(arg) != "":
+			if !setWatchInterval(attachedWatchInterval(arg), &opts.interval) {
 				return opts, false
 			}
 		case isWatchValueFlag(arg, "--json"):
@@ -330,6 +352,10 @@ func parseGHPRChecksWatchOptions(args []string) (ghPRChecksWatchOptions, bool) {
 		}
 	}
 	if !watch || len(positionals) != 1 || !isDigits(positionals[0]) {
+		return opts, false
+	}
+	// real gh rejects --jq without --json; delegate so it reports that itself.
+	if opts.jq != "" && len(opts.json) == 0 {
 		return opts, false
 	}
 	opts.number = positionals[0]
@@ -425,11 +451,24 @@ func printPRChecksWatchFinal(ctx context.Context, stdout io.Writer, items []any,
 		if !ok {
 			continue
 		}
-		if _, err := fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\n", firstString(item, "name"), firstString(item, "bucket"), firstString(item, "state"), firstString(item, "link")); err != nil {
+		if _, err := fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\n", watchSafeText(firstString(item, "name")), firstString(item, "bucket"), watchSafeText(firstString(item, "state")), watchSafeText(firstString(item, "link"))); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// watchSafeText strips ASCII/C1 control characters and invalid UTF-8 from
+// API-controlled strings so job/check names cannot inject terminal escape
+// sequences. Printable CSI remainders like "[31m" are harmless once the
+// escape introducer is gone.
+func watchSafeText(raw string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) || r == utf8.RuneError {
+			return -1
+		}
+		return r
+	}, raw)
 }
 
 func watchError(err error, progressPrinted bool) error {
@@ -441,12 +480,25 @@ func watchError(err error, progressPrinted bool) error {
 
 func hasWatchFlag(args []string) bool {
 	for _, arg := range args {
-		// Cobra bools also accept the explicit form; --watch=false stays unwatched.
-		if arg == "--watch" || arg == "--watch=true" {
+		if watchFlagTrue(arg) {
 			return true
 		}
 	}
 	return false
+}
+
+// watchFlagTrue mirrors pflag bool parsing: bare --watch or any ParseBool
+// true spelling counts; false spellings stay unwatched.
+func watchFlagTrue(arg string) bool {
+	if arg == "--watch" {
+		return true
+	}
+	value, ok := strings.CutPrefix(arg, "--watch=")
+	if !ok {
+		return false
+	}
+	parsed, err := strconv.ParseBool(value)
+	return err == nil && parsed
 }
 
 func watchFlagValue(args []string, index *int, arg string, name string, target *string) bool {
@@ -494,6 +546,11 @@ func floorGHWatchDelegateArgs(args []string) []string {
 	found := false
 	for index := 2; index < len(out); index++ {
 		arg := out[index]
+		if value := attachedWatchInterval(arg); value != "" {
+			found = true
+			out[index] = "-i" + floorWatchIntervalValue(value)
+			continue
+		}
 		for _, name := range []string{"-i", "--interval"} {
 			if arg == name {
 				found = true

--- a/cmd/octopool/gh_top_watch.go
+++ b/cmd/octopool/gh_top_watch.go
@@ -392,10 +392,28 @@ func relayPRChecksWatch(ctx context.Context, stdout io.Writer, opts ghPRChecksWa
 		if err != nil {
 			return watchError(err, progressPrinted)
 		}
-		// Zero registered checks must not read as green: real gh errors out
-		// instead of watching (push-then-watch races land here).
+		// Zero registered checks must not read as green. A cached empty
+		// snapshot may simply predate check registration, so confirm with a
+		// fresh sweep first; genuinely empty results error like real gh.
 		if len(items) == 0 {
-			return fmt.Errorf("no checks reported on pull request #%s", opts.number)
+			err := retryWatchTick(ctx, &backoff, func() error {
+				current, freshErr := relayPRHeadSHA(ctx, client, opts.repo, opts.number, 0)
+				if freshErr != nil {
+					return freshErr
+				}
+				freshItems, freshErr := prCheckItemsForSHAFresh(ctx, client, opts.repo, current)
+				if freshErr != nil {
+					return freshErr
+				}
+				items, sha = freshItems, current
+				return nil
+			})
+			if err != nil {
+				return watchError(err, progressPrinted)
+			}
+			if len(items) == 0 {
+				return fmt.Errorf("no checks reported on pull request #%s", opts.number)
+			}
 		}
 		pending, passing, failing, cancelled := checkWatchCounts(items)
 		counts := fmt.Sprintf("%d/%d/%d/%d", pending, passing, failing, cancelled)
@@ -452,6 +470,11 @@ func confirmPRChecksTerminal(
 	items, err := prCheckItemsForSHAFresh(ctx, client, opts.repo, current)
 	if err != nil {
 		return nil, false, err
+	}
+	// A fresh empty set after a terminal-looking cached snapshot is an
+	// anomaly (rerun re-registration, data lag) — never confirm it as green.
+	if len(items) == 0 {
+		return nil, false, fmt.Errorf("no checks reported on pull request #%s", opts.number)
 	}
 	pending, _, failing, _ := checkWatchCounts(items)
 	if pending == 0 || opts.failFast && failing > 0 {

--- a/cmd/octopool/gh_top_watch_test.go
+++ b/cmd/octopool/gh_top_watch_test.go
@@ -240,10 +240,26 @@ func TestGHPRChecksWatchFailFastIgnoresCancelled(t *testing.T) {
 	var out bytes.Buffer
 	result := handleGHPR(t.Context(), []string{"checks", "7", "-R", "openclaw/octopool", "--watch", "--fail-fast"}, &out)
 	// Cancelled is terminal but not failed: the watch must keep polling the
-	// pending check instead of fail-fasting, then exit 1 from the cancel bucket.
-	assertExitCode(t, result.err, 1)
+	// pending check instead of fail-fasting, and cancelled-only results exit 0
+	// exactly like real gh (Failed then Pending counts decide the exit code).
+	if result.action != ghComplete || result.err != nil {
+		t.Fatalf("action=%v err=%v", result.action, result.err)
+	}
 	if len(*sleeps) == 0 || !strings.Contains(out.String(), "checks: 1 pending, 0 pass, 0 fail, 1 cancel") {
 		t.Fatalf("sleeps=%v out=%q", *sleeps, out.String())
+	}
+}
+
+func TestGHWatchShapeLastWatchValueWins(t *testing.T) {
+	if isGHWatchShape([]string{"pr", "checks", "7", "--watch", "--watch=false"}) {
+		t.Fatal("--watch --watch=false must not count as a watch shape")
+	}
+	if !isGHWatchShape([]string{"pr", "checks", "7", "--watch=false", "--watch"}) {
+		t.Fatal("--watch=false --watch must count as a watch shape")
+	}
+	floored := floorGHWatchDelegateArgs([]string{"run", "watch", "42", "--", "-i1"})
+	if !reflect.DeepEqual(floored, []string{"run", "watch", "42", "--interval", "30", "--", "-i1"}) {
+		t.Fatalf("post-terminator tokens must stay untouched and floor injected before --, got %v", floored)
 	}
 }
 

--- a/cmd/octopool/gh_top_watch_test.go
+++ b/cmd/octopool/gh_top_watch_test.go
@@ -1,0 +1,334 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGHRunWatchPrintsTransitionsAndFetchesJobsOnce(t *testing.T) {
+	var runCalls int
+	var jobsCalls int
+	relayTestServer(t, func(body map[string]any) any {
+		switch body["path"] {
+		case "/repos/openclaw/octopool/actions/runs/42":
+			runCalls++
+			headers, _ := body["headers"].(map[string]any)
+			if headers["x-octopool-public-shape"] != "actions-summary-v1" {
+				t.Fatalf("run headers = %#v", headers)
+			}
+			statuses := []string{"queued", "in_progress", "in_progress", "completed"}
+			return map[string]any{"status": statuses[runCalls-1], "conclusion": "failure"}
+		case "/repos/openclaw/octopool/actions/runs/42/jobs":
+			jobsCalls++
+			headers, _ := body["headers"].(map[string]any)
+			query, _ := body["query"].(map[string]any)
+			if headers["x-octopool-public-shape"] != "actions-jobs-v1" || query["per_page"] != "100" {
+				t.Fatalf("jobs headers=%#v query=%#v", headers, query)
+			}
+			return map[string]any{
+				"total_count": 1,
+				"jobs": []map[string]any{{
+					"name": "Test", "status": "completed", "conclusion": "failure",
+					"steps": []map[string]any{
+						{"name": "Compile", "status": "completed", "conclusion": "success"},
+						{"name": "Unit tests", "status": "completed", "conclusion": "failure"},
+					},
+				}},
+			}
+		default:
+			t.Fatalf("unexpected path = %v", body["path"])
+			return nil
+		}
+	})
+	sleeps := recordWatchSleeps(t)
+	var out bytes.Buffer
+	result := handleGHRun(t.Context(), []string{"watch", "42", "-R", "openclaw/octopool"}, &out)
+	if result.action != ghComplete || result.err != nil {
+		t.Fatalf("action=%v err=%v", result.action, result.err)
+	}
+	wantLines := []string{
+		"Watching run 42 in openclaw/octopool (status: queued)",
+		"run 42: queued -> in_progress",
+		"run 42: in_progress -> completed",
+		"job Test: failure",
+		"  step Unit tests: failure",
+		"Run 42 completed with 'failure'",
+	}
+	for _, want := range wantLines {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
+	if runCalls != 4 || jobsCalls != 1 {
+		t.Fatalf("run calls=%d jobs calls=%d", runCalls, jobsCalls)
+	}
+	if want := []time.Duration{30 * time.Second, 60 * time.Second, 120 * time.Second}; !reflect.DeepEqual(*sleeps, want) {
+		t.Fatalf("sleeps=%v want=%v", *sleeps, want)
+	}
+}
+
+func TestGHRunWatchRequestedIntervalStartsAt45Seconds(t *testing.T) {
+	var calls int
+	relayTestServer(t, func(body map[string]any) any {
+		if strings.HasSuffix(body["path"].(string), "/jobs") {
+			return map[string]any{"total_count": 0, "jobs": []any{}}
+		}
+		calls++
+		status := "in_progress"
+		conclusion := ""
+		if calls == 2 {
+			status = "completed"
+			conclusion = "success"
+		}
+		return map[string]any{"status": status, "conclusion": conclusion}
+	})
+	sleeps := recordWatchSleeps(t)
+	result := handleGHRun(t.Context(), []string{"watch", "42", "-R", "openclaw/octopool", "-i", "45"}, &bytes.Buffer{})
+	if result.action != ghComplete || result.err != nil {
+		t.Fatalf("action=%v err=%v", result.action, result.err)
+	}
+	if want := []time.Duration{45 * time.Second}; !reflect.DeepEqual(*sleeps, want) {
+		t.Fatalf("sleeps=%v want=%v", *sleeps, want)
+	}
+}
+
+func TestGHRunWatchFloorsRequestedInterval(t *testing.T) {
+	var calls int
+	relayTestServer(t, func(body map[string]any) any {
+		if strings.HasSuffix(body["path"].(string), "/jobs") {
+			return map[string]any{"total_count": 0, "jobs": []any{}}
+		}
+		calls++
+		if calls == 1 {
+			return map[string]any{"status": "queued"}
+		}
+		return map[string]any{"status": "completed", "conclusion": "success"}
+	})
+	sleeps := recordWatchSleeps(t)
+	result := handleGHRun(t.Context(), []string{"watch", "42", "-R", "openclaw/octopool", "-i", "5"}, &bytes.Buffer{})
+	if result.action != ghComplete || result.err != nil {
+		t.Fatalf("action=%v err=%v", result.action, result.err)
+	}
+	if want := []time.Duration{30 * time.Second}; !reflect.DeepEqual(*sleeps, want) {
+		t.Fatalf("sleeps=%v want=%v", *sleeps, want)
+	}
+}
+
+func TestGHRunWatchExitStatusFailure(t *testing.T) {
+	relayTestServer(t, func(body map[string]any) any {
+		if strings.HasSuffix(body["path"].(string), "/jobs") {
+			return map[string]any{"total_count": 0, "jobs": []any{}}
+		}
+		return map[string]any{"status": "completed", "conclusion": "failure"}
+	})
+	recordWatchSleeps(t)
+	result := handleGHRun(t.Context(), []string{"watch", "42", "-R", "openclaw/octopool", "--exit-status"}, &bytes.Buffer{})
+	assertExitCode(t, result.err, 1)
+}
+
+func TestGHPRChecksWatchPendingToDone(t *testing.T) {
+	var checkCalls int
+	relayTestServer(t, func(body map[string]any) any {
+		switch body["path"] {
+		case "/repos/openclaw/octopool/pulls/7":
+			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+		case "/repos/openclaw/octopool/commits/abc1234/check-runs":
+			checkCalls++
+			status := "in_progress"
+			conclusion := ""
+			if checkCalls == 2 {
+				status = "completed"
+				conclusion = "success"
+			}
+			return map[string]any{
+				"total_count": 2,
+				"check_runs": []map[string]any{
+					{"name": "CI", "status": status, "conclusion": conclusion, "details_url": "https://example.test/ci"},
+					{"name": "Lint", "status": "completed", "conclusion": "success", "details_url": "https://example.test/lint"},
+				},
+			}
+		case "/repos/openclaw/octopool/commits/abc1234/status":
+			return map[string]any{"statuses": []any{}}
+		default:
+			t.Fatalf("unexpected path = %v", body["path"])
+			return nil
+		}
+	})
+	sleeps := recordWatchSleeps(t)
+	var out bytes.Buffer
+	result := handleGHPR(t.Context(), []string{"checks", "7", "-R", "openclaw/octopool", "--watch"}, &out)
+	if result.action != ghComplete || result.err != nil {
+		t.Fatalf("action=%v err=%v", result.action, result.err)
+	}
+	for _, want := range []string{
+		"checks: 1 pending, 1 pass, 0 fail",
+		"checks: 0 pending, 2 pass, 0 fail",
+		"CI\tpass\tSUCCESS\thttps://example.test/ci",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
+	if want := []time.Duration{30 * time.Second}; !reflect.DeepEqual(*sleeps, want) {
+		t.Fatalf("sleeps=%v want=%v", *sleeps, want)
+	}
+}
+
+func TestGHPRChecksWatchFailFast(t *testing.T) {
+	var checkCalls int
+	relayTestServer(t, func(body map[string]any) any {
+		switch body["path"] {
+		case "/repos/openclaw/octopool/pulls/7":
+			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+		case "/repos/openclaw/octopool/commits/abc1234/check-runs":
+			checkCalls++
+			return map[string]any{"total_count": 2, "check_runs": []map[string]any{
+				{"name": "CI", "status": "completed", "conclusion": "failure"},
+				{"name": "Integration", "status": "queued"},
+			}}
+		case "/repos/openclaw/octopool/commits/abc1234/status":
+			return map[string]any{"statuses": []any{}}
+		default:
+			t.Fatalf("unexpected path = %v", body["path"])
+			return nil
+		}
+	})
+	sleeps := recordWatchSleeps(t)
+	var out bytes.Buffer
+	result := handleGHPR(t.Context(), []string{"checks", "7", "-R", "openclaw/octopool", "--watch", "--fail-fast"}, &out)
+	assertExitCode(t, result.err, 1)
+	if checkCalls != 1 || len(*sleeps) != 0 {
+		t.Fatalf("check calls=%d sleeps=%v", checkCalls, *sleeps)
+	}
+	if !strings.Contains(out.String(), "checks: 1 pending, 0 pass, 1 fail") || !strings.Contains(out.String(), "CI\tfail\tFAILURE") {
+		t.Fatalf("out=%q", out.String())
+	}
+}
+
+func TestGHPRChecksWatchJSONFinalSnapshot(t *testing.T) {
+	relayTestServer(t, func(body map[string]any) any {
+		switch body["path"] {
+		case "/repos/openclaw/octopool/pulls/7":
+			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+		case "/repos/openclaw/octopool/commits/abc1234/check-runs":
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"name": "CI", "status": "completed", "conclusion": "success"}}}
+		case "/repos/openclaw/octopool/commits/abc1234/status":
+			return map[string]any{"statuses": []any{}}
+		default:
+			t.Fatalf("unexpected path = %v", body["path"])
+			return nil
+		}
+	})
+	recordWatchSleeps(t)
+	var out bytes.Buffer
+	result := handleGHPR(t.Context(), []string{"checks", "7", "-R", "openclaw/octopool", "--watch", "--json", "name,bucket"}, &out)
+	if result.action != ghComplete || result.err != nil {
+		t.Fatalf("action=%v err=%v", result.action, result.err)
+	}
+	if !strings.Contains(out.String(), `[{"bucket":"pass","name":"CI"}]`) {
+		t.Fatalf("out=%q", out.String())
+	}
+}
+
+func TestGHWatchDelegatesWithFlooredInterval(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "unsupported pr checks flag",
+			args: []string{"pr", "checks", "7", "--watch", "--required", "-i=5"},
+			want: "real-gh:pr checks 7 --watch --required -i=30",
+		},
+		{
+			name: "missing run id",
+			args: []string{"run", "watch"},
+			want: "real-gh:run watch --interval 30",
+		},
+		{
+			name: "unknown run flag",
+			args: []string{"run", "watch", "42", "--web"},
+			want: "real-gh:run watch 42 --web --interval 30",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OCTOPOOL_GH_PATH", fakeGH(t))
+			var out bytes.Buffer
+			if err := runGH(t.Context(), test.args, &out, &bytes.Buffer{}); err != nil {
+				t.Fatal(err)
+			}
+			if got := strings.TrimSpace(out.String()); got != test.want {
+				t.Fatalf("got=%q want=%q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestWatchTickRetriesThreeConsecutiveErrors(t *testing.T) {
+	sleeps := recordWatchSleeps(t)
+	backoff := newWatchBackoff(30 * time.Second)
+	calls := 0
+	err := retryWatchTick(t.Context(), &backoff, func() error {
+		calls++
+		return errors.New("relay unavailable")
+	})
+	if err == nil || calls != 3 {
+		t.Fatalf("err=%v calls=%d", err, calls)
+	}
+	if want := []time.Duration{30 * time.Second, 60 * time.Second}; !reflect.DeepEqual(*sleeps, want) {
+		t.Fatalf("sleeps=%v want=%v", *sleeps, want)
+	}
+}
+
+func TestWatchTickBailsImmediatelyOnDeterministicRefusal(t *testing.T) {
+	sleeps := recordWatchSleeps(t)
+	backoff := newWatchBackoff(30 * time.Second)
+	calls := 0
+	err := retryWatchTick(t.Context(), &backoff, func() error {
+		calls++
+		return localFallbackError{Reason: "repo_not_public"}
+	})
+	if !shouldRunRealGH(err) || calls != 1 {
+		t.Fatalf("err=%v calls=%d, want immediate fallback-eligible error", err, calls)
+	}
+	if len(*sleeps) != 0 {
+		t.Fatalf("sleeps=%v, want none before deterministic refusal surfaces", *sleeps)
+	}
+}
+
+func TestWatchFallbackOnlyBeforeProgress(t *testing.T) {
+	fallback := localFallbackError{Reason: "route denied"}
+	if err := watchError(fallback, false); !shouldRunRealGH(err) {
+		t.Fatalf("first-tick error should preserve fallback: %v", err)
+	}
+	if err := watchError(fallback, true); shouldRunRealGH(err) || err.Error() != fallback.Error() {
+		t.Fatalf("post-progress error should fail locally: %v", err)
+	}
+}
+
+func recordWatchSleeps(t *testing.T) *[]time.Duration {
+	t.Helper()
+	original := watchSleep
+	durations := []time.Duration{}
+	watchSleep = func(_ context.Context, duration time.Duration) error {
+		durations = append(durations, duration)
+		return nil
+	}
+	t.Cleanup(func() { watchSleep = original })
+	return &durations
+}
+
+func assertExitCode(t *testing.T, err error, code int) {
+	t.Helper()
+	var exit exitCodeError
+	if !errors.As(err, &exit) || exit.Code != code {
+		t.Fatalf("err=%v, want exit code %d", err, code)
+	}
+}

--- a/cmd/octopool/gh_top_watch_test.go
+++ b/cmd/octopool/gh_top_watch_test.go
@@ -286,11 +286,42 @@ func TestGHPRChecksWatchEqualsTrueSpelling(t *testing.T) {
 	if result.action != ghComplete || result.err != nil {
 		t.Fatalf("--watch=true must use the native watch path: action=%v err=%v", result.action, result.err)
 	}
-	if !isGHWatchShape([]string{"pr", "checks", "7", "--watch=true"}) {
-		t.Fatal("--watch=true must count as a watch shape for interval flooring")
+	for _, spelling := range []string{"--watch=true", "--watch=1", "--watch=t", "--watch=TRUE"} {
+		if !isGHWatchShape([]string{"pr", "checks", "7", spelling}) {
+			t.Fatalf("%s must count as a watch shape for interval flooring", spelling)
+		}
 	}
-	if isGHWatchShape([]string{"pr", "checks", "7", "--watch=false"}) {
-		t.Fatal("--watch=false must not count as a watch shape")
+	for _, spelling := range []string{"--watch=false", "--watch=0", "--watch=F"} {
+		if isGHWatchShape([]string{"pr", "checks", "7", spelling}) {
+			t.Fatalf("%s must not count as a watch shape", spelling)
+		}
+	}
+}
+
+func TestGHWatchParsersHandleAttachedInterval(t *testing.T) {
+	opts, ok := parseGHRunWatchOptions([]string{"42", "-i45"})
+	if !ok || opts.interval != 45*time.Second {
+		t.Fatalf("run watch -i45: ok=%v interval=%v", ok, opts.interval)
+	}
+	checkOpts, ok := parseGHPRChecksWatchOptions([]string{"7", "--watch", "-i5"})
+	if !ok || checkOpts.interval != watchMinInterval {
+		t.Fatalf("checks watch -i5 must floor: ok=%v interval=%v", ok, checkOpts.interval)
+	}
+	floored := floorGHWatchDelegateArgs([]string{"run", "watch", "42", "--json", "x", "-i5"})
+	if !reflect.DeepEqual(floored, []string{"run", "watch", "42", "--json", "x", "-i30"}) {
+		t.Fatalf("delegated -i5 must floor in place, got %v", floored)
+	}
+}
+
+func TestGHPRChecksWatchJQWithoutJSONDelegates(t *testing.T) {
+	if _, ok := parseGHPRChecksWatchOptions([]string{"7", "--watch", "--jq", ".x"}); ok {
+		t.Fatal("--jq without --json must delegate to real gh")
+	}
+}
+
+func TestWatchSafeTextStripsControlSequences(t *testing.T) {
+	if got := watchSafeText("ok\x1b[31mred\x9bx\x00\ttab"); got != "ok[31mredxtab" {
+		t.Fatalf("got %q", got)
 	}
 }
 

--- a/cmd/octopool/gh_top_watch_test.go
+++ b/cmd/octopool/gh_top_watch_test.go
@@ -272,6 +272,63 @@ func TestGHPRChecksWatchErrorsOnNoChecks(t *testing.T) {
 	}
 }
 
+func TestGHPRChecksWatchCachedEmptyRevalidatesFresh(t *testing.T) {
+	relayTestServer(t, func(body map[string]any) any {
+		switch path := body["path"].(string); {
+		case path == "/repos/openclaw/octopool/pulls/7":
+			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+		case strings.HasSuffix(path, "/check-runs"):
+			h, _ := body["headers"].(map[string]any)
+			if h["cache-control"] != "max-age=0" {
+				// Stale shared-cache entry from before checks registered.
+				return map[string]any{"total_count": 0, "check_runs": []any{}}
+			}
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"name": "CI", "status": "completed", "conclusion": "success"}}}
+		case strings.HasSuffix(path, "/status"):
+			return map[string]any{"total_count": 0, "statuses": []any{}}
+		default:
+			t.Fatalf("unexpected path = %v", path)
+			return nil
+		}
+	})
+	recordWatchSleeps(t)
+	var out bytes.Buffer
+	result := handleGHPR(t.Context(), []string{"checks", "7", "-R", "openclaw/octopool", "--watch"}, &out)
+	if result.action != ghComplete || result.err != nil {
+		t.Fatalf("cached emptiness must revalidate fresh and continue: action=%v err=%v", result.action, result.err)
+	}
+	if !strings.Contains(out.String(), "CI\tpass") {
+		t.Fatalf("out=%q", out.String())
+	}
+}
+
+func TestGHPRChecksWatchFreshEmptyTerminalIsNotGreen(t *testing.T) {
+	relayTestServer(t, func(body map[string]any) any {
+		switch path := body["path"].(string); {
+		case path == "/repos/openclaw/octopool/pulls/7":
+			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+		case strings.HasSuffix(path, "/check-runs"):
+			h, _ := body["headers"].(map[string]any)
+			if h["cache-control"] == "max-age=0" {
+				// Terminal confirmation sees the checks vanish (rerun lag).
+				return map[string]any{"total_count": 0, "check_runs": []any{}}
+			}
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"name": "CI", "status": "completed", "conclusion": "success"}}}
+		case strings.HasSuffix(path, "/status"):
+			return map[string]any{"total_count": 0, "statuses": []any{}}
+		default:
+			t.Fatalf("unexpected path = %v", path)
+			return nil
+		}
+	})
+	recordWatchSleeps(t)
+	var out bytes.Buffer
+	result := handleGHPR(t.Context(), []string{"checks", "7", "-R", "openclaw/octopool", "--watch"}, &out)
+	if result.err == nil || !strings.Contains(result.err.Error(), "no checks reported") {
+		t.Fatalf("fresh-empty terminal must not confirm green: err=%v", result.err)
+	}
+}
+
 func TestGHWatchShapeLastWatchValueWins(t *testing.T) {
 	if isGHWatchShape([]string{"pr", "checks", "7", "--watch", "--watch=false"}) {
 		t.Fatal("--watch --watch=false must not count as a watch shape")

--- a/cmd/octopool/gh_top_watch_test.go
+++ b/cmd/octopool/gh_top_watch_test.go
@@ -167,8 +167,8 @@ func TestGHPRChecksWatchPendingToDone(t *testing.T) {
 		t.Fatalf("action=%v err=%v", result.action, result.err)
 	}
 	for _, want := range []string{
-		"checks: 1 pending, 1 pass, 0 fail",
-		"checks: 0 pending, 2 pass, 0 fail",
+		"checks: 1 pending, 1 pass, 0 fail, 0 cancel",
+		"checks: 0 pending, 2 pass, 0 fail, 0 cancel",
 		"CI\tpass\tSUCCESS\thttps://example.test/ci",
 	} {
 		if !strings.Contains(out.String(), want) {
@@ -207,8 +207,43 @@ func TestGHPRChecksWatchFailFast(t *testing.T) {
 	if checkCalls != 2 || len(*sleeps) != 0 {
 		t.Fatalf("check calls=%d sleeps=%v", checkCalls, *sleeps)
 	}
-	if !strings.Contains(out.String(), "checks: 1 pending, 0 pass, 1 fail") || !strings.Contains(out.String(), "CI\tfail\tFAILURE") {
+	if !strings.Contains(out.String(), "checks: 1 pending, 0 pass, 1 fail, 0 cancel") || !strings.Contains(out.String(), "CI\tfail\tFAILURE") {
 		t.Fatalf("out=%q", out.String())
+	}
+}
+
+func TestGHPRChecksWatchFailFastIgnoresCancelled(t *testing.T) {
+	var checkCalls int
+	relayTestServer(t, func(body map[string]any) any {
+		switch body["path"] {
+		case "/repos/openclaw/octopool/pulls/7":
+			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+		case "/repos/openclaw/octopool/commits/abc1234/check-runs":
+			checkCalls++
+			pendingStatus := "queued"
+			pendingConclusion := ""
+			if checkCalls >= 2 {
+				pendingStatus, pendingConclusion = "completed", "success"
+			}
+			return map[string]any{"total_count": 2, "check_runs": []map[string]any{
+				{"name": "CI", "status": "completed", "conclusion": "cancelled"},
+				{"name": "Integration", "status": pendingStatus, "conclusion": pendingConclusion},
+			}}
+		case "/repos/openclaw/octopool/commits/abc1234/status":
+			return map[string]any{"statuses": []any{}}
+		default:
+			t.Fatalf("unexpected path = %v", body["path"])
+			return nil
+		}
+	})
+	sleeps := recordWatchSleeps(t)
+	var out bytes.Buffer
+	result := handleGHPR(t.Context(), []string{"checks", "7", "-R", "openclaw/octopool", "--watch", "--fail-fast"}, &out)
+	// Cancelled is terminal but not failed: the watch must keep polling the
+	// pending check instead of fail-fasting, then exit 1 from the cancel bucket.
+	assertExitCode(t, result.err, 1)
+	if len(*sleeps) == 0 || !strings.Contains(out.String(), "checks: 1 pending, 0 pass, 0 fail, 1 cancel") {
+		t.Fatalf("sleeps=%v out=%q", *sleeps, out.String())
 	}
 }
 

--- a/cmd/octopool/gh_top_watch_test.go
+++ b/cmd/octopool/gh_top_watch_test.go
@@ -230,8 +230,106 @@ func TestGHPRChecksWatchJSONFinalSnapshot(t *testing.T) {
 	if result.action != ghComplete || result.err != nil {
 		t.Fatalf("action=%v err=%v", result.action, result.err)
 	}
-	if !strings.Contains(out.String(), `[{"bucket":"pass","name":"CI"}]`) {
-		t.Fatalf("out=%q", out.String())
+	if strings.TrimSpace(out.String()) != `[{"bucket":"pass","name":"CI"}]` {
+		t.Fatalf("stdout must be pure JSON, got %q", out.String())
+	}
+}
+
+func TestGHPRChecksWatchJSONSuppressesProgressWhilePending(t *testing.T) {
+	ticks := 0
+	relayTestServer(t, func(body map[string]any) any {
+		switch body["path"] {
+		case "/repos/openclaw/octopool/pulls/7":
+			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+		case "/repos/openclaw/octopool/commits/abc1234/check-runs":
+			ticks++
+			status, conclusion := "in_progress", ""
+			if ticks > 1 {
+				status, conclusion = "completed", "success"
+			}
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"name": "CI", "status": status, "conclusion": conclusion}}}
+		case "/repos/openclaw/octopool/commits/abc1234/status":
+			return map[string]any{"statuses": []any{}}
+		default:
+			t.Fatalf("unexpected path = %v", body["path"])
+			return nil
+		}
+	})
+	recordWatchSleeps(t)
+	var out bytes.Buffer
+	result := handleGHPR(t.Context(), []string{"checks", "7", "-R", "openclaw/octopool", "--watch", "--json", "name,bucket"}, &out)
+	if result.action != ghComplete || result.err != nil {
+		t.Fatalf("action=%v err=%v", result.action, result.err)
+	}
+	if strings.TrimSpace(out.String()) != `[{"bucket":"pass","name":"CI"}]` {
+		t.Fatalf("stdout must stay pure across pending ticks, got %q", out.String())
+	}
+}
+
+func TestGHPRChecksWatchEqualsTrueSpelling(t *testing.T) {
+	relayTestServer(t, func(body map[string]any) any {
+		switch body["path"] {
+		case "/repos/openclaw/octopool/pulls/7":
+			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+		case "/repos/openclaw/octopool/commits/abc1234/check-runs":
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"name": "CI", "status": "completed", "conclusion": "success"}}}
+		case "/repos/openclaw/octopool/commits/abc1234/status":
+			return map[string]any{"statuses": []any{}}
+		default:
+			t.Fatalf("unexpected path = %v", body["path"])
+			return nil
+		}
+	})
+	recordWatchSleeps(t)
+	var out bytes.Buffer
+	result := handleGHPR(t.Context(), []string{"checks", "7", "-R", "openclaw/octopool", "--watch=true"}, &out)
+	if result.action != ghComplete || result.err != nil {
+		t.Fatalf("--watch=true must use the native watch path: action=%v err=%v", result.action, result.err)
+	}
+	if !isGHWatchShape([]string{"pr", "checks", "7", "--watch=true"}) {
+		t.Fatal("--watch=true must count as a watch shape for interval flooring")
+	}
+	if isGHWatchShape([]string{"pr", "checks", "7", "--watch=false"}) {
+		t.Fatal("--watch=false must not count as a watch shape")
+	}
+}
+
+func TestGHRunWatchPaginatesCompletedRunJobs(t *testing.T) {
+	jobsRequests := []string{}
+	relayTestServer(t, func(body map[string]any) any {
+		switch body["path"] {
+		case "/repos/openclaw/octopool/actions/runs/42":
+			return map[string]any{"id": 42, "status": "completed", "conclusion": "success"}
+		case "/repos/openclaw/octopool/actions/runs/42/jobs":
+			page := body["query"].(map[string]any)["page"].(string)
+			jobsRequests = append(jobsRequests, page)
+			jobs := []map[string]any{}
+			count := relayPageSize
+			offset := 0
+			if page == "2" {
+				count = 50
+				offset = relayPageSize
+			}
+			for index := 0; index < count; index++ {
+				jobs = append(jobs, map[string]any{"id": offset + index, "name": "job", "status": "completed", "conclusion": "success"})
+			}
+			return map[string]any{"total_count": 150, "jobs": jobs}
+		default:
+			t.Fatalf("unexpected path = %v", body["path"])
+			return nil
+		}
+	})
+	recordWatchSleeps(t)
+	var out bytes.Buffer
+	result := handleGHRun(t.Context(), []string{"watch", "42", "-R", "openclaw/octopool"}, &out)
+	if result.action != ghComplete || result.err != nil {
+		t.Fatalf("action=%v err=%v", result.action, result.err)
+	}
+	if len(jobsRequests) != 2 || jobsRequests[0] != "1" || jobsRequests[1] != "2" {
+		t.Fatalf("jobs pages requested = %v", jobsRequests)
+	}
+	if got := strings.Count(out.String(), "job job: success"); got != 150 {
+		t.Fatalf("job lines = %d, want 150", got)
 	}
 }
 

--- a/cmd/octopool/gh_top_watch_test.go
+++ b/cmd/octopool/gh_top_watch_test.go
@@ -21,7 +21,8 @@ func TestGHRunWatchPrintsTransitionsAndFetchesJobsOnce(t *testing.T) {
 			if headers["x-octopool-public-shape"] != "actions-summary-v1" {
 				t.Fatalf("run headers = %#v", headers)
 			}
-			statuses := []string{"queued", "in_progress", "in_progress", "completed"}
+			// The fifth read is the terminal confirmation with max-age=0.
+			statuses := []string{"queued", "in_progress", "in_progress", "completed", "completed"}
 			return map[string]any{"status": statuses[runCalls-1], "conclusion": "failure"}
 		case "/repos/openclaw/octopool/actions/runs/42/jobs":
 			jobsCalls++
@@ -64,7 +65,7 @@ func TestGHRunWatchPrintsTransitionsAndFetchesJobsOnce(t *testing.T) {
 			t.Fatalf("output missing %q:\n%s", want, out.String())
 		}
 	}
-	if runCalls != 4 || jobsCalls != 1 {
+	if runCalls != 5 || jobsCalls != 1 {
 		t.Fatalf("run calls=%d jobs calls=%d", runCalls, jobsCalls)
 	}
 	if want := []time.Duration{30 * time.Second, 60 * time.Second, 120 * time.Second}; !reflect.DeepEqual(*sleeps, want) {
@@ -81,7 +82,7 @@ func TestGHRunWatchRequestedIntervalStartsAt45Seconds(t *testing.T) {
 		calls++
 		status := "in_progress"
 		conclusion := ""
-		if calls == 2 {
+		if calls >= 2 {
 			status = "completed"
 			conclusion = "success"
 		}
@@ -141,7 +142,7 @@ func TestGHPRChecksWatchPendingToDone(t *testing.T) {
 			checkCalls++
 			status := "in_progress"
 			conclusion := ""
-			if checkCalls == 2 {
+			if checkCalls >= 2 {
 				status = "completed"
 				conclusion = "success"
 			}
@@ -202,7 +203,8 @@ func TestGHPRChecksWatchFailFast(t *testing.T) {
 	var out bytes.Buffer
 	result := handleGHPR(t.Context(), []string{"checks", "7", "-R", "openclaw/octopool", "--watch", "--fail-fast"}, &out)
 	assertExitCode(t, result.err, 1)
-	if checkCalls != 1 || len(*sleeps) != 0 {
+	// One polling read plus the fresh terminal confirmation sweep.
+	if checkCalls != 2 || len(*sleeps) != 0 {
 		t.Fatalf("check calls=%d sleeps=%v", checkCalls, *sleeps)
 	}
 	if !strings.Contains(out.String(), "checks: 1 pending, 0 pass, 1 fail") || !strings.Contains(out.String(), "CI\tfail\tFAILURE") {
@@ -210,59 +212,17 @@ func TestGHPRChecksWatchFailFast(t *testing.T) {
 	}
 }
 
-func TestGHPRChecksWatchJSONFinalSnapshot(t *testing.T) {
-	relayTestServer(t, func(body map[string]any) any {
-		switch body["path"] {
-		case "/repos/openclaw/octopool/pulls/7":
-			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
-		case "/repos/openclaw/octopool/commits/abc1234/check-runs":
-			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"name": "CI", "status": "completed", "conclusion": "success"}}}
-		case "/repos/openclaw/octopool/commits/abc1234/status":
-			return map[string]any{"statuses": []any{}}
-		default:
-			t.Fatalf("unexpected path = %v", body["path"])
-			return nil
-		}
-	})
-	recordWatchSleeps(t)
+func TestGHPRChecksWatchJSONDelegatesLikeRealGH(t *testing.T) {
+	// real gh rejects --watch with --json/--jq; the shim delegates so gh
+	// reports the combination itself.
 	var out bytes.Buffer
-	result := handleGHPR(t.Context(), []string{"checks", "7", "-R", "openclaw/octopool", "--watch", "--json", "name,bucket"}, &out)
-	if result.action != ghComplete || result.err != nil {
-		t.Fatalf("action=%v err=%v", result.action, result.err)
-	}
-	if strings.TrimSpace(out.String()) != `[{"bucket":"pass","name":"CI"}]` {
-		t.Fatalf("stdout must be pure JSON, got %q", out.String())
-	}
-}
-
-func TestGHPRChecksWatchJSONSuppressesProgressWhilePending(t *testing.T) {
-	ticks := 0
-	relayTestServer(t, func(body map[string]any) any {
-		switch body["path"] {
-		case "/repos/openclaw/octopool/pulls/7":
-			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
-		case "/repos/openclaw/octopool/commits/abc1234/check-runs":
-			ticks++
-			status, conclusion := "in_progress", ""
-			if ticks > 1 {
-				status, conclusion = "completed", "success"
-			}
-			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"name": "CI", "status": status, "conclusion": conclusion}}}
-		case "/repos/openclaw/octopool/commits/abc1234/status":
-			return map[string]any{"statuses": []any{}}
-		default:
-			t.Fatalf("unexpected path = %v", body["path"])
-			return nil
+	for _, args := range [][]string{
+		{"checks", "7", "-R", "openclaw/octopool", "--watch", "--json", "name,bucket"},
+		{"checks", "7", "-R", "openclaw/octopool", "--watch", "--jq", ".x"},
+	} {
+		if result := handleGHPR(t.Context(), args, &out); result.action != ghDelegate {
+			t.Fatalf("args %v must delegate, got action=%v", args, result.action)
 		}
-	})
-	recordWatchSleeps(t)
-	var out bytes.Buffer
-	result := handleGHPR(t.Context(), []string{"checks", "7", "-R", "openclaw/octopool", "--watch", "--json", "name,bucket"}, &out)
-	if result.action != ghComplete || result.err != nil {
-		t.Fatalf("action=%v err=%v", result.action, result.err)
-	}
-	if strings.TrimSpace(out.String()) != `[{"bucket":"pass","name":"CI"}]` {
-		t.Fatalf("stdout must stay pure across pending ticks, got %q", out.String())
 	}
 }
 
@@ -322,7 +282,7 @@ func TestGHPRChecksWatchRevalidatesHeadBeforeTerminal(t *testing.T) {
 	relayTestServer(t, func(body map[string]any) any {
 		switch path := body["path"].(string); {
 		case path == "/repos/openclaw/octopool/pulls/7":
-			headers := body["headers"].(map[string]any)
+			headers, _ := body["headers"].(map[string]any)
 			if headers["cache-control"] == "max-age=0" {
 				return map[string]any{"head": map[string]any{"sha": "newsha"}}
 			}
@@ -348,8 +308,85 @@ func TestGHPRChecksWatchRevalidatesHeadBeforeTerminal(t *testing.T) {
 	if result.action != ghComplete || result.err != nil {
 		t.Fatalf("action=%v err=%v", result.action, result.err)
 	}
-	if len(checkFetches) != 2 || checkFetches[0] != "oldsha" || checkFetches[1] != "newsha" {
-		t.Fatalf("check fetches = %v, want stale head rejected then re-polled", checkFetches)
+	// tick(oldsha) -> terminal confirm rejects on fresh head; tick(newsha) ->
+	// terminal -> fresh confirm sweep re-reads newsha's checks.
+	if len(checkFetches) != 3 || checkFetches[0] != "oldsha" || checkFetches[1] != "newsha" || checkFetches[2] != "newsha" {
+		t.Fatalf("check fetches = %v, want stale head rejected then re-polled with fresh confirm", checkFetches)
+	}
+}
+
+func TestGHRunWatchConfirmsTerminalWithFreshRead(t *testing.T) {
+	freshRunReads := 0
+	relayTestServer(t, func(body map[string]any) any {
+		switch path := body["path"].(string); {
+		case path == "/repos/openclaw/octopool/actions/runs/42":
+			headers, _ := body["headers"].(map[string]any)
+			if headers["cache-control"] == "max-age=0" {
+				freshRunReads++
+				if freshRunReads == 1 {
+					// The rerun is live even though the cache still says done.
+					return map[string]any{"id": 42, "status": "in_progress"}
+				}
+			}
+			conclusion := "failure"
+			if freshRunReads > 0 {
+				conclusion = "success"
+			}
+			return map[string]any{"id": 42, "status": "completed", "conclusion": conclusion}
+		case strings.HasSuffix(path, "/jobs"):
+			if h, _ := body["headers"].(map[string]any); h["cache-control"] != "max-age=0" {
+				t.Fatal("terminal jobs read must bypass cached staleness")
+			}
+			return map[string]any{"total_count": 0, "jobs": []any{}}
+		default:
+			t.Fatalf("unexpected path = %v", path)
+			return nil
+		}
+	})
+	recordWatchSleeps(t)
+	var out bytes.Buffer
+	result := handleGHRun(t.Context(), []string{"watch", "42", "-R", "openclaw/octopool", "--exit-status"}, &out)
+	if result.action != ghComplete || result.err != nil {
+		t.Fatalf("action=%v err=%v", result.action, result.err)
+	}
+	if freshRunReads != 2 {
+		t.Fatalf("fresh run reads = %d, want stale terminal rejected then confirmed", freshRunReads)
+	}
+	if !strings.Contains(out.String(), "completed -> in_progress") || !strings.Contains(out.String(), "Run 42 completed with 'success'") {
+		t.Fatalf("out=%q", out.String())
+	}
+}
+
+func TestGHPRChecksWatchConfirmsRerunSameHead(t *testing.T) {
+	freshCheckReads := 0
+	relayTestServer(t, func(body map[string]any) any {
+		switch path := body["path"].(string); {
+		case path == "/repos/openclaw/octopool/pulls/7":
+			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+		case strings.HasSuffix(path, "/check-runs"):
+			if h, _ := body["headers"].(map[string]any); h["cache-control"] == "max-age=0" {
+				freshCheckReads++
+				if freshCheckReads == 1 {
+					// Rerun in flight: same head SHA, cached payload obsolete.
+					return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"name": "CI", "status": "in_progress"}}}
+				}
+			}
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"name": "CI", "status": "completed", "conclusion": "success"}}}
+		case strings.HasSuffix(path, "/status"):
+			return map[string]any{"statuses": []any{}}
+		default:
+			t.Fatalf("unexpected path = %v", path)
+			return nil
+		}
+	})
+	recordWatchSleeps(t)
+	var out bytes.Buffer
+	result := handleGHPR(t.Context(), []string{"checks", "7", "-R", "openclaw/octopool", "--watch"}, &out)
+	if result.action != ghComplete || result.err != nil {
+		t.Fatalf("action=%v err=%v", result.action, result.err)
+	}
+	if freshCheckReads != 2 {
+		t.Fatalf("fresh check reads = %d, want rerun detected then confirmed", freshCheckReads)
 	}
 }
 

--- a/cmd/octopool/gh_top_watch_test.go
+++ b/cmd/octopool/gh_top_watch_test.go
@@ -250,6 +250,28 @@ func TestGHPRChecksWatchFailFastIgnoresCancelled(t *testing.T) {
 	}
 }
 
+func TestGHPRChecksWatchErrorsOnNoChecks(t *testing.T) {
+	relayTestServer(t, func(body map[string]any) any {
+		switch body["path"] {
+		case "/repos/openclaw/octopool/pulls/7":
+			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+		case "/repos/openclaw/octopool/commits/abc1234/check-runs":
+			return map[string]any{"total_count": 0, "check_runs": []any{}}
+		case "/repos/openclaw/octopool/commits/abc1234/status":
+			return map[string]any{"total_count": 0, "statuses": []any{}}
+		default:
+			t.Fatalf("unexpected path = %v", body["path"])
+			return nil
+		}
+	})
+	recordWatchSleeps(t)
+	var out bytes.Buffer
+	result := handleGHPR(t.Context(), []string{"checks", "7", "-R", "openclaw/octopool", "--watch"}, &out)
+	if result.err == nil || !strings.Contains(result.err.Error(), "no checks reported") {
+		t.Fatalf("zero checks must not read as green: err=%v", result.err)
+	}
+}
+
 func TestGHWatchShapeLastWatchValueWins(t *testing.T) {
 	if isGHWatchShape([]string{"pr", "checks", "7", "--watch", "--watch=false"}) {
 		t.Fatal("--watch --watch=false must not count as a watch shape")

--- a/cmd/octopool/gh_top_watch_test.go
+++ b/cmd/octopool/gh_top_watch_test.go
@@ -311,6 +311,46 @@ func TestGHWatchParsersHandleAttachedInterval(t *testing.T) {
 	if !reflect.DeepEqual(floored, []string{"run", "watch", "42", "--json", "x", "-i30"}) {
 		t.Fatalf("delegated -i5 must floor in place, got %v", floored)
 	}
+	terminated := floorGHWatchDelegateArgs([]string{"run", "watch", "--", "42"})
+	if !reflect.DeepEqual(terminated, []string{"run", "watch", "--interval", "30", "--", "42"}) {
+		t.Fatalf("injected interval must precede the -- terminator, got %v", terminated)
+	}
+}
+
+func TestGHPRChecksWatchRevalidatesHeadBeforeTerminal(t *testing.T) {
+	checkFetches := []string{}
+	relayTestServer(t, func(body map[string]any) any {
+		switch path := body["path"].(string); {
+		case path == "/repos/openclaw/octopool/pulls/7":
+			headers := body["headers"].(map[string]any)
+			if headers["cache-control"] == "max-age=0" {
+				return map[string]any{"head": map[string]any{"sha": "newsha"}}
+			}
+			sha := "oldsha"
+			if len(checkFetches) > 0 {
+				sha = "newsha"
+			}
+			return map[string]any{"head": map[string]any{"sha": sha}}
+		case strings.HasSuffix(path, "/check-runs"):
+			sha := strings.Split(path, "/")[5]
+			checkFetches = append(checkFetches, sha)
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"name": "CI", "status": "completed", "conclusion": "success"}}}
+		case strings.HasSuffix(path, "/status"):
+			return map[string]any{"statuses": []any{}}
+		default:
+			t.Fatalf("unexpected path = %v", path)
+			return nil
+		}
+	})
+	recordWatchSleeps(t)
+	var out bytes.Buffer
+	result := handleGHPR(t.Context(), []string{"checks", "7", "-R", "openclaw/octopool", "--watch"}, &out)
+	if result.action != ghComplete || result.err != nil {
+		t.Fatalf("action=%v err=%v", result.action, result.err)
+	}
+	if len(checkFetches) != 2 || checkFetches[0] != "oldsha" || checkFetches[1] != "newsha" {
+		t.Fatalf("check fetches = %v, want stale head rejected then re-polled", checkFetches)
+	}
 }
 
 func TestGHPRChecksWatchJQWithoutJSONDelegates(t *testing.T) {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -130,6 +130,7 @@ octopool gh pr view 85341 -R openclaw/openclaw --json number,files,commits,comme
 octopool gh pr list -R openclaw/openclaw --state open --limit 20 --json number,title,url
 octopool gh pr diff 85341 -R openclaw/openclaw --patch
 octopool gh pr checks 85341 -R openclaw/openclaw --json name,state,bucket,link,workflow
+octopool gh pr checks 85341 -R openclaw/openclaw --watch --fail-fast
 octopool gh search issues cache regression -R openclaw/openclaw --state open --json number,title,url
 octopool gh search prs rate limit -R openclaw/openclaw --state open --json number,title,url
 octopool gh issue view 80490 -R openclaw/openclaw --json number,title,state,url
@@ -137,6 +138,7 @@ octopool gh issue list -R openclaw/openclaw --state open --label bug --limit 20 
 octopool gh run list -R openclaw/openclaw --branch main --limit 10 --json databaseId,workflowName,status,conclusion,url
 octopool gh run view 26360397003 -R openclaw/openclaw --json databaseId,workflowName,status,conclusion,url
 octopool gh run view 26360397003 -R openclaw/openclaw --json status,conclusion,jobs
+octopool gh run watch 26360397003 -R openclaw/openclaw --exit-status
 octopool gh repo view openclaw/openclaw --json nameWithOwner,defaultBranchRef,url
 octopool gh workflow list -R openclaw/octopool --json id,name,path,state
 octopool gh workflow view ci.yml -R openclaw/octopool --json id,name,path,state
@@ -167,8 +169,9 @@ verified PR head SHA, allowing file pages to share a five-minute state-scoped ca
 `gh pr checks` uses the shared cache throughout: its PR
 head-SHA lookup sends `cache-control: max-age=60` so concurrent CI-polling sessions share
 one upstream PR read at most 60 seconds old, and the check/status reads for that SHA use
-the normal cache TTLs. Ask for raw `gh api` conditional requests only when instant
-freshness matters more than quota.
+the normal cache TTLs. Native `gh run watch` and `gh pr checks --watch` polling also stays
+on the relay, floors intervals at 30 seconds, and backs off to 120 seconds. Ask for raw
+`gh api` conditional requests only when instant freshness matters more than quota.
 `--jq` runs after `--json` filtering, matching the usual agent workflow for small
 machine-readable reads.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -109,10 +109,12 @@ octopool whoami
 
 Use `--json` for scripts.
 
-### `octopool gh api <GET path> [--jq <expr>]`
+### `octopool gh api <GET path> [--paginate] [--slurp] [--jq <expr>]`
 
 Relays a read-only `gh api` call through Octopool's cache and pool. Prints the GitHub
 response body exactly like `gh api`, optionally piping it through `jq -r <expr>`.
+GET reads using `--paginate` and `--slurp` stay relay-cached for up to 10 pages;
+longer result sets fall through to the real `gh` for a complete response.
 
 ```sh
 octopool gh api repos/openclaw/openclaw/pulls/85341 --jq .number
@@ -179,7 +181,7 @@ The command falls through to the real `gh` without contacting Octopool when any 
 hold:
 
 - method is not `GET`, or mutating field flags are present (`-f`, `-F`, `--field`,
-  `--raw-field`, `--paginate`, `--slurp`).
+  `--raw-field`).
 - a query key looks secret-bearing, or a header is outside the safe set
   (`accept`, `x-github-api-version`, `if-none-match`, `if-modified-since`).
 - `--jq` was requested but `jq` is not installed.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -114,7 +114,9 @@ Use `--json` for scripts.
 Relays a read-only `gh api` call through Octopool's cache and pool. Prints the GitHub
 response body exactly like `gh api`, optionally piping it through `jq -r <expr>`.
 GET reads using `--paginate` and `--slurp` stay relay-cached for up to 10 pages;
-longer result sets fall through to the real `gh` for a complete response.
+longer result sets and response shapes whose completion cannot be proven without
+Link headers (arrays and `total_count` object lists can) fall through to the real
+`gh` for a complete response.
 
 ```sh
 octopool gh api repos/openclaw/openclaw/pulls/85341 --jq .number


### PR DESCRIPTION
Stops the two biggest personal-quota leaks around the relay: watch commands and paginated api reads previously delegated to real gh (3s polling / uncached page sweeps), which measurably drained the personal 5000/hr token.

## Native watch (`gh run watch`, `gh pr checks --watch`)

- Polls relay-cached routes with a 30s interval floor and 30/60/120s backoff; `-i`/`--interval` honored above the floor (including `-i45` attached shorthand).
- Delegated watch shapes (unsupported flags, missing run id, `--` terminator forms) get their interval floored to 30s before real gh runs.
- Terminal results are confirmed with one `max-age=0` sweep per exit: reruns reuse run IDs and head SHAs while terminal CI payloads cache for 1h, so cached snapshots alone could exit false-green. Push-then-watch head movement, same-SHA check reruns, and empty/vanished check sets are all covered (empty never reads as green; matches real gh's "no checks reported" error).
- Completed-run jobs and commit statuses paginate to `total_count` (matrix runs >100 jobs; legacy status contexts >30).
- `checkExitCode` now matches gh trunk exactly: Failed -> 1, else Pending -> 8, cancelled exits 0 (also fixes the pre-existing non-watch path). `--fail-fast` gates on failed only.
- API-controlled strings in human output are stripped of control sequences (terminal-injection hardening).
- Real-gh flag contracts preserved: `--watch` with `--json`/`--jq` delegates so gh reports its own rejection.

## Relay-backed `gh api --paginate` / `--slurp`

- GET reads page through the shared cache at `per_page<=100` (oversized values clamp to GitHub's cap), stopping via short-page inference for arrays and `total_count` for object lists.
- Unprovable shapes (e.g. compare's `total_commits`), >10-page sweeps, and non-GET fall back to real gh — correctness never traded for cache hits.
- Output matches real gh: array pages coalesce into one JSON array (verified empirically against live gh output), `--slurp` wraps pages, `--jq` runs once per page, `--slurp`+`--jq` rejected with gh's own error.

## Proof

- `gofmt -l` clean, `go vet` clean, `go test ./cmd/octopool` green (36 tests incl. 25 new watch/pagination tests).
- 10 structured review rounds (Codex gpt-5.6-sol, xhigh); all accepted findings fixed. One finding consciously rejected: "un-merge array pages" contradicts live gh behavior (probe: 3 pages of labels emit ONE array, `jq -s length` == 1).

## Follow-up (out of scope here)

- Propagate `Link` header metadata through the relay envelope so pagination completion is authoritative instead of shape-inferred (protocol change, tracked separately).
