### PR TITLE
fix: make Actions caches attempt aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.5.3 - Unreleased
 
+### Fixes
+
+- Keep rerunnable base Actions runs and job lists short-lived, cache only completed attempt-qualified job lists long-term, share equivalent bounded `gh run view` job variants, and fail over instead of returning partial job pagination.
+
 ## 0.5.2 - 2026-08-08
 
 ### Changes

--- a/cmd/octopool/gh_top_fields.go
+++ b/cmd/octopool/gh_top_fields.go
@@ -33,6 +33,7 @@ var fieldMapRun = map[string][]string{
 	"headSha":      {"head_sha"},
 	"createdAt":    {"created_at"},
 	"updatedAt":    {"updated_at"},
+	"attempt":      {"run_attempt"},
 }
 
 var fieldMapRepo = map[string][]string{
@@ -123,7 +124,7 @@ var supportedRunListFields = supportedFields(
 
 var supportedRunViewFields = supportedFields(
 	"databaseId", "name", "workflowName", "status", "conclusion", "url", "headBranch",
-	"headSha", "event", "createdAt", "updatedAt", "displayTitle", "number", "jobs",
+	"headSha", "event", "createdAt", "updatedAt", "displayTitle", "number", "attempt", "jobs",
 )
 
 var supportedRepoFields = supportedFields(

--- a/cmd/octopool/gh_top_human_test.go
+++ b/cmd/octopool/gh_top_human_test.go
@@ -182,11 +182,11 @@ func TestHumanRunViewExactOutput(t *testing.T) {
 		case "/repos/openclaw/octopool/actions/runs/29614434370":
 			return map[string]any{
 				"id": 29614434370, "display_title": "chore(release): 0.4.7", "name": "release", "head_branch": "v0.4.7",
-				"event": "push", "status": "completed", "conclusion": "success",
+				"event": "push", "status": "completed", "conclusion": "success", "run_attempt": 1,
 				"created_at": "2026-07-17T21:21:25Z", "updated_at": "2026-07-17T21:22:52Z",
 				"html_url": "https://github.com/openclaw/octopool/actions/runs/29614434370",
 			}
-		case "/repos/openclaw/octopool/actions/runs/29614434370/jobs":
+		case "/repos/openclaw/octopool/actions/runs/29614434370/attempts/1/jobs":
 			return map[string]any{"total_count": 1, "jobs": []map[string]any{{
 				"id": 87996300812, "name": "goreleaser", "status": "completed", "conclusion": "success",
 				"started_at": "2026-07-17T21:21:27Z", "completed_at": "2026-07-17T21:22:51Z",
@@ -387,7 +387,7 @@ func TestHumanRunViewActiveJobOmitsDuration(t *testing.T) {
 		}
 		return map[string]any{
 			"id": 42, "status": "in_progress", "head_branch": "main", "name": "CI",
-			"event": "push", "created_at": "2026-07-17T21:58:00Z",
+			"event": "push", "created_at": "2026-07-17T21:58:00Z", "run_attempt": 1,
 			"html_url": "https://github.com/openclaw/octopool/actions/runs/42",
 		}
 	})
@@ -438,7 +438,7 @@ func TestHumanRunViewRendersFailedSteps(t *testing.T) {
 		}
 		return map[string]any{
 			"id": 42, "status": "completed", "conclusion": "failure", "head_branch": "main",
-			"name": "CI", "event": "push", "created_at": "2026-07-17T20:59:00Z",
+			"name": "CI", "event": "push", "created_at": "2026-07-17T20:59:00Z", "run_attempt": 1,
 			"html_url": "https://github.com/openclaw/octopool/actions/runs/42",
 		}
 	})
@@ -458,7 +458,7 @@ func TestHumanRunViewZeroJobFailureDiagnostic(t *testing.T) {
 		}
 		return map[string]any{
 			"id": 42, "status": "completed", "conclusion": "startup_failure", "head_branch": "main",
-			"name": "CI", "event": "push", "created_at": "2026-07-18T04:00:00Z",
+			"name": "CI", "event": "push", "created_at": "2026-07-18T04:00:00Z", "run_attempt": 1,
 			"html_url": "https://github.com/openclaw/octopool/actions/runs/42",
 		}
 	})

--- a/cmd/octopool/gh_top_options.go
+++ b/cmd/octopool/gh_top_options.go
@@ -19,6 +19,8 @@ type ghTopOptions struct {
 	branch      string
 	workflow    string
 	status      string
+	attempt     int
+	attemptSet  bool
 	author      string
 	assignee    string
 	labels      []string
@@ -41,6 +43,7 @@ func prepareGHTopOptions(args []string) (ghTopOptions, ghResult, bool) {
 func parseGHTopOptions(args []string) (ghTopOptions, bool, error) {
 	opts := ghTopOptions{limit: 30}
 	limitRaw := ""
+	attemptRaw := ""
 	for index := 0; index < len(args); index++ {
 		arg := args[index]
 		valueFlag := func(name string) (string, bool, error) {
@@ -71,6 +74,7 @@ func parseGHTopOptions(args []string) (ghTopOptions, bool, error) {
 			{"--branch", func(value string) { opts.branch = value }},
 			{"--workflow", func(value string) { opts.workflow = value }},
 			{"--status", func(value string) { opts.status = value }},
+			{"--attempt", func(value string) { attemptRaw = value; opts.attemptSet = true }},
 			{"--author", func(value string) { opts.author = value }},
 			{"--assignee", func(value string) { opts.assignee = value }},
 			{"--label", func(value string) { opts.labels = append(opts.labels, value) }},
@@ -103,6 +107,13 @@ func parseGHTopOptions(args []string) (ghTopOptions, bool, error) {
 			return opts, false, fmt.Errorf("--limit requires an integer: %w", err)
 		}
 		opts.limit = limit
+	}
+	if opts.attemptSet {
+		attempt, err := strconv.Atoi(attemptRaw)
+		if err != nil || attempt < 1 {
+			return opts, false, fmt.Errorf("--attempt requires a positive integer")
+		}
+		opts.attempt = attempt
 	}
 	return opts, false, nil
 }
@@ -151,9 +162,16 @@ func hasTopModifiers(opts ghTopOptions) bool {
 		opts.branch != "" ||
 		opts.workflow != "" ||
 		opts.status != "" ||
+		opts.attemptSet ||
 		opts.author != "" ||
 		opts.assignee != "" ||
 		len(opts.labels) > 0
+}
+
+func hasRunViewModifiers(opts ghTopOptions) bool {
+	opts.attempt = 0
+	opts.attemptSet = false
+	return hasTopModifiers(opts)
 }
 
 func hasTopModifiersExceptPatch(opts ghTopOptions) bool {

--- a/cmd/octopool/gh_top_options_test.go
+++ b/cmd/octopool/gh_top_options_test.go
@@ -60,3 +60,15 @@ func TestParseGHTopOptionsRejectsInvalidLimit(t *testing.T) {
 		t.Fatalf("fallback=%v err=%v", fallback, err)
 	}
 }
+
+func TestParseGHTopOptionsValidatesAttempt(t *testing.T) {
+	opts, fallback, err := parseGHTopOptions([]string{"42", "--attempt", "2"})
+	if err != nil || fallback || !opts.attemptSet || opts.attempt != 2 {
+		t.Fatalf("opts=%#v fallback=%v err=%v", opts, fallback, err)
+	}
+	for _, value := range []string{"0", "nope"} {
+		if _, _, err := parseGHTopOptions([]string{"42", "--attempt", value}); err == nil {
+			t.Fatalf("--attempt %s must fail", value)
+		}
+	}
+}

--- a/cmd/octopool/gh_top_run.go
+++ b/cmd/octopool/gh_top_run.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"strconv"
 )
 
 func handleGHRun(ctx context.Context, args []string, stdout io.Writer) ghResult {
@@ -55,7 +56,7 @@ func handleGHRun(ctx context.Context, args []string, stdout io.Writer) ghResult 
 		}
 		return ghCompleted(relayTop(ctx, stdout, request, opts, fieldMapRun))
 	case "view":
-		if len(opts.positionals) != 1 || !isDigits(opts.positionals[0]) || hasTopModifiers(opts) {
+		if len(opts.positionals) != 1 || !isDigits(opts.positionals[0]) || hasRunViewModifiers(opts) {
 			return ghDelegated()
 		}
 		repo, ok := repoFromOptionOrCurrent(opts.repo)
@@ -78,29 +79,35 @@ func relayRunView(ctx context.Context, stdout io.Writer, repo string, id string,
 	}
 	run := map[string]any{}
 	human := len(opts.json) == 0
-	if human || len(opts.json) > 1 || !hasJSONField(opts.json, "jobs") {
-		envelope, err := client.do(ctx, ghAPIRequest{
-			method:  "GET",
-			path:    repoPath(repo, "actions", "runs", id),
-			headers: map[string]string{"x-octopool-public-shape": publicShapeActionsSummary},
-		})
-		if err != nil {
-			return err
-		}
-		body, err := envelopeBodyBytes(envelope)
-		if err != nil {
-			return err
-		}
-		if err := json.Unmarshal(body, &run); err != nil {
-			return err
-		}
+	runPath := repoPath(repo, "actions", "runs", id)
+	if opts.attemptSet {
+		runPath = repoPath(repo, "actions", "runs", id, "attempts", strconv.Itoa(opts.attempt))
+	}
+	envelope, err := client.do(ctx, ghAPIRequest{
+		method:  "GET",
+		path:    runPath,
+		headers: map[string]string{"x-octopool-public-shape": publicShapeActionsSummary},
+	})
+	if err != nil {
+		return err
+	}
+	body, err := envelopeBodyBytes(envelope)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(body, &run); err != nil {
+		return err
 	}
 	if human || hasJSONField(opts.json, "jobs") {
+		attempt, ok := positiveJSONInt(run["run_attempt"])
+		if !ok {
+			return localFallbackError{Reason: "workflow run response did not include run_attempt"}
+		}
 		// per_page=100 with runJobs' incomplete-total fallback: >100-job runs
 		// delegate to real gh rather than truncating.
 		envelope, err := client.do(ctx, ghAPIRequest{
 			method: "GET",
-			path:   repoPath(repo, "actions", "runs", id, "jobs"),
+			path:   repoPath(repo, "actions", "runs", id, "attempts", strconv.Itoa(attempt), "jobs"),
 			query:  map[string]any{"per_page": "100"},
 			headers: map[string]string{
 				"x-octopool-public-shape": publicShapeActionsJobs,
@@ -128,6 +135,14 @@ func relayRunView(ctx context.Context, stdout io.Writer, repo string, id string,
 		return err
 	}
 	return writeBytes(ctx, stdout, filtered, opts.jq)
+}
+
+func positiveJSONInt(value any) (int, bool) {
+	parsed, ok := value.(float64)
+	if !ok || parsed < 1 || parsed != float64(int(parsed)) {
+		return 0, false
+	}
+	return int(parsed), true
 }
 
 func runJobs(envelope relayEnvelope) ([]any, error) {

--- a/cmd/octopool/gh_top_run_test.go
+++ b/cmd/octopool/gh_top_run_test.go
@@ -16,12 +16,13 @@ func TestRunGHRunViewComposesJobs(t *testing.T) {
 				t.Fatalf("run headers = %#v", body["headers"])
 			}
 			return map[string]any{
-				"id":         27398328238,
-				"status":     "completed",
-				"conclusion": "success",
-				"head_sha":   "20d9295e7d6258943d6682fe5532ba3f0caedd29",
+				"id":          27398328238,
+				"status":      "completed",
+				"conclusion":  "success",
+				"run_attempt": 2,
+				"head_sha":    "20d9295e7d6258943d6682fe5532ba3f0caedd29",
 			}
-		case "/repos/openclaw/octopool/actions/runs/27398328238/jobs":
+		case "/repos/openclaw/octopool/actions/runs/27398328238/attempts/2/jobs":
 			headers, ok := body["headers"].(map[string]any)
 			if !ok || headers["x-octopool-public-shape"] != "actions-jobs-v1" {
 				t.Fatalf("jobs headers = %#v", body["headers"])
@@ -81,6 +82,36 @@ func TestRunGHRunViewComposesJobs(t *testing.T) {
 	step := steps[0].(map[string]any)
 	if step["completedAt"] != "2026-06-12T06:15:26Z" {
 		t.Fatalf("step = %#v", step)
+	}
+}
+
+func TestRunGHRunViewUsesRequestedAttempt(t *testing.T) {
+	paths := []string{}
+	relayTestServer(t, func(body map[string]any) any {
+		path := body["path"].(string)
+		paths = append(paths, path)
+		if strings.HasSuffix(path, "/jobs") {
+			return map[string]any{"total_count": 0, "jobs": []any{}}
+		}
+		return map[string]any{
+			"id": 27398328238, "status": "completed", "conclusion": "failure", "run_attempt": 1,
+		}
+	})
+	var out bytes.Buffer
+	result := handleGHRun(t.Context(), []string{
+		"view", "27398328238", "--attempt", "1", "-R", "openclaw/octopool", "--json", "attempt,jobs",
+	}, &out)
+	if result.err != nil || result.action != ghComplete {
+		t.Fatalf("action=%v err=%v", result.action, result.err)
+	}
+	if got, want := strings.Join(paths, "\n"), strings.Join([]string{
+		"/repos/openclaw/octopool/actions/runs/27398328238/attempts/1",
+		"/repos/openclaw/octopool/actions/runs/27398328238/attempts/1/jobs",
+	}, "\n"); got != want {
+		t.Fatalf("paths:\n%s\nwant:\n%s", got, want)
+	}
+	if got := out.String(); !strings.Contains(got, `"attempt":1`) {
+		t.Fatalf("out = %s", got)
 	}
 }
 

--- a/cmd/octopool/gh_top_watch.go
+++ b/cmd/octopool/gh_top_watch.go
@@ -201,7 +201,11 @@ func relayRunWatch(ctx context.Context, stdout io.Writer, opts ghRunWatchOptions
 				}
 				continue
 			}
-			jobs, err := relayWatchRunJobs(ctx, client, opts.repo, opts.id, &backoff)
+			attempt, ok := positiveJSONInt(confirmed["run_attempt"])
+			if !ok {
+				return localFallbackError{Reason: "workflow run response did not include run_attempt"}
+			}
+			jobs, err := relayWatchRunJobs(ctx, client, opts.repo, opts.id, attempt, &backoff)
 			if err != nil {
 				return watchError(err, true)
 			}
@@ -251,7 +255,7 @@ func relayWatchRun(ctx context.Context, client ghRelayClient, repo string, id st
 	return run, nil
 }
 
-func relayWatchRunJobs(ctx context.Context, client ghRelayClient, repo string, id string, backoff *watchBackoff) ([]any, error) {
+func relayWatchRunJobs(ctx context.Context, client ghRelayClient, repo string, id string, attempt int, backoff *watchBackoff) ([]any, error) {
 	var jobs []any
 	err := retryWatchTick(ctx, backoff, func() error {
 		jobs = jobs[:0]
@@ -259,7 +263,7 @@ func relayWatchRunJobs(ctx context.Context, client ghRelayClient, repo string, i
 		for page := 1; page <= maxRelayPages; page++ {
 			envelope, err := client.do(ctx, ghAPIRequest{
 				method: "GET",
-				path:   repoPath(repo, "actions", "runs", id, "jobs"),
+				path:   repoPath(repo, "actions", "runs", id, "attempts", strconv.Itoa(attempt), "jobs"),
 				query:  map[string]any{"per_page": strconv.Itoa(relayPageSize), "page": strconv.Itoa(page)},
 				headers: map[string]string{
 					"x-octopool-public-shape": publicShapeActionsJobs,

--- a/cmd/octopool/gh_top_watch_test.go
+++ b/cmd/octopool/gh_top_watch_test.go
@@ -23,8 +23,8 @@ func TestGHRunWatchPrintsTransitionsAndFetchesJobsOnce(t *testing.T) {
 			}
 			// The fifth read is the terminal confirmation with max-age=0.
 			statuses := []string{"queued", "in_progress", "in_progress", "completed", "completed"}
-			return map[string]any{"status": statuses[runCalls-1], "conclusion": "failure"}
-		case "/repos/openclaw/octopool/actions/runs/42/jobs":
+			return map[string]any{"status": statuses[runCalls-1], "conclusion": "failure", "run_attempt": 2}
+		case "/repos/openclaw/octopool/actions/runs/42/attempts/2/jobs":
 			jobsCalls++
 			headers, _ := body["headers"].(map[string]any)
 			query, _ := body["query"].(map[string]any)
@@ -86,7 +86,7 @@ func TestGHRunWatchRequestedIntervalStartsAt45Seconds(t *testing.T) {
 			status = "completed"
 			conclusion = "success"
 		}
-		return map[string]any{"status": status, "conclusion": conclusion}
+		return map[string]any{"status": status, "conclusion": conclusion, "run_attempt": 1}
 	})
 	sleeps := recordWatchSleeps(t)
 	result := handleGHRun(t.Context(), []string{"watch", "42", "-R", "openclaw/octopool", "-i", "45"}, &bytes.Buffer{})
@@ -108,7 +108,7 @@ func TestGHRunWatchFloorsRequestedInterval(t *testing.T) {
 		if calls == 1 {
 			return map[string]any{"status": "queued"}
 		}
-		return map[string]any{"status": "completed", "conclusion": "success"}
+		return map[string]any{"status": "completed", "conclusion": "success", "run_attempt": 1}
 	})
 	sleeps := recordWatchSleeps(t)
 	result := handleGHRun(t.Context(), []string{"watch", "42", "-R", "openclaw/octopool", "-i", "5"}, &bytes.Buffer{})
@@ -125,7 +125,7 @@ func TestGHRunWatchExitStatusFailure(t *testing.T) {
 		if strings.HasSuffix(body["path"].(string), "/jobs") {
 			return map[string]any{"total_count": 0, "jobs": []any{}}
 		}
-		return map[string]any{"status": "completed", "conclusion": "failure"}
+		return map[string]any{"status": "completed", "conclusion": "failure", "run_attempt": 1}
 	})
 	recordWatchSleeps(t)
 	result := handleGHRun(t.Context(), []string{"watch", "42", "-R", "openclaw/octopool", "--exit-status"}, &bytes.Buffer{})
@@ -462,7 +462,7 @@ func TestGHRunWatchConfirmsTerminalWithFreshRead(t *testing.T) {
 			if freshRunReads > 0 {
 				conclusion = "success"
 			}
-			return map[string]any{"id": 42, "status": "completed", "conclusion": conclusion}
+			return map[string]any{"id": 42, "status": "completed", "conclusion": conclusion, "run_attempt": 2}
 		case strings.HasSuffix(path, "/jobs"):
 			if h, _ := body["headers"].(map[string]any); h["cache-control"] != "max-age=0" {
 				t.Fatal("terminal jobs read must bypass cached staleness")
@@ -537,8 +537,8 @@ func TestGHRunWatchPaginatesCompletedRunJobs(t *testing.T) {
 	relayTestServer(t, func(body map[string]any) any {
 		switch body["path"] {
 		case "/repos/openclaw/octopool/actions/runs/42":
-			return map[string]any{"id": 42, "status": "completed", "conclusion": "success"}
-		case "/repos/openclaw/octopool/actions/runs/42/jobs":
+			return map[string]any{"id": 42, "status": "completed", "conclusion": "success", "run_attempt": 1}
+		case "/repos/openclaw/octopool/actions/runs/42/attempts/1/jobs":
 			page := body["query"].(map[string]any)["page"].(string)
 			jobsRequests = append(jobsRequests, page)
 			jobs := []map[string]any{}

--- a/cmd/octopool/routes_generated.go
+++ b/cmd/octopool/routes_generated.go
@@ -77,6 +77,7 @@ var relayQueryPathPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`^/repos/(?:[A-Za-z0-9_.-]+)/(?:[A-Za-z0-9_.-]+)/actions/runs/(?:[0-9]+)$`),
 	regexp.MustCompile(`^/repos/(?:[A-Za-z0-9_.-]+)/(?:[A-Za-z0-9_.-]+)/actions/runs/(?:[0-9]+)/attempts/(?:[0-9]+)$`),
 	regexp.MustCompile(`^/repos/(?:[A-Za-z0-9_.-]+)/(?:[A-Za-z0-9_.-]+)/actions/runs/(?:[0-9]+)/jobs$`),
+	regexp.MustCompile(`^/repos/(?:[A-Za-z0-9_.-]+)/(?:[A-Za-z0-9_.-]+)/actions/runs/(?:[0-9]+)/attempts/(?:[0-9]+)/jobs$`),
 	regexp.MustCompile(`^/repos/(?:[A-Za-z0-9_.-]+)/(?:[A-Za-z0-9_.-]+)/actions/runs/(?:[0-9]+)/artifacts$`),
 	regexp.MustCompile(`^/repos/(?:[A-Za-z0-9_.-]+)/(?:[A-Za-z0-9_.-]+)/actions/jobs/(?:[0-9]+)$`),
 	regexp.MustCompile(`^/repos/(?:[A-Za-z0-9_.-]+)/(?:[A-Za-z0-9_.-]+)/actions/jobs/(?:[0-9]+)/logs$`),

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -109,8 +109,10 @@ web hit still re-checks that public proof covers the entry before returning it.
 
 Per route kind and response state (`cacheTTLSeconds`):
 
-- workflow runs, jobs, checks, check suites, and commit statuses → 60s while active;
-  terminal payloads get 1h fresh plus up to 24h bounded stale fallback
+- base workflow runs and base job lists → 60s even when terminal, because reruns reuse the run ID;
+  completed attempt-qualified run/job lists get 1h fresh plus up to 24h bounded stale fallback
+- checks, check suites, and commit statuses → 60s while active; terminal payloads get 1h fresh
+  plus up to 24h bounded stale fallback
 - run/workflow lists → 60s while active, 2m when every returned run is completed; lists
   remain mutable because new runs can appear
 - PR files with a validated state discriminator → 5m; PR commits, reviews,
@@ -191,6 +193,22 @@ All other exact shaped requests, including workflow-scoped paths, use the same t
 and never forward `limit` to GitHub. Locally shaped responses omit `ETag`, `Last-Modified`,
 `Content-Length`, and `Link` because those validators, lengths, and pagination links describe
 the upstream representation, not the transformed body.
+
+## Actions attempt job-list superset
+
+Shaped `gh run view` and `gh run watch` reads resolve the run's current positive
+`run_attempt`, then request `/actions/runs/{id}/attempts/{attempt}/jobs`. That attempt-qualified
+path is immutable after all returned jobs complete, while the base run and base jobs endpoints
+remain short-lived because a rerun can change both after they previously appeared terminal.
+Before granting the one-hour job-list TTL, Octopool separately verifies that exact attempt's
+run endpoint is completed; a list of currently completed jobs alone is not treated as proof.
+
+Equivalent shaped `page=1`, omitted/`latest` filter, and `per_page` values up to 100 share one
+100-job attempt-qualified cache entry. Octopool truncates that complete superset locally and
+removes upstream representation validators, lengths, and pagination links. If `total_count`
+exceeds the returned jobs—or is missing or invalid—the shaped request fails over to real `gh`
+without publishing or returning the partial page. `filter=all`, later pages, unshaped REST
+requests, active attempt data, and unsupported query variants retain exact semantics.
 
 ## Cache-hit integrity
 

--- a/docs/token-free.md
+++ b/docs/token-free.md
@@ -189,6 +189,7 @@ GET /repos/{owner}/{repo}/actions/runs
 GET /repos/{owner}/{repo}/actions/runs/{id}
 GET /repos/{owner}/{repo}/actions/runs/{id}/attempts/{attempt}
 GET /repos/{owner}/{repo}/actions/runs/{id}/jobs
+GET /repos/{owner}/{repo}/actions/runs/{id}/attempts/{attempt}/jobs
 GET /repos/{owner}/{repo}/actions/runs/{id}/artifacts
 GET /repos/{owner}/{repo}/actions/jobs/{id}
 GET /repos/{owner}/{repo}/check-runs/{id}/annotations

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -269,11 +269,15 @@ function freshTTLSeconds(
     case "issue":
       return closedIssue(response) ? 3_600 : 300;
     case "run":
-      return completedRun(response) ? TERMINAL_CI_TTL_SECONDS : 60;
+      return route.run_attempt !== undefined && completedRun(response)
+        ? TERMINAL_CI_TTL_SECONDS
+        : 60;
     case "run_list":
       return completedRunList(response) ? 120 : 60;
     case "jobs":
-      return completedJobs(response) ? TERMINAL_CI_TTL_SECONDS : 60;
+      return route.run_attempt_completed === true && completedJobs(response)
+        ? TERMINAL_CI_TTL_SECONDS
+        : 60;
     case "checks":
       return completedChecks(response) ? TERMINAL_CI_TTL_SECONDS : 60;
     case "check_suites":

--- a/src/github-html-actions.ts
+++ b/src/github-html-actions.ts
@@ -106,6 +106,10 @@ export function parseActionsRunHTML(
       `(?:\\u00b7|&#183;)\\s*${escapeRegex(owner)}/${escapeRegex(repo)}@([0-9A-Fa-f]{7,64})`,
     ).exec(html)?.[1];
   const branch = actionsRunBranch(html, owner, repo);
+  const runAttemptText = new RegExp(
+    `/${escapeRegex(owner)}/${escapeRegex(repo)}/actions/runs/${id}/job_groups_batch\\?attempt=([0-9]+)`,
+  ).exec(html)?.[1];
+  const runAttempt = runAttemptText === undefined ? undefined : Number(runAttemptText);
   if (
     title === undefined ||
     workflow === undefined ||
@@ -136,6 +140,9 @@ export function parseActionsRunHTML(
       .replace(/[\s-]+/g, "_"),
     created_at: createdAt,
     updated_at: addDuration(createdAt, duration) ?? createdAt,
+    ...(runAttempt !== undefined && Number.isSafeInteger(runAttempt) && runAttempt > 0
+      ? { run_attempt: runAttempt }
+      : {}),
   };
 }
 

--- a/src/github-public-actions.ts
+++ b/src/github-public-actions.ts
@@ -109,12 +109,21 @@ function actionsRunRequest(
   if (Object.keys(request.query ?? {}).length !== 0) {
     return undefined;
   }
-  const id = /\/actions\/runs\/([0-9]+)$/.exec(request.path)?.[1];
+  const match = /\/actions\/runs\/([0-9]+)(?:\/attempts\/([0-9]+))?$/.exec(request.path);
+  const id = match?.[1];
+  const attempt = match?.[2];
   if (id === undefined) {
     return undefined;
   }
   return {
-    url: `https://github.com/${encodedPathSegments([route.owner!, route.repo!, "actions", "runs", id])}`,
+    url: `https://github.com/${encodedPathSegments([
+      route.owner!,
+      route.repo!,
+      "actions",
+      "runs",
+      id,
+      ...(attempt === undefined ? [] : ["attempts", attempt]),
+    ])}`,
     headers: { accept: "text/html", "user-agent": "octopool" },
     capBytes: responseCapBytes(env, route),
     usesApiQuota: false,
@@ -137,14 +146,16 @@ function actionsRunJobsRequest(
   request: RelayRequest,
   route: RouteInfo,
 ): WebRequest | undefined {
-  const id = /\/actions\/runs\/([0-9]+)\/jobs$/.exec(request.path)?.[1];
+  const match = /\/actions\/runs\/([0-9]+)\/attempts\/([0-9]+)\/jobs$/.exec(request.path);
+  const id = match?.[1];
+  const attempt = match?.[2];
   const query = actionsJobsQuery(request.query);
-  if (id === undefined || query === undefined) {
+  if (id === undefined || attempt === undefined || query === undefined) {
     return undefined;
   }
   const runID = Number(id);
   return {
-    url: `https://github.com/${encodedPathSegments([route.owner!, route.repo!, "actions", "runs", id, "job_groups_batch"])}?attempt=1`,
+    url: `https://github.com/${encodedPathSegments([route.owner!, route.repo!, "actions", "runs", id, "job_groups_batch"])}?attempt=${attempt}`,
     headers: {
       accept: "application/json",
       referer: `https://github.com/${encodedPathSegments([route.owner!, route.repo!, "actions", "runs", id])}`,

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -130,11 +130,16 @@ export function classifyRoute(request: RelayRequest, policy: PoolPolicy): RouteI
       throw new HttpError(403, "owner_denied", `Owner ${routeOwner} is not allowed for this pool`);
     }
     const routeRepo = match.groups?.repo ?? searchRepo?.repo;
+    const rawRunAttempt = match.groups?.attempt;
+    const runAttempt = rawRunAttempt === undefined ? undefined : Number(rawRunAttempt);
     const info: RouteInfo = {
       kind: rule.kind,
       resource: rule.resource,
       routeKey: routeKeyForMatch(request.method, rule, match),
       ...(tokenFreeOnly ? { tokenFreeOnly: true } : {}),
+      ...(runAttempt !== undefined && Number.isSafeInteger(runAttempt) && runAttempt > 0
+        ? { run_attempt: runAttempt }
+        : {}),
       publicOnly: !allowedOwner,
       cacheable: rule.cacheable,
       largePayload: rule.largePayload === true,

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -16,7 +16,9 @@ import { supportsAnonymousGitHubAPI } from "./github-public-api";
 import { rateFromHeaders, type GitHubRate } from "./github-rate";
 import { callAnonymousGitHubAPI, callGitHubWeb } from "./github-web";
 import { sanitizeGitHubResponse } from "./github-sanitize";
+import { PUBLIC_SHAPES } from "./github-public-shapes";
 import { HttpError, jsonResponse, parseJsonObject } from "./http";
+import { isRecord } from "./object";
 import { githubResponseLocalFallbackReason, localFallbackError } from "./local-fallback";
 import { classifyRoute, normalizeRouteKey, validateRelayRequest } from "./policy";
 import type { PoolCoordinator } from "./pool-coordinator";
@@ -36,6 +38,12 @@ import {
   type RunListView,
   type RunListSupersetView,
 } from "./run-list-superset";
+import {
+  filterRunJobsSuperset,
+  runJobsSupersetIncomplete,
+  runJobsSupersetView,
+  type RunJobsSupersetView,
+} from "./run-jobs-superset";
 import {
   deleteTerminalLogCache,
   readTerminalLogCache,
@@ -74,6 +82,7 @@ type ActiveRelay = RelayBase & {
   cacheRequest: RelayRequest;
   runListView: RunListView | undefined;
   runListSuperset: RunListSupersetView | undefined;
+  runJobsSuperset: RunJobsSupersetView | undefined;
   runListExactFallback: boolean;
   terminalLogCacheKey: string | undefined;
   terminalLogCached: CachedTerminalLog | undefined;
@@ -160,10 +169,11 @@ async function prepareRelay(
   const cacheEnabled = shouldUseGitHubCache(base.request, route);
   const runListSuperset = runListSupersetView(base.request, route);
   const runListView = runListSuperset ?? runListShapeView(base.request, route);
+  const runJobsSuperset = cacheEnabled ? runJobsSupersetView(base.request, route) : undefined;
   const useRunListSuperset = cacheEnabled && runListSuperset !== undefined;
-  const cacheRequest = useRunListSuperset
-    ? runListSuperset.cacheRequest
-    : exactRunListRequest(base.request, route);
+  const cacheRequest =
+    runJobsSuperset?.cacheRequest ??
+    (useRunListSuperset ? runListSuperset.cacheRequest : exactRunListRequest(base.request, route));
   const cacheKey = cacheEnabled
     ? await githubCacheKey(base.request.pool, cacheRequest, route)
     : undefined;
@@ -174,6 +184,7 @@ async function prepareRelay(
     cacheRequest,
     runListView,
     runListSuperset,
+    runJobsSuperset,
     runListExactFallback: runListView !== undefined && !useRunListSuperset,
     terminalLogCacheKey: undefined,
     terminalLogCached: undefined,
@@ -474,8 +485,8 @@ async function callRevalidationAPI(
   identity?: Identity,
 ): Promise<GitHubRelayResponse | undefined> {
   const request: RelayRequest = {
-    ...state.request,
-    headers: { ...state.request.headers, ...candidate.headers },
+    ...state.cacheRequest,
+    headers: { ...state.cacheRequest.headers, ...candidate.headers },
   };
   try {
     if (tokenFree) {
@@ -742,6 +753,10 @@ async function switchRelayCacheKey(
 
 async function finalizeRelaySuccess(state: ActiveRelay, result: RelaySuccess): Promise<Response> {
   const cacheStatus = result.revalidated === true ? "hit" : state.cacheStatus;
+  rejectIncompleteRunJobs(state, result.github);
+  if (completedRunJobsResponse(result.github)) {
+    state.route = await proveRunAttemptCompleted(state);
+  }
   if (state.cacheKey !== undefined) {
     await publishGitHubCache(
       state.env,
@@ -769,9 +784,12 @@ async function finalizeRelaySuccess(state: ActiveRelay, result: RelaySuccess): P
   if (state.terminalLogCacheKey !== undefined) {
     await publishTerminalLogCache(state.env, state.terminalLogCacheKey, result.github);
   }
-  const clientResponse = filterRunListSuperset(result.github, state.runListView, {
-    preserveTotalCount: state.runListExactFallback,
-  });
+  const clientResponse = filterRunJobsSuperset(
+    filterRunListSuperset(result.github, state.runListView, {
+      preserveTotalCount: state.runListExactFallback,
+    }),
+    state.runJobsSuperset,
+  );
   const backend = auditBackend(result);
   const background: Promise<unknown>[] = [
     insertAudit(state.env, {
@@ -956,9 +974,13 @@ function cachedResponseParams(
   cacheStatus: "hit" | "stale",
   extras: { staleReason?: string; coalesced?: boolean } = {},
 ): Parameters<typeof serveCachedGitHubResponse>[2] {
-  const clientResponse = filterRunListSuperset(cached, state.runListView, {
-    preserveTotalCount: state.runListExactFallback,
-  });
+  rejectIncompleteRunJobs(state, cached);
+  const clientResponse = filterRunJobsSuperset(
+    filterRunListSuperset(cached, state.runListView, {
+      preserveTotalCount: state.runListExactFallback,
+    }),
+    state.runJobsSuperset,
+  );
   return {
     requestId: state.requestId,
     callerId: state.callerId,
@@ -1164,6 +1186,57 @@ async function serveFreshCachedRelayResponse(
     state.ctx,
     cachedResponseParams(state, cached, "hit", extras),
   );
+}
+
+function rejectIncompleteRunJobs(state: ActiveRelay, response: GitHubRelayResponse): void {
+  if (runJobsSupersetIncomplete(response, state.runJobsSuperset)) {
+    throw new HttpError(424, "fallback_local", "Run this request with local GitHub credentials", {
+      reason: "pagination_exhausted",
+    });
+  }
+}
+
+function completedRunJobsResponse(response: GitHubRelayResponse): boolean {
+  return (
+    isRecord(response.body) &&
+    Array.isArray(response.body.jobs) &&
+    response.body.jobs.length > 0 &&
+    response.body.jobs.every((job) => isRecord(job) && job.status === "completed")
+  );
+}
+
+async function proveRunAttemptCompleted(state: ActiveRelay): Promise<RouteInfo> {
+  if (state.route.kind !== "run_jobs" || state.route.run_attempt === undefined) {
+    return state.route;
+  }
+  const path = state.request.path.replace(/\/jobs$/, "");
+  const request: RelayRequest = {
+    pool: state.request.pool,
+    method: "GET",
+    path,
+    headers: { "x-octopool-public-shape": PUBLIC_SHAPES.actionsSummary },
+  };
+  const route: RouteInfo = {
+    ...state.route,
+    kind: "run_view",
+    routeKey: state.route.routeKey.replace(/\/jobs$/, ""),
+  };
+  try {
+    const response = await callGitHubWeb(state.env, request, route);
+    if (
+      response !== undefined &&
+      response.status >= 200 &&
+      response.status < 300 &&
+      isRecord(response.body) &&
+      response.body.status === "completed" &&
+      response.body.run_attempt === state.route.run_attempt
+    ) {
+      return { ...state.route, run_attempt_completed: true };
+    }
+  } catch {
+    // The proof only enables a longer TTL; failure keeps the conservative default.
+  }
+  return state.route;
 }
 
 async function switchToExactRunList(state: ActiveRelay): Promise<void> {

--- a/src/route-manifest.ts
+++ b/src/route-manifest.ts
@@ -256,6 +256,7 @@ export const ROUTES = [
   route("/repos/{owner}/{repo}/actions/runs/{id}", "run_view"),
   route("/repos/{owner}/{repo}/actions/runs/{id}/attempts/{attempt}", "run_view"),
   route("/repos/{owner}/{repo}/actions/runs/{id}/jobs", "run_jobs"),
+  route("/repos/{owner}/{repo}/actions/runs/{id}/attempts/{attempt}/jobs", "run_jobs"),
   route("/repos/{owner}/{repo}/actions/runs/{id}/artifacts", "run_artifacts"),
   route("/repos/{owner}/{repo}/actions/jobs/{id}", "job_view"),
   route("/repos/{owner}/{repo}/actions/jobs/{id}/logs", "job_logs", "core", {

--- a/src/run-jobs-superset.ts
+++ b/src/run-jobs-superset.ts
@@ -1,0 +1,93 @@
+import { PUBLIC_SHAPES } from "./github-public-shapes";
+import { isRecord } from "./object";
+import type { GitHubRelayResponse, RelayRequest, RouteInfo } from "./types";
+
+const MAX_PAGE_SIZE = 100;
+const DEFAULT_PAGE_SIZE = 30;
+const REPRESENTATION_HEADERS = new Set(["etag", "last-modified", "content-length", "link"]);
+
+export type RunJobsSupersetView = {
+  cacheRequest: RelayRequest;
+  limit: number;
+};
+
+export function runJobsSupersetView(
+  request: RelayRequest,
+  route: RouteInfo,
+): RunJobsSupersetView | undefined {
+  if (
+    route.kind !== "run_jobs" ||
+    request.headers?.["x-octopool-public-shape"] !== PUBLIC_SHAPES.actionsJobs
+  ) {
+    return undefined;
+  }
+  const query = request.query ?? {};
+  const allowed = new Set(["filter", "page", "per_page"]);
+  if (
+    Object.entries(query).some(
+      ([key, value]) => !allowed.has(key) || Array.isArray(value) || value === "",
+    ) ||
+    (query.page !== undefined && query.page !== "1") ||
+    (query.filter !== undefined && query.filter !== "latest")
+  ) {
+    return undefined;
+  }
+  const limit = pageSize(query.per_page);
+  if (query.per_page !== undefined && limit === undefined) {
+    return undefined;
+  }
+  return {
+    cacheRequest: {
+      ...request,
+      query: { page: "1", per_page: String(MAX_PAGE_SIZE) },
+    },
+    limit: limit ?? DEFAULT_PAGE_SIZE,
+  };
+}
+
+export function runJobsSupersetIncomplete(
+  response: GitHubRelayResponse,
+  view: RunJobsSupersetView | undefined,
+): boolean {
+  if (view === undefined || !isRecord(response.body) || !Array.isArray(response.body.jobs)) {
+    return false;
+  }
+  const total = response.body.total_count;
+  return (
+    typeof total !== "number" ||
+    !Number.isSafeInteger(total) ||
+    total < 0 ||
+    total !== response.body.jobs.length
+  );
+}
+
+export function filterRunJobsSuperset(
+  response: GitHubRelayResponse,
+  view: RunJobsSupersetView | undefined,
+): GitHubRelayResponse {
+  if (view === undefined || !isRecord(response.body) || !Array.isArray(response.body.jobs)) {
+    return response;
+  }
+  return {
+    ...response,
+    headers: Object.fromEntries(
+      Object.entries(response.headers).filter(
+        ([key]) => !REPRESENTATION_HEADERS.has(key.toLowerCase()),
+      ),
+    ),
+    body: {
+      ...response.body,
+      jobs: response.body.jobs.slice(0, view.limit),
+    },
+  };
+}
+
+function pageSize(value: string | string[] | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (Array.isArray(value) || !/^(?:[1-9]|[1-9][0-9]|100)$/.test(value)) {
+    return undefined;
+  }
+  return Number(value);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,8 @@ export type RouteInfo = {
   resource: string;
   routeKey: string;
   tokenFreeOnly?: boolean;
+  run_attempt?: number;
+  run_attempt_completed?: boolean;
   state_hint?: string;
   state_hint_source?: "cached" | "live";
   cacheable: boolean;

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -361,7 +361,7 @@ describe("github cache policy", () => {
       }),
       policy,
     );
-    expect(cacheTTLSeconds(run, response({ status: "completed" }))).toBe(3_600);
+    expect(cacheTTLSeconds(run, response({ status: "completed" }))).toBe(60);
     expect(cacheTTLSeconds(run, response({ status: "in_progress" }))).toBe(60);
 
     const runAttempt = classifyRoute(
@@ -373,6 +373,30 @@ describe("github cache policy", () => {
       policy,
     );
     expect(cacheTTLSeconds(runAttempt, response({ status: "in_progress" }))).toBe(60);
+    expect(cacheTTLSeconds(runAttempt, response({ status: "completed" }))).toBe(3_600);
+
+    const jobs = classifyRoute(
+      validateRelayRequest({
+        pool: "maintainers",
+        method: "GET",
+        path: "/repos/openclaw/openclaw/actions/runs/123/jobs",
+      }),
+      policy,
+    );
+    const attemptJobs = classifyRoute(
+      validateRelayRequest({
+        pool: "maintainers",
+        method: "GET",
+        path: "/repos/openclaw/openclaw/actions/runs/123/attempts/2/jobs",
+      }),
+      policy,
+    );
+    const completedJobs = response({ jobs: [{ status: "completed" }] });
+    expect(cacheTTLSeconds(jobs, completedJobs)).toBe(60);
+    expect(cacheTTLSeconds(attemptJobs, completedJobs)).toBe(60);
+    expect(cacheTTLSeconds({ ...attemptJobs, run_attempt_completed: true }, completedJobs)).toBe(
+      3_600,
+    );
 
     const runList = classifyRoute(
       validateRelayRequest({

--- a/test/e2e/actions-cache.test.ts
+++ b/test/e2e/actions-cache.test.ts
@@ -619,6 +619,127 @@ describe("Actions run-list superset", () => {
   });
 });
 
+describe("Actions attempt job-list cache", () => {
+  beforeEach(seedPool);
+
+  it("shares bounded latest variants on an attempt-qualified complete page", async () => {
+    const upstream = vi.fn<typeof fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      const url = new URL(request.url);
+      if (url.hostname === "github.com") {
+        return jsonResponse({ message: "public parser unavailable" }, 404);
+      }
+      expect(request.headers.get("authorization")).toBeNull();
+      if (url.pathname.endsWith("/attempts/2")) {
+        return jsonResponse({ id: 42, status: "completed", run_attempt: 2 });
+      }
+      return jsonResponse({
+        total_count: 2,
+        jobs: [
+          { id: 1, status: "completed", conclusion: "success" },
+          { id: 2, status: "completed", conclusion: "success" },
+        ],
+      });
+    });
+    vi.stubGlobal("fetch", upstream);
+    const path = "/repos/openclaw/octopool/actions/runs/42/attempts/2/jobs";
+
+    const first = await relay(path, undefined, {
+      query: { per_page: "1" },
+      headers: { "x-octopool-public-shape": "actions-jobs-v1" },
+    });
+    expect(await first.json<RelayEnvelope>()).toMatchObject({
+      body: { total_count: 2, jobs: [{ id: 1 }] },
+      relay: { cache: "miss", route_kind: "run_jobs" },
+    });
+    const second = await relay(path, undefined, {
+      query: { filter: "latest", page: "1", per_page: "2" },
+      headers: { "x-octopool-public-shape": "actions-jobs-v1" },
+    });
+    expect(await second.json<RelayEnvelope>()).toMatchObject({
+      body: { total_count: 2, jobs: [{ id: 1 }, { id: 2 }] },
+      relay: { cache: "hit", route_kind: "run_jobs" },
+    });
+    expect(upstream).toHaveBeenCalledTimes(4);
+    expect(
+      await env.DB.prepare(
+        `SELECT COUNT(*) AS count,
+                unixepoch(MAX(expires_at)) - unixepoch(MAX(created_at)) AS ttl
+         FROM github_cache_entries WHERE route_kind = 'run_jobs'`,
+      ).first(),
+    ).toEqual({ count: 1, ttl: 3600 });
+  });
+
+  it("keeps completed-looking jobs short-lived until the owning attempt is terminal", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input) => {
+        const url = new URL(new Request(input).url);
+        if (url.hostname === "github.com") {
+          return jsonResponse({ message: "public parser unavailable" }, 404);
+        }
+        if (url.pathname.endsWith("/attempts/2")) {
+          return jsonResponse({ id: 42, status: "in_progress", run_attempt: 2 });
+        }
+        return jsonResponse({
+          total_count: 1,
+          jobs: [{ id: 1, status: "completed", conclusion: "success" }],
+        });
+      }),
+    );
+    const response = await relay(
+      "/repos/openclaw/octopool/actions/runs/42/attempts/2/jobs",
+      undefined,
+      {
+        query: { per_page: "100" },
+        headers: { "x-octopool-public-shape": "actions-jobs-v1" },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(
+      await env.DB.prepare(
+        `SELECT unixepoch(expires_at) - unixepoch(created_at) AS ttl
+         FROM github_cache_entries WHERE route_kind = 'run_jobs'`,
+      ).first(),
+    ).toEqual({ ttl: 60 });
+  });
+
+  it("fails closed and does not cache when total_count proves another page exists", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input) => {
+        const url = new URL(new Request(input).url);
+        if (url.hostname === "github.com") {
+          return jsonResponse({ message: "public parser unavailable" }, 404);
+        }
+        if (url.pathname.endsWith("/attempts/2")) {
+          return jsonResponse({ id: 42, status: "completed", run_attempt: 2 });
+        }
+        return jsonResponse({ total_count: 3, jobs: [{ id: 1 }, { id: 2 }] });
+      }),
+    );
+    const response = await relay(
+      "/repos/openclaw/octopool/actions/runs/42/attempts/2/jobs",
+      undefined,
+      {
+        query: { per_page: "100" },
+        headers: { "x-octopool-public-shape": "actions-jobs-v1" },
+      },
+    );
+
+    expect(response.status).toBe(424);
+    expect(await response.json()).toMatchObject({
+      error: { code: "fallback_local", details: { reason: "pagination_exhausted" } },
+    });
+    expect(
+      await env.DB.prepare(
+        "SELECT COUNT(*) AS count FROM github_cache_entries WHERE route_kind = 'run_jobs'",
+      ).first(),
+    ).toEqual({ count: 0 });
+  });
+});
+
 function terminalLogUpstream(status: "completed" | "in_progress") {
   return vi.fn<typeof fetch>(async (input, init) => {
     const request = new Request(input, init);

--- a/test/e2e/cache-revalidation.test.ts
+++ b/test/e2e/cache-revalidation.test.ts
@@ -92,7 +92,7 @@ describe("Worker end-to-end cache revalidation", () => {
                 unixepoch(expires_at) - unixepoch(created_at) AS ttl
          FROM github_cache_entries WHERE route_kind = 'run_view'`,
       ).first(),
-    ).toEqual({ status: "completed", ttl: 3_600 });
+    ).toEqual({ status: "completed", ttl: 60 });
   });
 
   it.each([202, 204])(

--- a/test/github-web.test.ts
+++ b/test/github-web.test.ts
@@ -513,6 +513,7 @@ describe("github web provider", () => {
             <span>Triggered via pull request <relative-time datetime="2026-06-11T06:38:49Z"></relative-time></span>
             <a href="/openclaw/octopool/commit/1e6a563d13924ba423febe3a4cb47eeb9d594322">1e6a563</a>
             <a class="branch-name" title="main" href="/openclaw/octopool/tree/refs/heads/main">main</a>
+            <div data-job-groups-fetch-url="/openclaw/octopool/actions/runs/27328786454/job_groups_batch?attempt=2"></div>
             <span>Total duration</span><a class="h4 color-fg-default">2m 49s</a>
           `),
       ),
@@ -533,6 +534,7 @@ describe("github web provider", () => {
         display_title: "fix: harden setup",
         status: "completed",
         conclusion: "success",
+        run_attempt: 2,
         event: "pull_request",
       },
       backend: "web",
@@ -585,7 +587,7 @@ describe("github web provider", () => {
     const request = validateRelayRequest({
       pool: "maintainers",
       method: "GET",
-      path: "/repos/openclaw/octopool/actions/runs/27398328238/jobs",
+      path: "/repos/openclaw/octopool/actions/runs/27398328238/attempts/2/jobs",
       query: { per_page: "100" },
       headers: { "x-octopool-public-shape": "actions-jobs-v1" },
     });
@@ -595,7 +597,7 @@ describe("github web provider", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
-      "https://github.com/openclaw/octopool/actions/runs/27398328238/job_groups_batch?attempt=1",
+      "https://github.com/openclaw/octopool/actions/runs/27398328238/job_groups_batch?attempt=2",
       expect.objectContaining({
         headers: expect.objectContaining({ "x-requested-with": "XMLHttpRequest" }),
       }),

--- a/test/policy.test.ts
+++ b/test/policy.test.ts
@@ -162,6 +162,7 @@ describe("route policy", () => {
       "/repos/openclaw/openclaw/commits/v1.2.3",
       "/repos/openclaw/openclaw/statuses/ac49d8e2295a093f168baa45312e1e29238c0351",
       "/repos/openclaw/openclaw/actions/runs/26360397003/jobs",
+      "/repos/openclaw/openclaw/actions/runs/26360397003/attempts/2/jobs",
       "/repos/openclaw/openclaw/actions/runs/26360397003/attempts/2",
       "/repos/openclaw/openclaw/actions/jobs/77594668516/logs",
       "/repos/openclaw/openclaw/issues/80490/comments",
@@ -281,6 +282,16 @@ describe("route policy", () => {
       owner: "steipete",
       publicOnly: true,
     });
+  });
+
+  it("marks attempt-qualified run and job views", () => {
+    for (const path of [
+      "/repos/openclaw/openclaw/actions/runs/26360397003/attempts/2",
+      "/repos/openclaw/openclaw/actions/runs/26360397003/attempts/2/jobs",
+    ]) {
+      const request = validateRelayRequest({ pool: "maintainers", method: "GET", path });
+      expect(classifyRoute(request, policy)).toMatchObject({ run_attempt: 2 });
+    }
   });
 
   it("denies non-OpenClaw owners when public pooling is disabled", () => {

--- a/test/route-manifest.test.ts
+++ b/test/route-manifest.test.ts
@@ -4,7 +4,7 @@ import { ROUTES } from "../src/route-manifest";
 
 describe("route manifest", () => {
   it("has unique route identities and patterns", () => {
-    expect(ROUTES).toHaveLength(118);
+    expect(ROUTES).toHaveLength(119);
     expect(new Set(ROUTES.map((route) => route.kind)).size).toBe(115);
     expect(new Set(ROUTES.map((route) => route.id)).size).toBe(ROUTES.length);
     expect(new Set(ROUTES.map((route) => route.pattern.source)).size).toBe(ROUTES.length);
@@ -21,7 +21,7 @@ describe("route manifest", () => {
   });
 
   it("defines backend eligibility on every concrete route", () => {
-    expect(ROUTES.filter((route) => route.capabilities.publicApi)).toHaveLength(110);
+    expect(ROUTES.filter((route) => route.capabilities.publicApi)).toHaveLength(111);
     expect(ROUTES.filter((route) => route.capabilities.fallback === "local")).toHaveLength(27);
     expect(ROUTES.filter((route) => route.capabilities.fallback === "github_public")).toHaveLength(
       1,
@@ -30,7 +30,7 @@ describe("route manifest", () => {
       ROUTES.filter(
         (route) => route.capabilities.publicApi || route.capabilities.fallback !== "pool",
       ),
-    ).toHaveLength(115);
+    ).toHaveLength(116);
   });
 
   it("splits SHA-shaped and ref-named commit paths onto distinct routes", () => {

--- a/test/run-jobs-superset.test.ts
+++ b/test/run-jobs-superset.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { githubCacheKey } from "../src/cache";
+import { classifyRoute, defaultPolicy, validateRelayRequest } from "../src/policy";
+import {
+  filterRunJobsSuperset,
+  runJobsSupersetIncomplete,
+  runJobsSupersetView,
+} from "../src/run-jobs-superset";
+
+describe("Actions job-list superset", () => {
+  const policy = defaultPolicy("openclaw");
+
+  it("canonicalizes equivalent bounded latest-attempt variants", async () => {
+    const request = (query: Record<string, string>) =>
+      validateRelayRequest({
+        pool: "maintainers",
+        method: "GET",
+        path: "/repos/openclaw/octopool/actions/runs/42/attempts/2/jobs",
+        query,
+        headers: { "x-octopool-public-shape": "actions-jobs-v1" },
+      });
+    const first = request({ per_page: "30" });
+    const second = request({ filter: "latest", page: "1", per_page: "100" });
+    const firstRoute = classifyRoute(first, policy);
+    const secondRoute = classifyRoute(second, policy);
+    const firstView = runJobsSupersetView(first, firstRoute);
+    const secondView = runJobsSupersetView(second, secondRoute);
+
+    expect(firstView).toMatchObject({
+      cacheRequest: { query: { page: "1", per_page: "100" } },
+      limit: 30,
+    });
+    expect(secondView).toMatchObject({ limit: 100 });
+    await expect(githubCacheKey("maintainers", firstView!.cacheRequest, firstRoute)).resolves.toBe(
+      await githubCacheKey("maintainers", secondView!.cacheRequest, secondRoute),
+    );
+  });
+
+  it.each([[{ page: "2" }], [{ filter: "all" }], [{ per_page: "101" }]])(
+    "keeps unsupported or potentially multi-attempt query %o exact",
+    (query) => {
+      const request = validateRelayRequest({
+        pool: "maintainers",
+        method: "GET",
+        path: "/repos/openclaw/octopool/actions/runs/42/jobs",
+        query,
+        headers: { "x-octopool-public-shape": "actions-jobs-v1" },
+      });
+      expect(runJobsSupersetView(request, classifyRoute(request, policy))).toBeUndefined();
+    },
+  );
+
+  it("refuses incomplete pagination and strips canonical representation headers", () => {
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/actions/runs/42/attempts/2/jobs",
+      query: { per_page: "1" },
+      headers: { "x-octopool-public-shape": "actions-jobs-v1" },
+    });
+    const view = runJobsSupersetView(request, classifyRoute(request, policy));
+    const response = {
+      status: 200,
+      headers: {
+        etag: '"canonical"',
+        link: '<https://api.github.com/jobs?page=2>; rel="next"',
+        "content-length": "123",
+        "content-type": "application/json",
+      },
+      body: { total_count: 2, jobs: [{ id: 1 }, { id: 2 }] },
+      body_encoding: "json" as const,
+    };
+
+    expect(runJobsSupersetIncomplete(response, view)).toBe(false);
+    expect(filterRunJobsSuperset(response, view)).toEqual({
+      ...response,
+      headers: { "content-type": "application/json" },
+      body: { total_count: 2, jobs: [{ id: 1 }] },
+    });
+    expect(
+      runJobsSupersetIncomplete(
+        { ...response, body: { total_count: 3, jobs: [{ id: 1 }, { id: 2 }] } },
+        view,
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- keep base Actions run and job-list cache entries short-lived because reruns reuse the run ID
- route `gh run view` and `gh run watch` job reads through exact attempt-qualified endpoints
- share complete bounded `actions-jobs-v1` variants while failing over when pagination is incomplete
- grant the terminal job-list TTL only after a separate completed-attempt proof

## Safety contract

- unshaped REST, `filter=all`, later pages, and unsupported query variants retain exact semantics
- shaped responses strip validators, lengths, and pagination links from the canonical upstream representation
- `total_count` must exactly match the cached jobs array; partial or invalid pages are neither cached nor returned
- base run/job responses remain fresh enough to observe reruns; historical attempt paths remain isolated

## Proof

- `pnpm check`
- `go test -race ./...`
- focused cache, relay-security, Actions Worker E2E, and Go CLI tests
- compiled CLI → contract relay behavior validation for current attempt, explicit historical attempt, rerun movement, and 100-of-101 failover
- clean structured autoreview
