### PR TITLE
fix: paged gh api bursts dead-end on internal_error when D1 is overloaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.5.6 - Unreleased
 
+### Fixes
+
+- Report Cloudflare backend overload (D1/Durable Object request queues backing up) as typed `relay_overloaded` — `424 fallback_local` on the relay so the shim backs off and delegates to real `gh` — instead of an untyped `internal_error` 500 that dead-ended paged `gh api` bursts.
+
 ### Changes
 
 - Redesign the operator dashboard as an editorial ledger: serif display type, hairline-rule sections, tick-marked rate gauges with low-headroom coloring, and right-aligned tabular numerals.

--- a/cmd/octopool/gh_relay.go
+++ b/cmd/octopool/gh_relay.go
@@ -63,7 +63,7 @@ var relayRetryDelays = []time.Duration{time.Second, 3 * time.Second}
 func transientFallbackReason(reason string) bool {
 	switch reason {
 	case "identities_cooling_down", "identity_pool_depleted",
-		"github_identity_depleted", "github_rate_limited":
+		"github_identity_depleted", "github_rate_limited", "relay_overloaded":
 		return true
 	default:
 		return false

--- a/cmd/octopool/gh_relay_client_test.go
+++ b/cmd/octopool/gh_relay_client_test.go
@@ -140,3 +140,17 @@ type discardWriter struct{}
 func (discardWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
+
+func TestTransientFallbackReasons(t *testing.T) {
+	for _, reason := range []string{
+		"identities_cooling_down", "identity_pool_depleted",
+		"github_identity_depleted", "github_rate_limited", "relay_overloaded",
+	} {
+		if !transientFallbackReason(reason) {
+			t.Fatalf("%s should retry before local fallback", reason)
+		}
+	}
+	if transientFallbackReason("route_denied") {
+		t.Fatal("route_denied must not retry; it always resolves locally")
+	}
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -328,7 +328,8 @@ These are dev/CI escape hatches, not the everyday UX:
   `fallback_local`, useful for proving relay/cache coverage.
 - `OCTOPOOL_RELAY_RETRIES` — how many times transient pool-exhaustion fallbacks
   (`identities_cooling_down`, `identity_pool_depleted`, `github_identity_depleted`,
-  `github_rate_limited`) are retried against the relay (1s, then 3s backoff) before the CLI
+  `github_rate_limited`, `relay_overloaded`) are retried against the relay (1s, then 3s
+  backoff) before the CLI
   falls back to real `gh`. Default `2`; `0` disables retries.
 - `OCTOPOOL_ADMIN_TOKEN` — admin token for `octopool admin`.
 - `OCTOPOOL_ALLOW_INSECURE_LOGIN=1` — permit non-HTTPS login for local dev.

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -261,6 +261,11 @@ direct-fetch bypass.
   `type:issue|pr` / `state:open|closed`; repository search accepts plain terms only. Invalid
   queries return `424 fallback_local` with reason `search_denied`.
 
+When a Cloudflare backend (D1 or the pool Durable Object) rejects work because its
+request queue backed up, the relay returns `424 fallback_local` with reason
+`relay_overloaded` (other surfaces report `503 relay_overloaded`) instead of an untyped
+`internal_error`, so the shim can back off and delegate to real `gh`.
+
 Every repo route additionally passes a public-visibility check before a pooled identity
 or cache entry is used — see [Cache & public-repo guard](cache.md).
 The complete list of relay paths eligible for anonymous API or public web/raw/Git

--- a/src/http.ts
+++ b/src/http.ts
@@ -22,7 +22,25 @@ export function jsonResponse(body: unknown, status = 200, headers?: HeadersInit)
   });
 }
 
+// D1 and Durable Objects throw untyped Errors when their request queues back up
+// ("D1 DB is overloaded. Requests queued for too long."). Without this mapping the
+// worker boundary reports internal_error 500, which callers cannot distinguish
+// from a bug and therefore never retry or fall back on.
+export function backendOverloadedError(error: unknown): HttpError | undefined {
+  if (error instanceof HttpError || !(error instanceof Error)) {
+    return undefined;
+  }
+  if (!/is overloaded|queued for too long/i.test(error.message)) {
+    return undefined;
+  }
+  return new HttpError(503, "relay_overloaded", "Octopool backend is overloaded; retry shortly");
+}
+
 export function errorResponse(error: unknown, requestId?: string): Response {
+  const overloaded = backendOverloadedError(error);
+  if (overloaded !== undefined) {
+    error = overloaded;
+  }
   if (error instanceof HttpError) {
     return jsonResponse(
       {

--- a/src/local-fallback.ts
+++ b/src/local-fallback.ts
@@ -1,12 +1,13 @@
 import type { GitHubRate } from "./github-rate";
-import { HttpError } from "./http";
+import { backendOverloadedError, HttpError } from "./http";
 
 export function localFallbackError(error: unknown): HttpError | undefined {
-  if (!(error instanceof HttpError) || !localFallbackReasons.has(error.code)) {
+  const typed = error instanceof HttpError ? error : backendOverloadedError(error);
+  if (typed === undefined || !localFallbackReasons.has(typed.code)) {
     return undefined;
   }
   return new HttpError(424, "fallback_local", "Run this request with local GitHub credentials", {
-    reason: error.code,
+    reason: typed.code,
   });
 }
 
@@ -34,6 +35,7 @@ const localFallbackReasons = new Set([
   "logs_denied",
   "no_identity",
   "owner_denied",
+  "relay_overloaded",
   "repo_not_public",
   "repo_public_check_failed",
   "route_denied",

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -118,6 +118,22 @@ export async function relayGitHub(
   ctx: ExecutionContext,
   requestId: string,
 ): Promise<Response> {
+  try {
+    return await relayGitHubRequest(request, env, ctx, requestId);
+  } catch (error) {
+    // Backend overload can strike before handleRelayError owns the request
+    // (auth/policy D1 reads) or inside its stale-cache reads; the shim must
+    // still see typed fallback_local instead of a dead-end internal_error.
+    throw localFallbackError(error) ?? error;
+  }
+}
+
+async function relayGitHubRequest(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+  requestId: string,
+): Promise<Response> {
   const started = Date.now();
   const body = await parseJsonObject(request);
   const relayRequest = validateRelayRequest(body);

--- a/test/local-fallback.test.ts
+++ b/test/local-fallback.test.ts
@@ -11,6 +11,21 @@ describe("local gh fallback signal", () => {
     expect(fallback?.details).toMatchObject({ reason: "route_denied" });
   });
 
+  it("converts backend overload errors into a typed retryable fallback", () => {
+    const fallback = localFallbackError(
+      new Error("D1_ERROR: D1 DB is overloaded. Requests queued for too long."),
+    );
+
+    expect(fallback?.status).toBe(424);
+    expect(fallback?.code).toBe("fallback_local");
+    expect(fallback?.details).toMatchObject({ reason: "relay_overloaded" });
+
+    expect(localFallbackError(new Error("Durable Object is overloaded"))?.details).toMatchObject({
+      reason: "relay_overloaded",
+    });
+    expect(localFallbackError(new Error("TypeError: fetch failed"))).toBeUndefined();
+  });
+
   it("does not hide auth or malformed-request failures behind local fallback", () => {
     expect(localFallbackError(new HttpError(401, "missing_auth", "Missing bearer token"))).toBe(
       undefined,

--- a/test/web-routing.test.ts
+++ b/test/web-routing.test.ts
@@ -123,6 +123,18 @@ describe("web routing helpers", () => {
     expect(shouldUseWebError(request)).toBe(false);
   });
 
+  it("reports backend overload as a typed retryable error, not internal_error", async () => {
+    const response = errorResponse(
+      new Error("D1_ERROR: D1 DB is overloaded. Requests queued for too long."),
+      "req-overload",
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "relay_overloaded", request_id: "req-overload" },
+    });
+  });
+
   it("includes safe error details in API error responses", async () => {
     const response = errorResponse(
       new HttpError(401, "github_auth_failed", "GitHub token check failed with 403", {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a burst of sequential paged reads through the shim (observed with `gh api "repos/openclaw/openclaw/actions/runs?head_sha=...&per_page=30&page=N"` on 2026-08-08 ~23:00-23:40 PT) would succeed for the first pages and then fail with `{"error":{"code":"internal_error"}}` for **every** subsequent request for minutes. This repeatedly broke openclaw's `scripts/pr prepare-run` hosted-gates verification, which pages that endpoint, and forced manual real-gh fallbacks.

## Why This Change Was Made

Live `wrangler tail` during a reproduction showed the real failure: Cloudflare D1 throws an untyped `Error: D1_ERROR: D1 DB is overloaded. Requests queued for too long.` from the relay's D1 reads/writes (each `run_list` page caches a ~270KB-1.3MB body into a single D1 primary). The raw error escaped `handleRelayError` (which only types `HttpError`s) and the worker boundary reported it as `internal_error` 500 — which the CLI treats as a hard failure, not a fallback. The strings `pagination_exhausted` / `identity_pool_depleted` in the binary were red herrings; those paths were already typed.

The fix maps D1/Durable Object queue-overload errors to a typed `503 relay_overloaded` at the worker error boundary, translates it to the existing `424 fallback_local` contract (reason `relay_overloaded`) on the relay path — including auth/policy D1 reads that run before `handleRelayError` owns the request — and adds `relay_overloaded` to the shim's transient-reason list so it backs off (1s, 3s) and then delegates to real `gh`. Already-deployed CLIs get the local fallback for free because `parseLocalFallback` accepts any reason string.

## User Impact

Paged `gh api` bursts through the shim no longer dead-end on `internal_error` during D1 overload: the CLI backs off, retries against the relay (often landing on the now-filled cache), and otherwise falls back to the caller's local `gh` transparently. Non-relay surfaces (stats, dashboard data) report a typed retryable `503 relay_overloaded` instead of a 500.

## Evidence

- Reproduced live before the fix: pages 1-3 of the head_sha-filtered runs list succeeded, pages 4-8 all returned `internal_error` (request_ids `65191181-...`, `95d78392-...`, `beed8616-...`, `fac10c52-...`, `e0052e07-...`).
- `wrangler tail` captured the uncaught exception for those exact requests: `EXC: Error - D1_ERROR: D1 DB is overloaded. Requests queued for too long.` plus a caught `github cache write failed` with the same error. A concurrent `wrangler d1 execute` console query failed with the same overload code (7429), confirming the D1-side queue backup.
- No audit rows exist for the failing request_ids — the exception escaped before audit insertion, matching the untyped-path diagnosis.
- `pnpm test` (25 files, 216 tests), `go test ./...`, `go vet ./...`, `pnpm build` (tsc src+test), `pnpm lint`, `pnpm format:check` all green; new unit tests cover the overload classifier, the fallback translation, the 503 error response, and the shim's transient-reason list.

Follow-up (not in this PR): reduce the D1 write pressure itself — `run_list`/`run_jobs`/`commit_check_runs` cache rows average 70KB-270KB (max 1.3MB) into a single D1 primary; bounding D1-cached body size (edge-cache-only above a threshold) or D1 read replication would shrink the overload window.
