### PR TITLE
fix: bound historical public proof expiry

### DIFF
--- a/sql/queries/d1.sql
+++ b/sql/queries/d1.sql
@@ -383,6 +383,7 @@ FROM github_public_repos
 WHERE lower(owner) = ?1
   AND lower(repo) = ?2
   AND checked_at >= datetime(?3, '-5 seconds')
+  AND expires_at > datetime(CURRENT_TIMESTAMP, '-5 seconds')
 LIMIT 1;
 
 -- name: FreshCoveringPublicRepoProof :one

--- a/src/generated/sql.ts
+++ b/src/generated/sql.ts
@@ -110,7 +110,7 @@ export const queries = {
   upsertPublicRepoProof:
     "INSERT INTO github_public_repos (owner, repo, checked_at, expires_at)\nVALUES (?1, ?2, CURRENT_TIMESTAMP, datetime(CURRENT_TIMESTAMP, ?3))\nON CONFLICT(owner, repo) DO UPDATE SET\n  checked_at = excluded.checked_at,\n  expires_at = excluded.expires_at",
   coveringPublicRepoProof:
-    "SELECT checked_at, expires_at\nFROM github_public_repos\nWHERE lower(owner) = ?1\n  AND lower(repo) = ?2\n  AND checked_at >= datetime(?3, '-5 seconds')\nLIMIT 1",
+    "SELECT checked_at, expires_at\nFROM github_public_repos\nWHERE lower(owner) = ?1\n  AND lower(repo) = ?2\n  AND checked_at >= datetime(?3, '-5 seconds')\n  AND expires_at > datetime(CURRENT_TIMESTAMP, '-5 seconds')\nLIMIT 1",
   freshCoveringPublicRepoProof:
     "SELECT checked_at, expires_at\nFROM github_public_repos\nWHERE lower(owner) = ?1\n  AND lower(repo) = ?2\n  AND checked_at >= datetime(?3, '-5 seconds')\n  AND expires_at > CURRENT_TIMESTAMP\nLIMIT 1",
   freshPRStateProof:

--- a/src/public-repos.ts
+++ b/src/public-repos.ts
@@ -24,6 +24,7 @@ type PublicProofCoordinator = Pick<
 const EDGE_CACHE_NAMESPACE = "public-repo-v1";
 const PROOF_WAIT_MS = 4_000;
 const PROOF_POLL_MS = 100;
+const HISTORICAL_PROOF_EXPIRY_SLACK_MS = 5_000;
 
 export async function ensurePublicGitHubRepo(
   env: Env,
@@ -332,7 +333,7 @@ function publicProofCovers(
     Number.isFinite(expiresAt) &&
     Number.isFinite(cacheAt) &&
     checkedAt >= cacheAt - 5_000 &&
-    (!requireFresh || expiresAt > Date.now())
+    expiresAt > Date.now() - (requireFresh ? 0 : HISTORICAL_PROOF_EXPIRY_SLACK_MS)
   );
 }
 

--- a/test/public-repos.test.ts
+++ b/test/public-repos.test.ts
@@ -149,7 +149,12 @@ describe("public repo guard", () => {
       )
       .mockResolvedValueOnce(new Response("temporary web failure", { status: 503 }));
     vi.stubGlobal("fetch", fetchMock);
-    const first = vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(proof());
+    const checkedAt = Date.now() - 30_000;
+    const recentlyExpiredProof = {
+      checked_at: sqliteUTC(checkedAt),
+      expires_at: sqliteUTC(Date.now() - 2_000),
+    };
+    const first = vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(recentlyExpiredProof);
     const run = vi.fn(async () => ({}));
     const bind = vi.fn(() => ({ first, run }));
     const prepare = vi.fn(() => ({ bind }));
@@ -157,10 +162,36 @@ describe("public repo guard", () => {
     await ensurePublicGitHubRepo(
       { ...env(), DB: { prepare } } as unknown as Env,
       route(),
-      "2026-05-28 00:00:00",
+      sqliteUTC(checkedAt),
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects historical proof beyond the expiry slack", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("temporary API failure", { status: 503 }))
+      .mockResolvedValueOnce(new Response("temporary API failure", { status: 503 }))
+      .mockResolvedValueOnce(new Response("temporary web failure", { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const checkedAt = Date.now() - 90_000;
+    const expiredProof = {
+      checked_at: sqliteUTC(checkedAt),
+      expires_at: sqliteUTC(Date.now() - 60_000),
+    };
+    const first = vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(expiredProof);
+    const run = vi.fn(async () => ({}));
+    const bind = vi.fn(() => ({ first, run }));
+    const prepare = vi.fn(() => ({ bind }));
+
+    await expect(
+      ensurePublicGitHubRepo(
+        { ...env(), DB: { prepare } } as unknown as Env,
+        route(),
+        sqliteUTC(checkedAt),
+      ),
+    ).rejects.toMatchObject({ status: 502, code: "repo_public_check_failed" });
   });
 
   it("proves public visibility from the repository page when API quotas are exhausted", async () => {


### PR DESCRIPTION
## What changed

- enforce a five-second expiry slack for non-fresh public repository proofs
- apply the same bound in runtime validation and the authoritative D1 query
- regenerate the SQL bindings
- cover historical proofs both inside and beyond the slack window

## Why

During GitHub API and repository-page failures, the historical fallback only checked whether a proof covered the cached response creation time. An expired D1 proof could therefore authorize stale cached content without a bounded expiry window.

Public repository visibility is an authorization condition, so even outage fallback must have an explicit lifetime boundary.

## Impact

Fresh proofs still require `expires_at > now`. Historical fallback may use a proof for at most five seconds after expiry; older proofs fail closed with `repo_public_check_failed`.

## Validation

- `pnpm test` — 195 tests passed
- `pnpm test:e2e` — 71 tests passed
- `pnpm build`
- `pnpm sql:compile`
- formatting and lint checks

Closes #30