### PR TITLE
fix: reject expired public proofs immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.5.1 - Unreleased
 
+### Fixes
+
+- Reject expired public-repository proofs immediately during GitHub outage fallback, keeping runtime and D1 authorization checks fail-closed (thanks @luojiyin1987).
+
 ## 0.5.0 - 2026-07-18
 
 ### Changes

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -196,8 +196,8 @@ A fresh or bounded-stale hit is only served if:
 
 - the source identity recorded on the entry is still an active candidate for the route
   (web-origin entries have no identity), and
-- the repo's public-visibility proof still covers the entry (re-checked, with a small
-  historical-proof allowance during GitHub outages / secondary-rate-limit — see below).
+- the repo's unexpired public-visibility proof still covers the entry (re-checked during
+  GitHub outages / secondary-rate-limit — see below).
 
 If the eligible token-free and pooled backends are unavailable, depleted, cooling down,
 or rate-limited, Octopool may serve an expired public cache entry for a short route-specific
@@ -251,9 +251,11 @@ is public.
 
 If the live public check fails with a `5xx`, or a `403` with `x-ratelimit-remaining: 0`
 (secondary rate limit), the guard may fall back to a previously recorded proof that was
-captured close to the cache entry's creation time (within 5s). This lets cached public
-data keep serving through transient GitHub failures without ever relaxing the
-private-repo block — a hard `404`/private response always denies.
+captured close to the cache entry's creation time (within 5s) and has not expired. There is
+no post-expiry grace window: a proof whose expiry equals or precedes the current time is
+rejected immediately with `repo_public_check_failed`. This lets cached public data keep
+serving through transient GitHub failures without ever relaxing the private-repo block — a
+hard `404`/private response always denies.
 
 ## Schema
 

--- a/sql/queries/d1.sql
+++ b/sql/queries/d1.sql
@@ -383,6 +383,7 @@ FROM github_public_repos
 WHERE lower(owner) = ?1
   AND lower(repo) = ?2
   AND checked_at >= datetime(?3, '-5 seconds')
+  AND expires_at > CURRENT_TIMESTAMP
 LIMIT 1;
 
 -- name: FreshCoveringPublicRepoProof :one

--- a/src/generated/sql.ts
+++ b/src/generated/sql.ts
@@ -110,7 +110,7 @@ export const queries = {
   upsertPublicRepoProof:
     "INSERT INTO github_public_repos (owner, repo, checked_at, expires_at)\nVALUES (?1, ?2, CURRENT_TIMESTAMP, datetime(CURRENT_TIMESTAMP, ?3))\nON CONFLICT(owner, repo) DO UPDATE SET\n  checked_at = excluded.checked_at,\n  expires_at = excluded.expires_at",
   coveringPublicRepoProof:
-    "SELECT checked_at, expires_at\nFROM github_public_repos\nWHERE lower(owner) = ?1\n  AND lower(repo) = ?2\n  AND checked_at >= datetime(?3, '-5 seconds')\nLIMIT 1",
+    "SELECT checked_at, expires_at\nFROM github_public_repos\nWHERE lower(owner) = ?1\n  AND lower(repo) = ?2\n  AND checked_at >= datetime(?3, '-5 seconds')\n  AND expires_at > CURRENT_TIMESTAMP\nLIMIT 1",
   freshCoveringPublicRepoProof:
     "SELECT checked_at, expires_at\nFROM github_public_repos\nWHERE lower(owner) = ?1\n  AND lower(repo) = ?2\n  AND checked_at >= datetime(?3, '-5 seconds')\n  AND expires_at > CURRENT_TIMESTAMP\nLIMIT 1",
   freshPRStateProof:

--- a/src/public-repos.ts
+++ b/src/public-repos.ts
@@ -285,7 +285,7 @@ async function cachedPublicGitHubRepoCovers(
   const edgeKey = publicProofKey(owner, repo);
   const edge = await readEdgeJSON<PublicRepoProof>(EDGE_CACHE_NAMESPACE, edgeKey);
   if (edge !== undefined) {
-    if (publicProofCovers(edge, cacheCreatedAt, requireFresh)) {
+    if (publicProofCovers(edge, cacheCreatedAt)) {
       return true;
     }
     await deleteEdgeJSON(EDGE_CACHE_NAMESPACE, edgeKey);
@@ -296,7 +296,7 @@ async function cachedPublicGitHubRepoCovers(
   const row = await env.DB.prepare(query)
     .bind(owner, repo, cacheCreatedAt)
     .first<PublicRepoProof>();
-  if (row === null || !publicProofCovers(row, cacheCreatedAt, requireFresh)) {
+  if (row === null || !publicProofCovers(row, cacheCreatedAt)) {
     return false;
   }
   const ttlSeconds = Math.floor((parseSQLiteTimestamp(row.expires_at) - Date.now()) / 1000);
@@ -319,11 +319,7 @@ async function waitForConcurrentPublicProof(
   return false;
 }
 
-function publicProofCovers(
-  proof: PublicRepoProof,
-  cacheCreatedAt: string,
-  requireFresh: boolean,
-): boolean {
+function publicProofCovers(proof: PublicRepoProof, cacheCreatedAt: string): boolean {
   const checkedAt = parseSQLiteTimestamp(proof.checked_at);
   const expiresAt = parseSQLiteTimestamp(proof.expires_at);
   const cacheAt = parseSQLiteTimestamp(cacheCreatedAt);
@@ -332,7 +328,7 @@ function publicProofCovers(
     Number.isFinite(expiresAt) &&
     Number.isFinite(cacheAt) &&
     checkedAt >= cacheAt - 5_000 &&
-    (!requireFresh || expiresAt > Date.now())
+    expiresAt > Date.now()
   );
 }
 

--- a/test/e2e/public-repos.test.ts
+++ b/test/e2e/public-repos.test.ts
@@ -1,0 +1,77 @@
+import { env } from "cloudflare:workers";
+import { describe, expect, it, vi } from "vitest";
+import { deleteEdgeJSON } from "../../src/edge-cache";
+import { queries } from "../../src/generated/sql";
+import { githubUpstream, jsonResponse, relay, seedPool } from "./harness";
+
+describe("public repository proof expiry", () => {
+  it("requires D1 historical proofs to expire strictly after the current time", async () => {
+    await env.DB.prepare(
+      `INSERT INTO github_public_repos (owner, repo, checked_at, expires_at)
+       VALUES ('openclaw', 'octopool', datetime('now', '-10 seconds'), CURRENT_TIMESTAMP)`,
+    ).run();
+    const proof = await env.DB.prepare(
+      `SELECT checked_at FROM github_public_repos
+       WHERE owner = 'openclaw' AND repo = 'octopool'`,
+    ).first<{ checked_at: string }>();
+    expect(proof).not.toBeNull();
+
+    const atExpiry = await env.DB.prepare(queries.coveringPublicRepoProof)
+      .bind("openclaw", "octopool", proof!.checked_at)
+      .first();
+    expect(atExpiry).toBeNull();
+
+    await env.DB.prepare(
+      `UPDATE github_public_repos
+       SET expires_at = datetime('now', '+1 minute')
+       WHERE owner = 'openclaw' AND repo = 'octopool'`,
+    ).run();
+    const unexpired = await env.DB.prepare(queries.coveringPublicRepoProof)
+      .bind("openclaw", "octopool", proof!.checked_at)
+      .first();
+    expect(unexpired).toMatchObject({ checked_at: proof!.checked_at });
+  });
+
+  it("fails closed at the relay when the historical proof expires", async () => {
+    await seedPool();
+    vi.stubGlobal(
+      "fetch",
+      githubUpstream({
+        primary: jsonResponse({ id: 30, full_name: "openclaw/octopool", private: false }),
+      }),
+    );
+    expect((await relay("/repos/openclaw/octopool")).status).toBe(200);
+
+    const cache = await env.DB.prepare("SELECT cache_key FROM github_cache_entries LIMIT 1").first<{
+      cache_key: string;
+    }>();
+    expect(cache).not.toBeNull();
+    await env.DB.batch([
+      env.DB.prepare(
+        `UPDATE github_cache_entries
+         SET expires_at = datetime('now', '-1 second'),
+             stale_expires_at = datetime('now', '+1 hour')
+         WHERE cache_key = ?`,
+      ).bind(cache!.cache_key),
+      env.DB.prepare(
+        `UPDATE github_public_repos
+         SET expires_at = CURRENT_TIMESTAMP
+         WHERE owner = 'openclaw' AND repo = 'octopool'`,
+      ),
+    ]);
+    await Promise.all([
+      deleteEdgeJSON("github-v1", cache!.cache_key),
+      deleteEdgeJSON("public-repo-v1", "openclaw/octopool"),
+    ]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => jsonResponse({ message: "upstream unavailable" }, 503)),
+    );
+
+    const response = await relay("/repos/openclaw/octopool");
+    expect(response.status).toBe(424);
+    expect(await response.json()).toMatchObject({
+      error: { code: "fallback_local", details: { reason: "repo_public_check_failed" } },
+    });
+  });
+});

--- a/test/public-repos.test.ts
+++ b/test/public-repos.test.ts
@@ -135,7 +135,9 @@ describe("public repo guard", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("keeps historical proof fallback when unauthenticated retry also fails", async () => {
+  it("uses an unexpired historical proof when unauthenticated retry also fails", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-07-27T16:00:00.000Z");
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(
@@ -149,7 +151,12 @@ describe("public repo guard", () => {
       )
       .mockResolvedValueOnce(new Response("temporary web failure", { status: 503 }));
     vi.stubGlobal("fetch", fetchMock);
-    const first = vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(proof());
+    const checkedAt = Date.now() - 30_000;
+    const unexpiredProof = {
+      checked_at: sqliteUTC(checkedAt),
+      expires_at: sqliteUTC(Date.now() + 1_000),
+    };
+    const first = vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(unexpiredProof);
     const run = vi.fn(async () => ({}));
     const bind = vi.fn(() => ({ first, run }));
     const prepare = vi.fn(() => ({ bind }));
@@ -157,10 +164,45 @@ describe("public repo guard", () => {
     await ensurePublicGitHubRepo(
       { ...env(), DB: { prepare } } as unknown as Env,
       route(),
-      "2026-05-28 00:00:00",
+      sqliteUTC(checkedAt),
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it.each([
+    ["at the expiry boundary", 0],
+    ["after the expiry boundary", -1_000],
+  ])("rejects a historical proof %s even if D1 returns it", async (_label, expiryOffsetMs) => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-07-27T16:00:00.000Z");
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("temporary API failure", { status: 503 }))
+      .mockResolvedValueOnce(new Response("temporary API failure", { status: 503 }))
+      .mockResolvedValueOnce(new Response("temporary web failure", { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const checkedAt = Date.now() - 30_000;
+    const expiredProof = {
+      checked_at: sqliteUTC(checkedAt),
+      expires_at: sqliteUTC(Date.now() + expiryOffsetMs),
+    };
+    const first = vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(expiredProof);
+    const run = vi.fn(async () => ({}));
+    const bind = vi.fn(() => ({ first, run }));
+    const prepare = vi.fn(() => ({ bind }));
+
+    await expect(
+      ensurePublicGitHubRepo(
+        { ...env(), DB: { prepare } } as unknown as Env,
+        route(),
+        sqliteUTC(checkedAt),
+      ),
+    ).rejects.toMatchObject({
+      status: 502,
+      code: "repo_public_check_failed",
+      message: "GitHub public repository check failed with 503",
+    });
   });
 
   it("proves public visibility from the repository page when API quotas are exhausted", async () => {


### PR DESCRIPTION
## Summary

- reject historical public-repository proofs immediately when `expires_at <= now`
- enforce the same strict predicate in the authoritative D1 query and Worker-side validation
- cover future, exact-expiry, post-expiry, D1 clock-skew, and full relay failure behavior
- document the fail-closed policy and credit the original PR #31 author

## Context

This implements the maintainer decision on #30: no post-expiry grace window. It adapts the salvageable enforcement and test approach from the closed contributor PR #31, with `luojiyin <luojiyin@hotmail.com>` retained as co-author.

Closes #30

## Proof

- `pnpm check` — 196 unit tests, 73 Worker e2e tests, TypeScript build, Go tests, and Go vet passed
- focused public-repo guard tests — 19 passed
- focused D1/relay e2e tests — 2 passed
- Codex autoreview — clean, no accepted/actionable findings
- behavior contract — unexpired accepted; exact-expiry and expired rejected with `repo_public_check_failed`; D1 equality boundary and relay response verified
