### PR TITLE
feat: zero-cost conditional revalidation for expired cache entries

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -43,7 +43,7 @@ need to re-contact GitHub just to validate the hint.
 
 ### What is cached
 
-Only `200` responses on cacheable routes are stored. The cache is **bypassed** when:
+Only successful `2xx` responses on cacheable routes are stored. The cache is **bypassed** when:
 
 - the route is a log route, large-payload route, or `rate_limit`, or
 - the request carries a conditional header (`if-none-match` / `if-modified-since`).

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -18,6 +18,13 @@ direct repository-resource response also proves that the repository is public, a
 separate repository metadata request; routes that need a pooled identity still run the
 explicit public-repository guard first. Successful results write through to both layers.
 
+Expired API-origin entries with an `etag` or `last-modified` validator are conditionally
+revalidated through the API before the normal token-free/API/pool fill chain. Anonymous REST
+entries are distinguished from web/raw/page entries by their stored `x-ratelimit-resource`
+header; identity-backed entries are always API-origin. A `304` reruns cache-hit integrity,
+then republishes the stored body with TTLs recomputed from that body. Web-origin validators
+are never sent across transports.
+
 ### Cache key
 
 SHA-256 (base64url) over a stable, sorted JSON of: pool, method, path, normalized
@@ -144,6 +151,8 @@ status as `hit`, `stale`, `miss`, `bypass`, or `unknown`, which powers `octopool
 the dashboard hit-rate/top-route views. Coalesced followers are marked separately. Stats
 count both fresh and stale hits as saved GitHub requests and expose an eligible hit rate
 that excludes failed misses and deliberate local fallback responses.
+Successful `304` refreshes use the existing `hit` status so current stats and CLI parsers count
+the saved request, with `fallback_reason = cache_revalidated` as the distinct audit marker.
 
 ## Public-repo guard
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -34,6 +34,20 @@ export type CachedGitHubResponse = GitHubRelayResponse & {
   expires_at: string;
 };
 
+export function githubCacheRevalidationHeaders(
+  cached: CachedGitHubResponse,
+): Record<string, string> | undefined {
+  if (cached.identity === undefined && cached.headers["x-ratelimit-resource"] === undefined) {
+    return undefined;
+  }
+  const etag = cached.headers.etag;
+  if (etag !== undefined) {
+    return { "if-none-match": etag };
+  }
+  const lastModified = cached.headers["last-modified"];
+  return lastModified === undefined ? undefined : { "if-modified-since": lastModified };
+}
+
 export async function githubCacheKey(
   pool: string,
   request: RelayRequest,

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -190,7 +190,7 @@ export async function writeGitHubCache(
   response: GitHubRelayResponse,
   identity?: Identity,
 ): Promise<void> {
-  if (response.status !== 200) {
+  if (response.status < 200 || response.status >= 300) {
     return;
   }
   const ttlSeconds = cacheTTLSeconds(route, response);

--- a/src/github-public-api.ts
+++ b/src/github-public-api.ts
@@ -64,6 +64,15 @@ export function publicAPIRequest(
   };
 }
 
+export function supportsAnonymousGitHubAPI(request: RelayRequest, route: RouteInfo): boolean {
+  return (
+    (releaseRoute(route) && defaultGitHubJSONAccept(request.headers?.accept)) ||
+    (request.method === "GET" &&
+      capabilitiesForRouteKind(route.kind).publicApi &&
+      defaultGitHubJSONAccept(request.headers?.accept))
+  );
+}
+
 export async function storePublicAPIRate(
   env: Env,
   resource: string,

--- a/src/github-web.ts
+++ b/src/github-web.ts
@@ -4,6 +4,7 @@ import { actionsPageRequest } from "./github-public-actions";
 import { mediaFormat, mediaWebRequest, rawContentRequest } from "./github-public-content";
 import { gitRefRequest } from "./github-public-git";
 import { releasePageRequest, summaryPageRequest } from "./github-public-pages";
+import { githubResponseHeaders } from "./github-response";
 import type { WebRequest } from "./github-web-types";
 import { fetchWebResponse, readWebBody } from "./github-web-transport";
 import type { GitHubRelayResponse, RelayRequest, RouteInfo } from "./types";
@@ -55,6 +56,56 @@ export async function callGitHubWeb(
     }
   }
   return undefined;
+}
+
+export async function callAnonymousGitHubAPI(
+  env: Env,
+  request: RelayRequest,
+  route: RouteInfo,
+): Promise<GitHubRelayResponse | undefined> {
+  const api = webRequests(env, request, route).find((candidate) => candidate.usesApiQuota);
+  if (api === undefined) {
+    return undefined;
+  }
+  const fetched = await fetchWebResponse(
+    api.url,
+    { ...api.headers, ...conditionalHeaders(request.headers) },
+    parsePositiveInt(env.REQUEST_TIMEOUT_MS, 15_000),
+  );
+  if (fetched === undefined) {
+    return undefined;
+  }
+  const { response, url: responseURL } = fetched;
+  await storePublicAPIRate(env, route.resource, response.headers);
+  if (response.status === 304) {
+    return {
+      status: 304,
+      headers: githubResponseHeaders(response.headers),
+      body: null,
+      body_encoding: "text",
+      backend: "web",
+    };
+  }
+  if (response.status < 200 || response.status >= 300) {
+    return undefined;
+  }
+  try {
+    const body = await readWebBody(response, api.capBytes);
+    return await api.payload(new Uint8Array(body), response.headers, response.status, responseURL);
+  } catch {
+    return undefined;
+  }
+}
+
+function conditionalHeaders(headers: Record<string, string> | undefined): Record<string, string> {
+  return {
+    ...(headers?.["if-none-match"] === undefined
+      ? {}
+      : { "if-none-match": headers["if-none-match"] }),
+    ...(headers?.["if-modified-since"] === undefined
+      ? {}
+      : { "if-modified-since": headers["if-modified-since"] }),
+  };
 }
 
 function webRequests(env: Env, request: RelayRequest, route: RouteInfo): WebRequest[] {

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -307,6 +307,9 @@ async function revalidateStaleRelayCache(state: ActiveRelay): Promise<Response |
         return restoreSharedCacheFill(state);
       }
     }
+    if (!usesTokenFreeAPI && !(await guardRevalidationPublicRepo(state))) {
+      return undefined;
+    }
     const github = await callRevalidationAPI(state, candidates[0]!, usesTokenFreeAPI);
     if (github === undefined) {
       return restoreSharedCacheFill(state);
@@ -317,6 +320,9 @@ async function revalidateStaleRelayCache(state: ActiveRelay): Promise<Response |
     return response ?? restoreSharedCacheFill(state);
   }
   if (identities.length === 0) {
+    return undefined;
+  }
+  if (!(await guardRevalidationPublicRepo(state))) {
     return undefined;
   }
 
@@ -485,24 +491,8 @@ async function finishRevalidation(
 }
 
 async function restoreSharedCacheFill(state: ActiveRelay): Promise<Response | undefined> {
-  state.identity = undefined;
-  if (state.cacheKey === state.sharedCacheKey && state.cacheKey !== undefined) {
-    await finishGitHubCacheFill(state.coordinator, state.cacheKey, state.cacheFillToken);
-    state.cacheFillToken = undefined;
-  } else {
-    await switchRelayCacheKey(state, state.sharedCacheKey);
-  }
-  const coalesced = await coalesceRelayCacheMiss(state);
-  if (
-    coalesced === undefined ||
-    !(await cachedResponseAvailable(
-      state.env,
-      state.request.pool,
-      state.route,
-      coalesced,
-      state.coordinator,
-    ))
-  ) {
+  const coalesced = await restoreSharedCacheFillState(state);
+  if (coalesced === undefined) {
     return undefined;
   }
   return serveCachedGitHubResponse(
@@ -510,6 +500,29 @@ async function restoreSharedCacheFill(state: ActiveRelay): Promise<Response | un
     state.ctx,
     cachedResponseParams(state, coalesced, "hit", { coalesced: true }),
   );
+}
+
+async function guardRevalidationPublicRepo(state: ActiveRelay): Promise<boolean> {
+  try {
+    await ensurePublicGitHubRepo(state.env, state.route, undefined, state.coordinator);
+    return true;
+  } catch {
+    await restoreSharedCacheFillState(state);
+    return false;
+  }
+}
+
+async function restoreSharedCacheFillState(
+  state: ActiveRelay,
+): Promise<CachedGitHubResponse | undefined> {
+  state.identity = undefined;
+  if (state.cacheKey === state.sharedCacheKey && state.cacheKey !== undefined) {
+    await finishGitHubCacheFill(state.coordinator, state.cacheKey, state.cacheFillToken);
+    state.cacheFillToken = undefined;
+  } else {
+    await switchRelayCacheKey(state, state.sharedCacheKey);
+  }
+  return coalesceRelayCacheMiss(state);
 }
 
 async function callTokenFreeBackend(state: ActiveRelay): Promise<Response | undefined> {

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -294,12 +294,27 @@ async function revalidateStaleRelayCache(state: ActiveRelay): Promise<Response |
 
   const usesTokenFreeAPI = supportsAnonymousGitHubAPI(state.request, state.route);
   if (usesTokenFreeAPI || capabilities.fallback === "github_public") {
+    if (state.cacheFillToken === undefined) {
+      const coalesced = await coalesceRelayCacheMiss(state);
+      if (coalesced !== undefined) {
+        return serveCachedGitHubResponse(
+          state.env,
+          state.ctx,
+          cachedResponseParams(state, coalesced, "hit", { coalesced: true }),
+        );
+      }
+      if (state.cacheFillToken === undefined) {
+        return restoreSharedCacheFill(state);
+      }
+    }
     const github = await callRevalidationAPI(state, candidates[0]!, usesTokenFreeAPI);
-    return github === undefined
-      ? undefined
-      : finishRevalidation(state, candidates[0]!, github, undefined, {
-          backend: usesTokenFreeAPI ? "web" : "github_public",
-        });
+    if (github === undefined) {
+      return restoreSharedCacheFill(state);
+    }
+    const response = await finishRevalidation(state, candidates[0]!, github, undefined, {
+      backend: usesTokenFreeAPI ? "web" : "github_public",
+    });
+    return response ?? restoreSharedCacheFill(state);
   }
   if (identities.length === 0) {
     return undefined;
@@ -471,7 +486,12 @@ async function finishRevalidation(
 
 async function restoreSharedCacheFill(state: ActiveRelay): Promise<Response | undefined> {
   state.identity = undefined;
-  await switchRelayCacheKey(state, state.sharedCacheKey);
+  if (state.cacheKey === state.sharedCacheKey && state.cacheKey !== undefined) {
+    await finishGitHubCacheFill(state.coordinator, state.cacheKey, state.cacheFillToken);
+    state.cacheFillToken = undefined;
+  } else {
+    await switchRelayCacheKey(state, state.sharedCacheKey);
+  }
   const coalesced = await coalesceRelayCacheMiss(state);
   if (
     coalesced === undefined ||

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -278,6 +278,17 @@ async function coalesceRelayCacheMiss(
 }
 
 async function revalidateStaleRelayCache(state: ActiveRelay): Promise<Response | undefined> {
+  try {
+    return await attemptStaleRelayCacheRevalidation(state);
+  } catch {
+    await restoreAfterFailedRevalidation(state);
+    return undefined;
+  }
+}
+
+async function attemptStaleRelayCacheRevalidation(
+  state: ActiveRelay,
+): Promise<Response | undefined> {
   if (state.cacheKey === undefined) {
     return undefined;
   }
@@ -433,7 +444,7 @@ async function finishRevalidation(
   identity: Identity | undefined,
   result: Pick<RelaySuccess, "backend" | "leaseReason">,
 ): Promise<Response | undefined> {
-  if (github.status === 200) {
+  if (github.status >= 200 && github.status < 300) {
     if (identity === undefined && anonymousGitHubResponseProvesPublicRepo(state.route)) {
       await recordPublicGitHubRepo(state.env, state.route);
     } else {
@@ -488,6 +499,29 @@ async function finishRevalidation(
     revalidated: true,
     upstreamStatus: 304,
   });
+}
+
+async function restoreAfterFailedRevalidation(state: ActiveRelay): Promise<void> {
+  if (
+    state.identity === undefined &&
+    state.cacheKey === state.sharedCacheKey &&
+    (state.cacheKey === undefined || state.cacheFillToken !== undefined)
+  ) {
+    return;
+  }
+  try {
+    state.identity = undefined;
+    await switchRelayCacheKey(state, state.sharedCacheKey);
+    if (state.cacheKey !== undefined && state.cacheFillToken === undefined) {
+      state.cacheFillToken = (await state.coordinator.claimCacheFill(state.cacheKey)) ?? undefined;
+    }
+  } catch {
+    state.identity = undefined;
+    state.cacheKey = state.sharedCacheKey;
+    state.cacheFillToken = undefined;
+    state.cacheStatus = state.sharedCacheKey === undefined ? "bypass" : "miss";
+    state.cacheable = state.sharedCacheKey !== undefined;
+  }
 }
 
 async function restoreSharedCacheFill(state: ActiveRelay): Promise<Response | undefined> {

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -1,6 +1,7 @@
 import { authenticateCaller } from "./auth";
 import {
   type CachedGitHubResponse,
+  githubCacheRevalidationHeaders,
   githubCacheKey,
   readGitHubCache,
   readStaleGitHubCache,
@@ -11,8 +12,9 @@ import {
 import { coalesceGitHubCacheMiss, finishGitHubCacheFill } from "./cache-coalesce";
 import { insertAudit, loadIdentities, loadPoolPolicy } from "./db";
 import { callGitHub, callPublicGitHub } from "./github";
+import { supportsAnonymousGitHubAPI } from "./github-public-api";
 import { rateFromHeaders, type GitHubRate } from "./github-rate";
-import { callGitHubWeb } from "./github-web";
+import { callAnonymousGitHubAPI, callGitHubWeb } from "./github-web";
 import { sanitizeGitHubResponse } from "./github-sanitize";
 import { HttpError, jsonResponse, parseJsonObject } from "./http";
 import { githubResponseLocalFallbackReason, localFallbackError } from "./local-fallback";
@@ -66,6 +68,13 @@ type RelaySuccess = {
   backend?: "web" | "github_public";
   leaseReason?: SelectionResult["reason"];
   rate?: GitHubRate;
+  revalidated?: boolean;
+  upstreamStatus?: number;
+};
+
+type RevalidationCandidate = {
+  cached: CachedGitHubResponse;
+  headers: Record<string, string>;
 };
 
 export async function relayGitHub(
@@ -158,6 +167,11 @@ async function executeRelay(state: ActiveRelay): Promise<Response> {
       state.ctx,
       cachedResponseParams(state, coalesced, "hit", { coalesced: true }),
     );
+  }
+
+  const revalidated = await revalidateStaleRelayCache(state);
+  if (revalidated !== undefined) {
+    return revalidated;
   }
 
   const web = await callTokenFreeBackend(state);
@@ -261,6 +275,221 @@ async function coalesceRelayCacheMiss(
     return undefined;
   }
   return fill.cached;
+}
+
+async function revalidateStaleRelayCache(state: ActiveRelay): Promise<Response | undefined> {
+  if (state.cacheKey === undefined) {
+    return undefined;
+  }
+  const capabilities = capabilitiesForRouteKind(state.route.kind);
+  const identities =
+    capabilities.fallback === "pool"
+      ? await loadIdentities(state.env, state.request.pool, state.route)
+      : [];
+  await rememberIdentityCacheKeys(state, identities);
+  const candidates = await staleRevalidationCandidates(state);
+  if (candidates.length === 0) {
+    return undefined;
+  }
+
+  const usesTokenFreeAPI = supportsAnonymousGitHubAPI(state.request, state.route);
+  if (usesTokenFreeAPI || capabilities.fallback === "github_public") {
+    const github = await callRevalidationAPI(state, candidates[0]!, usesTokenFreeAPI);
+    return github === undefined
+      ? undefined
+      : finishRevalidation(state, candidates[0]!, github, undefined, {
+          backend: usesTokenFreeAPI ? "web" : "github_public",
+        });
+  }
+  if (identities.length === 0) {
+    return undefined;
+  }
+
+  let selection: SelectionResult;
+  try {
+    selection = await selectIdentity(state.coordinator, {
+      pool: state.request.pool,
+      routeKey: state.route.routeKey,
+      resource: state.route.resource,
+      candidates: identities.map((identity) => ({ id: identity.id, weight: identity.weight })),
+    });
+  } catch {
+    return undefined;
+  }
+  const identity = findIdentity(identities, selection.identityId);
+  const identityCacheKey = await githubCacheKey(
+    state.request.pool,
+    state.request,
+    state.route,
+    identity,
+  );
+  state.identity = identity;
+  await switchRelayCacheKey(state, identityCacheKey);
+  const coalesced = await coalesceRelayCacheMiss(state);
+  if (coalesced !== undefined) {
+    if (
+      await cachedResponseAvailable(
+        state.env,
+        state.request.pool,
+        state.route,
+        coalesced,
+        state.coordinator,
+        identity,
+      )
+    ) {
+      return serveCachedGitHubResponse(
+        state.env,
+        state.ctx,
+        cachedResponseParams(state, coalesced, "hit", { coalesced: true }),
+      );
+    }
+    return restoreSharedCacheFill(state);
+  }
+  if (state.cacheFillToken === undefined) {
+    return restoreSharedCacheFill(state);
+  }
+  const github = await callRevalidationAPI(state, candidates[0]!, false, identity);
+  if (github === undefined) {
+    return restoreSharedCacheFill(state);
+  }
+  const response = await finishRevalidation(state, candidates[0]!, github, identity, {
+    leaseReason: selection.reason,
+  });
+  return response ?? restoreSharedCacheFill(state);
+}
+
+async function staleRevalidationCandidates(state: ActiveRelay): Promise<RevalidationCandidate[]> {
+  const candidates: RevalidationCandidate[] = [];
+  for (const candidate of staleCacheCandidates(state)) {
+    const cached = await readStaleGitHubCache(state.env, candidate.cacheKey, state.route);
+    if (cached === undefined) {
+      continue;
+    }
+    const headers = githubCacheRevalidationHeaders(cached);
+    if (headers !== undefined) {
+      candidates.push({ cached, headers });
+    }
+  }
+  return candidates.sort(
+    (left, right) =>
+      Number(left.cached.identity !== undefined) - Number(right.cached.identity !== undefined),
+  );
+}
+
+async function callRevalidationAPI(
+  state: ActiveRelay,
+  candidate: RevalidationCandidate,
+  tokenFree: boolean,
+  identity?: Identity,
+): Promise<GitHubRelayResponse | undefined> {
+  const request: RelayRequest = {
+    ...state.request,
+    headers: { ...state.request.headers, ...candidate.headers },
+  };
+  try {
+    if (tokenFree) {
+      return await callAnonymousGitHubAPI(state.env, request, state.route);
+    }
+    if (identity !== undefined) {
+      return sanitizeGitHubResponse(
+        state.route,
+        await callGitHub(state.env, identity, request, state.route),
+      );
+    }
+    return sanitizeGitHubResponse(
+      state.route,
+      await callPublicGitHub(state.env, request, state.route),
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+async function finishRevalidation(
+  state: ActiveRelay,
+  candidate: RevalidationCandidate,
+  github: GitHubRelayResponse,
+  identity: Identity | undefined,
+  result: Pick<RelaySuccess, "backend" | "leaseReason">,
+): Promise<Response | undefined> {
+  if (github.status === 200) {
+    if (identity === undefined && anonymousGitHubResponseProvesPublicRepo(state.route)) {
+      await recordPublicGitHubRepo(state.env, state.route);
+    } else {
+      await ensurePublicGitHubRepo(state.env, state.route, undefined, state.coordinator);
+    }
+    return finalizeRelaySuccess(state, {
+      github: sanitizeGitHubResponse(state.route, github),
+      ...(identity === undefined ? {} : { identity }),
+      ...result,
+      rate: rateFromHeaders(github.headers),
+    });
+  }
+  if (github.status !== 304) {
+    if (identity !== undefined) {
+      await state.coordinator.recordResult(
+        coordinatorResult(state, identity, github.status, rateFromHeaders(github.headers)),
+      );
+    }
+    return undefined;
+  }
+
+  let available = false;
+  try {
+    available = await cachedResponseAvailable(
+      state.env,
+      state.request.pool,
+      state.route,
+      candidate.cached,
+      state.coordinator,
+      candidate.cached.identity,
+      true,
+    );
+  } catch {
+    available = false;
+  }
+  if (!available) {
+    return undefined;
+  }
+  const refreshed: GitHubRelayResponse = {
+    status: candidate.cached.status,
+    headers: { ...candidate.cached.headers, ...github.headers },
+    body: candidate.cached.body,
+    ...(candidate.cached.body_encoding === undefined
+      ? {}
+      : { body_encoding: candidate.cached.body_encoding }),
+  };
+  return finalizeRelaySuccess(state, {
+    github: refreshed,
+    ...(identity === undefined ? {} : { identity }),
+    ...result,
+    rate: rateFromHeaders(github.headers),
+    revalidated: true,
+    upstreamStatus: 304,
+  });
+}
+
+async function restoreSharedCacheFill(state: ActiveRelay): Promise<Response | undefined> {
+  state.identity = undefined;
+  await switchRelayCacheKey(state, state.sharedCacheKey);
+  const coalesced = await coalesceRelayCacheMiss(state);
+  if (
+    coalesced === undefined ||
+    !(await cachedResponseAvailable(
+      state.env,
+      state.request.pool,
+      state.route,
+      coalesced,
+      state.coordinator,
+    ))
+  ) {
+    return undefined;
+  }
+  return serveCachedGitHubResponse(
+    state.env,
+    state.ctx,
+    cachedResponseParams(state, coalesced, "hit", { coalesced: true }),
+  );
 }
 
 async function callTokenFreeBackend(state: ActiveRelay): Promise<Response | undefined> {
@@ -390,6 +619,7 @@ async function switchRelayCacheKey(
 }
 
 async function finalizeRelaySuccess(state: ActiveRelay, result: RelaySuccess): Promise<Response> {
+  const cacheStatus = result.revalidated === true ? "hit" : state.cacheStatus;
   if (state.cacheKey !== undefined) {
     await publishGitHubCache(
       state.env,
@@ -412,14 +642,20 @@ async function finalizeRelaySuccess(state: ActiveRelay, result: RelaySuccess): P
       ...(result.identity === undefined ? {} : { identityId: result.identity.id }),
       status: result.github.status,
       durationMs: Date.now() - state.started,
-      cacheStatus: state.cacheStatus,
+      ...(result.revalidated === true ? { fallbackReason: "cache_revalidated" } : {}),
+      cacheStatus,
       cacheable: state.cacheable,
     }),
   ];
   if (result.identity !== undefined) {
     background.push(
       state.coordinator.recordResult(
-        coordinatorResult(state, result.identity, result.github.status, result.rate),
+        coordinatorResult(
+          state,
+          result.identity,
+          result.upstreamStatus ?? result.github.status,
+          result.rate,
+        ),
       ),
     );
   }
@@ -436,7 +672,7 @@ async function finalizeRelaySuccess(state: ActiveRelay, result: RelaySuccess): P
       pool: state.request.pool,
       request_id: state.requestId,
       cacheable: state.route.cacheable,
-      cache: state.cacheStatus,
+      cache: cacheStatus,
       stale_ok: false,
       route_kind: state.route.kind,
       ...(result.backend === undefined ? {} : { backend: result.backend }),

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   cacheTTLSeconds,
+  githubCacheRevalidationHeaders,
   githubCacheKey,
   pruneExpiredGitHubCache,
   readGitHubCache,
@@ -317,6 +318,38 @@ describe("github cache policy", () => {
 
     const rate = validateRelayRequest({ pool: "maintainers", method: "GET", path: "/rate_limit" });
     expect(shouldUseGitHubCache(rate, classifyRoute(rate, policy))).toBe(false);
+  });
+
+  it("revalidates identity and anonymous API entries but not web entries", () => {
+    const base = {
+      status: 200,
+      body: { id: 1 },
+      body_encoding: "json" as const,
+      created_at: sqliteUTC(Date.now() - 120_000),
+      expires_at: sqliteUTC(Date.now() - 60_000),
+    };
+    expect(
+      githubCacheRevalidationHeaders({
+        ...base,
+        headers: { etag: '"identity"' },
+        identity: { id: "primary", kind: "pat" },
+      }),
+    ).toEqual({ "if-none-match": '"identity"' });
+    expect(
+      githubCacheRevalidationHeaders({
+        ...base,
+        headers: {
+          "last-modified": "Fri, 18 Jul 2026 06:00:00 GMT",
+          "x-ratelimit-resource": "core",
+        },
+      }),
+    ).toEqual({ "if-modified-since": "Fri, 18 Jul 2026 06:00:00 GMT" });
+    expect(
+      githubCacheRevalidationHeaders({
+        ...base,
+        headers: { etag: '"web"', "last-modified": "Fri, 18 Jul 2026 06:00:00 GMT" },
+      }),
+    ).toBeUndefined();
   });
 
   it("keeps mutable CI TTLs short and caches terminal CI for an hour", () => {

--- a/test/e2e/cache-revalidation.test.ts
+++ b/test/e2e/cache-revalidation.test.ts
@@ -232,7 +232,10 @@ describe("Worker end-to-end cache revalidation", () => {
     const leader = relay(RUN_PATH);
     await started;
     const follower = relay(RUN_PATH);
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    // Outlast the first 4s coalescing wait while the leader still owns its 8s fill lease.
+    // A follower must wait/claim again instead of starting another conditional request.
+    await new Promise((resolve) => setTimeout(resolve, 4_250));
+    const conditionalCallsBeforePublish = conditionalCalls;
     releaseRevalidation();
     const envelopes = await Promise.all(
       [leader, follower].map(async (responsePromise) =>
@@ -250,6 +253,7 @@ describe("Worker end-to-end cache revalidation", () => {
         relay: expect.objectContaining({ cache: "hit", coalesced: true }),
       }),
     ]);
+    expect(conditionalCallsBeforePublish).toBe(1);
     expect(conditionalCalls).toBe(1);
     expect(
       await env.DB.prepare(

--- a/test/e2e/cache-revalidation.test.ts
+++ b/test/e2e/cache-revalidation.test.ts
@@ -202,6 +202,60 @@ describe("Worker end-to-end cache revalidation", () => {
     ).toHaveLength(1);
   });
 
+  it("fails closed before authenticated revalidation when a repository becomes private", async () => {
+    await seedPool();
+    const path = "/repos/openclaw/octopool/pulls/42";
+    const options = { headers: { accept: "application/vnd.github.diff" } };
+    let privateRepo = false;
+    let authenticatedCallsAfterPrivate = 0;
+    const upstream = vi.fn<typeof fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      const token = bearer(request);
+      if (request.url === "https://github.com/openclaw/octopool/pull/42.diff") {
+        return new Response("unavailable", { status: 503 });
+      }
+      if (token === "test-org-token") {
+        return jsonResponse({ private: privateRepo });
+      }
+      if (token === "test-primary-token") {
+        if (privateRepo) {
+          authenticatedCallsAfterPrivate++;
+        }
+        return new Response("diff --git a/a b/a\n", {
+          headers: {
+            "content-type": "text/plain",
+            etag: '"private-boundary"',
+            ...rateHeaders({ remaining: 4_999 }),
+          },
+        });
+      }
+      throw new Error(`unexpected upstream ${request.url}`);
+    });
+    vi.stubGlobal("fetch", upstream);
+
+    const primed = await relay(path, undefined, options);
+    expect(primed.status).toBe(200);
+    await expireCacheEntry("pr_view");
+    privateRepo = true;
+
+    const response = await relay(path, undefined, options);
+
+    expect(response.status).toBe(424);
+    expect(await response.json()).toMatchObject({
+      error: { code: "fallback_local", details: { reason: "repo_not_public" } },
+    });
+    expect(authenticatedCallsAfterPrivate).toBe(0);
+    expect(
+      upstream.mock.calls.filter(([input, init]) => {
+        const request = new Request(input, init);
+        return (
+          bearer(request) === "test-primary-token" &&
+          request.headers.get("if-none-match") === '"private-boundary"'
+        );
+      }),
+    ).toHaveLength(0);
+  });
+
   it("publishes a 304 refresh to coalesced waiters", async () => {
     await seedPool();
     let releaseRevalidation!: () => void;

--- a/test/e2e/cache-revalidation.test.ts
+++ b/test/e2e/cache-revalidation.test.ts
@@ -1,0 +1,282 @@
+import { env } from "cloudflare:workers";
+import { describe, expect, it, vi } from "vitest";
+import { deleteEdgeJSON } from "../../src/edge-cache";
+import { bearer, jsonResponse, rateHeaders, relay, seedPool } from "./harness";
+
+const RUN_PATH = "/repos/openclaw/octopool/actions/runs/123";
+
+type RelayEnvelope = {
+  body: { id?: number; status?: string; content?: string };
+  relay: { cache: string; coalesced?: boolean; route_kind: string };
+};
+
+describe("Worker end-to-end cache revalidation", () => {
+  it("refreshes an anonymous API entry on 304 with stored body and state-derived TTL", async () => {
+    await seedPool();
+    let apiCalls = 0;
+    const upstream = vi.fn<typeof fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      expect(bearer(request)).toBeUndefined();
+      expect(request.url).toBe(`https://api.github.com${RUN_PATH}`);
+      apiCalls++;
+      if (request.headers.get("if-none-match") === '"run-v1"') {
+        return new Response(null, { status: 304, headers: apiHeaders('"run-v1"') });
+      }
+      return jsonResponse(
+        { id: 123, status: "in_progress", conclusion: null },
+        200,
+        apiHeaders('"run-v1"'),
+      );
+    });
+    vi.stubGlobal("fetch", upstream);
+
+    await relay(RUN_PATH);
+    await expireCacheEntry("run_view");
+    const response = await relay(RUN_PATH);
+
+    expect(await response.json<RelayEnvelope>()).toMatchObject({
+      body: { id: 123, status: "in_progress" },
+      relay: { cache: "hit", route_kind: "run_view" },
+    });
+    expect(apiCalls).toBe(2);
+    expect(
+      await env.DB.prepare(
+        `SELECT unixepoch(expires_at) - unixepoch(created_at) AS ttl
+         FROM github_cache_entries WHERE route_kind = 'run_view'`,
+      ).first(),
+    ).toEqual({ ttl: 60 });
+    expect(
+      await env.DB.prepare(
+        "SELECT cache_status, fallback_reason FROM audit_events ORDER BY rowid DESC LIMIT 1",
+      ).first(),
+    ).toEqual({ cache_status: "hit", fallback_reason: "cache_revalidated" });
+  });
+
+  it("stores a replacement response when conditional revalidation returns 200", async () => {
+    await seedPool();
+    let apiCalls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        const request = new Request(input, init);
+        expect(request.url).toBe(`https://api.github.com${RUN_PATH}`);
+        apiCalls++;
+        if (request.headers.get("if-none-match") === '"run-v1"') {
+          return jsonResponse(
+            { id: 123, status: "completed", conclusion: "success" },
+            200,
+            apiHeaders('"run-v2"'),
+          );
+        }
+        return jsonResponse(
+          { id: 123, status: "in_progress", conclusion: null },
+          200,
+          apiHeaders('"run-v1"'),
+        );
+      }),
+    );
+
+    await relay(RUN_PATH);
+    await expireCacheEntry("run_view");
+    const response = await relay(RUN_PATH);
+
+    expect(await response.json<RelayEnvelope>()).toMatchObject({
+      body: { id: 123, status: "completed" },
+      relay: { cache: "miss", route_kind: "run_view" },
+    });
+    expect(apiCalls).toBe(2);
+    expect(
+      await env.DB.prepare(
+        `SELECT json_extract(body_json, '$.status') AS status,
+                unixepoch(expires_at) - unixepoch(created_at) AS ttl
+         FROM github_cache_entries WHERE route_kind = 'run_view'`,
+      ).first(),
+    ).toEqual({ status: "completed", ttl: 3_600 });
+  });
+
+  it("uses the normal fill chain when an API entry has no validator", async () => {
+    await seedPool();
+    let apiCalls = 0;
+    let conditionalCalls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        const request = new Request(input, init);
+        apiCalls++;
+        if (request.headers.has("if-none-match") || request.headers.has("if-modified-since")) {
+          conditionalCalls++;
+        }
+        return jsonResponse(
+          { id: 123, status: apiCalls === 1 ? "in_progress" : "completed" },
+          200,
+          rateHeaders({ remaining: 59 }),
+        );
+      }),
+    );
+
+    await relay(RUN_PATH);
+    await expireCacheEntry("run_view");
+    const response = await relay(RUN_PATH);
+
+    expect(await response.json<RelayEnvelope>()).toMatchObject({
+      body: { status: "completed" },
+      relay: { cache: "miss" },
+    });
+    expect(apiCalls).toBe(2);
+    expect(conditionalCalls).toBe(0);
+  });
+
+  it("does not send web-origin validators to the GitHub API", async () => {
+    await seedPool();
+    let rawCalls = 0;
+    let conditionalCalls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        const request = new Request(input, init);
+        expect(request.url).toBe(
+          "https://raw.githubusercontent.com/openclaw/octopool/main/README.md",
+        );
+        if (request.headers.has("if-none-match") || request.headers.has("if-modified-since")) {
+          conditionalCalls++;
+        }
+        rawCalls++;
+        return new Response(rawCalls === 1 ? "old" : "new", {
+          headers: { etag: '"raw-etag"', "content-type": "text/plain" },
+        });
+      }),
+    );
+    const options = { query: { ref: "main" } };
+
+    await relay("/repos/openclaw/octopool/contents/README.md", undefined, options);
+    await expireCacheEntry("contents");
+    const response = await relay("/repos/openclaw/octopool/contents/README.md", undefined, options);
+
+    expect(await response.json<RelayEnvelope>()).toMatchObject({
+      body: { content: "bmV3" },
+      relay: { cache: "miss", route_kind: "contents" },
+    });
+    expect(rawCalls).toBe(2);
+    expect(conditionalCalls).toBe(0);
+  });
+
+  it("falls through to a fresh fill when a 304 source identity is revoked", async () => {
+    await seedPool();
+    let phase: "prime" | "revalidate" = "prime";
+    const upstream = vi.fn<typeof fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      const token = bearer(request);
+      if (token === "test-org-token") {
+        return jsonResponse({ private: false });
+      }
+      if (token === "test-primary-token") {
+        return jsonResponse({ id: 123, status: "in_progress" }, 200, apiHeaders('"identity-run"'));
+      }
+      if (phase === "prime") {
+        return jsonResponse({ message: "anonymous unavailable" }, 503);
+      }
+      if (request.headers.get("if-none-match") === '"identity-run"') {
+        await env.DB.prepare(
+          "UPDATE identities SET status = 'disabled' WHERE id = 'primary'",
+        ).run();
+        return new Response(null, { status: 304, headers: apiHeaders('"identity-run"') });
+      }
+      return jsonResponse({ id: 123, status: "completed" }, 200, apiHeaders('"anonymous-run"'));
+    });
+    vi.stubGlobal("fetch", upstream);
+
+    await relay(RUN_PATH);
+    await expireCacheEntry("run_view");
+    phase = "revalidate";
+    const response = await relay(RUN_PATH);
+
+    expect(await response.json<RelayEnvelope>()).toMatchObject({
+      body: { id: 123, status: "completed" },
+      relay: { cache: "miss", route_kind: "run_view" },
+    });
+    expect(
+      upstream.mock.calls.filter(([input, init]) => {
+        const request = new Request(input, init);
+        return request.headers.get("if-none-match") === '"identity-run"';
+      }),
+    ).toHaveLength(1);
+  });
+
+  it("publishes a 304 refresh to coalesced waiters", async () => {
+    await seedPool();
+    let releaseRevalidation!: () => void;
+    let revalidationStarted!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseRevalidation = resolve;
+    });
+    const started = new Promise<void>((resolve) => {
+      revalidationStarted = resolve;
+    });
+    let conditionalCalls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        const request = new Request(input, init);
+        if (request.headers.get("if-none-match") === '"run-v1"') {
+          conditionalCalls++;
+          revalidationStarted();
+          await gate;
+          return new Response(null, { status: 304, headers: apiHeaders('"run-v1"') });
+        }
+        return jsonResponse({ id: 123, status: "in_progress" }, 200, apiHeaders('"run-v1"'));
+      }),
+    );
+
+    await relay(RUN_PATH);
+    await expireCacheEntry("run_view");
+    const leader = relay(RUN_PATH);
+    await started;
+    const follower = relay(RUN_PATH);
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    releaseRevalidation();
+    const envelopes = await Promise.all(
+      [leader, follower].map(async (responsePromise) =>
+        (await responsePromise).json<RelayEnvelope>(),
+      ),
+    );
+
+    expect(envelopes).toEqual([
+      expect.objectContaining({
+        body: expect.objectContaining({ id: 123, status: "in_progress" }),
+        relay: expect.objectContaining({ cache: "hit" }),
+      }),
+      expect.objectContaining({
+        body: expect.objectContaining({ id: 123, status: "in_progress" }),
+        relay: expect.objectContaining({ cache: "hit", coalesced: true }),
+      }),
+    ]);
+    expect(conditionalCalls).toBe(1);
+    expect(
+      await env.DB.prepare(
+        "SELECT COUNT(*) AS count FROM audit_events WHERE fallback_reason = 'cache_revalidated'",
+      ).first(),
+    ).toEqual({ count: 1 });
+  });
+});
+
+async function expireCacheEntry(routeKind: string): Promise<void> {
+  const row = await env.DB.prepare(
+    "SELECT cache_key FROM github_cache_entries WHERE route_kind = ? LIMIT 1",
+  )
+    .bind(routeKind)
+    .first<{ cache_key: string }>();
+  expect(row).not.toBeNull();
+  await env.DB.prepare(
+    `UPDATE github_cache_entries
+     SET expires_at = datetime('now', '-1 second'),
+         stale_expires_at = datetime('now', '+1 hour')
+     WHERE cache_key = ?`,
+  )
+    .bind(row!.cache_key)
+    .run();
+  await deleteEdgeJSON("github-v1", row!.cache_key);
+}
+
+function apiHeaders(etag: string): HeadersInit {
+  return { ...rateHeaders({ remaining: 59 }), etag };
+}

--- a/test/e2e/cache-revalidation.test.ts
+++ b/test/e2e/cache-revalidation.test.ts
@@ -6,7 +6,8 @@ import { bearer, jsonResponse, rateHeaders, relay, seedPool } from "./harness";
 const RUN_PATH = "/repos/openclaw/octopool/actions/runs/123";
 
 type RelayEnvelope = {
-  body: { id?: number; status?: string; content?: string };
+  status: number;
+  body: { id?: number; status?: string; content?: string } | null;
   relay: { cache: string; coalesced?: boolean; route_kind: string };
 };
 
@@ -92,6 +93,95 @@ describe("Worker end-to-end cache revalidation", () => {
          FROM github_cache_entries WHERE route_kind = 'run_view'`,
       ).first(),
     ).toEqual({ status: "completed", ttl: 3_600 });
+  });
+
+  it.each([202, 204])(
+    "publishes a %i replacement response without a second fill",
+    async (replacementStatus) => {
+      await seedPool();
+      let apiCalls = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>(async (input, init) => {
+          const request = new Request(input, init);
+          if (request.url !== `https://api.github.com${RUN_PATH}`) {
+            return new Response("unavailable", { status: 503 });
+          }
+          apiCalls++;
+          if (request.headers.get("if-none-match") === '"run-v1"') {
+            return replacementStatus === 204
+              ? new Response(null, { status: 204, headers: apiHeaders('"run-v2"') })
+              : jsonResponse(
+                  { id: 123, status: "queued" },
+                  replacementStatus,
+                  apiHeaders('"run-v2"'),
+                );
+          }
+          return jsonResponse({ id: 123, status: "in_progress" }, 200, apiHeaders('"run-v1"'));
+        }),
+      );
+
+      await relay(RUN_PATH);
+      await expireCacheEntry("run_view");
+      const replacement = await relay(RUN_PATH);
+
+      expect(await replacement.json<RelayEnvelope>()).toMatchObject({
+        status: replacementStatus,
+        body: replacementStatus === 204 ? null : { id: 123, status: "queued" },
+        relay: { cache: "miss", route_kind: "run_view" },
+      });
+      const cached = await relay(RUN_PATH);
+      expect(await cached.json<RelayEnvelope>()).toMatchObject({
+        status: replacementStatus,
+        body: replacementStatus === 204 ? null : { id: 123, status: "queued" },
+        relay: { cache: "hit", route_kind: "run_view" },
+      });
+      expect(apiCalls).toBe(2);
+      expect(
+        await env.DB.prepare(
+          "SELECT status, body_json FROM github_cache_entries WHERE route_kind = 'run_view'",
+        ).first(),
+      ).toEqual({
+        status: replacementStatus,
+        body_json: replacementStatus === 204 ? "null" : '{"id":123,"status":"queued"}',
+      });
+    },
+  );
+
+  it("falls through to the normal anonymous fill when identity loading fails", async () => {
+    await seedPool();
+    let apiCalls = 0;
+    let conditionalCalls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        const request = new Request(input, init);
+        if (request.url !== `https://api.github.com${RUN_PATH}`) {
+          return new Response("unavailable", { status: 503 });
+        }
+        apiCalls++;
+        if (request.headers.has("if-none-match") || request.headers.has("if-modified-since")) {
+          conditionalCalls++;
+        }
+        return jsonResponse(
+          { id: 123, status: apiCalls === 1 ? "in_progress" : "completed" },
+          200,
+          apiHeaders('"run-v1"'),
+        );
+      }),
+    );
+
+    await relay(RUN_PATH);
+    await expireCacheEntry("run_view");
+    await env.DB.prepare("ALTER TABLE identities RENAME TO unavailable_identities").run();
+    const response = await relay(RUN_PATH);
+
+    expect(await response.json<RelayEnvelope>()).toMatchObject({
+      body: { id: 123, status: "completed" },
+      relay: { cache: "miss", route_kind: "run_view" },
+    });
+    expect(apiCalls).toBe(2);
+    expect(conditionalCalls).toBe(0);
   });
 
   it("uses the normal fill chain when an API entry has no validator", async () => {


### PR DESCRIPTION
GitHub's documented conditional-request behavior makes 304 responses cost ZERO rate limit — but the relay refilled expired cache entries with full unconditional fetches, discarding the ETags it already stores. CI routes cycle every 60s TTL with mostly-unchanged payloads (~16k candidate misses/day), so this changes the quota economics rather than shaving demand.

Design:
- On a cacheable miss where an expired-but-present entry is API-sourced (identity present, or stored `x-ratelimit-resource` — no schema migration) and carries a validator, send If-None-Match/If-Modified-Since via the normal candidate selection before the regular transport chain.
- 304 → re-run the exact stale-serve integrity gates (active source identity, public-repo proof) and republish the stored body with fresh TTLs; coalesced waiters resolve from the leader's refresh like a normal fill.
- 2xx → replacement stored as today (contract extended from "200 only" to 2xx, docs updated); other statuses and any revalidation-only failure fall through to the untouched normal chain — revalidation strictly fails open.
- Web-origin entries (their validators belong to other transports) and client-supplied conditionals keep today's behavior.
- Audit rides existing enums (`hit` + fallback_reason `cache_revalidated`) so `octopool stats` counts saved requests with no CLI change.

Hardened across four review rounds: anonymous-path revalidation now coalesces on the shared fill token (test proves exactly one upstream conditional under concurrent waiters); the pooled branch runs the public-repository guard BEFORE any authenticated call, with a private-flip regression proving zero credential exposure and fail-closed `repo_not_public`; identity-load failures and non-200 2xx responses fail open.

Proof: 186 unit + 50 e2e tests green, tsc/lint/format clean, final autoreview (Codex gpt-5.6-sol, xhigh) clean — "patch is correct". Requires a wrangler deploy to take effect; expect `octopool stats` backend counts on run_view/run_jobs/commit_check_runs to drop sharply while hit-class counts absorb the revalidated refreshes.
