### PR TITLE
feat: redesign the operator dashboard as an editorial ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.5.6 - Unreleased
 
+### Changes
+
+- Redesign the operator dashboard as an editorial ledger: serif display type, hairline-rule sections, tick-marked rate gauges with low-headroom coloring, and right-aligned tabular numerals.
+
 ## 0.5.5 - 2026-08-08
 
 ### Fixes

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -4,160 +4,181 @@ const DASHBOARD_HTML = `<!doctype html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="robots" content="noindex">
-<meta name="theme-color" content="#07110f">
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='9' fill='%230d1917'/%3E%3Ccircle cx='16' cy='14' r='7' fill='none' stroke='%2365e6b4' stroke-width='2'/%3E%3Cpath d='M10 22c2-2 3 2 6 0s4 2 6 0' fill='none' stroke='%2365e6b4' stroke-width='2' stroke-linecap='round'/%3E%3C/svg%3E">
-<title>octopool dashboard</title>
+<meta name="theme-color" content="#08080c">
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='8' fill='%230b0b10'/%3E%3Ccircle cx='16' cy='13' r='6.5' fill='%23ff3355'/%3E%3Cpath d='M10 22c2-2 3 2 6 0s4 2 6 0' fill='none' stroke='%23ff3355' stroke-width='2.4' stroke-linecap='round'/%3E%3C/svg%3E">
+<title>octopool · control room</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;1,400&family=Instrument+Serif:ital@0;1&display=swap">
 <style>
-  :root{color-scheme:dark;--bg:#07110f;--panel:#0d1917;--panel-strong:#11211e;--line:#203a34;--line-soft:rgba(115,160,148,.16);--text:#f2f7f4;--muted:#8fa9a1;--dim:#648078;--mint:#65e6b4;--mint-soft:rgba(101,230,180,.12);--coral:#ff7a73;--coral-soft:rgba(255,122,115,.12);--amber:#f3c96b;--ink:#06100d;--shadow:0 24px 70px rgba(0,0,0,.28)}
+  :root{color-scheme:dark;--bg:#08080c;--text:#ebe7dc;--body:#cdc8bc;--muted:#a09a8c;--dim:#625d51;--red:#ff3355;--amber:#e6b45c;--green:#5dc98f;--rule:#232330;--rule-soft:#17171f;--serif:"Instrument Serif","Iowan Old Style",Georgia,serif;--mono:"IBM Plex Mono",ui-monospace,SFMono-Regular,Menlo,monospace}
   *{box-sizing:border-box}
   html{min-width:320px;background:var(--bg)}
-  body{margin:0;background:
-    radial-gradient(circle at 18% -10%,rgba(44,173,133,.17),transparent 31rem),
-    radial-gradient(circle at 92% 8%,rgba(255,122,115,.07),transparent 25rem),
-    linear-gradient(rgba(116,175,158,.035) 1px,transparent 1px),
-    linear-gradient(90deg,rgba(116,175,158,.035) 1px,transparent 1px),
-    var(--bg);background-size:auto,auto,32px 32px,32px 32px,auto;color:var(--text);font:14px/1.5 "Avenir Next","Segoe UI",sans-serif;-webkit-font-smoothing:antialiased}
-  body::before{content:"";position:fixed;inset:0;pointer-events:none;background:linear-gradient(115deg,transparent 0 49.8%,rgba(101,230,180,.025) 50%,transparent 50.2%)}
-  main{min-height:100vh;padding:34px 28px 56px}
-  header{display:flex;align-items:flex-end;justify-content:space-between;gap:28px;margin:0 auto 24px;max-width:1460px}
-  .brand{display:flex;align-items:flex-start;gap:14px}
-  .brandmark{position:relative;flex:0 0 auto;width:42px;height:42px;border:1px solid rgba(101,230,180,.36);border-radius:13px;background:linear-gradient(145deg,rgba(101,230,180,.18),rgba(101,230,180,.03));box-shadow:inset 0 1px rgba(255,255,255,.08),0 10px 30px rgba(0,0,0,.18)}
-  .brandmark::before{content:"";position:absolute;inset:9px;border:2px solid var(--mint);border-radius:50%}
-  .brandmark::after{content:"";position:absolute;left:12px;right:12px;bottom:7px;height:7px;background:radial-gradient(circle,var(--mint) 2px,transparent 2.5px) 0 0/9px 7px}
-  .eyebrow,.section-label{display:block;color:var(--mint);font:700 10px/1.2 ui-monospace,SFMono-Regular,Menlo,monospace;text-transform:uppercase;letter-spacing:.15em}
-  h1{margin:5px 0 0;font-size:27px;line-height:1.08;font-weight:650;letter-spacing:-.035em}
-  .sub{margin:7px 0 0;color:var(--muted);font-size:13px}
-  .header-actions{display:flex;align-items:center;gap:10px}
-  .live{display:inline-flex;align-items:center;gap:8px;height:38px;padding:0 13px;border:1px solid var(--line-soft);border-radius:999px;background:rgba(13,25,23,.62);color:var(--muted);font:700 10px/1 ui-monospace,SFMono-Regular,Menlo,monospace;text-transform:uppercase;letter-spacing:.1em}
-  .live::before{content:"";width:7px;height:7px;border-radius:50%;background:var(--mint);box-shadow:0 0 0 4px rgba(101,230,180,.09),0 0 18px rgba(101,230,180,.55)}
-  .shell{max-width:1460px;margin:0 auto;display:grid;grid-template-columns:242px minmax(0,1fr);gap:18px}
-  aside,.panel,.tile{background:linear-gradient(145deg,rgba(17,33,30,.96),rgba(11,23,20,.96));border:1px solid var(--line-soft);box-shadow:inset 0 1px rgba(255,255,255,.025),var(--shadow)}
-  aside{padding:17px;align-self:start;position:sticky;top:18px;border-radius:18px}
-  .aside-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:17px}
-  .aside-index{color:var(--dim);font:700 10px/1 ui-monospace,SFMono-Regular,Menlo,monospace}
-  label{display:block;color:var(--muted);font:700 10px/1.2 ui-monospace,SFMono-Regular,Menlo,monospace;text-transform:uppercase;letter-spacing:.12em;margin:0 0 8px}
-  input{width:100%;height:42px;border:1px solid var(--line);border-radius:10px;background:rgba(3,12,10,.72);color:var(--text);padding:9px 11px;font:600 13px/1 ui-monospace,SFMono-Regular,Menlo,monospace;outline:none;transition:border-color .18s,box-shadow .18s}
-  input:focus{border-color:rgba(101,230,180,.68);box-shadow:0 0 0 3px rgba(101,230,180,.09)}
-  button,.linkbtn{height:40px;border:1px solid transparent;border-radius:10px;background:var(--mint);color:var(--ink);padding:0 13px;font:750 12px/1 "Avenir Next","Segoe UI",sans-serif;text-decoration:none;cursor:pointer;display:inline-flex;align-items:center;justify-content:center;transition:transform .18s,background .18s,border-color .18s,color .18s}
-  button:hover,.linkbtn:hover{transform:translateY(-1px)}
-  button:focus-visible,.linkbtn:focus-visible{outline:2px solid var(--mint);outline-offset:3px}
-  button:disabled{cursor:wait;opacity:.64;transform:none}
-  button.secondary,.linkbtn.secondary{background:rgba(255,255,255,.035);color:var(--text);border-color:var(--line)}
-  .controls{display:grid;gap:11px}
-  .row{display:grid;grid-template-columns:1fr auto;gap:8px;align-items:center}
-  .who{display:grid;grid-template-columns:36px minmax(0,1fr);gap:10px;align-items:center;margin-top:17px;padding-top:17px;border-top:1px solid var(--line-soft);color:var(--muted);font-size:11px;min-width:0}
-  .avatar{display:grid;place-items:center;width:36px;height:36px;border:1px solid rgba(101,230,180,.26);border-radius:11px;background:var(--mint-soft);color:var(--mint);font:750 13px/1 ui-monospace,SFMono-Regular,Menlo,monospace;text-transform:uppercase}
-  .who-copy{min-width:0}
-  .who strong{display:block;color:var(--text);font-size:13px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-  .who span{display:block;margin-top:2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-  .grid{display:grid;gap:18px;min-width:0}
-  .tiles{display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:11px}
-  .tile{position:relative;overflow:hidden;padding:15px 15px 14px;min-height:112px;border-radius:16px;animation:rise .45s both}
-  .tile:nth-child(2){animation-delay:.04s}.tile:nth-child(3){animation-delay:.08s}.tile:nth-child(4){animation-delay:.12s}.tile:nth-child(5){animation-delay:.16s}
-  .tile::after{content:"";position:absolute;top:0;left:15px;width:34px;height:2px;border-radius:0 0 4px 4px;background:var(--mint);box-shadow:0 0 16px rgba(101,230,180,.55)}
-  .tile.warn::after{background:var(--amber);box-shadow:0 0 16px rgba(243,201,107,.45)}
-  .tile.hot::after{background:var(--coral);box-shadow:0 0 16px rgba(255,122,115,.45)}
-  .tile span{display:block;color:var(--muted);font:700 9px/1.2 ui-monospace,SFMono-Regular,Menlo,monospace;text-transform:uppercase;letter-spacing:.12em}
-  .tile b{display:block;margin-top:14px;font:650 27px/1 "Avenir Next","Segoe UI",sans-serif;letter-spacing:-.04em}
-  .tile small{display:block;margin-top:9px;color:var(--dim);font:600 11px/1.2 ui-monospace,SFMono-Regular,Menlo,monospace;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-  .panel{padding:0;overflow:hidden;border-radius:18px;animation:rise .45s .14s both}
-  .panel-head{display:flex;justify-content:space-between;align-items:center;gap:12px;min-height:57px;padding:0 17px;border-bottom:1px solid var(--line-soft);background:rgba(255,255,255,.012)}
-  .panel-head .section-label{color:var(--dim)}
-  h2{margin:0;font-size:14px;font-weight:650;letter-spacing:-.01em}
+  body{margin:0;background:var(--bg);color:var(--text);font:400 13px/1.55 var(--mono);-webkit-font-smoothing:antialiased}
+  body::before{content:"";position:fixed;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--red) 0 28%,rgba(255,51,85,.35) 62%,transparent);z-index:60}
+  body::after{content:"";position:fixed;inset:0;pointer-events:none;opacity:.045;z-index:50;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='140' height='140' filter='url(%23n)'/%3E%3C/svg%3E")}
+  ::selection{background:var(--red);color:#fff}
+  main{max-width:1360px;margin:0 auto;padding:0 40px 88px}
+  main>*{animation:rise .55s both}
+  main>:nth-child(2){animation-delay:.05s}main>:nth-child(3){animation-delay:.1s}main>:nth-child(4){animation-delay:.15s}main>:nth-child(5){animation-delay:.2s}main>:nth-child(6){animation-delay:.25s}main>:nth-child(7){animation-delay:.3s}main>:nth-child(8){animation-delay:.34s}
+  .mast-top{display:flex;justify-content:space-between;align-items:center;gap:20px;padding:20px 0;border-bottom:1px solid var(--rule)}
+  .wordmark{display:inline-flex;align-items:center;gap:10px;color:var(--text);text-decoration:none}
+  .wordmark svg{display:block}
+  .wordmark b{font:600 13px/1 var(--mono);letter-spacing:.08em;text-transform:uppercase}
+  .wordmark em{font:500 9.5px/1 var(--mono);font-style:normal;color:var(--red);letter-spacing:.2em;text-transform:uppercase;padding-top:1px}
+  .mast-nav{display:flex;align-items:center;gap:24px}
+  .mast-nav a{color:var(--muted);text-decoration:none;font:500 10px/1 var(--mono);letter-spacing:.16em;text-transform:uppercase;border-bottom:1px solid transparent;padding-bottom:2px;transition:color .2s,border-color .2s}
+  .mast-nav a:hover{color:var(--text);border-color:var(--red)}
+  .mast-hero{display:flex;justify-content:space-between;align-items:flex-end;gap:44px;padding:46px 0 32px}
+  h1{margin:0;font:400 clamp(40px,5vw,58px)/.95 var(--serif);letter-spacing:-.01em}
+  .dek{margin:14px 0 0;color:var(--muted);font-size:12.5px;max-width:52ch}
+  .console{display:flex;align-items:flex-end;gap:14px;flex:0 0 auto}
+  .console label{display:block;margin-bottom:7px;color:var(--dim);font:600 9.5px/1 var(--mono);letter-spacing:.18em;text-transform:uppercase}
+  .console input{width:200px;background:transparent;border:0;border-bottom:1px solid var(--rule);border-radius:0;color:var(--text);font:500 14px/1 var(--mono);padding:7px 2px;outline:0;transition:border-color .2s}
+  .console input:focus{border-color:var(--red)}
+  button{border:0;border-radius:3px;background:var(--text);color:#0a0a0f;height:34px;padding:0 16px;font:600 10.5px/1 var(--mono);letter-spacing:.14em;text-transform:uppercase;cursor:pointer;transition:background .18s,color .18s,transform .18s}
+  button:hover{background:var(--red);color:#fff;transform:translateY(-1px)}
+  button:focus-visible{outline:2px solid var(--red);outline-offset:3px}
+  button:disabled{cursor:wait;opacity:.55;transform:none}
+  .wire-line{display:flex;flex-wrap:wrap;align-items:center;gap:10px 12px;padding:12px 2px;border-top:1px solid var(--rule);border-bottom:1px solid var(--rule);color:var(--muted);font:500 10.5px/1.4 var(--mono);letter-spacing:.06em}
+  .wire-line strong{color:var(--text);font-weight:600}
+  .wire-note{color:var(--dim)}
+  .beacon{width:7px;height:7px;border-radius:50%;background:var(--dim);flex:0 0 auto}
+  .wire-line.on .beacon{background:var(--red);animation:pulse 2.2s ease-out infinite}
+  .error{display:none;margin:16px 0 0;padding:10px 14px;border-left:2px solid var(--red);background:rgba(255,51,85,.07);color:#ff8fa0;font-size:11.5px}
+  .figures{display:grid;grid-template-columns:repeat(5,minmax(0,1fr));border-bottom:1px solid var(--rule)}
+  .figure{padding:28px 24px 26px;border-left:1px solid var(--rule);min-width:0}
+  .figure:first-child{border-left:0;padding-left:2px}
+  .figure span{display:block;color:var(--muted);font:600 9.5px/1.3 var(--mono);letter-spacing:.15em;text-transform:uppercase}
+  .figure b{display:block;margin:12px 0 9px;font:400 40px/1 var(--serif);letter-spacing:0}
+  .figure small{display:block;color:var(--dim);font-size:10.5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .figure.warn b{color:var(--amber)}
+  .figure.hot b{color:var(--red)}
+  .sect{padding-top:38px;min-width:0}
+  .sect-head{display:flex;align-items:baseline;gap:14px;padding-bottom:10px;border-bottom:1px solid var(--rule)}
+  .idx{color:var(--red);font:600 10px/1 var(--mono);letter-spacing:.1em}
+  h2{margin:0;font:italic 400 21px/1.1 var(--serif);letter-spacing:.01em}
+  .note{margin-left:auto;color:var(--dim);font:500 9.5px/1.3 var(--mono);letter-spacing:.14em;text-transform:uppercase;text-align:right}
+  .duo{display:grid;grid-template-columns:1fr 1fr;gap:0 56px}
   .table-wrap{overflow-x:auto}
-  table{width:100%;border-collapse:collapse;table-layout:fixed}
-  th,td{padding:10px 17px;border-bottom:1px solid var(--line-soft);text-align:left;vertical-align:middle;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-  tbody tr:last-child td{border-bottom:0}
+  table{width:100%;border-collapse:collapse}
+  th{padding:12px 14px 8px;border-bottom:1px solid var(--rule-soft);color:var(--dim);font:600 9px/1.3 var(--mono);letter-spacing:.14em;text-transform:uppercase;text-align:left;white-space:nowrap}
+  td{padding:9px 14px;border-bottom:1px solid var(--rule-soft);color:var(--body);font-size:11.5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:420px;font-variant-numeric:tabular-nums}
+  th:first-child,td:first-child{padding-left:2px}
+  th:last-child,td:last-child{padding-right:2px}
+  td:first-child{color:var(--text)}
+  th.num,td.num{text-align:right}
   tbody tr{transition:background .15s}
-  tbody tr:hover{background:rgba(101,230,180,.035)}
-  th{color:var(--dim);font:700 9px/1.2 ui-monospace,SFMono-Regular,Menlo,monospace;text-transform:uppercase;letter-spacing:.12em}
-  td{color:#dbe8e3;font-size:12px}
-  td:first-child{color:var(--text);font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11px}
-  .pill{display:inline-flex;align-items:center;justify-content:center;min-width:49px;height:23px;padding:0 8px;border:1px solid var(--line);border-radius:7px;background:rgba(255,255,255,.04);color:var(--text);font:750 10px/1 ui-monospace,SFMono-Regular,Menlo,monospace}
-  .pill.ok{border-color:rgba(101,230,180,.24);background:var(--mint-soft);color:var(--mint)}
-  .pill.warn{border-color:rgba(243,201,107,.24);background:rgba(243,201,107,.1);color:var(--amber)}
-  .pill.hot{border-color:rgba(255,122,115,.24);background:var(--coral-soft);color:var(--coral)}
-  .bars{display:grid;gap:14px;padding:18px 17px 20px}
-  .bar{display:grid;grid-template-columns:190px minmax(0,1fr) 80px;align-items:center;gap:14px;color:var(--muted);font:600 11px/1.2 ui-monospace,SFMono-Regular,Menlo,monospace}
-  .bar>div:last-child{text-align:right;color:var(--text)}
-  .meter{height:7px;border-radius:999px;background:#05100d;overflow:hidden;box-shadow:inset 0 0 0 1px rgba(115,160,148,.12)}
-  .fill{height:100%;width:0;border-radius:inherit;background:linear-gradient(90deg,var(--coral),var(--amber) 42%,var(--mint));box-shadow:0 0 16px rgba(101,230,180,.24);transition:width .55s ease}
-  .empty{margin:10px 0;padding:16px;color:var(--dim);border:1px dashed var(--line);border-radius:10px;background:rgba(3,12,10,.3)}
-  td .empty{margin:0}
-  .error{display:none;margin-top:13px;padding:11px;border-radius:10px;background:var(--coral-soft);color:#ffaaa5;border:1px solid rgba(255,122,115,.26);font-size:12px}
-  @keyframes rise{from{opacity:0;transform:translateY(7px)}to{opacity:1;transform:none}}
-  @media (max-width:1160px){.tiles{grid-template-columns:repeat(3,minmax(0,1fr))}.tile:nth-child(n+4){grid-column:span 1}}
-  @media (max-width:900px){main{padding:22px 16px 40px}.shell{grid-template-columns:1fr}.tiles{grid-template-columns:repeat(2,minmax(0,1fr))}aside{position:static}.controls{grid-template-columns:minmax(0,1fr) auto;align-items:end}.who{margin-top:14px;padding:14px 0 0;border-top:1px solid var(--line-soft);border-left:0}.error{grid-column:1/-1}.bar{grid-template-columns:1fr}.bar>div:last-child{text-align:left}}
-  @media (max-width:620px){header{align-items:flex-start}.header-actions{align-items:flex-end;flex-direction:column}.live{height:32px}.shell{gap:14px}.controls{grid-template-columns:1fr}.tiles{grid-template-columns:1fr 1fr}.tile{min-height:104px}.panel-head{padding:0 13px}th,td{padding:10px 13px;min-width:105px}table{min-width:620px}}
-  @media (max-width:430px){main{padding:18px 12px 32px}.brandmark{display:none}.header-actions .live{display:none}h1{font-size:23px}.sub{max-width:230px}.tiles{grid-template-columns:1fr}.tile{min-height:96px}}
-  @media (prefers-reduced-motion:reduce){*,*::before,*::after{scroll-behavior:auto!important;animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important}}
+  tbody tr:hover{background:rgba(255,51,85,.045)}
+  .pill{display:inline-block;min-width:36px;padding:2px 7px;border:1px solid var(--rule);border-radius:3px;text-align:center;font:600 10px/1.5 var(--mono);color:var(--body)}
+  .pill.ok{color:var(--green);border-color:rgba(93,201,143,.32);background:rgba(93,201,143,.06)}
+  .pill.warn{color:var(--amber);border-color:rgba(230,180,92,.32);background:rgba(230,180,92,.06)}
+  .pill.hot{color:var(--red);border-color:rgba(255,51,85,.32);background:rgba(255,51,85,.07)}
+  .gauges{padding-top:4px}
+  .gauge{display:grid;grid-template-columns:minmax(180px,260px) minmax(0,1fr) 90px;grid-template-areas:"label meter value";gap:18px;align-items:center;padding:10px 0;border-bottom:1px solid var(--rule-soft);color:var(--muted);font-size:11px}
+  .glabel{grid-area:label;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .gval{grid-area:value;text-align:right;color:var(--text);font-size:11.5px;font-variant-numeric:tabular-nums}
+  .meter{grid-area:meter;position:relative;height:4px;background:var(--rule-soft)}
+  .meter::after{content:"";position:absolute;inset:0;background:repeating-linear-gradient(90deg,transparent 0,transparent calc(25% - 1px),var(--bg) calc(25% - 1px),var(--bg) 25%)}
+  .fill{position:absolute;top:0;bottom:0;left:0;width:0;background:var(--text);transition:width .6s ease}
+  .fill.warn{background:var(--amber)}
+  .fill.hot{background:var(--red)}
+  .empty{padding:14px 2px;border-bottom:1px solid var(--rule-soft);color:var(--dim);font-style:italic;font-size:11.5px}
+  td .empty,td.empty{border-bottom:0;padding:14px 0}
+  @keyframes rise{from{opacity:0;transform:translateY(10px)}to{opacity:1;transform:none}}
+  @keyframes pulse{0%{box-shadow:0 0 0 0 rgba(255,51,85,.5)}70%{box-shadow:0 0 0 6px rgba(255,51,85,0)}100%{box-shadow:0 0 0 0 rgba(255,51,85,0)}}
+  @media (max-width:1100px){
+    .duo{grid-template-columns:1fr}
+    .figures{grid-template-columns:repeat(3,minmax(0,1fr))}
+    .figure:nth-child(3n+1){border-left:0;padding-left:2px}
+    .figure:nth-child(n+4){border-top:1px solid var(--rule)}
+  }
+  @media (max-width:760px){
+    main{padding:0 20px 64px}
+    .mast-hero{flex-direction:column;align-items:stretch;gap:26px;padding:32px 0 26px}
+    .console input{width:100%;flex:1}
+    .console{width:100%}
+    .figures{grid-template-columns:repeat(2,minmax(0,1fr))}
+    .figure:nth-child(odd){border-left:0;padding-left:2px}
+    .figure:nth-child(even){border-left:1px solid var(--rule)}
+    .figure:nth-child(n+3){border-top:1px solid var(--rule)}
+    .gauge{grid-template-columns:minmax(0,1fr) 80px;grid-template-areas:"label label" "meter value";gap:8px 14px}
+    .table-wrap table{min-width:600px}
+  }
+  @media (max-width:480px){
+    .figures{grid-template-columns:1fr}
+    .figure:nth-child(n){border-left:0;border-top:1px solid var(--rule);padding-left:2px}
+    .figure:first-child{border-top:0}
+    .mast-nav{gap:16px}
+    .figure b{font-size:34px}
+  }
+  @media (prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important}}
 </style>
 </head>
 <body>
 <main>
   <header>
-    <div class="brand">
-      <div class="brandmark" aria-hidden="true"></div>
+    <div class="mast-top">
+      <a class="wordmark" href="/dashboard">
+        <svg width="20" height="20" viewBox="0 0 32 32" aria-hidden="true"><circle cx="16" cy="13" r="6.5" fill="#ff3355"/><path d="M10 22c2-2 3 2 6 0s4 2 6 0" fill="none" stroke="#ff3355" stroke-width="2.4" stroke-linecap="round"/></svg>
+        <b>octopool</b><em>operator wire</em>
+      </a>
+      <nav class="mast-nav">
+        <a href="https://docs.octopool.dev/">Docs</a>
+        <a href="/logout">Log out</a>
+      </nav>
+    </div>
+    <div class="mast-hero">
       <div>
-        <span class="eyebrow">Octopool / operator</span>
         <h1>Relay control room</h1>
-        <p class="sub">GitHub capacity, shared cache, and maintainer traffic.</p>
+        <p class="dek">GitHub capacity, shared cache, and maintainer traffic — one pool at a time.</p>
+      </div>
+      <div class="console">
+        <div style="flex:1;min-width:0">
+          <label for="pool">Pool</label>
+          <input id="pool" value="maintainers" spellcheck="false" autocomplete="off">
+        </div>
+        <button id="load">Refresh</button>
       </div>
     </div>
-    <div class="header-actions">
-      <span class="live">Session active</span>
-      <a class="linkbtn secondary" href="https://docs.octopool.dev/">Documentation</a>
-    </div>
+    <div class="wire-line" id="who"><span class="beacon"></span><strong>Loading</strong><span class="wire-note">Checking web session.</span></div>
+    <div class="error" id="error" role="alert" aria-live="polite"></div>
   </header>
-  <div class="shell">
-    <aside>
-      <div class="aside-head"><span class="section-label">Workspace</span><span class="aside-index">01</span></div>
-      <div class="controls">
-        <div><label for="pool">Pool</label><input id="pool" value="maintainers" spellcheck="false"></div>
-        <div class="row"><button id="load">Refresh data</button><a class="linkbtn secondary" href="/logout">Log out</a></div>
-      </div>
-      <div class="who" id="who">
-        <div class="avatar" aria-hidden="true">...</div>
-        <div class="who-copy"><strong>Loading</strong><span>Checking web session.</span></div>
-      </div>
-      <div class="error" id="error" role="alert" aria-live="polite"></div>
-    </aside>
-    <section class="grid">
-      <div class="tiles" id="tiles"></div>
-      <div class="panel">
-        <div class="panel-head"><h2>Identity Limits</h2><span class="section-label" id="rate-count"></span></div>
-        <div class="bars" id="rates"></div>
-      </div>
-      <div class="panel">
-        <div class="panel-head"><h2>Cache By Route</h2><span class="section-label">fresh / total</span></div>
-        <div class="table-wrap"><table><thead><tr><th>Route</th><th>Fresh</th><th>Total</th><th>Latest</th></tr></thead><tbody id="cache-routes"></tbody></table></div>
-      </div>
-      <div class="panel">
-        <div class="panel-head"><h2>Top Routes</h2><span class="section-label">24 hours</span></div>
-        <div class="table-wrap"><table><thead><tr><th>Route</th><th>Requests</th><th>Eligible hit</th><th>Coalesced</th><th>Fallback</th><th>Svc errors</th></tr></thead><tbody id="route-usage"></tbody></table></div>
-      </div>
-      <div class="panel">
-        <div class="panel-head"><h2>Request Patterns</h2><span class="section-label">7 days / normalized keys</span></div>
-        <div class="table-wrap"><table><thead><tr><th>Route key</th><th>Requests</th><th>Hits</th><th>Misses</th><th>Coalesced</th><th>Fallback</th><th>Latest</th></tr></thead><tbody id="route-keys"></tbody></table></div>
-      </div>
-      <div class="panel">
-        <div class="panel-head"><h2>Fallback & Failure Causes</h2><span class="section-label">7 days</span></div>
-        <div class="table-wrap"><table><thead><tr><th>Outcome</th><th>Route</th><th>Requests</th><th>Latest</th></tr></thead><tbody id="error-codes"></tbody></table></div>
-      </div>
-      <div class="panel">
-        <div class="panel-head"><h2>Who Uses It</h2><span class="section-label">7 days</span></div>
-        <div class="table-wrap"><table><thead><tr><th>User</th><th>Requests</th><th>Errors</th><th>Avg ms</th><th>Last seen</th></tr></thead><tbody id="callers"></tbody></table></div>
-      </div>
-      <div class="panel">
-        <div class="panel-head"><h2>Client Sessions</h2><span class="section-label">7 days</span></div>
-        <div class="table-wrap"><table><thead><tr><th>User</th><th>Client</th><th>Requests</th><th>Saved</th><th>Backend</th><th>Errors</th><th>Last seen</th></tr></thead><tbody id="clients"></tbody></table></div>
-      </div>
-      <div class="panel">
-        <div class="panel-head"><h2>Recent Traffic</h2><span class="section-label">latest 20</span></div>
-        <div class="table-wrap"><table><thead><tr><th>When</th><th>Caller</th><th>Client</th><th>Route</th><th>Status</th><th>Identity</th></tr></thead><tbody id="recent"></tbody></table></div>
-      </div>
+  <section class="figures" id="tiles" aria-label="Key figures"></section>
+  <section class="sect">
+    <div class="sect-head"><span class="idx">01</span><h2>Identity limits</h2><span class="note" id="rate-count"></span></div>
+    <div class="gauges" id="rates"></div>
+  </section>
+  <div class="duo">
+    <section class="sect">
+      <div class="sect-head"><span class="idx">02</span><h2>Cache by route</h2><span class="note">fresh / total</span></div>
+      <div class="table-wrap"><table><thead><tr><th>Route</th><th class="num">Fresh</th><th class="num">Total</th><th class="num">Latest</th></tr></thead><tbody id="cache-routes"></tbody></table></div>
+    </section>
+    <section class="sect">
+      <div class="sect-head"><span class="idx">03</span><h2>Fallback &amp; failure causes</h2><span class="note">7 days</span></div>
+      <div class="table-wrap"><table><thead><tr><th>Outcome</th><th>Route</th><th class="num">Requests</th><th class="num">Latest</th></tr></thead><tbody id="error-codes"></tbody></table></div>
     </section>
   </div>
+  <section class="sect">
+    <div class="sect-head"><span class="idx">04</span><h2>Top routes</h2><span class="note">24 hours</span></div>
+    <div class="table-wrap"><table><thead><tr><th>Route</th><th class="num">Requests</th><th class="num">Eligible hit</th><th class="num">Coalesced</th><th class="num">Fallback</th><th class="num">Svc errors</th></tr></thead><tbody id="route-usage"></tbody></table></div>
+  </section>
+  <section class="sect">
+    <div class="sect-head"><span class="idx">05</span><h2>Request patterns</h2><span class="note">7 days · normalized keys</span></div>
+    <div class="table-wrap"><table><thead><tr><th>Route key</th><th class="num">Requests</th><th class="num">Hits</th><th class="num">Misses</th><th class="num">Coalesced</th><th class="num">Fallback</th><th class="num">Latest</th></tr></thead><tbody id="route-keys"></tbody></table></div>
+  </section>
+  <section class="sect">
+    <div class="sect-head"><span class="idx">06</span><h2>Callers</h2><span class="note">7 days</span></div>
+    <div class="table-wrap"><table><thead><tr><th>User</th><th class="num">Requests</th><th class="num">Errors</th><th class="num">Avg ms</th><th class="num">Last seen</th></tr></thead><tbody id="callers"></tbody></table></div>
+  </section>
+  <section class="sect">
+    <div class="sect-head"><span class="idx">07</span><h2>Client sessions</h2><span class="note">7 days</span></div>
+    <div class="table-wrap"><table><thead><tr><th>User</th><th>Client</th><th class="num">Requests</th><th class="num">Saved</th><th class="num">Backend</th><th class="num">Errors</th><th class="num">Last seen</th></tr></thead><tbody id="clients"></tbody></table></div>
+  </section>
+  <section class="sect">
+    <div class="sect-head"><span class="idx">08</span><h2>Recent traffic</h2><span class="note">latest 20</span></div>
+    <div class="table-wrap"><table><thead><tr><th>When</th><th>Caller</th><th>Client</th><th>Route</th><th>Status</th><th>Identity</th></tr></thead><tbody id="recent"></tbody></table></div>
+  </section>
 </main>
 <script>
 const $ = (id) => document.getElementById(id);
@@ -205,19 +226,17 @@ async function load() {
   } finally {
     if (serial === loadSerial) {
       loadButton.disabled = false;
-      loadButton.textContent = "Refresh data";
+      loadButton.textContent = "Refresh";
     }
   }
 }
 
 function render(data) {
-  const avatar = el("div", data.operator.github_login.slice(0, 2), "avatar");
-  avatar.setAttribute("aria-hidden", "true");
-  const whoCopy = el("div", "", "who-copy");
-  const generated = el("span", data.pool + " · updated " + rel(data.generated_at));
-  generated.title = data.generated_at;
-  whoCopy.append(el("strong", data.operator.github_login), generated);
-  $("who").replaceChildren(avatar, whoCopy);
+  const who = $("who");
+  who.classList.add("on");
+  const note = el("span", "pool " + data.pool + " · updated " + rel(data.generated_at), "wire-note");
+  note.title = data.generated_at;
+  who.replaceChildren(el("span", "", "beacon"), el("strong", data.operator.github_login), note);
   $("tiles").replaceChildren(
     tile("Requests / 24h", fmt(data.usage.requests_24h), fmt(data.usage.service_errors_24h) + " svc · " + fmt(data.usage.fallbacks_24h) + " fallback · " + fmt(data.usage.denied_24h) + " denied", data.usage.service_errors_24h ? "hot" : ""),
     tile("Eligible cache hit", pct(data.usage.eligible_cache_hit_rate_24h), pct(data.usage.cache_hit_rate_24h) + " raw · " + fmt(data.usage.coalesced_24h) + " coalesced"),
@@ -226,13 +245,13 @@ function render(data) {
     tile("Identity health", fmt(data.identities.active) + "/" + fmt(data.identities.total), data.coordinator.cooldowns.length + " cooldowns", data.coordinator.cooldowns.length ? "warn" : ""),
   );
   renderRates(data);
-  rows("cache-routes", data.cache.routes, (item) => [item.route_kind, item.fresh_entries, item.entries, rel(item.latest_created_at)], 4);
-  rows("route-usage", data.route_usage, (item) => [item.route_kind, item.requests, pct(item.eligible_cache_hit_rate), item.coalesced, item.fallbacks, item.service_errors], 6);
-  rows("route-keys", data.route_keys_7d, (item) => [item.route_key, item.requests, item.cache_hits, item.cache_misses, item.coalesced, item.fallbacks, rel(item.latest_seen_at)], 7);
-  rows("error-codes", data.error_codes_7d, (item) => [item.outcome, item.route_kind, item.requests, rel(item.latest_seen_at)], 4);
-  rows("callers", data.users, (item) => [item.github_login, item.requests, item.errors, Math.round(item.avg_duration_ms || 0), rel(item.last_seen)]);
-  rows("clients", data.clients, (item) => [item.github_login, item.client_name, item.requests, item.saved_github_requests, item.backend_requests, item.errors, rel(item.last_seen)], 7);
-  rows("recent", data.recent, (item) => [rel(item.created_at), item.github_login, item.client_name || "legacy", item.route_kind, statusPill(item.status, item.fallback_reason || item.error_code), item.identity_id || "none"], 6);
+  rows("cache-routes", data.cache.routes, (item) => [item.route_kind, fmt(item.fresh_entries), fmt(item.entries), rel(item.latest_created_at)]);
+  rows("error-codes", data.error_codes_7d, (item) => [item.outcome, item.route_kind, fmt(item.requests), rel(item.latest_seen_at)]);
+  rows("route-usage", data.route_usage, (item) => [item.route_kind, fmt(item.requests), pct(item.eligible_cache_hit_rate), fmt(item.coalesced), fmt(item.fallbacks), fmt(item.service_errors)]);
+  rows("route-keys", data.route_keys_7d, (item) => [item.route_key, fmt(item.requests), fmt(item.cache_hits), fmt(item.cache_misses), fmt(item.coalesced), fmt(item.fallbacks), rel(item.latest_seen_at)]);
+  rows("callers", data.users, (item) => [item.github_login, fmt(item.requests), fmt(item.errors), fmt(Math.round(item.avg_duration_ms || 0)), rel(item.last_seen)]);
+  rows("clients", data.clients, (item) => [item.github_login, item.client_name, fmt(item.requests), fmt(item.saved_github_requests), fmt(item.backend_requests), fmt(item.errors), rel(item.last_seen)]);
+  rows("recent", data.recent, (item) => [rel(item.created_at), item.github_login, item.client_name || "legacy", item.route_kind, statusPill(item.status, item.fallback_reason || item.error_code), item.identity_id || "none"]);
 }
 
 function renderRates(data) {
@@ -246,9 +265,9 @@ function renderRates(data) {
   }
   for (const rate of data.coordinator.rates) {
     const identity = identities.get(rate.identity_id);
-    const label = (identity ? identity.login : rate.identity_id) + " · " + rate.resource;
-    const row = el("div", "", "bar");
-    row.append(el("div", label), meter(ratePercent(rate)), el("div", fmt(rate.remaining)));
+    const label = (identity ? identity.login : rate.identity_id) + " / " + rate.resource;
+    const row = el("div", "", "gauge");
+    row.append(el("div", label, "glabel"), meter(ratePercent(rate)), el("div", fmt(rate.remaining), "gval"));
     target.append(row);
   }
 }
@@ -259,38 +278,45 @@ function ratePercent(rate) {
   return Math.max(0, Math.min(100, (Number(rate.remaining || 0) / limit) * 100));
 }
 
-function rows(id, items, map, columns = 5) {
+function rows(id, items, map) {
   const body = $(id);
+  const ths = body.closest("table").tHead.rows[0].cells;
   body.replaceChildren();
   if (!items.length) {
     const tr = document.createElement("tr");
     const td = document.createElement("td");
-    td.colSpan = columns;
-    td.append(el("div", "No data yet.", "empty"));
+    td.colSpan = ths.length;
+    td.className = "empty";
+    td.textContent = "No data yet.";
     tr.append(td);
     body.append(tr);
     return;
   }
   for (const item of items) {
     const tr = document.createElement("tr");
-    for (const value of map(item)) {
+    map(item).forEach((value, index) => {
       const td = document.createElement("td");
+      td.className = ths[index] ? ths[index].className : "";
       if (value instanceof Node) td.append(value);
-      else td.textContent = String(value ?? "");
+      else {
+        const text = String(value ?? "");
+        td.textContent = text;
+        if (text.length > 26) td.title = text;
+      }
       tr.append(td);
-    }
+    });
     body.append(tr);
   }
 }
 
 function tile(label, value, detail, tone) {
-  const node = el("div", "", "tile" + (tone ? " " + tone : ""));
+  const node = el("div", "", "figure" + (tone ? " " + tone : ""));
   node.append(el("span", label), el("b", value), el("small", detail));
   return node;
 }
 function meter(pct) {
   const m = el("div", "", "meter");
-  const f = el("div", "", "fill");
+  const f = el("div", "", "fill" + (pct < 12 ? " hot" : pct < 30 ? " warn" : ""));
   f.style.width = pct + "%";
   m.append(f);
   return m;
@@ -302,11 +328,9 @@ function statusPill(status, title) {
   return node;
 }
 function resetDashboard() {
-  const avatar = el("div", "--", "avatar");
-  avatar.setAttribute("aria-hidden", "true");
-  const whoCopy = el("div", "", "who-copy");
-  whoCopy.append(el("strong", "Not loaded"), el("span", "Use your GitHub web login."));
-  $("who").replaceChildren(avatar, whoCopy);
+  const who = $("who");
+  who.classList.remove("on");
+  who.replaceChildren(el("span", "", "beacon"), el("strong", "Not loaded"), el("span", "Use your GitHub web login.", "wire-note"));
   $("tiles").replaceChildren();
   $("rates").replaceChildren();
   $("rate-count").textContent = "";

--- a/test/dashboard.test.ts
+++ b/test/dashboard.test.ts
@@ -2,11 +2,10 @@ import { describe, expect, it } from "vitest";
 import { dashboardResponse } from "../src/dashboard";
 
 describe("dashboard page", () => {
-  it("separates the account footer from tablet-sized pool controls", async () => {
+  it("sizes table empty states from the table header instead of hardcoded column counts", async () => {
     const html = await dashboardResponse().text();
-    expect(html).toContain(
-      ".who{margin-top:14px;padding:14px 0 0;border-top:1px solid var(--line-soft);border-left:0}",
-    );
+    expect(html).toContain('const ths = body.closest("table").tHead.rows[0].cells;');
+    expect(html).toContain("td.colSpan = ths.length;");
   });
 
   it("uses website session auth instead of browser-stored admin tokens", async () => {
@@ -18,8 +17,8 @@ describe("dashboard page", () => {
     expect(html).toContain('credentials: "same-origin"');
     expect(html).toContain('aria-live="polite"');
     expect(html).toContain("Eligible cache hit");
-    expect(html).toContain("Request Patterns");
-    expect(html).toContain("Fallback & Failure Causes");
+    expect(html).toContain("Request patterns");
+    expect(html).toContain("Fallback &amp; failure causes");
     expect(html).toContain("function ratePercent(rate)");
     expect(html).not.toContain("rate.remaining / 50");
     expect(html).not.toContain("OCTOPOOL_ADMIN_TOKEN");


### PR DESCRIPTION
## Summary

Complete visual redesign of the operator dashboard. The old page was a generic glassy-panel dashboard: gradient tiles, glowing mint accents, drop shadows, a sticky sidebar. This replaces it with an editorial-ledger aesthetic that gives the app a real typographic point of view and adopts the landing page's red as the single brand accent.

- Instrument Serif display type for the page title, section headings, and key figures; IBM Plex Mono for all data.
- Panels and cards replaced with hairline-ruled sections carrying red index numbers (01-08); the five key figures sit in one ruled band.
- Identity rate meters are now thin gauges with 25% tick marks that turn amber below 30% and red below 12% remaining headroom, so a nearly exhausted identity is visible at a glance.
- Numeric table columns are right-aligned with tabular numerals; cache-by-route and failure-causes share a two-column row on wide screens.
- The row renderer derives empty-state colspans and per-column alignment from the actual table header instead of hardcoded counts, removing a "added a column, forgot the number" bug class. The test suite now pins that behavior.

Data wiring, session/auth flow, error handling, and the `/v1/dashboard` contract are unchanged.

## Before / After

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/openclaw/octopool/b3253b669ce971a1a3d593c9233392648fc57de7/before.jpg) | ![after](https://raw.githubusercontent.com/openclaw/octopool/b3253b669ce971a1a3d593c9233392648fc57de7/after.jpg) |

Screenshots use mock data; also verified responsive at 900px and 375px widths.

## Proof

- Codex autoreview (Sol, high): clean, no accepted findings.
- `pnpm test` 214 passed, `pnpm test:e2e` 78 passed, `pnpm lint`, `pnpm format:check`, `pnpm build` all green.
