### PR TITLE
fix: complete filtered Actions run lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.4 - Unreleased
+
+### Fixes
+
+- Fall back to exact Actions queries whenever a shared page cannot fill a requested branch/status filter, even when the public page reports its bounded page size as the total.
+
 ## 0.5.3 - 2026-08-08
 
 ### Fixes

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -188,8 +188,8 @@ run-list TTL policy. Fresh variants filter the cached runs by exact `head_branch
 The derived response's `total_count` is the number of matching runs found in the cached
 canonical page before truncation. Shim consumers ignore totals beyond the returned page; this
 is deliberately not a claim about older GitHub pages. If local filtering returns fewer than
-the requested limit while GitHub's canonical `total_count` proves that older runs were not
-captured, Octopool falls back to the exact upstream filtered request. Page values above 1,
+the requested limit, Octopool falls back to the exact upstream filtered request because a
+bounded public page cannot prove that older matching runs do not exist. Page values above 1,
 page sizes above 100, workflow-scoped page sizes above 25, unknown query parameters,
 unsupported GitHub status values, and requests without the shim shape keep exact upstream
 and per-query cache behavior. Conditional shim requests bypass the canonical cache but still translate the

--- a/src/run-list-superset.ts
+++ b/src/run-list-superset.ts
@@ -145,16 +145,13 @@ export function runListSupersetUnderfilled(
     view === undefined ||
     (view.branch === undefined && view.status === undefined) ||
     !isRecord(response.body) ||
-    !Array.isArray(response.body.workflow_runs) ||
-    typeof response.body.total_count !== "number" ||
-    !Number.isSafeInteger(response.body.total_count)
+    !Array.isArray(response.body.workflow_runs)
   ) {
     return false;
   }
-  return (
-    filterRuns(response.body.workflow_runs, view).length < view.limit &&
-    response.body.total_count > response.body.workflow_runs.length
-  );
+  // A bounded public page can report only the captured page size as total_count.
+  // Fewer local matches therefore never prove that older matching runs do not exist.
+  return filterRuns(response.body.workflow_runs, view).length < view.limit;
 }
 
 function filterRuns(runs: unknown[], view: RunListView): Record<string, unknown>[] {

--- a/test/e2e/actions-cache.test.ts
+++ b/test/e2e/actions-cache.test.ts
@@ -428,7 +428,7 @@ describe("Actions run-list superset", () => {
     expect(branch.body).toMatchObject({ total_count: 3 });
     expect(runIDs(branch.body)).toEqual([1, 2]);
 
-    const status = await shapedRunList({ status: "failure", per_page: "20" });
+    const status = await shapedRunList({ status: "failure", per_page: "1" });
     expect(status.body).toMatchObject({ total_count: 1 });
     expect(runIDs(status.body)).toEqual([2]);
 
@@ -524,6 +524,40 @@ describe("Actions run-list superset", () => {
     expect(urls.map((url) => url.hostname)).toEqual(["github.com", "github.com"]);
     expect(Object.fromEntries(urls[0]!.searchParams)).toEqual({});
     expect(Object.fromEntries(urls[1]!.searchParams)).toEqual({ query: "branch:target" });
+  });
+
+  it("does not treat a page-sized total as proof that a filter is complete", async () => {
+    const urls: URL[] = [];
+    const upstream = vi.fn<typeof fetch>(async (input) => {
+      const url = new URL(new Request(input).url);
+      urls.push(url);
+      if (url.hostname === "api.github.com") {
+        return jsonResponse({
+          total_count: 20,
+          workflow_runs: Array.from({ length: 20 }, (_, index) =>
+            run(index + 100, "main", "completed", "failure"),
+          ),
+        });
+      }
+      if (url.searchParams.get("query") === "status:failure") {
+        return new Response("<strong>20 workflow runs</strong>");
+      }
+      return new Response(
+        runListHTML(
+          25,
+          Array.from({ length: 25 }, (_, index) => [index + 1, "main", "completed successfully"]),
+        ),
+      );
+    });
+    vi.stubGlobal("fetch", upstream);
+
+    const response = await shapedRunList({ status: "failure", limit: "20" });
+    expect(runIDs(response.body)).toHaveLength(20);
+    expect(urls.map((url) => url.hostname)).toEqual(["github.com", "github.com", "api.github.com"]);
+    expect(Object.fromEntries(urls[2]!.searchParams)).toEqual({
+      per_page: "20",
+      status: "failure",
+    });
   });
 
   it("preserves GitHub validation for unsupported status values", async () => {

--- a/test/run-list-superset.test.ts
+++ b/test/run-list-superset.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { classifyRoute, defaultPolicy, validateRelayRequest } from "../src/policy";
-import { filterRunListSuperset, runListSupersetView } from "../src/run-list-superset";
+import {
+  filterRunListSuperset,
+  runListSupersetUnderfilled,
+  runListSupersetView,
+} from "../src/run-list-superset";
 
 describe("Actions run-list superset eligibility", () => {
   it("canonicalizes supported repo-level shim queries", () => {
@@ -173,5 +177,34 @@ describe("Actions run-list superset eligibility", () => {
     );
 
     expect(response.body).toMatchObject({ total_count: 100, workflow_runs: [{ id: 1 }] });
+  });
+
+  it("treats a filtered shortfall as underfilled even when total_count equals the page", () => {
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/actions/runs",
+      query: { status: "failure", limit: "20" },
+      headers: { "x-octopool-public-shape": "actions-summary-v1" },
+    });
+    const view = runListSupersetView(request, classifyRoute(request, defaultPolicy("openclaw")));
+
+    expect(
+      runListSupersetUnderfilled(
+        {
+          status: 200,
+          headers: {},
+          body: {
+            total_count: 25,
+            workflow_runs: Array.from({ length: 25 }, (_, id) => ({
+              id,
+              status: "completed",
+              conclusion: "success",
+            })),
+          },
+        },
+        view,
+      ),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- treat every branch/status canonical-page shortfall as underfilled
- switch to the exact filtered request even when the bounded public page reports `total_count == captured page length`
- open the 0.5.4 hotfix changelog

## Regression

After the 0.5.3 deployment, `gh run list --status failure --limit 20` returned zero while GitHub's exact API returned 20 failures. GitHub's public Actions page reported its bounded 25-card page size as the total, so Octopool incorrectly treated zero local matches as complete.

## Proof

- `pnpm check`
- `go test -race ./...`
- focused unit and local-Worker E2E regression: 25 nonmatching canonical cards → incomplete exact page → complete 20-run API response
- source-blind request-API behavior clause passed
- relay-security tests
- clean structured autoreview
