### PR TITLE
fix: normalize client identity probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Keep rerunnable base Actions runs and job lists short-lived, cache only completed attempt-qualified job lists long-term, share equivalent bounded `gh run view` job variants, and fail over instead of returning partial job pagination.
 - Keep closed-but-unmerged PR summaries mutable, share safe hydrated summary/file shapes, and recheck the PR head after file pagination so moving heads fail over instead of mixing revisions.
 - Reject incomplete public-page Actions parses instead of returning partial filtered run lists.
+- Normalize macOS `.local` client aliases and satisfy the exact `gh api user --jq .login` probe after a quota-free Octopool caller-health check.
 
 ## 0.5.2 - 2026-08-08
 

--- a/cmd/octopool/gh.go
+++ b/cmd/octopool/gh.go
@@ -43,7 +43,13 @@ func runGH(ctx context.Context, args []string, stdout io.Writer, stderr io.Write
 	if request.paginate {
 		request = prepareGHAPIPagination(request)
 	}
-	if fallback || request.method != "GET" || !safeRelayRequest(request) || request.jq != "" && !jqAvailable() {
+	if fallback || request.method != "GET" || !safeRelayRequest(request) {
+		return execRealGH(ctx, args, stdout, stderr)
+	}
+	if handled, err := writeLocalUserLogin(ctx, request, stdout); handled {
+		return err
+	}
+	if request.jq != "" && !jqAvailable() {
 		return execRealGH(ctx, args, stdout, stderr)
 	}
 	client, err := newGHRelayClient()

--- a/cmd/octopool/gh_local_user.go
+++ b/cmd/octopool/gh_local_user.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+func writeLocalUserLogin(ctx context.Context, request ghAPIRequest, stdout io.Writer) (bool, error) {
+	if request.path != "/user" || request.method != "GET" || request.jq != ".login" ||
+		request.paginate || request.slurp || len(request.query) != 0 || len(request.headers) != 0 ||
+		strings.TrimSpace(os.Getenv("OCTOPOOL_TOKEN")) != "" {
+		return false, nil
+	}
+	auth, err := loadAuth()
+	if err != nil || auth.Token == "" || strings.TrimSpace(auth.Login) == "" {
+		return false, nil
+	}
+	baseURL := envDefault("OCTOPOOL_URL", auth.URL)
+	if err := validateAuthURLForRequest(auth, baseURL, "OCTOPOOL_TOKEN"); err != nil {
+		return false, nil
+	}
+	pool := firstNonEmpty(auth.Pool, "maintainers")
+	response, err := getJSONRaw(ctx, apiURL(baseURL, "/v1/pools/"+urlPath(pool)+"/health"), auth.Token)
+	if err != nil {
+		return false, nil
+	}
+	_ = response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return false, nil
+	}
+	_, err = fmt.Fprintln(stdout, auth.Login)
+	return true, err
+}

--- a/cmd/octopool/gh_local_user_test.go
+++ b/cmd/octopool/gh_local_user_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestWriteLocalUserLogin(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/v1/pools/maintainers/health" || request.Header.Get("authorization") != "Bearer op_token" {
+			t.Fatalf("unexpected health request: %s auth=%q", request.URL.Path, request.Header.Get("authorization"))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+	if err := saveAuth(authFile{
+		URL: server.URL, Pool: "maintainers", Token: "op_token", Login: "alice", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	request := ghAPIRequest{method: "GET", path: "/user", query: map[string]any{}, headers: map[string]string{}, jq: ".login"}
+	var out bytes.Buffer
+	handled, err := writeLocalUserLogin(t.Context(), request, &out)
+	if err != nil || !handled || out.String() != "alice\n" {
+		t.Fatalf("handled=%v err=%v out=%q", handled, err, out.String())
+	}
+}
+
+func TestWriteLocalUserLoginRejectsOverridesAndBroaderShapes(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "")
+	if err := saveAuth(authFile{
+		URL: "https://octopool.dev", Pool: "maintainers", Token: "op_token", Login: "alice", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	base := ghAPIRequest{method: "GET", path: "/user", query: map[string]any{}, headers: map[string]string{}, jq: ".login"}
+	t.Setenv("OCTOPOOL_TOKEN", "override")
+	if handled, _ := writeLocalUserLogin(t.Context(), base, &bytes.Buffer{}); handled {
+		t.Fatal("token override must not use the stored login")
+	}
+	t.Setenv("OCTOPOOL_TOKEN", "")
+	for _, request := range []ghAPIRequest{
+		{method: "GET", path: "/user", query: map[string]any{}, headers: map[string]string{}, jq: ".id"},
+		{method: "GET", path: "/user", query: map[string]any{}, headers: map[string]string{"accept": "application/json"}, jq: ".login"},
+		{method: "GET", path: "/users/alice", query: map[string]any{}, headers: map[string]string{}, jq: ".login"},
+	} {
+		if handled, _ := writeLocalUserLogin(t.Context(), request, &bytes.Buffer{}); handled {
+			t.Fatalf("broader request was handled: %#v", request)
+		}
+	}
+}
+
+func TestNormalizeClientName(t *testing.T) {
+	for input, expected := range map[string]string{
+		"clawstudio.local":   "clawstudio",
+		"clawstudio.LOCAL":   "clawstudio",
+		" clawstudio.local ": "clawstudio",
+		"clawstudio":         "clawstudio",
+		"local":              "local",
+	} {
+		if got := normalizeClientName(input); got != expected {
+			t.Fatalf("normalizeClientName(%q)=%q want %q", input, got, expected)
+		}
+	}
+}

--- a/cmd/octopool/login.go
+++ b/cmd/octopool/login.go
@@ -51,10 +51,11 @@ func runLogin(ctx context.Context, args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
+	clientName := normalizeClientName(*client)
 	body := map[string]any{
 		"github_token": token,
 		"pool":         server.Pool,
-		"client_name":  strings.TrimSpace(*client),
+		"client_name":  clientName,
 	}
 	out, status, err := doRaw(ctx, apiURL(server.APIBase, "/v1/login/github-cli"), "", body)
 	if err != nil {
@@ -70,7 +71,7 @@ func runLogin(ctx context.Context, args []string, stdout io.Writer) error {
 	if response.Token == "" {
 		return errors.New("login response did not include a caller token")
 	}
-	resolvedClient := firstNonEmpty(response.Caller.ClientName, strings.TrimSpace(*client))
+	resolvedClient := firstNonEmpty(response.Caller.ClientName, clientName)
 	if err := saveAuth(authFile{
 		URL:       server.APIBase,
 		Pool:      server.Pool,
@@ -97,11 +98,19 @@ func defaultClientName() string {
 	if err != nil || strings.TrimSpace(hostname) == "" {
 		return "unknown"
 	}
-	hostname = strings.TrimSpace(hostname)
+	hostname = normalizeClientName(hostname)
 	if len(hostname) > 80 {
 		return hostname[:80]
 	}
 	return hostname
+}
+
+func normalizeClientName(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) > len(".local") && strings.HasSuffix(strings.ToLower(value), ".local") {
+		return value[:len(value)-len(".local")]
+	}
+	return value
 }
 
 func normalizeLoginArgs(args []string) []string {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -83,6 +83,8 @@ octopool login --client build-mac
   login, client, timestamp).
 - The default client name is the local hostname. `--client` overrides it; re-login rotates
   only that named client's caller token and leaves the user's other clients active.
+  macOS `.local` suffixes are normalized away at login and audit time so the same host does
+  not split usage across Bonjour and short hostname spellings.
 - Each caller retains up to 16 named clients. Adding another retires the least recently
   updated session, which bounds abandoned hostname and ephemeral-runner credentials.
 - Octopool validates the GitHub identity and OpenClaw org membership during login, and
@@ -92,7 +94,7 @@ octopool login --client build-mac
 
 ```sh
 octopool login
-# logged in to https://octopool.dev as steipete for pool maintainers from steipete-mbp.local
+# logged in to https://octopool.dev as steipete for pool maintainers from steipete-mbp
 ```
 
 ### `octopool whoami [--json]`
@@ -104,7 +106,7 @@ octopool whoami
 # server: https://octopool.dev
 # pool: maintainers
 # login: steipete
-# client: steipete-mbp.local
+# client: steipete-mbp
 ```
 
 Use `--json` for scripts.
@@ -123,6 +125,11 @@ to the real `gh` for a complete response.
 octopool gh api repos/openclaw/openclaw/pulls/85341 --jq .number
 # 85341
 ```
+
+The exact `gh api user --jq .login` identity probe first validates the saved caller token
+against Octopool's pool-health endpoint, then prints the saved login without spending GitHub
+API or pooled-identity quota. Token/URL overrides, other projections, headers, queries, and
+full user-profile reads retain the normal relay or real-`gh` behavior.
 
 ### `octopool gh pr|issue|run|repo|release ...`
 
@@ -266,7 +273,7 @@ enter these aggregates.
 ```sh
 octopool stats
 # pool: maintainers
-# client: steipete-mbp.local
+# client: steipete-mbp
 # requests: 54 (1 service errors, 2 local fallbacks)
 # cache: 82.4% hit (40 hits, 2 stale, 9 misses, 3 bypass, 0 unknown)
 # eligible: 49/54 requests, 85.7% hit
@@ -280,7 +287,7 @@ octopool stats
 # fallback reasons:
 #   identity_pool_depleted / contents: 1 req
 # clients:
-#   steipete-mbp.local: 38 req, 31 saved, 7 backend, 1 fallback
+#   steipete-mbp: 38 req, 31 saved, 7 backend, 1 fallback
 ```
 
 Use `--json` for dashboards or scripts that want the raw aggregate:

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,4 +1,5 @@
 import { bytesToBase64URL } from "./encoding";
+import { normalizeClientName } from "./client-name";
 import { HttpError, parsePositiveInt, requestBearer } from "./http";
 import { queries } from "./generated/sql";
 import type { Caller } from "./types";
@@ -31,7 +32,7 @@ export async function authenticateCaller(
     throw new HttpError(403, "org_denied", `Caller is not a ${allowedOrg} org user`);
   }
   await ensureFreshOrgMembership(env, row);
-  return row;
+  return { ...row, client_name: normalizeClientName(row.client_name) };
 }
 
 export async function authenticateAdmin(request: Request, env: Env): Promise<void> {

--- a/src/client-name.ts
+++ b/src/client-name.ts
@@ -1,0 +1,6 @@
+export function normalizeClientName(value: string): string {
+  const trimmed = value.trim();
+  return trimmed.length > ".local".length && trimmed.toLowerCase().endsWith(".local")
+    ? trimmed.slice(0, -".local".length)
+    : trimmed;
+}

--- a/src/provisioning.ts
+++ b/src/provisioning.ts
@@ -5,6 +5,7 @@ import {
   verifyGitHubOrgMember,
   verifyGitHubOrgMemberWithToken,
 } from "./auth";
+import { normalizeClientName } from "./client-name";
 import { ensureCliCaller } from "./callers";
 import { requestedLoginPool } from "./config";
 import { ensurePool } from "./db";
@@ -63,7 +64,7 @@ function parseClientName(value: unknown): string {
   if (typeof value !== "string") {
     throw new HttpError(400, "client_name_invalid", "client_name must be a string");
   }
-  const clientName = value.trim();
+  const clientName = normalizeClientName(value);
   if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/.test(clientName)) {
     throw new HttpError(
       400,

--- a/test/client-name.test.ts
+++ b/test/client-name.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { normalizeClientName } from "../src/client-name";
+
+describe("client name normalization", () => {
+  it.each([
+    ["clawstudio.local", "clawstudio"],
+    ["clawstudio.LOCAL", "clawstudio"],
+    ["  clawstudio.local  ", "clawstudio"],
+    ["clawstudio", "clawstudio"],
+    ["local", "local"],
+  ])("normalizes %s to %s", (input, expected) => {
+    expect(normalizeClientName(input)).toBe(expected);
+  });
+});

--- a/test/e2e/control-plane.test.ts
+++ b/test/e2e/control-plane.test.ts
@@ -16,6 +16,19 @@ import {
 } from "./harness";
 
 describe("Worker end-to-end control plane", () => {
+  it("attributes legacy macOS .local client aliases to the canonical host", async () => {
+    await seedPool();
+    await env.DB.prepare(
+      "UPDATE caller_tokens SET client_name = 'clawstudio.local' WHERE id = 'caller-client-token'",
+    ).run();
+
+    const response = await authenticatedGet(`/v1/pools/${POOL}/stats?since=24h`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      operator: { client_name: "clawstudio" },
+    });
+  });
+
   it("reports active, disabled, empty, and missing pool health correctly", async () => {
     await seedPool({ secondary: true });
     await env.DB.prepare("UPDATE identities SET status = 'disabled' WHERE id = 'secondary'").run();


### PR DESCRIPTION
## Summary

- normalize trailing macOS `.local` client aliases at CLI login, server provisioning, and authenticated audit attribution
- satisfy only the exact `gh api user --jq .login` probe from saved auth after an authenticated Octopool pool-health check
- avoid GitHub API and pooled-identity quota for that common probe without treating stale/revoked caller auth as healthy

## Boundaries

- token or URL overrides, headers, queries, pagination, other jq projections, and full user profiles retain normal relay/real-`gh` behavior
- no command text or new telemetry schema is recorded
- no pool coordinator, cooldown, public/private guard, or identity-selection policy changes

## Proof

- `pnpm check`
- `go test -race ./...`
- focused client normalization, control-plane, relay-security, and Go CLI tests
- source-blind login/probe fixture: canonical client, one authenticated health request, zero relay/GitHub requests
- live candidate returned the production login while `user_view` telemetry remained unchanged
- clean structured autoreview
