### PR TITLE
fix: reject incomplete Actions page parses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Keep rerunnable base Actions runs and job lists short-lived, cache only completed attempt-qualified job lists long-term, share equivalent bounded `gh run view` job variants, and fail over instead of returning partial job pagination.
 - Keep closed-but-unmerged PR summaries mutable, share safe hydrated summary/file shapes, and recheck the PR head after file pagination so moving heads fail over instead of mixing revisions.
+- Reject incomplete public-page Actions parses instead of returning partial filtered run lists.
 
 ## 0.5.2 - 2026-08-08
 

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -198,6 +198,8 @@ All other exact shaped requests, including workflow-scoped paths, use the same t
 and never forward `limit` to GitHub. Locally shaped responses omit `ETag`, `Last-Modified`,
 `Content-Length`, and `Link` because those validators, lengths, and pagination links describe
 the upstream representation, not the transformed body.
+Public Actions pages must also expose at least `min(total_count, per_page)` parseable cards;
+otherwise Octopool discards the page and falls back to exact anonymous API JSON.
 
 ## Actions attempt job-list superset
 

--- a/src/github-public-actions.ts
+++ b/src/github-public-actions.ts
@@ -86,6 +86,9 @@ function actionsRunListRequest(
       if (parsed === undefined) {
         return undefined;
       }
+      if (parsed.workflow_runs.length < Math.min(parsed.total_count, query.perPage)) {
+        return undefined;
+      }
       parsed.workflow_runs = parsed.workflow_runs.slice(0, query.perPage);
       const runs = await Promise.all(
         parsed.workflow_runs.map((run) =>

--- a/test/e2e/actions-cache.test.ts
+++ b/test/e2e/actions-cache.test.ts
@@ -509,7 +509,12 @@ describe("Actions run-list superset", () => {
           ]),
         );
       }
-      return new Response(runListHTML(200, [[1, "main", "completed successfully"]]));
+      return new Response(
+        runListHTML(
+          200,
+          Array.from({ length: 25 }, (_, index) => [index + 1, "main", "completed successfully"]),
+        ),
+      );
     });
     vi.stubGlobal("fetch", upstream);
 

--- a/test/github-web.test.ts
+++ b/test/github-web.test.ts
@@ -471,6 +471,43 @@ describe("github web provider", () => {
     );
   });
 
+  it("falls back when a filtered Actions page advertises more runs than it parses", async () => {
+    const exact = {
+      total_count: 11,
+      workflow_runs: Array.from({ length: 11 }, (_, index) => ({
+        id: index + 1,
+        status: "completed",
+        conclusion: "failure",
+      })),
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("<strong>11 workflow runs</strong>"))
+      .mockResolvedValueOnce(Response.json(exact));
+    vi.stubGlobal("fetch", fetchMock);
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/actions/runs",
+      query: { per_page: "20", status: "failure" },
+      headers: { "x-octopool-public-shape": "actions-summary-v1" },
+    });
+
+    await expect(
+      callGitHubWeb(env(), request, classifyRoute(request, policy)),
+    ).resolves.toMatchObject({ body: exact, backend: "github" });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://github.com/openclaw/octopool/actions?query=status%3Afailure",
+      expect.any(Object),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.github.com/repos/openclaw/octopool/actions/runs?per_page=20&status=failure",
+      expect.any(Object),
+    );
+  });
+
   it("prefers Actions HTML without consulting a stored API rate snapshot", async () => {
     const prepare = vi.fn(() => {
       throw new Error("stored API rate should not be read");


### PR DESCRIPTION
## Summary

- require a public Actions page to expose at least `min(total_count, per_page)` parseable run cards
- discard incomplete page parses and continue through the existing exact API/pool/local fallback chain
- leave all canonical page sizes and query eligibility unchanged

## Why the scope stays narrow

A 100-run response for a large public repository measured 2,592,217 bytes, above Octopool's 2 MiB route cap. Folding small filtered requests or 80-run workflow requests into a generic 100-run superset could therefore turn valid calls into over-cap failures. Unshaped status/event/head-SHA scans and later pages remain exact and are caller-side optimization candidates.

## Proof

- `pnpm check`
- `go test -race ./...`
- focused Actions parser/Worker E2E and relay-security tests
- source-blind local Worker: complete public page miss→hit; incomplete filtered page failed closed with zero stdout and no cache entry while API fallback was unavailable
- clean structured autoreview on the reduced three-line production change
