### PR TITLE
fix: keep PR file hydration head consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Keep rerunnable base Actions runs and job lists short-lived, cache only completed attempt-qualified job lists long-term, share equivalent bounded `gh run view` job variants, and fail over instead of returning partial job pagination.
+- Keep closed-but-unmerged PR summaries mutable, share safe hydrated summary/file shapes, and recheck the PR head after file pagination so moving heads fail over instead of mixing revisions.
 
 ## 0.5.2 - 2026-08-08
 

--- a/cmd/octopool/gh_top_checks.go
+++ b/cmd/octopool/gh_top_checks.go
@@ -49,9 +49,12 @@ func relayPRCheckItems(ctx context.Context, client ghRelayClient, repo string, n
 
 func relayPRHeadSHA(ctx context.Context, client ghRelayClient, repo string, number string, maxAgeSeconds int) (string, error) {
 	prEnvelope, err := client.do(ctx, ghAPIRequest{
-		method:  "GET",
-		path:    repoPath(repo, "pulls", number),
-		headers: map[string]string{"cache-control": "max-age=" + strconv.Itoa(maxAgeSeconds)},
+		method: "GET",
+		path:   repoPath(repo, "pulls", number),
+		headers: map[string]string{
+			"cache-control":           "max-age=" + strconv.Itoa(maxAgeSeconds),
+			"x-octopool-public-shape": publicShapePullRequestSummary,
+		},
 	})
 	if err != nil {
 		return "", err

--- a/cmd/octopool/gh_top_pr.go
+++ b/cmd/octopool/gh_top_pr.go
@@ -117,7 +117,16 @@ func relayHydratedPRView(ctx context.Context, stdout io.Writer, repo string, num
 	if err != nil {
 		return err
 	}
-	prEnvelope, err := client.do(ctx, ghAPIRequest{method: "GET", path: repoPath(repo, "pulls", number)})
+	headers := hydratedPRViewHeaders(opts)
+	if hasJSONField(opts.json, "files") {
+		if headers == nil {
+			headers = map[string]string{}
+		}
+		headers["cache-control"] = "max-age=0"
+	}
+	prEnvelope, err := client.do(ctx, ghAPIRequest{
+		method: "GET", path: repoPath(repo, "pulls", number), headers: headers,
+	})
 	if err != nil {
 		return err
 	}
@@ -129,17 +138,25 @@ func relayHydratedPRView(ctx context.Context, stdout io.Writer, repo string, num
 	if err := json.Unmarshal(body, &pr); err != nil {
 		return err
 	}
+	filesHeadSHA := ""
 	for _, field := range opts.json {
 		switch field {
 		case "files":
-			routeHint := map[string]string{}
-			if sha := nestedStringValue(pr, "head", "sha"); sha != "" {
-				routeHint["pr_head_sha"] = sha
+			sha := nestedStringValue(pr, "head", "sha")
+			if sha == "" {
+				return localFallbackError{Reason: "pull request response did not include head.sha"}
 			}
-			files, err := relayPagedArray(ctx, client, repoPath(repo, "pulls", number, "files"), routeHint)
+			files, err := relayPagedArrayWithHeaders(
+				ctx,
+				client,
+				repoPath(repo, "pulls", number, "files"),
+				map[string]string{"pr_head_sha": sha},
+				map[string]string{"x-octopool-public-shape": publicShapePullRequestFiles},
+			)
 			if err != nil {
 				return err
 			}
+			filesHeadSHA = sha
 			pr["files"] = mapPRFiles(files)
 		case "commits":
 			commits, err := relayPagedArray(ctx, client, repoPath(repo, "pulls", number, "commits"), nil)
@@ -161,6 +178,15 @@ func relayHydratedPRView(ctx context.Context, stdout io.Writer, repo string, num
 			pr["reviews"] = mapPRReviews(reviews)
 		}
 	}
+	if filesHeadSHA != "" {
+		currentSHA, err := relayPRHeadSHA(ctx, client, repo, number, 0)
+		if err != nil {
+			return err
+		}
+		if currentSHA != filesHeadSHA {
+			return localFallbackError{Reason: "pull request head changed during file pagination"}
+		}
+	}
 	raw, err := json.Marshal(pr)
 	if err != nil {
 		return err
@@ -172,7 +198,29 @@ func relayHydratedPRView(ctx context.Context, stdout io.Writer, repo string, num
 	return writeBytes(ctx, stdout, filtered, opts.jq)
 }
 
+func hydratedPRViewHeaders(opts ghTopOptions) map[string]string {
+	for _, field := range opts.json {
+		if needsHydratedPR([]string{field}) {
+			continue
+		}
+		if !supportedPublicPRViewFields[field] {
+			return nil
+		}
+	}
+	return map[string]string{"x-octopool-public-shape": publicShapePullRequestSummary}
+}
+
 func relayPagedArray(ctx context.Context, client ghRelayClient, path string, routeHint map[string]string) ([]any, error) {
+	return relayPagedArrayWithHeaders(ctx, client, path, routeHint, nil)
+}
+
+func relayPagedArrayWithHeaders(
+	ctx context.Context,
+	client ghRelayClient,
+	path string,
+	routeHint map[string]string,
+	headers map[string]string,
+) ([]any, error) {
 	items := []any{}
 	complete := false
 	for page := 1; page <= maxRelayPages; page++ {
@@ -180,6 +228,7 @@ func relayPagedArray(ctx context.Context, client ghRelayClient, path string, rou
 			method:    "GET",
 			path:      path,
 			query:     map[string]any{"per_page": strconv.Itoa(relayPageSize), "page": strconv.Itoa(page)},
+			headers:   headers,
 			routeHint: routeHint,
 		})
 		if err != nil {

--- a/cmd/octopool/gh_top_pr_test.go
+++ b/cmd/octopool/gh_top_pr_test.go
@@ -7,9 +7,15 @@ import (
 )
 
 func TestRunGHPRViewHydratesDetails(t *testing.T) {
+	prCalls := 0
 	relayTestServer(t, func(body map[string]any) any {
 		switch body["path"] {
 		case "/repos/openclaw/octopool/pulls/7":
+			prCalls++
+			headers := body["headers"].(map[string]any)
+			if headers["x-octopool-public-shape"] != "pr-summary-v1" || headers["cache-control"] != "max-age=0" {
+				t.Fatalf("PR headers = %#v", headers)
+			}
 			return map[string]any{
 				"number":   7,
 				"title":    "hydrate pr",
@@ -17,6 +23,10 @@ func TestRunGHPRViewHydratesDetails(t *testing.T) {
 				"head":     map[string]any{"sha": "0123456789abcdef0123456789abcdef01234567"},
 			}
 		case "/repos/openclaw/octopool/pulls/7/files":
+			headers := body["headers"].(map[string]any)
+			if headers["x-octopool-public-shape"] != "pr-files-v1" {
+				t.Fatalf("files headers = %#v", headers)
+			}
 			hint := body["route_hint"].(map[string]any)
 			if hint["pr_head_sha"] != "0123456789abcdef0123456789abcdef01234567" {
 				t.Fatalf("route hint = %#v", hint)
@@ -43,11 +53,41 @@ func TestRunGHPRViewHydratesDetails(t *testing.T) {
 	if result.err != nil || result.action != ghComplete {
 		t.Fatalf("action=%v err=%v", result.action, result.err)
 	}
+	if prCalls != 2 {
+		t.Fatalf("PR calls = %d, want initial and final head reads", prCalls)
+	}
 	got := out.String()
 	for _, want := range []string{"cmd/octopool/gh.go", "abc1234", "looks good", "APPROVED"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("out missing %q: %s", want, got)
 		}
+	}
+}
+
+func TestRunGHPRViewFilesFallsBackWhenHeadMoves(t *testing.T) {
+	prCalls := 0
+	relayTestServer(t, func(body map[string]any) any {
+		switch body["path"] {
+		case "/repos/openclaw/octopool/pulls/7":
+			prCalls++
+			sha := "0123456789abcdef0123456789abcdef01234567"
+			if prCalls == 2 {
+				sha = "fedcba9876543210fedcba9876543210fedcba98"
+			}
+			return map[string]any{"number": 7, "head": map[string]any{"sha": sha}}
+		case "/repos/openclaw/octopool/pulls/7/files":
+			return []map[string]any{{"filename": "moving.ts"}}
+		default:
+			t.Fatalf("path = %v", body["path"])
+			return nil
+		}
+	})
+
+	result := handleGHPR(t.Context(), []string{
+		"view", "7", "-R", "openclaw/octopool", "--json", "number,files",
+	}, &bytes.Buffer{})
+	if result.action != ghFail || !isLocalFallback(result.err) {
+		t.Fatalf("action=%v err=%v", result.action, result.err)
 	}
 }
 
@@ -78,6 +118,9 @@ func TestRunGHPRChecksUsesCacheableRequests(t *testing.T) {
 			}
 			if _, ok := headers["if-none-match"]; ok {
 				t.Fatalf("unexpected cache-bypass header: %#v", headers)
+			}
+			if headers["x-octopool-public-shape"] != "pr-summary-v1" {
+				t.Fatalf("expected public PR summary shape, got %#v", headers)
 			}
 		}
 		switch body["path"] {

--- a/cmd/octopool/routes_generated.go
+++ b/cmd/octopool/routes_generated.go
@@ -12,6 +12,7 @@ const (
 	publicShapeIssueSearch        = "issue-search-v1"
 	publicShapePullRequestList    = "pr-list-v1"
 	publicShapePullRequestSummary = "pr-summary-v1"
+	publicShapePullRequestFiles   = "pr-files-v1"
 	publicShapeLabelList          = "label-list-v1"
 	publicShapeWorkflowList       = "workflow-list-v1"
 	publicShapeWorkflowView       = "workflow-view-v1"

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -41,6 +41,11 @@ that already know the current PR state can use that to avoid mixing entries acro
 SHAs while letting Octopool keep `files` warm longer. Hints are first checked against
 GitHub and then cached briefly in `github_pr_state_proofs`, so repeated cache hits do not
 need to re-contact GitHub just to validate the hint.
+The `gh pr view --json files` shim resolves the head with `max-age=0`, sends a dedicated
+`pr-files-v1` shape plus the verified head on every bounded page, and resolves the head
+again after all hydration. If the head moved, the entire command falls back to real `gh`
+instead of returning pages that may span revisions. Missing heads and lists beyond the
+bounded pagination window also fall back.
 
 ### What is cached
 
@@ -119,7 +124,7 @@ Per route kind and response state (`cacheTTLSeconds`):
   comments, issue comments/events/timeline, and undiscriminated PR files → 1m..5m
 - supported repository-scoped `gh search issues|prs` shim calls use anonymous API before
   any allowed search-bucket identity
-- closed PRs/issues → 1h; open PRs → 2m; open issues → 5m
+- merged PRs and closed issues → 1h; open or closed-unmerged PRs → 2m; open issues → 5m
 - release lists/latest → 5m; release by tag/id → 1h
 - immutable commit objects → 24h; commit lists → 5m; contents → 1h
 - repo metadata → 10m; workflow metadata → 1h

--- a/docs/token-free.md
+++ b/docs/token-free.md
@@ -66,30 +66,33 @@ API-only because the advertisement cannot prove their target object type.
 These mappings are used only when the requested top-level `gh --json` fields fit the
 documented public shape.
 
-Current shape IDs are `pr-summary-v1`, `pr-list-v1`, `issue-summary-v1`,
+Current shape IDs are `pr-summary-v1`, `pr-files-v1`, `pr-list-v1`, `issue-summary-v1`,
 `issue-list-v1`, `label-list-v1`, `workflow-list-v1`, `workflow-view-v1`,
 `actions-summary-v1`, `actions-jobs-v1`, and `release-summary-v1`.
 
-| Relay request                                                 | Public source                                                                                               | Shape/limits                                                               |
-| ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| `GET /repos/{owner}/{repo}/pulls/{number}`                    | `https://github.com/{owner}/{repo}/pull/{number}`                                                           | PR summary fields; no query                                                |
-| `GET /repos/{owner}/{repo}/pulls`                             | `https://github.com/{owner}/{repo}/issues?q=is%3Apr...`                                                     | First page; complete embedded result required                              |
-| `GET /repos/{owner}/{repo}/issues/{number}`                   | `https://github.com/{owner}/{repo}/issues/{number}`                                                         | Issue summary fields; no query                                             |
-| `GET /repos/{owner}/{repo}/issues`                            | `https://github.com/{owner}/{repo}/issues?q=is%3Aissue...`                                                  | First page; complete embedded result required                              |
-| `GET /repos/{owner}/{repo}/labels`                            | `https://github.com/{owner}/{repo}/labels`                                                                  | First page; complete embedded label set required                           |
-| `GET /repos/{owner}/{repo}/actions/workflows`                 | `https://github.com/{owner}/{repo}/actions`                                                                 | Up to 10 workflow pages                                                    |
-| `GET /repos/{owner}/{repo}/actions/workflows/{workflow}`      | Same Actions workflow list                                                                                  | Lookup by workflow ID or YAML filename                                     |
-| `GET /repos/{owner}/{repo}/actions/runs`                      | `https://github.com/{owner}/{repo}/actions?query={filters}`                                                 | Up to 25 runs; optional branch/status filters; shared public-page superset |
-| `GET /repos/{owner}/{repo}/actions/workflows/{workflow}/runs` | `https://github.com/{owner}/{repo}/actions/workflows/{workflow}?query={filters}`                            | Up to 25 runs; shared per-workflow public-page superset                    |
-| `GET /repos/{owner}/{repo}/actions/runs/{id}`                 | `https://github.com/{owner}/{repo}/actions/runs/{id}`                                                       | Run summary; no query                                                      |
-| `GET /repos/{owner}/{repo}/actions/runs/{id}/jobs`            | `https://github.com/{owner}/{repo}/actions/runs/{id}/job_groups_batch?attempt=1`, then each public job page | Latest attempt; up to 25 job pages                                         |
-| `GET /repos/{owner}/{repo}/releases/latest`                   | `https://github.com/{owner}/{repo}/releases/latest`                                                         | Release summary used by `gh release view`                                  |
-| `GET /repos/{owner}/{repo}/releases/tags/{tag}`               | `https://github.com/{owner}/{repo}/releases/tag/{tag}`                                                      | Release summary used by `gh release view`; no query                        |
+| Relay request                                                         | Public source                                                                                                       | Shape/limits                                                               |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `GET /repos/{owner}/{repo}/pulls/{number}`                            | `https://github.com/{owner}/{repo}/pull/{number}`                                                                   | PR summary fields; no query                                                |
+| `GET /repos/{owner}/{repo}/pulls`                                     | `https://github.com/{owner}/{repo}/issues?q=is%3Apr...`                                                             | First page; complete embedded result required                              |
+| `GET /repos/{owner}/{repo}/issues/{number}`                           | `https://github.com/{owner}/{repo}/issues/{number}`                                                                 | Issue summary fields; no query                                             |
+| `GET /repos/{owner}/{repo}/issues`                                    | `https://github.com/{owner}/{repo}/issues?q=is%3Aissue...`                                                          | First page; complete embedded result required                              |
+| `GET /repos/{owner}/{repo}/labels`                                    | `https://github.com/{owner}/{repo}/labels`                                                                          | First page; complete embedded label set required                           |
+| `GET /repos/{owner}/{repo}/actions/workflows`                         | `https://github.com/{owner}/{repo}/actions`                                                                         | Up to 10 workflow pages                                                    |
+| `GET /repos/{owner}/{repo}/actions/workflows/{workflow}`              | Same Actions workflow list                                                                                          | Lookup by workflow ID or YAML filename                                     |
+| `GET /repos/{owner}/{repo}/actions/runs`                              | `https://github.com/{owner}/{repo}/actions?query={filters}`                                                         | Up to 25 runs; optional branch/status filters; shared public-page superset |
+| `GET /repos/{owner}/{repo}/actions/workflows/{workflow}/runs`         | `https://github.com/{owner}/{repo}/actions/workflows/{workflow}?query={filters}`                                    | Up to 25 runs; shared per-workflow public-page superset                    |
+| `GET /repos/{owner}/{repo}/actions/runs/{id}`                         | `https://github.com/{owner}/{repo}/actions/runs/{id}`                                                               | Run summary; no query                                                      |
+| `GET /repos/{owner}/{repo}/actions/runs/{id}/attempts/{attempt}/jobs` | `https://github.com/{owner}/{repo}/actions/runs/{id}/job_groups_batch?attempt={attempt}`, then each public job page | Exact attempt; up to 25 job pages                                          |
+| `GET /repos/{owner}/{repo}/releases/latest`                           | `https://github.com/{owner}/{repo}/releases/latest`                                                                 | Release summary used by `gh release view`                                  |
+| `GET /repos/{owner}/{repo}/releases/tags/{tag}`                       | `https://github.com/{owner}/{repo}/releases/tag/{tag}`                                                              | Release summary used by `gh release view`; no query                        |
 
 Supported field sets:
 
 - PR view: `number`, `title`, `state`, `url`, `createdAt`, `closedAt`, `mergedAt`,
   `headRefName`, `headRefOid`, `baseRefName`.
+- PR files: `path`, `additions`, `deletions`, `changeType`, and `originalPath`; the
+  `pr-files-v1` shape uses exact anonymous API data plus a verified head discriminator,
+  not a reduced public-page parser.
 - PR list: `number`, `title`, `state`, `url`, `author`, `createdAt`, `updatedAt`,
   `closedAt`, `mergedAt`, `isDraft`, `labels`.
 - Issue view: `number`, `title`, `body`, `state`, `url`, `author`, `createdAt`,
@@ -99,7 +102,8 @@ Supported field sets:
 - Labels and workflows: `id`, `name`, `description`, `color`, `url` for labels;
   `id`, `name`, `path`, `state` for workflows.
 - Run summary: `databaseId`, `name`, `workflowName`, `status`, `conclusion`, `url`,
-  `headBranch`, `headSha`, `event`, `createdAt`, `updatedAt`, `displayTitle`, `number`.
+  `headBranch`, `headSha`, `event`, `createdAt`, `updatedAt`, `displayTitle`, `number`,
+  and `attempt` for run views.
 - Run jobs add `jobs` with bounded job and step metadata.
 - Release summary: `tagName`, `name`, `url`, `isDraft`, `isPrerelease`, `createdAt`,
   `publishedAt`, `body`.

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -348,7 +348,7 @@ function closedPR(response?: GitHubRelayResponse): boolean {
   if (!isRecord(response?.body)) {
     return false;
   }
-  return response.body.state === "closed" || typeof response.body.merged_at === "string";
+  return typeof response.body.merged_at === "string";
 }
 
 function closedIssue(response?: GitHubRelayResponse): boolean {

--- a/src/github-public-shapes.ts
+++ b/src/github-public-shapes.ts
@@ -6,6 +6,7 @@ export const PUBLIC_SHAPES = {
   issueSearch: "issue-search-v1",
   pullRequestList: "pr-list-v1",
   pullRequestSummary: "pr-summary-v1",
+  pullRequestFiles: "pr-files-v1",
   labelList: "label-list-v1",
   workflowList: "workflow-list-v1",
   workflowView: "workflow-view-v1",

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -514,7 +514,10 @@ describe("github cache policy", () => {
       }),
       policy,
     );
-    expect(cacheTTLSeconds(pr, response({ state: "closed", merged_at: null }))).toBe(3_600);
+    expect(cacheTTLSeconds(pr, response({ state: "closed", merged_at: null }))).toBe(120);
+    expect(
+      cacheTTLSeconds(pr, response({ state: "closed", merged_at: "2026-08-08T00:00:00Z" })),
+    ).toBe(3_600);
     expect(cacheTTLSeconds(pr, response({ state: "open" }))).toBe(120);
 
     const user = classifyRoute(

--- a/test/token-free-docs.test.ts
+++ b/test/token-free-docs.test.ts
@@ -43,7 +43,7 @@ describe("token-free endpoint documentation", () => {
       "raw.githubusercontent.com/{owner}/{repo}/{ref}/{path}",
       "{repo}.git/info/refs?service=git-upload-pack",
       "/issues?q=is%3Aissue",
-      "/actions/runs/{id}/job_groups_batch?attempt=1",
+      "/actions/runs/{id}/job_groups_batch?attempt={attempt}",
       "/actions/workflows_partial?query=&page={page}",
       "/releases/tag/{tag}",
     ]) {


### PR DESCRIPTION
## Summary

- keep closed-but-unmerged PR summaries on the mutable two-minute cache policy
- share field-compatible hydrated/head reads through `pr-summary-v1`
- mark hydrated file pages with `pr-files-v1` and a verified head SHA
- resolve the head again after all hydration and fail over if it moved

## Safety contract

- merged PRs retain the long summary TTL; closed PRs that can reopen or receive head movement do not
- unsupported base fields keep exact REST semantics rather than borrowing a reduced public summary
- every bounded file page carries the same nonempty head discriminator
- missing heads, moving heads, and pagination beyond the existing bound fall back to real `gh`

## Proof

- `pnpm check`
- `go test -race ./...`
- focused PR-state, max-age, relay-security, cache, docs, and Go CLI tests
- source-blind 101-file pagination and moving-head behavior contract
- compiled candidate against a live 269-file PR through the production relay
- compiled CLI → local Worker/D1/Durable Object → public GitHub E2E
- clean structured autoreview
