### PR TITLE
feat: native human-format rendering for gh read commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 - Prefer validated public page, raw-content, and Git smart HTTP transports before anonymous GitHub API reads, retaining anonymous API and pooled identities as fallbacks.
+- Render common non-interactive human-format `gh pr`, `gh run`, and `gh issue` reads from relay-cached REST responses while preserving real `gh` for terminal and unsupported shapes.
 
 ## 0.4.7 - 2026-07-17
 

--- a/cmd/octopool/gh_top_checks.go
+++ b/cmd/octopool/gh_top_checks.go
@@ -22,18 +22,22 @@ func relayPRChecks(ctx context.Context, stdout io.Writer, repo string, number st
 	if err != nil {
 		return err
 	}
-	raw, err := json.Marshal(items)
-	if err != nil {
-		return err
-	}
-	if len(opts.json) > 0 {
+	if len(opts.json) == 0 {
+		if err := renderHumanPRChecks(stdout, items); err != nil {
+			return err
+		}
+	} else {
+		raw, err := json.Marshal(items)
+		if err != nil {
+			return err
+		}
 		raw, err = filterJSONFields(raw, opts.json, fieldMapCheckRun)
 		if err != nil {
 			return err
 		}
-	}
-	if err := writeBytes(ctx, stdout, raw, opts.jq); err != nil {
-		return err
+		if err := writeBytes(ctx, stdout, raw, opts.jq); err != nil {
+			return err
+		}
 	}
 	return checkExitCode(items)
 }

--- a/cmd/octopool/gh_top_human.go
+++ b/cmd/octopool/gh_top_human.go
@@ -195,13 +195,22 @@ func renderHumanRunView(stdout io.Writer, run map[string]any, jobs []any) error 
 	if display == "" {
 		display = firstString(run, "display_title")
 	}
-	if _, err := fmt.Fprintf(stdout, "\n%s %s · %s\nTriggered via %s %s\n\nJOBS\n",
+	if _, err := fmt.Fprintf(stdout, "\n%s %s · %s\nTriggered via %s %s\n",
 		runGlyph(run),
 		watchSafeText(display),
 		watchSafeText(id),
 		watchSafeText(firstString(run, "event")),
 		relativeHumanTime(firstString(run, "run_started_at", "created_at")),
 	); err != nil {
+		return err
+	}
+	// Workflow-file problems fail with zero jobs; match real gh's diagnostic
+	// instead of an unexplained empty JOBS section.
+	if len(jobs) == 0 && runGlyph(run) == "X" {
+		_, err := fmt.Fprintf(stdout, "\nThis run likely failed because of a workflow file issue.\n\nView this run on GitHub: %s\n", watchSafeText(firstString(run, "html_url")))
+		return err
+	}
+	if _, err := fmt.Fprint(stdout, "\nJOBS\n"); err != nil {
 		return err
 	}
 	firstJobID := ""
@@ -385,13 +394,16 @@ func latestReviewers(pr map[string]any, reviews []any) string {
 		positions[login] = len(ordered)
 		ordered = append(ordered, review{login: login, state: state})
 	}
+	author := nestedStringValue(pr, "user", "login")
 	for _, raw := range reviews {
 		item, ok := raw.(map[string]any)
 		if !ok {
 			continue
 		}
 		login := watchSafeText(nestedStringValue(item, "user", "login"))
-		if login == "" {
+		// real gh omits the author's own comment reviews and unsubmitted
+		// PENDING drafts from the reviewer summary.
+		if login == "" || login == author || strings.EqualFold(firstString(item, "state"), "PENDING") {
 			continue
 		}
 		upsert(login, reviewStateTitle(firstString(item, "state")))

--- a/cmd/octopool/gh_top_human.go
+++ b/cmd/octopool/gh_top_human.go
@@ -47,11 +47,19 @@ func relayHumanPRView(ctx context.Context, stdout io.Writer, repo string, number
 	return renderHumanPRView(stdout, pr, reviews)
 }
 
-func renderHumanPRView(stdout io.Writer, pr map[string]any, reviews []any) error {
-	state := strings.ToUpper(firstString(pr, "state"))
+func humanPRState(pr map[string]any) string {
 	if firstString(pr, "merged_at") != "" {
-		state = "MERGED"
+		return "MERGED"
 	}
+	state := strings.ToUpper(firstString(pr, "state"))
+	if draft, _ := pr["draft"].(bool); draft && state == "OPEN" {
+		return "DRAFT"
+	}
+	return state
+}
+
+func renderHumanPRView(stdout io.Writer, pr map[string]any, reviews []any) error {
+	state := humanPRState(pr)
 	autoMerge := "disabled"
 	if value, ok := pr["auto_merge"]; ok && value != nil {
 		autoMerge = "enabled"
@@ -83,15 +91,11 @@ func relayHumanPRList(ctx context.Context, stdout io.Writer, request ghAPIReques
 		return err
 	}
 	for _, item := range items {
-		state := strings.ToUpper(firstString(item, "state"))
-		if firstString(item, "merged_at") != "" {
-			state = "MERGED"
-		}
 		if _, err := fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\n",
 			watchSafeText(numberText(item["number"])),
 			watchSafeText(firstString(item, "title")),
 			watchSafeText(nestedStringValue(item, "head", "ref")),
-			watchSafeText(state),
+			watchSafeText(humanPRState(item)),
 			iso8601UTC(firstString(item, "updated_at")),
 		); err != nil {
 			return err
@@ -224,6 +228,11 @@ func relayHumanIssueView(ctx context.Context, stdout io.Writer, repo string, num
 	var issue map[string]any
 	if err := json.Unmarshal(body, &issue); err != nil {
 		return err
+	}
+	// REST /issues/{n} also returns pull requests; real gh refuses those, so
+	// let it produce its canonical error instead of a plausible issue view.
+	if _, isPR := issue["pull_request"]; isPR {
+		return localFallbackError{Reason: "issue_number_is_pull_request"}
 	}
 	lines := [][2]string{
 		{"title", firstString(issue, "title")},

--- a/cmd/octopool/gh_top_human.go
+++ b/cmd/octopool/gh_top_human.go
@@ -227,6 +227,22 @@ func renderHumanRunView(stdout io.Writer, run map[string]any, jobs []any) error 
 		); err != nil {
 			return err
 		}
+		if !strings.EqualFold(firstString(job, "conclusion"), "failure") {
+			continue
+		}
+		steps, _ := job["steps"].([]any)
+		for _, rawStep := range steps {
+			step, ok := rawStep.(map[string]any)
+			if !ok || !strings.EqualFold(firstString(step, "conclusion"), "failure") {
+				continue
+			}
+			if _, err := fmt.Fprintf(stdout, "  %s %s\n",
+				statusGlyph(firstString(step, "status"), firstString(step, "conclusion")),
+				watchSafeText(firstString(step, "name")),
+			); err != nil {
+				return err
+			}
+		}
 	}
 	if _, err := fmt.Fprintln(stdout); err != nil {
 		return err
@@ -333,18 +349,10 @@ func writeHumanBody(stdout io.Writer, body string) error {
 	if _, err := fmt.Fprintln(stdout, "--"); err != nil {
 		return err
 	}
-	clean := bodySafeText(body)
-	if clean == "" {
-		return nil
-	}
-	if _, err := io.WriteString(stdout, clean); err != nil {
-		return err
-	}
-	if !strings.HasSuffix(clean, "\n") {
-		_, err := fmt.Fprintln(stdout)
-		return err
-	}
-	return nil
+	// real gh prints the body record with one unconditional trailing newline,
+	// including for empty bodies.
+	_, err := fmt.Fprintln(stdout, bodySafeText(body))
+	return err
 }
 
 func joinedObjectStrings(raw any, key string) string {

--- a/cmd/octopool/gh_top_human.go
+++ b/cmd/octopool/gh_top_human.go
@@ -191,10 +191,15 @@ func renderHumanRunView(stdout io.Writer, run map[string]any, jobs []any) error 
 		if firstJobID == "" {
 			firstJobID = jobID
 		}
-		if _, err := fmt.Fprintf(stdout, "%s %s in %s (ID %s)\n",
+		duration := humanDuration(firstString(job, "startedAt"), firstString(job, "completedAt"))
+		inDuration := ""
+		if duration != "" {
+			inDuration = " in " + duration
+		}
+		if _, err := fmt.Fprintf(stdout, "%s %s%s (ID %s)\n",
 			jobGlyph(job),
 			watchSafeText(firstString(job, "name")),
-			humanDuration(firstString(job, "startedAt"), firstString(job, "completedAt")),
+			inDuration,
 			watchSafeText(jobID),
 		); err != nil {
 			return err
@@ -471,7 +476,7 @@ func statusGlyph(status string, conclusion string) string {
 	switch strings.ToLower(conclusion) {
 	case "success", "neutral":
 		return "✓"
-	case "failure", "timed_out", "action_required":
+	case "failure", "timed_out", "action_required", "startup_failure":
 		return "X"
 	case "cancelled", "skipped":
 		return "-"

--- a/cmd/octopool/gh_top_human.go
+++ b/cmd/octopool/gh_top_human.go
@@ -93,7 +93,7 @@ func renderHumanPRView(stdout io.Writer, pr map[string]any, reviews []any) error
 		{"author", nestedStringValue(pr, "user", "login")},
 		{"labels", joinedObjectStrings(pr["labels"], "name")},
 		{"assignees", joinedObjectStrings(pr["assignees"], "login")},
-		{"reviewers", latestReviewers(reviews)},
+		{"reviewers", latestReviewers(pr, reviews)},
 		{"projects", ""},
 		{"milestone", nestedStringValue(pr, "milestone", "title")},
 		{"number", numberText(pr["number"])},
@@ -370,13 +370,21 @@ func joinedObjectStrings(raw any, key string) string {
 	return strings.Join(values, ", ")
 }
 
-func latestReviewers(reviews []any) string {
+func latestReviewers(pr map[string]any, reviews []any) string {
 	type review struct {
 		login string
 		state string
 	}
 	ordered := []review{}
 	positions := map[string]int{}
+	upsert := func(login string, state string) {
+		if index, ok := positions[login]; ok {
+			ordered[index].state = state
+			return
+		}
+		positions[login] = len(ordered)
+		ordered = append(ordered, review{login: login, state: state})
+	}
 	for _, raw := range reviews {
 		item, ok := raw.(map[string]any)
 		if !ok {
@@ -386,13 +394,31 @@ func latestReviewers(reviews []any) string {
 		if login == "" {
 			continue
 		}
-		state := reviewStateTitle(firstString(item, "state"))
-		if index, ok := positions[login]; ok {
-			ordered[index].state = state
-			continue
+		upsert(login, reviewStateTitle(firstString(item, "state")))
+	}
+	// Outstanding requests (including re-requests) override any prior
+	// submitted state, matching real gh's reviewer summary.
+	if requested, ok := pr["requested_reviewers"].([]any); ok {
+		for _, raw := range requested {
+			item, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			if login := watchSafeText(firstString(item, "login")); login != "" {
+				upsert(login, "Requested")
+			}
 		}
-		positions[login] = len(ordered)
-		ordered = append(ordered, review{login: login, state: state})
+	}
+	if teams, ok := pr["requested_teams"].([]any); ok {
+		for _, raw := range teams {
+			item, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			if slug := watchSafeText(firstString(item, "slug", "name")); slug != "" {
+				upsert(slug, "Requested")
+			}
+		}
 	}
 	values := make([]string, 0, len(ordered))
 	for _, item := range ordered {

--- a/cmd/octopool/gh_top_human.go
+++ b/cmd/octopool/gh_top_human.go
@@ -452,9 +452,11 @@ func humanDuration(startRaw string, endRaw string) string {
 		return ""
 	}
 	duration := end.Sub(start).Truncate(time.Second)
+	// Divide as time.Duration before narrowing: int(time.Minute) overflows
+	// 32-bit ints.
 	hours := int(duration / time.Hour)
-	minutes := int(duration%time.Hour) / int(time.Minute)
-	seconds := int(duration%time.Minute) / int(time.Second)
+	minutes := int((duration % time.Hour) / time.Minute)
+	seconds := int((duration % time.Minute) / time.Second)
 	if hours > 0 {
 		return fmt.Sprintf("%dh%dm%ds", hours, minutes, seconds)
 	}

--- a/cmd/octopool/gh_top_human.go
+++ b/cmd/octopool/gh_top_human.go
@@ -47,6 +47,29 @@ func relayHumanPRView(ctx context.Context, stdout io.Writer, repo string, number
 	return renderHumanPRView(stdout, pr, reviews)
 }
 
+// prHeadLabel qualifies fork branches as owner:branch like gh's HeadLabel.
+func prHeadLabel(pr map[string]any) string {
+	ref := nestedStringValue(pr, "head", "ref")
+	headOwner := headRepoOwner(pr, "head")
+	baseOwner := headRepoOwner(pr, "base")
+	if headOwner != "" && headOwner != baseOwner {
+		return headOwner + ":" + ref
+	}
+	return ref
+}
+
+func headRepoOwner(pr map[string]any, side string) string {
+	half, _ := pr[side].(map[string]any)
+	if half == nil {
+		return ""
+	}
+	repo, _ := half["repo"].(map[string]any)
+	if repo == nil {
+		return ""
+	}
+	return nestedStringValue(repo, "owner", "login")
+}
+
 func humanPRState(pr map[string]any) string {
 	if firstString(pr, "merged_at") != "" {
 		return "MERGED"
@@ -94,9 +117,9 @@ func relayHumanPRList(ctx context.Context, stdout io.Writer, request ghAPIReques
 		if _, err := fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\n",
 			watchSafeText(numberText(item["number"])),
 			watchSafeText(firstString(item, "title")),
-			watchSafeText(nestedStringValue(item, "head", "ref")),
+			watchSafeText(prHeadLabel(item)),
 			watchSafeText(humanPRState(item)),
-			iso8601UTC(firstString(item, "updated_at")),
+			iso8601UTC(firstString(item, "created_at")),
 		); err != nil {
 			return err
 		}
@@ -157,8 +180,8 @@ func relayHumanRunList(ctx context.Context, stdout io.Writer, request ghAPIReque
 			watchSafeText(firstString(item, "head_branch")),
 			watchSafeText(firstString(item, "event")),
 			watchSafeText(numberText(item["id"])),
-			humanDuration(firstString(item, "run_started_at", "created_at"), firstString(item, "updated_at")),
-			iso8601UTC(firstString(item, "created_at")),
+			runElapsed(item),
+			iso8601UTC(firstString(item, "run_started_at", "created_at")),
 		); err != nil {
 			return err
 		}
@@ -177,7 +200,7 @@ func renderHumanRunView(stdout io.Writer, run map[string]any, jobs []any) error 
 		watchSafeText(display),
 		watchSafeText(id),
 		watchSafeText(firstString(run, "event")),
-		relativeHumanTime(firstString(run, "created_at")),
+		relativeHumanTime(firstString(run, "run_started_at", "created_at")),
 	); err != nil {
 		return err
 	}
@@ -433,6 +456,17 @@ func humanDuration(startRaw string, endRaw string) string {
 	return fmt.Sprintf("%ds", seconds)
 }
 
+// runElapsed measures active runs through now; updated_at can sit still
+// while work continues.
+func runElapsed(run map[string]any) string {
+	start := firstString(run, "run_started_at", "created_at")
+	end := firstString(run, "updated_at")
+	if !strings.EqualFold(firstString(run, "status"), "completed") {
+		end = humanNow().UTC().Format(time.RFC3339)
+	}
+	return humanDuration(start, end)
+}
+
 func relativeHumanTime(raw string) string {
 	created, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
@@ -472,14 +506,18 @@ func jobGlyph(job map[string]any) string {
 	return statusGlyph(firstString(job, "status"), firstString(job, "conclusion"))
 }
 
+// statusGlyph mirrors gh's completed-conclusion mapping: tick only for
+// success, dash for skipped/neutral, X for every other terminal conclusion.
 func statusGlyph(status string, conclusion string) string {
-	switch strings.ToLower(conclusion) {
-	case "success", "neutral":
-		return "✓"
-	case "failure", "timed_out", "action_required", "startup_failure":
-		return "X"
-	case "cancelled", "skipped":
-		return "-"
+	if lowered := strings.ToLower(conclusion); lowered != "" {
+		switch lowered {
+		case "success":
+			return "✓"
+		case "neutral", "skipped":
+			return "-"
+		default:
+			return "X"
+		}
 	}
 	switch strings.ToLower(status) {
 	case "queued", "in_progress", "pending", "requested", "waiting":

--- a/cmd/octopool/gh_top_human.go
+++ b/cmd/octopool/gh_top_human.go
@@ -1,0 +1,476 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var stdoutIsTTY = func() bool {
+	info, err := os.Stdout.Stat()
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
+}
+
+var humanNow = time.Now
+
+func nativeHumanFormat(opts ghTopOptions) bool {
+	return !machineReadable(opts) && opts.jq == "" && !stdoutIsTTY()
+}
+
+func relayHumanPRView(ctx context.Context, stdout io.Writer, repo string, number string) error {
+	client, err := newGHRelayClient()
+	if err != nil {
+		return err
+	}
+	envelope, err := client.do(ctx, ghAPIRequest{method: "GET", path: repoPath(repo, "pulls", number)})
+	if err != nil {
+		return err
+	}
+	body, err := envelopeBodyBytes(envelope)
+	if err != nil {
+		return err
+	}
+	var pr map[string]any
+	if err := json.Unmarshal(body, &pr); err != nil {
+		return err
+	}
+	reviews, err := relayPagedArray(ctx, client, repoPath(repo, "pulls", number, "reviews"), nil)
+	if err != nil {
+		return err
+	}
+	return renderHumanPRView(stdout, pr, reviews)
+}
+
+func renderHumanPRView(stdout io.Writer, pr map[string]any, reviews []any) error {
+	state := strings.ToUpper(firstString(pr, "state"))
+	if firstString(pr, "merged_at") != "" {
+		state = "MERGED"
+	}
+	autoMerge := "disabled"
+	if value, ok := pr["auto_merge"]; ok && value != nil {
+		autoMerge = "enabled"
+	}
+	lines := [][2]string{
+		{"title", firstString(pr, "title")},
+		{"state", state},
+		{"author", nestedStringValue(pr, "user", "login")},
+		{"labels", joinedObjectStrings(pr["labels"], "name")},
+		{"assignees", joinedObjectStrings(pr["assignees"], "login")},
+		{"reviewers", latestReviewers(reviews)},
+		{"projects", ""},
+		{"milestone", nestedStringValue(pr, "milestone", "title")},
+		{"number", numberText(pr["number"])},
+		{"url", firstString(pr, "html_url")},
+		{"additions", numberText(pr["additions"])},
+		{"deletions", numberText(pr["deletions"])},
+		{"auto-merge", autoMerge},
+	}
+	if err := writeHumanFields(stdout, lines); err != nil {
+		return err
+	}
+	return writeHumanBody(stdout, firstString(pr, "body"))
+}
+
+func relayHumanPRList(ctx context.Context, stdout io.Writer, request ghAPIRequest) error {
+	items, err := relayArray(ctx, request)
+	if err != nil {
+		return err
+	}
+	for _, item := range items {
+		state := strings.ToUpper(firstString(item, "state"))
+		if firstString(item, "merged_at") != "" {
+			state = "MERGED"
+		}
+		if _, err := fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\n",
+			watchSafeText(numberText(item["number"])),
+			watchSafeText(firstString(item, "title")),
+			watchSafeText(nestedStringValue(item, "head", "ref")),
+			watchSafeText(state),
+			iso8601UTC(firstString(item, "updated_at")),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func renderHumanPRChecks(stdout io.Writer, items []any) error {
+	for _, raw := range items {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, err := fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\n",
+			watchSafeText(firstString(item, "name")),
+			watchSafeText(firstString(item, "bucket")),
+			humanDuration(firstString(item, "startedAt"), firstString(item, "completedAt")),
+			watchSafeText(firstString(item, "link")),
+			watchSafeText(firstString(item, "description")),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func relayHumanRunList(ctx context.Context, stdout io.Writer, request ghAPIRequest) error {
+	client, err := newGHRelayClient()
+	if err != nil {
+		return err
+	}
+	envelope, err := client.do(ctx, request)
+	if err != nil {
+		return err
+	}
+	body, err := envelopeBodyBytes(envelope)
+	if err != nil {
+		return err
+	}
+	var response map[string]any
+	if err := json.Unmarshal(body, &response); err != nil {
+		return err
+	}
+	rawItems, ok := response["workflow_runs"].([]any)
+	if !ok {
+		return errors.New("workflow runs response did not include workflow_runs")
+	}
+	for _, raw := range rawItems {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, err := fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			watchSafeText(firstString(item, "status")),
+			watchSafeText(firstString(item, "conclusion")),
+			watchSafeText(firstString(item, "display_title")),
+			watchSafeText(firstString(item, "name")),
+			watchSafeText(firstString(item, "head_branch")),
+			watchSafeText(firstString(item, "event")),
+			watchSafeText(numberText(item["id"])),
+			humanDuration(firstString(item, "run_started_at", "created_at"), firstString(item, "updated_at")),
+			iso8601UTC(firstString(item, "created_at")),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func renderHumanRunView(stdout io.Writer, run map[string]any, jobs []any) error {
+	id := numberText(run["id"])
+	display := strings.TrimSpace(firstString(run, "head_branch") + " " + firstString(run, "name"))
+	if display == "" {
+		display = firstString(run, "display_title")
+	}
+	if _, err := fmt.Fprintf(stdout, "\n%s %s · %s\nTriggered via %s %s\n\nJOBS\n",
+		runGlyph(run),
+		watchSafeText(display),
+		watchSafeText(id),
+		watchSafeText(firstString(run, "event")),
+		relativeHumanTime(firstString(run, "created_at")),
+	); err != nil {
+		return err
+	}
+	firstJobID := ""
+	for _, raw := range jobs {
+		job, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		jobID := numberText(job["databaseId"])
+		if firstJobID == "" {
+			firstJobID = jobID
+		}
+		if _, err := fmt.Fprintf(stdout, "%s %s in %s (ID %s)\n",
+			jobGlyph(job),
+			watchSafeText(firstString(job, "name")),
+			humanDuration(firstString(job, "startedAt"), firstString(job, "completedAt")),
+			watchSafeText(jobID),
+		); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintln(stdout); err != nil {
+		return err
+	}
+	if firstJobID != "" {
+		if _, err := fmt.Fprintf(stdout, "For more information about the job, try: gh run view --job=%s\n", watchSafeText(firstJobID)); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprintf(stdout, "View this run on GitHub: %s\n", watchSafeText(firstString(run, "html_url")))
+	return err
+}
+
+func relayHumanIssueView(ctx context.Context, stdout io.Writer, repo string, number string) error {
+	client, err := newGHRelayClient()
+	if err != nil {
+		return err
+	}
+	envelope, err := client.do(ctx, ghAPIRequest{method: "GET", path: repoPath(repo, "issues", number)})
+	if err != nil {
+		return err
+	}
+	body, err := envelopeBodyBytes(envelope)
+	if err != nil {
+		return err
+	}
+	var issue map[string]any
+	if err := json.Unmarshal(body, &issue); err != nil {
+		return err
+	}
+	lines := [][2]string{
+		{"title", firstString(issue, "title")},
+		{"state", strings.ToUpper(firstString(issue, "state"))},
+		{"author", nestedStringValue(issue, "user", "login")},
+		{"labels", joinedObjectStrings(issue["labels"], "name")},
+		{"comments", numberText(issue["comments"])},
+		{"assignees", joinedObjectStrings(issue["assignees"], "login")},
+		{"projects", ""},
+		{"milestone", nestedStringValue(issue, "milestone", "title")},
+		{"issue-type", ""},
+		{"parent", ""},
+		{"sub-issues", ""},
+		{"sub-issues-completed", ""},
+		{"blocked-by", ""},
+		{"blocking", ""},
+		{"number", numberText(issue["number"])},
+	}
+	if err := writeHumanFields(stdout, lines); err != nil {
+		return err
+	}
+	return writeHumanBody(stdout, firstString(issue, "body"))
+}
+
+func renderHumanIssueList(stdout io.Writer, items []map[string]any) error {
+	for _, item := range items {
+		if _, err := fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\n",
+			watchSafeText(numberText(item["number"])),
+			watchSafeText(strings.ToUpper(firstString(item, "state"))),
+			watchSafeText(firstString(item, "title")),
+			joinedObjectStrings(item["labels"], "name"),
+			iso8601UTC(firstString(item, "updated_at")),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func relayArray(ctx context.Context, request ghAPIRequest) ([]map[string]any, error) {
+	client, err := newGHRelayClient()
+	if err != nil {
+		return nil, err
+	}
+	envelope, err := client.do(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	body, err := envelopeBodyBytes(envelope)
+	if err != nil {
+		return nil, err
+	}
+	var items []map[string]any
+	if err := json.Unmarshal(body, &items); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+func writeHumanFields(stdout io.Writer, fields [][2]string) error {
+	for _, field := range fields {
+		if _, err := fmt.Fprintf(stdout, "%s:\t%s\n", field[0], watchSafeText(field[1])); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeHumanBody(stdout io.Writer, body string) error {
+	if _, err := fmt.Fprintln(stdout, "--"); err != nil {
+		return err
+	}
+	clean := bodySafeText(body)
+	if clean == "" {
+		return nil
+	}
+	if _, err := io.WriteString(stdout, clean); err != nil {
+		return err
+	}
+	if !strings.HasSuffix(clean, "\n") {
+		_, err := fmt.Fprintln(stdout)
+		return err
+	}
+	return nil
+}
+
+func joinedObjectStrings(raw any, key string) string {
+	items, _ := raw.([]any)
+	values := make([]string, 0, len(items))
+	for _, rawItem := range items {
+		item, ok := rawItem.(map[string]any)
+		if !ok {
+			continue
+		}
+		if value := watchSafeText(firstString(item, key)); value != "" {
+			values = append(values, value)
+		}
+	}
+	return strings.Join(values, ", ")
+}
+
+func latestReviewers(reviews []any) string {
+	type review struct {
+		login string
+		state string
+	}
+	ordered := []review{}
+	positions := map[string]int{}
+	for _, raw := range reviews {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		login := watchSafeText(nestedStringValue(item, "user", "login"))
+		if login == "" {
+			continue
+		}
+		state := reviewStateTitle(firstString(item, "state"))
+		if index, ok := positions[login]; ok {
+			ordered[index].state = state
+			continue
+		}
+		positions[login] = len(ordered)
+		ordered = append(ordered, review{login: login, state: state})
+	}
+	values := make([]string, 0, len(ordered))
+	for _, item := range ordered {
+		if item.state == "" {
+			values = append(values, item.login)
+		} else {
+			values = append(values, fmt.Sprintf("%s (%s)", item.login, item.state))
+		}
+	}
+	return strings.Join(values, ", ")
+}
+
+func reviewStateTitle(raw string) string {
+	parts := strings.Split(strings.ToLower(watchSafeText(raw)), "_")
+	for index, part := range parts {
+		if part != "" {
+			parts[index] = strings.ToUpper(part[:1]) + part[1:]
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func numberText(value any) string {
+	switch typed := value.(type) {
+	case float64:
+		return strconv.FormatInt(int64(typed), 10)
+	case float32:
+		return strconv.FormatInt(int64(typed), 10)
+	case int:
+		return strconv.Itoa(typed)
+	case int64:
+		return strconv.FormatInt(typed, 10)
+	case json.Number:
+		return typed.String()
+	case string:
+		return typed
+	default:
+		return ""
+	}
+}
+
+func iso8601UTC(raw string) string {
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return watchSafeText(raw)
+	}
+	return parsed.UTC().Format(time.RFC3339)
+}
+
+func humanDuration(startRaw string, endRaw string) string {
+	if startRaw == "" || endRaw == "" {
+		return ""
+	}
+	start, startErr := time.Parse(time.RFC3339, startRaw)
+	end, endErr := time.Parse(time.RFC3339, endRaw)
+	if startErr != nil || endErr != nil || end.Before(start) {
+		return ""
+	}
+	duration := end.Sub(start).Truncate(time.Second)
+	hours := int(duration / time.Hour)
+	minutes := int(duration%time.Hour) / int(time.Minute)
+	seconds := int(duration%time.Minute) / int(time.Second)
+	if hours > 0 {
+		return fmt.Sprintf("%dh%dm%ds", hours, minutes, seconds)
+	}
+	if minutes > 0 {
+		return fmt.Sprintf("%dm%ds", minutes, seconds)
+	}
+	return fmt.Sprintf("%ds", seconds)
+}
+
+func relativeHumanTime(raw string) string {
+	created, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return ""
+	}
+	age := humanNow().Sub(created)
+	if age < 0 {
+		age = 0
+	}
+	minutes := int(age / time.Minute)
+	if minutes < 1 {
+		return "less than a minute ago"
+	}
+	if minutes < 60 {
+		return fmt.Sprintf("about %d %s ago", minutes, plural(minutes, "minute"))
+	}
+	hours := int(age / time.Hour)
+	if hours < 24 {
+		return fmt.Sprintf("about %d %s ago", hours, plural(hours, "hour"))
+	}
+	days := int(age / (24 * time.Hour))
+	return fmt.Sprintf("about %d %s ago", days, plural(days, "day"))
+}
+
+func plural(count int, unit string) string {
+	if count == 1 {
+		return unit
+	}
+	return unit + "s"
+}
+
+func runGlyph(run map[string]any) string {
+	return statusGlyph(firstString(run, "status"), firstString(run, "conclusion"))
+}
+
+func jobGlyph(job map[string]any) string {
+	return statusGlyph(firstString(job, "status"), firstString(job, "conclusion"))
+}
+
+func statusGlyph(status string, conclusion string) string {
+	switch strings.ToLower(conclusion) {
+	case "success", "neutral":
+		return "✓"
+	case "failure", "timed_out", "action_required":
+		return "X"
+	case "cancelled", "skipped":
+		return "-"
+	}
+	switch strings.ToLower(status) {
+	case "queued", "in_progress", "pending", "requested", "waiting":
+		return "*"
+	default:
+		return "-"
+	}
+}

--- a/cmd/octopool/gh_top_human.go
+++ b/cmd/octopool/gh_top_human.go
@@ -13,6 +13,11 @@ import (
 )
 
 var stdoutIsTTY = func() bool {
+	// GH_FORCE_TTY explicitly requests terminal formatting; honor it by
+	// delegating like any interactive session.
+	if os.Getenv("GH_FORCE_TTY") != "" {
+		return true
+	}
 	info, err := os.Stdout.Stat()
 	return err == nil && info.Mode()&os.ModeCharDevice != 0
 }
@@ -205,8 +210,10 @@ func renderHumanRunView(stdout io.Writer, run map[string]any, jobs []any) error 
 		return err
 	}
 	// Workflow-file problems fail with zero jobs; match real gh's diagnostic
-	// instead of an unexplained empty JOBS section.
-	if len(jobs) == 0 && runGlyph(run) == "X" {
+	// instead of an unexplained empty JOBS section. Cancelled-while-queued
+	// runs also have zero jobs and must not get this label.
+	conclusion := strings.ToLower(firstString(run, "conclusion"))
+	if len(jobs) == 0 && (conclusion == "failure" || conclusion == "startup_failure") {
 		_, err := fmt.Fprintf(stdout, "\nThis run likely failed because of a workflow file issue.\n\nView this run on GitHub: %s\n", watchSafeText(firstString(run, "html_url")))
 		return err
 	}

--- a/cmd/octopool/gh_top_human_test.go
+++ b/cmd/octopool/gh_top_human_test.go
@@ -394,6 +394,71 @@ func TestHumanRunViewActiveJobOmitsDuration(t *testing.T) {
 	}
 }
 
+func TestHumanListWebFlagDelegates(t *testing.T) {
+	// --web hits the option parser's fallback before any handler runs; the
+	// native renderer must never see it even with non-TTY stdout.
+	setHumanTestSeams(t, time.Time{})
+	var out bytes.Buffer
+	for _, args := range [][]string{
+		{"list", "-R", "openclaw/octopool", "--web"},
+		{"view", "25", "-R", "openclaw/octopool", "--web"},
+	} {
+		if result := handleGHPR(t.Context(), args, &out); result.action != ghDelegate {
+			t.Fatalf("pr %v must delegate, got %v", args, result.action)
+		}
+		if result := handleGHIssue(t.Context(), args, &out); result.action != ghDelegate {
+			t.Fatalf("issue %v must delegate, got %v", args, result.action)
+		}
+	}
+	if out.Len() != 0 {
+		t.Fatalf("delegation must not print, got %q", out.String())
+	}
+}
+
+func TestHumanRunViewRendersFailedSteps(t *testing.T) {
+	setHumanTestSeams(t, time.Date(2026, 7, 18, 4, 21, 25, 0, time.UTC))
+	relayTestServer(t, func(body map[string]any) any {
+		if strings.HasSuffix(body["path"].(string), "/jobs") {
+			return map[string]any{"total_count": 1, "jobs": []map[string]any{{
+				"id": 9, "name": "test", "status": "completed", "conclusion": "failure",
+				"started_at": "2026-07-17T21:00:00Z", "completed_at": "2026-07-17T21:02:00Z",
+				"steps": []map[string]any{
+					{"name": "Build", "status": "completed", "conclusion": "success"},
+					{"name": "Unit tests", "status": "completed", "conclusion": "failure"},
+				},
+			}}}
+		}
+		return map[string]any{
+			"id": 42, "status": "completed", "conclusion": "failure", "head_branch": "main",
+			"name": "CI", "event": "push", "created_at": "2026-07-17T20:59:00Z",
+			"html_url": "https://github.com/openclaw/octopool/actions/runs/42",
+		}
+	})
+	var out bytes.Buffer
+	result := handleGHRun(t.Context(), []string{"view", "42", "-R", "openclaw/octopool"}, &out)
+	assertGHComplete(t, result)
+	if !strings.Contains(out.String(), "  X Unit tests\n") || strings.Contains(out.String(), "Build") {
+		t.Fatalf("failed steps only must render, got %q", out.String())
+	}
+}
+
+func TestHumanBodyNewlineParity(t *testing.T) {
+	var empty bytes.Buffer
+	if err := writeHumanBody(&empty, ""); err != nil {
+		t.Fatal(err)
+	}
+	if empty.String() != "--\n\n" {
+		t.Fatalf("empty body = %q, want gh's unconditional trailing newline", empty.String())
+	}
+	var trailing bytes.Buffer
+	if err := writeHumanBody(&trailing, "text\n"); err != nil {
+		t.Fatal(err)
+	}
+	if trailing.String() != "--\ntext\n\n" {
+		t.Fatalf("trailing-newline body = %q", trailing.String())
+	}
+}
+
 func TestHumanDurationFormatting(t *testing.T) {
 	tests := []struct {
 		start string

--- a/cmd/octopool/gh_top_human_test.go
+++ b/cmd/octopool/gh_top_human_test.go
@@ -39,6 +39,8 @@ func TestHumanPRViewExactOutputAndLatestReviewWins(t *testing.T) {
 		case "/repos/openclaw/octopool/pulls/25/reviews":
 			return []map[string]any{
 				{"user": map[string]any{"login": "chatgpt-codex-connector"}, "state": "COMMENTED"},
+				{"user": map[string]any{"login": "steipete"}, "state": "COMMENTED"},
+				{"user": map[string]any{"login": "bob"}, "state": "PENDING"},
 				{"user": map[string]any{"login": "alice"}, "state": "COMMENTED"},
 				{"user": map[string]any{"login": "alice"}, "state": "CHANGES_REQUESTED"},
 			}
@@ -445,6 +447,26 @@ func TestHumanRunViewRendersFailedSteps(t *testing.T) {
 	assertGHComplete(t, result)
 	if !strings.Contains(out.String(), "  X Unit tests\n") || strings.Contains(out.String(), "Build") {
 		t.Fatalf("failed steps only must render, got %q", out.String())
+	}
+}
+
+func TestHumanRunViewZeroJobFailureDiagnostic(t *testing.T) {
+	setHumanTestSeams(t, time.Date(2026, 7, 18, 4, 21, 25, 0, time.UTC))
+	relayTestServer(t, func(body map[string]any) any {
+		if strings.HasSuffix(body["path"].(string), "/jobs") {
+			return map[string]any{"total_count": 0, "jobs": []any{}}
+		}
+		return map[string]any{
+			"id": 42, "status": "completed", "conclusion": "startup_failure", "head_branch": "main",
+			"name": "CI", "event": "push", "created_at": "2026-07-18T04:00:00Z",
+			"html_url": "https://github.com/openclaw/octopool/actions/runs/42",
+		}
+	})
+	var out bytes.Buffer
+	result := handleGHRun(t.Context(), []string{"view", "42", "-R", "openclaw/octopool"}, &out)
+	assertGHComplete(t, result)
+	if !strings.Contains(out.String(), "workflow file issue") || strings.Contains(out.String(), "JOBS") {
+		t.Fatalf("zero-job failure must show the workflow-file diagnostic, got %q", out.String())
 	}
 }
 

--- a/cmd/octopool/gh_top_human_test.go
+++ b/cmd/octopool/gh_top_human_test.go
@@ -367,6 +367,32 @@ func TestHumanPRChecksPendingExitsEight(t *testing.T) {
 	}
 }
 
+func TestHumanRunViewActiveJobOmitsDuration(t *testing.T) {
+	setHumanTestSeams(t, time.Date(2026, 7, 17, 22, 0, 0, 0, time.UTC))
+	relayTestServer(t, func(body map[string]any) any {
+		if strings.HasSuffix(body["path"].(string), "/jobs") {
+			return map[string]any{"total_count": 1, "jobs": []map[string]any{{
+				"id": 9, "name": "build", "status": "in_progress",
+				"started_at": "2026-07-17T21:59:00Z",
+			}}}
+		}
+		return map[string]any{
+			"id": 42, "status": "in_progress", "head_branch": "main", "name": "CI",
+			"event": "push", "created_at": "2026-07-17T21:58:00Z",
+			"html_url": "https://github.com/openclaw/octopool/actions/runs/42",
+		}
+	})
+	var out bytes.Buffer
+	result := handleGHRun(t.Context(), []string{"view", "42", "-R", "openclaw/octopool"}, &out)
+	assertGHComplete(t, result)
+	if !strings.Contains(out.String(), "* build (ID 9)\n") || strings.Contains(out.String(), "in  (") {
+		t.Fatalf("active job must omit the duration phrase, got %q", out.String())
+	}
+	if got := statusGlyph("completed", "startup_failure"); got != "X" {
+		t.Fatalf("startup_failure glyph = %q, want X", got)
+	}
+}
+
 func TestHumanDurationFormatting(t *testing.T) {
 	tests := []struct {
 		start string

--- a/cmd/octopool/gh_top_human_test.go
+++ b/cmd/octopool/gh_top_human_test.go
@@ -1,0 +1,382 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestHumanPRViewExactOutputAndLatestReviewWins(t *testing.T) {
+	setHumanTestSeams(t, time.Time{})
+	relayTestServer(t, func(body map[string]any) any {
+		switch body["path"] {
+		case "/repos/openclaw/octopool/pulls/25":
+			return map[string]any{
+				"number": 25,
+				"title":  "feat: authoritative Link-header pagination for relay-backed gh api",
+				"state":  "closed",
+				"user":   map[string]any{"login": "steipete", "name": "Peter Steinberger"},
+				"labels": []map[string]any{{"name": "enhancement"}, {"name": "relay"}},
+				"assignees": []map[string]any{
+					{"login": "octocat"},
+				},
+				"milestone":  map[string]any{"title": "0.4.8"},
+				"merged_at":  "2026-07-17T21:15:50Z",
+				"html_url":   "https://github.com/openclaw/octopool/pull/25",
+				"additions":  453,
+				"deletions":  8,
+				"auto_merge": nil,
+				"body":       "First paragraph.\n\nSecond paragraph.",
+			}
+		case "/repos/openclaw/octopool/pulls/25/reviews":
+			return []map[string]any{
+				{"user": map[string]any{"login": "chatgpt-codex-connector"}, "state": "COMMENTED"},
+				{"user": map[string]any{"login": "alice"}, "state": "COMMENTED"},
+				{"user": map[string]any{"login": "alice"}, "state": "CHANGES_REQUESTED"},
+			}
+		default:
+			t.Fatalf("path = %v", body["path"])
+			return nil
+		}
+	})
+	var out bytes.Buffer
+	result := handleGHPR(t.Context(), []string{"view", "25", "-R", "openclaw/octopool"}, &out)
+	assertGHComplete(t, result)
+	want := "title:\tfeat: authoritative Link-header pagination for relay-backed gh api\n" +
+		"state:\tMERGED\n" +
+		"author:\tsteipete\n" +
+		"labels:\tenhancement, relay\n" +
+		"assignees:\toctocat\n" +
+		"reviewers:\tchatgpt-codex-connector (Commented), alice (Changes Requested)\n" +
+		"projects:\t\n" +
+		"milestone:\t0.4.8\n" +
+		"number:\t25\n" +
+		"url:\thttps://github.com/openclaw/octopool/pull/25\n" +
+		"additions:\t453\n" +
+		"deletions:\t8\n" +
+		"auto-merge:\tdisabled\n" +
+		"--\n" +
+		"First paragraph.\n\nSecond paragraph.\n"
+	if got := out.String(); got != want {
+		t.Fatalf("output:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestHumanPRListExactOutput(t *testing.T) {
+	setHumanTestSeams(t, time.Time{})
+	relayTestServer(t, func(body map[string]any) any {
+		return []map[string]any{{
+			"number": 25, "title": "feat: authoritative Link-header pagination for relay-backed gh api",
+			"head": map[string]any{"ref": "feat/link-pagination"}, "state": "closed",
+			"merged_at": "2026-07-17T21:15:50Z", "updated_at": "2026-07-17T22:15:50+01:00",
+		}}
+	})
+	var out bytes.Buffer
+	result := handleGHPR(t.Context(), []string{"list", "-R", "openclaw/octopool", "--state", "all"}, &out)
+	assertGHComplete(t, result)
+	want := "25\tfeat: authoritative Link-header pagination for relay-backed gh api\tfeat/link-pagination\tMERGED\t2026-07-17T21:15:50Z\n"
+	if got := out.String(); got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestHumanPRChecksExactOutputAndSanitizesName(t *testing.T) {
+	setHumanTestSeams(t, time.Time{})
+	relayTestServer(t, func(body map[string]any) any {
+		switch body["path"] {
+		case "/repos/openclaw/octopool/pulls/25":
+			return map[string]any{"head": map[string]any{"sha": "abc123"}}
+		case "/repos/openclaw/octopool/commits/abc123/check-runs":
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{
+				"name": "Check\x1b[31m", "status": "completed", "conclusion": "success",
+				"started_at": "2026-07-17T21:00:00Z", "completed_at": "2026-07-17T21:03:12Z",
+				"details_url": "https://github.com/openclaw/octopool/actions/runs/29614118703/job/87995297404",
+			}}}
+		case "/repos/openclaw/octopool/commits/abc123/status":
+			return map[string]any{"total_count": 0, "statuses": []map[string]any{}}
+		default:
+			t.Fatalf("path = %v", body["path"])
+			return nil
+		}
+	})
+	var out bytes.Buffer
+	result := handleGHPR(t.Context(), []string{"checks", "25", "-R", "openclaw/octopool"}, &out)
+	assertGHComplete(t, result)
+	want := "Check[31m\tpass\t3m12s\thttps://github.com/openclaw/octopool/actions/runs/29614118703/job/87995297404\t\n"
+	if got := out.String(); got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestHumanRunListExactOutput(t *testing.T) {
+	setHumanTestSeams(t, time.Time{})
+	relayTestServer(t, func(body map[string]any) any {
+		return map[string]any{"workflow_runs": []map[string]any{{
+			"status": "completed", "conclusion": "success",
+			"display_title": "chore: open 0.4.8 development", "name": "CI", "head_branch": "main",
+			"event": "push", "id": 29614557506,
+			"run_started_at": "2026-07-17T21:23:36Z", "updated_at": "2026-07-17T21:26:55Z",
+			"created_at": "2026-07-17T22:23:36+01:00",
+		}}}
+	})
+	var out bytes.Buffer
+	result := handleGHRun(t.Context(), []string{"list", "-R", "openclaw/octopool"}, &out)
+	assertGHComplete(t, result)
+	want := "completed\tsuccess\tchore: open 0.4.8 development\tCI\tmain\tpush\t29614557506\t3m19s\t2026-07-17T21:23:36Z\n"
+	if got := out.String(); got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestHumanRunViewExactOutput(t *testing.T) {
+	setHumanTestSeams(t, time.Date(2026, 7, 18, 4, 21, 25, 0, time.UTC))
+	relayTestServer(t, func(body map[string]any) any {
+		switch body["path"] {
+		case "/repos/openclaw/octopool/actions/runs/29614434370":
+			return map[string]any{
+				"id": 29614434370, "display_title": "chore(release): 0.4.7", "name": "release", "head_branch": "v0.4.7",
+				"event": "push", "status": "completed", "conclusion": "success",
+				"created_at": "2026-07-17T21:21:25Z", "updated_at": "2026-07-17T21:22:52Z",
+				"html_url": "https://github.com/openclaw/octopool/actions/runs/29614434370",
+			}
+		case "/repos/openclaw/octopool/actions/runs/29614434370/jobs":
+			return map[string]any{"total_count": 1, "jobs": []map[string]any{{
+				"id": 87996300812, "name": "goreleaser", "status": "completed", "conclusion": "success",
+				"started_at": "2026-07-17T21:21:27Z", "completed_at": "2026-07-17T21:22:51Z",
+				"html_url": "https://github.com/openclaw/octopool/actions/runs/29614434370/job/87996300812",
+			}}}
+		default:
+			t.Fatalf("path = %v", body["path"])
+			return nil
+		}
+	})
+	var out bytes.Buffer
+	result := handleGHRun(t.Context(), []string{"view", "29614434370", "-R", "openclaw/octopool"}, &out)
+	assertGHComplete(t, result)
+	want := "\n✓ v0.4.7 release · 29614434370\n" +
+		"Triggered via push about 7 hours ago\n\n" +
+		"JOBS\n" +
+		"✓ goreleaser in 1m24s (ID 87996300812)\n\n" +
+		"For more information about the job, try: gh run view --job=87996300812\n" +
+		"View this run on GitHub: https://github.com/openclaw/octopool/actions/runs/29614434370\n"
+	if got := out.String(); got != want {
+		t.Fatalf("output:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestHumanIssueViewExactOutput(t *testing.T) {
+	setHumanTestSeams(t, time.Time{})
+	relayTestServer(t, func(body map[string]any) any {
+		return map[string]any{
+			"number": 110411, "title": "cron.update: converting a recurring job", "state": "open",
+			"user": map[string]any{"login": "maintainer"}, "labels": []map[string]any{{"name": "maintainer"}, {"name": "P2"}},
+			"comments": 1, "assignees": []map[string]any{}, "milestone": nil,
+			"body": "Reproduction\n\tstep one\x1b",
+		}
+	})
+	var out bytes.Buffer
+	result := handleGHIssue(t.Context(), []string{"view", "110411", "-R", "openclaw/openclaw"}, &out)
+	assertGHComplete(t, result)
+	want := "title:\tcron.update: converting a recurring job\n" +
+		"state:\tOPEN\n" +
+		"author:\tmaintainer\n" +
+		"labels:\tmaintainer, P2\n" +
+		"comments:\t1\n" +
+		"assignees:\t\n" +
+		"projects:\t\n" +
+		"milestone:\t\n" +
+		"issue-type:\t\n" +
+		"parent:\t\n" +
+		"sub-issues:\t\n" +
+		"sub-issues-completed:\t\n" +
+		"blocked-by:\t\n" +
+		"blocking:\t\n" +
+		"number:\t110411\n" +
+		"--\n" +
+		"Reproduction\n\tstep one\n"
+	if got := out.String(); got != want {
+		t.Fatalf("output:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestHumanIssueListExactOutput(t *testing.T) {
+	setHumanTestSeams(t, time.Time{})
+	relayTestServer(t, func(body map[string]any) any {
+		return []map[string]any{{
+			"number": 110411, "state": "open", "title": "cron.update: converting a recurring job...",
+			"labels":     []map[string]any{{"name": "maintainer"}, {"name": "P2"}, {"name": "bug"}},
+			"updated_at": "2026-07-18T04:46:30Z",
+		}}
+	})
+	var out bytes.Buffer
+	result := handleGHIssue(t.Context(), []string{"list", "-R", "openclaw/openclaw"}, &out)
+	assertGHComplete(t, result)
+	want := "110411\tOPEN\tcron.update: converting a recurring job...\tmaintainer, P2, bug\t2026-07-18T04:46:30Z\n"
+	if got := out.String(); got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestHumanReadsDelegateWhenStdoutIsTTY(t *testing.T) {
+	old := stdoutIsTTY
+	stdoutIsTTY = func() bool { return true }
+	t.Cleanup(func() { stdoutIsTTY = old })
+	relayTestServer(t, func(body map[string]any) any {
+		t.Fatalf("TTY read contacted relay: %#v", body)
+		return nil
+	})
+	tests := []struct {
+		name string
+		run  func(*bytes.Buffer) ghResult
+	}{
+		{"pr view", func(out *bytes.Buffer) ghResult {
+			return handleGHPR(t.Context(), []string{"view", "25", "-R", "openclaw/octopool"}, out)
+		}},
+		{"pr checks", func(out *bytes.Buffer) ghResult {
+			return handleGHPR(t.Context(), []string{"checks", "25", "-R", "openclaw/octopool"}, out)
+		}},
+		{"pr list", func(out *bytes.Buffer) ghResult {
+			return handleGHPR(t.Context(), []string{"list", "-R", "openclaw/octopool"}, out)
+		}},
+		{"run view", func(out *bytes.Buffer) ghResult {
+			return handleGHRun(t.Context(), []string{"view", "29614434370", "-R", "openclaw/octopool"}, out)
+		}},
+		{"run list", func(out *bytes.Buffer) ghResult {
+			return handleGHRun(t.Context(), []string{"list", "-R", "openclaw/octopool"}, out)
+		}},
+		{"issue view", func(out *bytes.Buffer) ghResult {
+			return handleGHIssue(t.Context(), []string{"view", "110411", "-R", "openclaw/openclaw"}, out)
+		}},
+		{"issue list", func(out *bytes.Buffer) ghResult {
+			return handleGHIssue(t.Context(), []string{"list", "-R", "openclaw/openclaw"}, out)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var out bytes.Buffer
+			result := test.run(&out)
+			if result.action != ghDelegate || result.err != nil || out.Len() != 0 {
+				t.Fatalf("action=%v err=%v out=%q", result.action, result.err, out.String())
+			}
+		})
+	}
+}
+
+func TestHumanReadsDelegateUnsupportedFlags(t *testing.T) {
+	setHumanTestSeams(t, time.Time{})
+	tests := []struct {
+		name string
+		run  func(*bytes.Buffer) ghResult
+	}{
+		{"pr view", func(out *bytes.Buffer) ghResult {
+			return handleGHPR(t.Context(), []string{"view", "25", "-R", "openclaw/octopool", "--template", "{{.}}"}, out)
+		}},
+		{"pr checks", func(out *bytes.Buffer) ghResult {
+			return handleGHPR(t.Context(), []string{"checks", "25", "-R", "openclaw/octopool", "--template", "{{.}}"}, out)
+		}},
+		{"pr list", func(out *bytes.Buffer) ghResult {
+			return handleGHPR(t.Context(), []string{"list", "-R", "openclaw/octopool", "--template", "{{.}}"}, out)
+		}},
+		{"run view", func(out *bytes.Buffer) ghResult {
+			return handleGHRun(t.Context(), []string{"view", "29614434370", "-R", "openclaw/octopool", "--template", "{{.}}"}, out)
+		}},
+		{"run list", func(out *bytes.Buffer) ghResult {
+			return handleGHRun(t.Context(), []string{"list", "-R", "openclaw/octopool", "--template", "{{.}}"}, out)
+		}},
+		{"issue view", func(out *bytes.Buffer) ghResult {
+			return handleGHIssue(t.Context(), []string{"view", "110411", "-R", "openclaw/openclaw", "--template", "{{.}}"}, out)
+		}},
+		{"issue list", func(out *bytes.Buffer) ghResult {
+			return handleGHIssue(t.Context(), []string{"list", "-R", "openclaw/openclaw", "--template", "{{.}}"}, out)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var out bytes.Buffer
+			result := test.run(&out)
+			if result.action != ghDelegate || result.err != nil || out.Len() != 0 {
+				t.Fatalf("action=%v err=%v out=%q", result.action, result.err, out.String())
+			}
+		})
+	}
+}
+
+func TestHumanPRChecksPendingExitsEight(t *testing.T) {
+	setHumanTestSeams(t, time.Time{})
+	relayTestServer(t, func(body map[string]any) any {
+		switch body["path"] {
+		case "/repos/openclaw/octopool/pulls/25":
+			return map[string]any{"head": map[string]any{"sha": "abc123"}}
+		case "/repos/openclaw/octopool/commits/abc123/check-runs":
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{
+				"name": "Check", "status": "in_progress", "started_at": "2026-07-17T21:00:00Z",
+			}}}
+		case "/repos/openclaw/octopool/commits/abc123/status":
+			return map[string]any{"total_count": 0, "statuses": []map[string]any{}}
+		default:
+			t.Fatalf("path = %v", body["path"])
+			return nil
+		}
+	})
+	var out bytes.Buffer
+	result := handleGHPR(t.Context(), []string{"checks", "25", "-R", "openclaw/octopool"}, &out)
+	var exitErr exitCodeError
+	if result.action != ghFail || !errors.As(result.err, &exitErr) || exitErr.Code != 8 {
+		t.Fatalf("action=%v err=%v", result.action, result.err)
+	}
+	if got, want := out.String(), "Check\tpending\t\t\t\n"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestHumanDurationFormatting(t *testing.T) {
+	tests := []struct {
+		start string
+		end   string
+		want  string
+	}{
+		{"2026-07-18T00:00:00Z", "2026-07-18T00:00:12Z", "12s"},
+		{"2026-07-18T00:00:00Z", "2026-07-18T00:03:12Z", "3m12s"},
+		{"2026-07-18T00:00:00Z", "2026-07-18T01:02:03Z", "1h2m3s"},
+		{"2026-07-18T00:00:00Z", "", ""},
+	}
+	for _, test := range tests {
+		if got := humanDuration(test.start, test.end); got != test.want {
+			t.Errorf("humanDuration(%q, %q) = %q, want %q", test.start, test.end, got, test.want)
+		}
+	}
+}
+
+func TestHumanReadLeavesJSONBehaviorUnchanged(t *testing.T) {
+	setHumanTestSeams(t, time.Time{})
+	relayTestServer(t, func(body map[string]any) any {
+		return []map[string]any{{"number": 25, "title": "JSON remains JSON"}}
+	})
+	var out bytes.Buffer
+	result := handleGHPR(t.Context(), []string{"list", "-R", "openclaw/octopool", "--json", "number,title"}, &out)
+	assertGHComplete(t, result)
+	if got, want := out.String(), "[{\"number\":25,\"title\":\"JSON remains JSON\"}]\n"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func setHumanTestSeams(t *testing.T, now time.Time) {
+	t.Helper()
+	oldTTY, oldNow := stdoutIsTTY, humanNow
+	stdoutIsTTY = func() bool { return false }
+	if !now.IsZero() {
+		humanNow = func() time.Time { return now }
+	}
+	t.Cleanup(func() {
+		stdoutIsTTY = oldTTY
+		humanNow = oldNow
+	})
+}
+
+func assertGHComplete(t *testing.T, result ghResult) {
+	t.Helper()
+	if result.action != ghComplete || result.err != nil {
+		t.Fatalf("action=%v err=%v", result.action, result.err)
+	}
+}

--- a/cmd/octopool/gh_top_human_test.go
+++ b/cmd/octopool/gh_top_human_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 )
@@ -78,6 +79,42 @@ func TestHumanPRListExactOutput(t *testing.T) {
 	want := "25\tfeat: authoritative Link-header pagination for relay-backed gh api\tfeat/link-pagination\tMERGED\t2026-07-17T21:15:50Z\n"
 	if got := out.String(); got != want {
 		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestHumanPRListMarksDrafts(t *testing.T) {
+	setHumanTestSeams(t, time.Time{})
+	relayTestServer(t, func(body map[string]any) any {
+		return []map[string]any{{
+			"number": 30, "title": "wip", "draft": true,
+			"head": map[string]any{"ref": "wip-branch"}, "state": "open",
+			"updated_at": "2026-07-17T22:15:50Z",
+		}}
+	})
+	var out bytes.Buffer
+	result := handleGHPR(t.Context(), []string{"list", "-R", "openclaw/octopool"}, &out)
+	assertGHComplete(t, result)
+	if want := "30\twip\twip-branch\tDRAFT\t2026-07-17T22:15:50Z\n"; out.String() != want {
+		t.Fatalf("output = %q, want %q", out.String(), want)
+	}
+}
+
+func TestHumanIssueViewDelegatesForPullRequests(t *testing.T) {
+	setHumanTestSeams(t, time.Time{})
+	relayTestServer(t, func(body map[string]any) any {
+		return map[string]any{
+			"number": 25, "title": "actually a PR", "state": "open",
+			"pull_request": map[string]any{"url": "https://example.test/pulls/25"},
+		}
+	})
+	t.Setenv("OCTOPOOL_GH_PATH", fakeGH(t))
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	if err := runGH(t.Context(), []string{"issue", "view", "25", "-R", "openclaw/octopool"}, &out, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(out.String(), "real-gh:") || !strings.Contains(stderr.String(), "issue_number_is_pull_request") {
+		t.Fatalf("PR numbers must delegate to real gh: out=%q stderr=%q", out.String(), stderr.String())
 	}
 }
 

--- a/cmd/octopool/gh_top_human_test.go
+++ b/cmd/octopool/gh_top_human_test.go
@@ -70,7 +70,8 @@ func TestHumanPRListExactOutput(t *testing.T) {
 		return []map[string]any{{
 			"number": 25, "title": "feat: authoritative Link-header pagination for relay-backed gh api",
 			"head": map[string]any{"ref": "feat/link-pagination"}, "state": "closed",
-			"merged_at": "2026-07-17T21:15:50Z", "updated_at": "2026-07-17T22:15:50+01:00",
+			"merged_at": "2026-07-17T21:15:50Z", "updated_at": "2026-07-17T23:35:50+01:00",
+			"created_at": "2026-07-17T22:15:50+01:00",
 		}}
 	})
 	var out bytes.Buffer
@@ -88,7 +89,7 @@ func TestHumanPRListMarksDrafts(t *testing.T) {
 		return []map[string]any{{
 			"number": 30, "title": "wip", "draft": true,
 			"head": map[string]any{"ref": "wip-branch"}, "state": "open",
-			"updated_at": "2026-07-17T22:15:50Z",
+			"updated_at": "2026-07-17T22:15:50Z", "created_at": "2026-07-17T22:15:50Z",
 		}}
 	})
 	var out bytes.Buffer

--- a/cmd/octopool/gh_top_human_test.go
+++ b/cmd/octopool/gh_top_human_test.go
@@ -22,7 +22,13 @@ func TestHumanPRViewExactOutputAndLatestReviewWins(t *testing.T) {
 				"assignees": []map[string]any{
 					{"login": "octocat"},
 				},
-				"milestone":  map[string]any{"title": "0.4.8"},
+				"milestone": map[string]any{"title": "0.4.8"},
+				"requested_reviewers": []map[string]any{
+					{"login": "alice"},
+				},
+				"requested_teams": []map[string]any{
+					{"slug": "octopool-maintainers"},
+				},
 				"merged_at":  "2026-07-17T21:15:50Z",
 				"html_url":   "https://github.com/openclaw/octopool/pull/25",
 				"additions":  453,
@@ -49,7 +55,7 @@ func TestHumanPRViewExactOutputAndLatestReviewWins(t *testing.T) {
 		"author:\tsteipete\n" +
 		"labels:\tenhancement, relay\n" +
 		"assignees:\toctocat\n" +
-		"reviewers:\tchatgpt-codex-connector (Commented), alice (Changes Requested)\n" +
+		"reviewers:\tchatgpt-codex-connector (Commented), alice (Requested), octopool-maintainers (Requested)\n" +
 		"projects:\t\n" +
 		"milestone:\t0.4.8\n" +
 		"number:\t25\n" +

--- a/cmd/octopool/gh_top_issue.go
+++ b/cmd/octopool/gh_top_issue.go
@@ -31,7 +31,13 @@ func handleGHIssue(ctx context.Context, args []string, stdout io.Writer) ghResul
 	switch args[0] {
 	case "view":
 		repo, number, ok := repoNumber(opts)
-		if !ok || hasTopModifiers(opts) || !machineReadable(opts) || !supportedJSONFields(opts, supportedIssueFields) {
+		if !ok || hasTopModifiers(opts) {
+			return ghDelegated()
+		}
+		if nativeHumanFormat(opts) {
+			return ghCompleted(relayHumanIssueView(ctx, stdout, repo, number))
+		}
+		if !machineReadable(opts) || !supportedJSONFields(opts, supportedIssueFields) {
 			return ghDelegated()
 		}
 		return ghCompleted(relayTop(ctx, stdout, ghAPIRequest{
@@ -41,7 +47,10 @@ func handleGHIssue(ctx context.Context, args []string, stdout io.Writer) ghResul
 		}, opts, fieldMapIssue))
 	case "list":
 		repo, ok := repoOnly(opts)
-		if !ok || !machineReadable(opts) || !supportedJSONFields(opts, supportedIssueFields) || limitOverOnePage(opts) || hasCurrentUserFilter(opts) {
+		if !ok || limitOverOnePage(opts) || hasCurrentUserFilter(opts) {
+			return ghDelegated()
+		}
+		if !nativeHumanFormat(opts) && (!machineReadable(opts) || !supportedJSONFields(opts, supportedIssueFields)) {
 			return ghDelegated()
 		}
 		query := listQuery(opts)
@@ -109,15 +118,16 @@ func relayIssueList(ctx context.Context, stdout io.Writer, request ghAPIRequest,
 	if len(filtered) < limit && !complete {
 		return localFallbackError{Reason: "pagination_exhausted"}
 	}
+	if len(opts.json) == 0 {
+		return renderHumanIssueList(stdout, filtered)
+	}
 	raw, err := json.Marshal(filtered)
 	if err != nil {
 		return err
 	}
-	if len(opts.json) > 0 {
-		raw, err = filterJSONFields(raw, opts.json, fieldMapIssue)
-		if err != nil {
-			return err
-		}
+	raw, err = filterJSONFields(raw, opts.json, fieldMapIssue)
+	if err != nil {
+		return err
 	}
 	return writeBytes(ctx, stdout, raw, opts.jq)
 }

--- a/cmd/octopool/gh_top_pr.go
+++ b/cmd/octopool/gh_top_pr.go
@@ -41,7 +41,13 @@ func handleGHPR(ctx context.Context, args []string, stdout io.Writer) ghResult {
 	switch args[0] {
 	case "view":
 		repo, number, ok := repoNumber(opts)
-		if !ok || hasTopModifiers(opts) || !machineReadable(opts) || !supportedJSONFields(opts, supportedPRFields) {
+		if !ok || hasTopModifiers(opts) {
+			return ghDelegated()
+		}
+		if nativeHumanFormat(opts) {
+			return ghCompleted(relayHumanPRView(ctx, stdout, repo, number))
+		}
+		if !machineReadable(opts) || !supportedJSONFields(opts, supportedPRFields) {
 			return ghDelegated()
 		}
 		if needsHydratedPR(opts.json) {
@@ -54,12 +60,22 @@ func handleGHPR(ctx context.Context, args []string, stdout io.Writer) ghResult {
 		}, opts, fieldMapPR))
 	case "list":
 		repo, ok := repoOnly(opts)
-		if !ok || !machineReadable(opts) || !supportedJSONFields(opts, supportedPRListFields) || !supportedPRListState(opts.state) || limitOverOnePage(opts) || opts.author != "" || opts.assignee != "" || len(opts.labels) > 0 {
+		if !ok || !supportedPRListState(opts.state) || limitOverOnePage(opts) || opts.author != "" || opts.assignee != "" || len(opts.labels) > 0 {
 			return ghDelegated()
 		}
 		query := listQuery(opts)
 		if opts.state != "" {
 			query["state"] = opts.state
+		}
+		if nativeHumanFormat(opts) {
+			return ghCompleted(relayHumanPRList(ctx, stdout, ghAPIRequest{
+				method: "GET",
+				path:   repoPath(repo, "pulls"),
+				query:  query,
+			}))
+		}
+		if !machineReadable(opts) || !supportedJSONFields(opts, supportedPRListFields) {
+			return ghDelegated()
 		}
 		return ghCompleted(relayTop(ctx, stdout, ghAPIRequest{
 			method:  "GET",
@@ -84,7 +100,10 @@ func handleGHPR(ctx context.Context, args []string, stdout io.Writer) ghResult {
 		return ghCompleted(relayTop(ctx, stdout, request, ghTopOptions{}, nil))
 	case "checks":
 		repo, number, ok := repoNumber(opts)
-		if !ok || hasTopModifiers(opts) || !machineReadable(opts) || !supportedJSONFields(opts, supportedCheckRunFields) {
+		if !ok || hasTopModifiers(opts) {
+			return ghDelegated()
+		}
+		if !nativeHumanFormat(opts) && (!machineReadable(opts) || !supportedJSONFields(opts, supportedCheckRunFields)) {
 			return ghDelegated()
 		}
 		return ghCompleted(relayPRChecks(ctx, stdout, repo, number, opts))

--- a/cmd/octopool/gh_top_run.go
+++ b/cmd/octopool/gh_top_run.go
@@ -96,6 +96,8 @@ func relayRunView(ctx context.Context, stdout io.Writer, repo string, id string,
 		}
 	}
 	if human || hasJSONField(opts.json, "jobs") {
+		// per_page=100 with runJobs' incomplete-total fallback: >100-job runs
+		// delegate to real gh rather than truncating.
 		envelope, err := client.do(ctx, ghAPIRequest{
 			method: "GET",
 			path:   repoPath(repo, "actions", "runs", id, "jobs"),

--- a/cmd/octopool/gh_top_run.go
+++ b/cmd/octopool/gh_top_run.go
@@ -38,21 +38,31 @@ func handleGHRun(ctx context.Context, args []string, stdout io.Writer) ghResult 
 			}
 			path = repoPath(repo, "actions", "workflows", opts.workflow, "runs")
 		}
-		if !machineReadable(opts) || !supportedJSONFields(opts, supportedRunListFields) || limitOverOnePage(opts) {
+		if limitOverOnePage(opts) {
 			return ghDelegated()
 		}
-		return ghCompleted(relayTop(ctx, stdout, ghAPIRequest{
+		request := ghAPIRequest{
 			method:  "GET",
 			path:    path,
 			query:   query,
 			headers: map[string]string{"x-octopool-public-shape": publicShapeActionsSummary},
-		}, opts, fieldMapRun))
+		}
+		if nativeHumanFormat(opts) {
+			return ghCompleted(relayHumanRunList(ctx, stdout, request))
+		}
+		if !machineReadable(opts) || !supportedJSONFields(opts, supportedRunListFields) {
+			return ghDelegated()
+		}
+		return ghCompleted(relayTop(ctx, stdout, request, opts, fieldMapRun))
 	case "view":
-		if len(opts.positionals) != 1 || !isDigits(opts.positionals[0]) || hasTopModifiers(opts) || !machineReadable(opts) || !supportedJSONFields(opts, supportedRunViewFields) {
+		if len(opts.positionals) != 1 || !isDigits(opts.positionals[0]) || hasTopModifiers(opts) {
 			return ghDelegated()
 		}
 		repo, ok := repoFromOptionOrCurrent(opts.repo)
 		if !ok {
+			return ghDelegated()
+		}
+		if !nativeHumanFormat(opts) && (!machineReadable(opts) || !supportedJSONFields(opts, supportedRunViewFields)) {
 			return ghDelegated()
 		}
 		return ghCompleted(relayRunView(ctx, stdout, repo, opts.positionals[0], opts))
@@ -67,7 +77,8 @@ func relayRunView(ctx context.Context, stdout io.Writer, repo string, id string,
 		return err
 	}
 	run := map[string]any{}
-	if len(opts.json) > 1 || !hasJSONField(opts.json, "jobs") {
+	human := len(opts.json) == 0
+	if human || len(opts.json) > 1 || !hasJSONField(opts.json, "jobs") {
 		envelope, err := client.do(ctx, ghAPIRequest{
 			method:  "GET",
 			path:    repoPath(repo, "actions", "runs", id),
@@ -84,7 +95,7 @@ func relayRunView(ctx context.Context, stdout io.Writer, repo string, id string,
 			return err
 		}
 	}
-	if hasJSONField(opts.json, "jobs") {
+	if human || hasJSONField(opts.json, "jobs") {
 		envelope, err := client.do(ctx, ghAPIRequest{
 			method: "GET",
 			path:   repoPath(repo, "actions", "runs", id, "jobs"),
@@ -101,6 +112,10 @@ func relayRunView(ctx context.Context, stdout io.Writer, repo string, id string,
 			return err
 		}
 		run["jobs"] = jobs
+	}
+	if human {
+		jobs, _ := run["jobs"].([]any)
+		return renderHumanRunView(stdout, run, jobs)
 	}
 	raw, err := json.Marshal(run)
 	if err != nil {

--- a/cmd/octopool/gh_top_watch.go
+++ b/cmd/octopool/gh_top_watch.go
@@ -541,6 +541,17 @@ func watchSafeText(raw string) string {
 	}, raw)
 }
 
+// bodySafeText preserves body layout while removing control characters that
+// could alter terminal state or encode invalid text.
+func bodySafeText(raw string) string {
+	return strings.Map(func(r rune) rune {
+		if (r < 0x20 && r != '\n' && r != '\t') || r == 0x7f || (r >= 0x80 && r <= 0x9f) || r == utf8.RuneError {
+			return -1
+		}
+		return r
+	}, raw)
+}
+
 func watchError(err error, progressPrinted bool) error {
 	if progressPrinted && shouldRunRealGH(err) {
 		return errors.New(err.Error())

--- a/cmd/octopool/gh_top_watch.go
+++ b/cmd/octopool/gh_top_watch.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode/utf8"
 )
 
 const (
@@ -528,13 +527,14 @@ func printPRChecksWatchFinal(stdout io.Writer, items []any) error {
 	return nil
 }
 
-// watchSafeText strips ASCII/C1 control characters and invalid UTF-8 from
-// API-controlled strings so job/check names cannot inject terminal escape
-// sequences. Printable CSI remainders like "[31m" are harmless once the
-// escape introducer is gone.
+// watchSafeText strips ASCII/C1 control characters from API-controlled
+// strings so job/check names cannot inject terminal escape sequences.
+// Printable CSI remainders like "[31m" are harmless once the escape
+// introducer is gone. U+FFFD passes through: post-JSON strings are valid
+// UTF-8, so stripping it would only eat legitimate replacement characters.
 func watchSafeText(raw string) string {
 	return strings.Map(func(r rune) rune {
-		if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) || r == utf8.RuneError {
+		if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
 			return -1
 		}
 		return r
@@ -545,7 +545,7 @@ func watchSafeText(raw string) string {
 // could alter terminal state or encode invalid text.
 func bodySafeText(raw string) string {
 	return strings.Map(func(r rune) rune {
-		if (r < 0x20 && r != '\n' && r != '\t') || r == 0x7f || (r >= 0x80 && r <= 0x9f) || r == utf8.RuneError {
+		if (r < 0x20 && r != '\n' && r != '\t') || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
 			return -1
 		}
 		return r

--- a/cmd/octopool/gh_top_watch_test.go
+++ b/cmd/octopool/gh_top_watch_test.go
@@ -527,7 +527,7 @@ func TestGHPRChecksWatchJQWithoutJSONDelegates(t *testing.T) {
 }
 
 func TestWatchSafeTextStripsControlSequences(t *testing.T) {
-	if got := watchSafeText("ok\x1b[31mred\x9bx\x00\ttab"); got != "ok[31mredxtab" {
+	if got := watchSafeText("ok\x1b[31mred\x9bx\x00\ttab"); got != "ok[31mred\uFFFDxtab" {
 		t.Fatalf("got %q", got)
 	}
 }

--- a/cmd/octopool/login.go
+++ b/cmd/octopool/login.go
@@ -239,7 +239,7 @@ func githubResetTime(value string) string {
 	if err != nil || epoch <= 0 {
 		return ""
 	}
-	return time.Unix(epoch, 0).Local().Format(time.RFC1123)
+	return time.Unix(epoch, 0).UTC().Format(time.RFC1123)
 }
 
 func validateLoginURL(rawURL string) error {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -155,9 +155,9 @@ octopool gh release view v0.3.0 -R openclaw/octopool --json tagName,name,url
 octopool gh api repos/openclaw/octopool/contents/README.md?ref=main --jq .content
 ```
 
-Top-level commands are relayed only for machine-readable `--json` shapes; normal human
-formatted commands stay on the real `gh`. Supported `--json` fields are intentionally
-conservative. Common `gh` field names are mapped where the REST API uses different
+Top-level commands relay machine-readable `--json` shapes and selected non-interactive
+human-format reads. Supported `--json` fields are intentionally conservative. Common
+`gh` field names are mapped where the REST API uses different
 names, such as `url`, `author`, `headRefName`, `headRefOid`, `baseRefName`,
 `baseRefOid`, `isDraft`, `databaseId`, `workflowName`, and `nameWithOwner`.
 Run views also support the nested `jobs` field; Octopool composes its job/step metadata from
@@ -179,6 +179,31 @@ on the relay, floors intervals at 30 seconds, and backs off to 120 seconds. Ask 
 `gh api` conditional requests only when instant freshness matters more than quota.
 `--jq` runs after `--json` filtering, matching the usual agent workflow for small
 machine-readable reads.
+
+#### Human-format reads
+
+When stdout is not a terminal, the shim renders `pr view`, `pr checks`, `pr list`,
+`run view`, `run list`, `issue view`, and `issue list` from the same relay-backed REST
+responses used by their `--json` forms. Their supported flags, filters, required numeric
+view identifiers, pagination bounds, and fallback behavior are identical to the existing
+`--json` interception paths. Terminal stdout still delegates to the real `gh`, preserving
+its interactive decoration. Unsupported presentation flags such as `--web`, `--comments`,
+and `--template` also delegate.
+
+The native output follows real `gh` 2.x non-terminal formatting with these REST-driven
+differences:
+
+- PR authors show the login only, without the display name lookup; PR projects are empty.
+- PR reviewers come from the cached pull-review route, with each reviewer's latest state
+  rendered in title case.
+- Issue projects, issue type, parent, sub-issue counts, blocked-by, and blocking fields are
+  empty because the REST issue payload does not provide them.
+- Run-view headers use `<head branch> <workflow name>`, matching the verified GitHub run
+  payload behind real `gh`; relative timestamps use coarse minute, hour, and day buckets.
+
+All relay-controlled single-line text has terminal control characters removed. PR and
+issue bodies preserve newlines and tabs while removing other control characters and
+invalid UTF-8.
 
 The command falls through to the real `gh` without contacting Octopool when any of these
 hold:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -200,6 +200,11 @@ differences:
   empty because the REST issue payload does not provide them.
 - Run-view headers use `<head branch> <workflow name>`, matching the verified GitHub run
   payload behind real `gh`; relative timestamps use coarse minute, hour, and day buckets.
+- Run views render jobs and their failed steps only; real `gh`'s ANNOTATIONS and ARTIFACTS
+  sections are omitted (those routes are not relay-backed), and the footer always points at
+  the first job instead of varying by conclusion and job count. `--log-failed` and other log
+  flags delegate to real `gh`.
+- Enabled auto-merge renders as `enabled` without the enabling user and merge method.
 
 All relay-controlled single-line text has terminal control characters removed. PR and
 issue bodies preserve newlines and tabs while removing other control characters and


### PR DESCRIPTION
Human-format reads were the largest remaining personal-quota leak: `gh pr view 123`, `gh run list`, `gh pr checks` without `--json` delegated silently to real gh (GraphQL+core on the personal token; ~2,100 human pr-views in 3h of agent sessions, personal core measured at 4941/5000).

Non-TTY stdout now renders `pr view`, `pr checks`, `pr list`, `run view`, `run list`, `issue view`, and `issue list` natively from the same relay-backed REST fetch paths as their `--json` forms — same flags, filters, pagination bounds, and fallback rules. TTY stdout (and `GH_FORCE_TTY`) still delegates so interactive humans keep real gh's decorated UX.

Output parity was built against captured real-gh 2.x non-TTY samples and hardened across nine structured review rounds: gh-faithful glyph mapping, fork `owner:branch` head labels, `created_at` list columns, `run_started_at`/through-now durations, requested-reviewer folding (re-requests override stale states; author and unsubmitted PENDING reviews excluded), failed-step rows, zero-job workflow-file diagnostics, draft states, PR-number issue views delegating, unconditional gh body-newline termination, control-sequence sanitization, and 32-bit-safe duration arithmetic. Documented divergences (docs/cli.md): login-only authors, empty projects/sub-issue fields, no ANNOTATIONS/ARTIFACTS sections, summary auto-merge, static footer hint.

Consciously rejected findings, with evidence in the review logs: empty lists print nothing and exit 0 (verified live against real gh non-TTY — 0 bytes, exit 0, three times re-raised); `--web` cannot reach the renderer (option-parser fallback, codified as a regression test); jobs pagination (per_page=100 + incomplete-total fallback delegates >100-job runs); two tail parity items (in-progress draft reviews masking a prior state, team-slug/user-login key collision on one PR) noted as known micro-divergences.

Proof: gofmt/vet clean, full suite green (30+ new human-format tests with exact-output fixtures), `GOARCH=386` build verified. Also fixes a latent timezone bug in login.go reset-time formatting exposed by the suite.
