### PR TITLE
fix: gh reads fail on transient relay errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Keep megabyte-class response bodies (paged run lists, check-run sweeps) out of the shared D1 cache — they stay per-colo edge-cached — so write bursts no longer queue the D1 primary into "overloaded" failures.
 - Report Cloudflare backend overload (D1/Durable Object request queues backing up) as typed `relay_overloaded` — `424 fallback_local` on the relay so the shim backs off and delegates to real `gh` — instead of an untyped `internal_error` 500 that dead-ended paged `gh api` bursts.
+- Retry transient relay `internal_error` and malformed 502/503/504 responses without falling back to local GitHub quota, preserve correlated request IDs in CLI failures, and log unexpected Worker exceptions safely for diagnosis.
 
 ### Changes
 

--- a/cmd/octopool/api_error.go
+++ b/cmd/octopool/api_error.go
@@ -1,16 +1,55 @@
 package main
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type apiErrorDetails struct {
+	GitHubRateLimitReset     string `json:"github_rate_limit_reset"`
+	GitHubRateLimitRemaining string `json:"github_rate_limit_remaining"`
+	GitHubRateLimitResource  string `json:"github_rate_limit_resource"`
+	GitHubRetryAfter         string `json:"github_retry_after"`
+	FallbackReason           string `json:"reason"`
+}
+
+type apiError struct {
+	Code      string          `json:"code"`
+	Message   string          `json:"message"`
+	RequestID string          `json:"request_id"`
+	Details   apiErrorDetails `json:"details"`
+}
+
 type apiErrorResponse struct {
-	Error struct {
-		Code      string `json:"code"`
-		Message   string `json:"message"`
-		RequestID string `json:"request_id"`
-		Details   struct {
-			GitHubRateLimitReset     string `json:"github_rate_limit_reset"`
-			GitHubRateLimitRemaining string `json:"github_rate_limit_remaining"`
-			GitHubRateLimitResource  string `json:"github_rate_limit_resource"`
-			GitHubRetryAfter         string `json:"github_retry_after"`
-			FallbackReason           string `json:"reason"`
-		} `json:"details"`
-	} `json:"error"`
+	Error apiError `json:"error"`
+}
+
+// relayResponseError is the single decoded representation of a non-2xx relay response.
+type relayResponseError struct {
+	Status int
+	apiError
+}
+
+func parseRelayResponseError(status int, out []byte) *relayResponseError {
+	parsed := apiErrorResponse{}
+	if err := json.Unmarshal(out, &parsed); err != nil || parsed.Error.Code == "" {
+		return &relayResponseError{Status: status}
+	}
+	return &relayResponseError{Status: status, apiError: parsed.Error}
+}
+
+func (err *relayResponseError) Error() string {
+	label := fmt.Sprintf("octopool request failed (HTTP %d", err.Status)
+	if err.Code != "" {
+		label += ", " + err.Code
+	}
+	label += ")"
+	detail := err.Message
+	if detail == "" {
+		detail = "malformed relay error response"
+	}
+	if err.RequestID != "" {
+		return fmt.Sprintf("%s: %s (request_id: %s)", label, detail, err.RequestID)
+	}
+	return label + ": " + detail
 }

--- a/cmd/octopool/gh_fallback.go
+++ b/cmd/octopool/gh_fallback.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -33,32 +32,22 @@ func shouldRunRealGH(err error) bool {
 	return isLocalFallback(err) || errors.Is(err, errOctopoolNotLoggedIn)
 }
 
-func parseLocalFallback(out []byte) (localFallbackError, bool) {
-	var response apiErrorResponse
-	if err := json.Unmarshal(out, &response); err != nil {
-		return localFallbackError{}, false
-	}
-	if response.Error.Code != "fallback_local" {
-		return localFallbackError{}, false
-	}
-	reason := response.Error.Details.FallbackReason
-	if reason == "" {
-		reason = response.Error.Message
-	}
-	return localFallbackError{Reason: reason}, true
-}
-
-func parseAuthFallback(out []byte) (localFallbackError, bool) {
-	var response apiErrorResponse
-	if err := json.Unmarshal(out, &response); err != nil {
-		return localFallbackError{}, false
-	}
-	switch response.Error.Code {
+func localFallbackFromRelayError(relay *relayResponseError) (localFallbackError, bool) {
+	switch relay.Code {
+	case "fallback_local":
+		return localFallbackError{Reason: relayFallbackReason(relay)}, true
 	case "missing_auth", "invalid_auth":
 		return localFallbackError{Reason: "octopool auth unavailable"}, true
 	default:
 		return localFallbackError{}, false
 	}
+}
+
+func relayFallbackReason(relay *relayResponseError) string {
+	if relay.Details.FallbackReason != "" {
+		return relay.Details.FallbackReason
+	}
+	return relay.Message
 }
 
 func execRealGHAfterLocalFallback(

--- a/cmd/octopool/gh_relay.go
+++ b/cmd/octopool/gh_relay.go
@@ -83,29 +83,52 @@ func relayRetryAttempts() int {
 }
 
 func (client ghRelayClient) do(ctx context.Context, request ghAPIRequest) (relayEnvelope, error) {
+	// All callers construct GET requests; keep writes outside the shared retry path.
+	if request.method != "GET" {
+		return relayEnvelope{}, fmt.Errorf("relay client requires GET, got %q", request.method)
+	}
 	retries := relayRetryAttempts()
 	for attempt := 0; ; attempt++ {
 		envelope, err := client.doOnce(ctx, request)
-		var fallback localFallbackError
-		if err == nil || attempt >= retries ||
-			!errors.As(err, &fallback) || !transientFallbackReason(fallback.Reason) {
+		if err == nil {
 			return envelope, err
 		}
-		delay := relayRetryDelays[min(attempt, len(relayRetryDelays)-1)]
-		if !sleepContext(ctx, delay) {
-			return envelope, err
+		if attempt < retries && transientRelayFailure(err) {
+			delay := relayRetryDelays[min(attempt, len(relayRetryDelays)-1)]
+			if err := sleepContext(ctx, delay); err != nil {
+				return envelope, err
+			}
+			continue
 		}
+		var relay *relayResponseError
+		if errors.As(err, &relay) {
+			if fallback, ok := localFallbackFromRelayError(relay); ok {
+				return envelope, fallback
+			}
+		}
+		return envelope, err
 	}
 }
 
-func sleepContext(ctx context.Context, delay time.Duration) bool {
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
+func transientRelayFailure(err error) bool {
+	var relay *relayResponseError
+	if !errors.As(err, &relay) {
 		return false
-	case <-timer.C:
+	}
+	if relay.Code == "fallback_local" {
+		return transientFallbackReason(relayFallbackReason(relay))
+	}
+	if relay.Status < 500 || relay.Status > 599 {
+		return false
+	}
+	if relay.Code != "" {
+		return relay.Code == "internal_error"
+	}
+	switch relay.Status {
+	case 502, 503, 504:
 		return true
+	default:
+		return false
 	}
 }
 
@@ -128,14 +151,8 @@ func (client ghRelayClient) doOnce(ctx context.Context, request ghAPIRequest) (r
 	if err != nil {
 		return relayEnvelope{}, err
 	}
-	if status >= 400 {
-		if fallback, ok := parseAuthFallback(out); ok {
-			return relayEnvelope{}, fallback
-		}
-		if fallback, ok := parseLocalFallback(out); ok {
-			return relayEnvelope{}, fallback
-		}
-		return relayEnvelope{}, fmt.Errorf("octopool request failed: %s", strings.TrimSpace(string(out)))
+	if status < 200 || status >= 300 {
+		return relayEnvelope{}, parseRelayResponseError(status, out)
 	}
 	var envelope relayEnvelope
 	if err := json.Unmarshal(out, &envelope); err != nil {

--- a/cmd/octopool/gh_relay_client_test.go
+++ b/cmd/octopool/gh_relay_client_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -17,7 +19,8 @@ func TestWriteGHBodyAllowsNullTextBody(t *testing.T) {
 }
 
 func TestParseLocalFallback(t *testing.T) {
-	err, ok := parseLocalFallback([]byte(`{"error":{"code":"fallback_local","message":"Run locally","details":{"reason":"route_denied"}}}`))
+	relay := parseRelayResponseError(http.StatusFailedDependency, []byte(`{"error":{"code":"fallback_local","message":"Run locally","details":{"reason":"route_denied"}}}`))
+	err, ok := localFallbackFromRelayError(relay)
 	if !ok {
 		t.Fatal("expected fallback")
 	}
@@ -26,59 +29,179 @@ func TestParseLocalFallback(t *testing.T) {
 	}
 }
 
-func TestGHRelayClientInvalidAuthUsesLocalFallback(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte(`{"error":{"code":"invalid_auth","message":"Invalid caller token"}}`))
-	}))
-	t.Cleanup(server.Close)
+func TestParseRelayResponseErrorRedactsMalformedBody(t *testing.T) {
+	relay := parseRelayResponseError(http.StatusBadGateway, []byte("secret upstream response"))
+	if relay.Status != http.StatusBadGateway || relay.Code != "" {
+		t.Fatalf("relay error = %#v", relay)
+	}
+	if got := relay.Error(); got != "octopool request failed (HTTP 502): malformed relay error response" {
+		t.Fatalf("error = %q", got)
+	}
+}
 
-	client := ghRelayClient{token: "stale", baseURL: server.URL, pool: "maintainers"}
+func TestRelayRetryAttempts(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		raw  string
+		want int
+	}{
+		{name: "default", want: len(relayRetryDelays)},
+		{name: "zero", raw: "0", want: 0},
+		{name: "larger than schedule", raw: "5", want: 5},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OCTOPOOL_RELAY_RETRIES", test.raw)
+			if got := relayRetryAttempts(); got != test.want {
+				t.Fatalf("relayRetryAttempts() = %d, want %d", got, test.want)
+			}
+		})
+	}
+}
+
+func TestGHRelayClientInvalidAuthUsesLocalFallback(t *testing.T) {
+	client, calls := newRelayTestClient(t, func(int64) (int, string) {
+		return http.StatusUnauthorized, `{"error":{"code":"invalid_auth","message":"Invalid caller token"}}`
+	})
 	_, err := client.do(t.Context(), ghAPIRequest{method: "GET", path: "/repos/openclaw/openclaw"})
 	if !isLocalFallback(err) {
 		t.Fatalf("expected local fallback, got %v", err)
 	}
-}
-
-func TestGHRelayClientRetriesTransientFallback(t *testing.T) {
-	restoreDelays := relayRetryDelays
-	relayRetryDelays = []time.Duration{time.Millisecond, time.Millisecond}
-	t.Cleanup(func() { relayRetryDelays = restoreDelays })
-
-	var calls atomic.Int64
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		if calls.Add(1) < 3 {
-			w.WriteHeader(http.StatusFailedDependency)
-			_, _ = w.Write([]byte(`{"error":{"code":"fallback_local","message":"Run locally","details":{"reason":"identities_cooling_down"}}}`))
-			return
-		}
-		_, _ = w.Write([]byte(`{"status":200,"body":{"ok":true},"body_encoding":"json"}`))
-	}))
-	t.Cleanup(server.Close)
-
-	client := ghRelayClient{token: "token", baseURL: server.URL, pool: "maintainers"}
-	envelope, err := client.do(t.Context(), ghAPIRequest{method: "GET", path: "/repos/openclaw/openclaw"})
-	if err != nil {
-		t.Fatalf("expected retry success, got %v", err)
-	}
-	if envelope.Status != 200 {
-		t.Fatalf("status = %d", envelope.Status)
-	}
-	if got := calls.Load(); got != 3 {
+	if got := calls.Load(); got != 1 {
 		t.Fatalf("calls = %d", got)
 	}
 }
 
-func TestGHRelayClientDoesNotRetryStructuralFallback(t *testing.T) {
-	var calls atomic.Int64
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		calls.Add(1)
-		w.WriteHeader(http.StatusFailedDependency)
-		_, _ = w.Write([]byte(`{"error":{"code":"fallback_local","message":"Run locally","details":{"reason":"route_denied"}}}`))
-	}))
-	t.Cleanup(server.Close)
+func TestGHRelayClientRetriesTransientFailuresThenSucceeds(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		failures int64
+		status   int
+		body     string
+	}{
+		{
+			name:     "transient fallback",
+			failures: 2,
+			status:   http.StatusFailedDependency,
+			body:     `{"error":{"code":"fallback_local","message":"Run locally","details":{"reason":"identities_cooling_down"}}}`,
+		},
+		{
+			name:     "typed internal_error",
+			failures: 2,
+			status:   http.StatusInternalServerError,
+			body:     `{"error":{"code":"internal_error","message":"Internal error","request_id":"transient-request"}}`,
+		},
+		{
+			name:     "malformed 502",
+			failures: 1,
+			status:   http.StatusBadGateway,
+			body:     "malformed gateway response",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OCTOPOOL_RELAY_RETRIES", "")
+			useTestRelayRetryDelays(t, time.Millisecond, time.Millisecond)
+			client, calls := newRelayTestClient(t, func(call int64) (int, string) {
+				if call <= test.failures {
+					return test.status, test.body
+				}
+				return http.StatusOK, `{"status":200,"body":{"ok":true},"body_encoding":"json"}`
+			})
 
-	client := ghRelayClient{token: "token", baseURL: server.URL, pool: "maintainers"}
+			envelope, err := client.do(t.Context(), ghAPIRequest{method: "GET", path: "/repos/openclaw/octopool"})
+			if err != nil {
+				t.Fatalf("expected retry success, got %v", err)
+			}
+			if envelope.Status != http.StatusOK {
+				t.Fatalf("status = %d", envelope.Status)
+			}
+			if got, want := calls.Load(), test.failures+1; got != want {
+				t.Fatalf("calls = %d, want %d", got, want)
+			}
+		})
+	}
+}
+
+func TestGHRelayClientPersistentInternalErrorExhaustsRetries(t *testing.T) {
+	t.Setenv("OCTOPOOL_RELAY_RETRIES", "4")
+	useTestRelayRetryDelays(t, time.Millisecond)
+	client, calls := newRelayTestClient(t, func(call int64) (int, string) {
+		requestID := "request-" + strconv.FormatInt(call, 10)
+		return http.StatusInternalServerError, `{"error":{"code":"internal_error","message":"Internal error","request_id":"` + requestID + `"}}`
+	})
+
+	_, err := client.do(t.Context(), ghAPIRequest{method: "GET", path: "/repos/openclaw/octopool"})
+	var relay *relayResponseError
+	if !errors.As(err, &relay) {
+		t.Fatalf("expected typed relay error, got %v", err)
+	}
+	if relay.Status != http.StatusInternalServerError || relay.Code != "internal_error" || relay.RequestID != "request-5" {
+		t.Fatalf("relay error = %#v", relay)
+	}
+	if got := calls.Load(); got != 5 {
+		t.Fatalf("calls = %d", got)
+	}
+	if got := err.Error(); got != "octopool request failed (HTTP 500, internal_error): Internal error (request_id: request-5)" {
+		t.Fatalf("error = %q", got)
+	}
+	if shouldRunRealGH(err) {
+		t.Fatal("exhausted relay service error must not fall back to real gh")
+	}
+}
+
+func TestTransientRelayFailure(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "typed internal 500", err: &relayResponseError{Status: http.StatusInternalServerError, apiError: apiError{Code: "internal_error"}}, want: true},
+		{name: "typed internal 400", err: &relayResponseError{Status: http.StatusBadRequest, apiError: apiError{Code: "internal_error"}}},
+		{name: "typed config 503", err: &relayResponseError{Status: http.StatusServiceUnavailable, apiError: apiError{Code: "admin_unconfigured"}}},
+		{name: "malformed 502", err: &relayResponseError{Status: http.StatusBadGateway}, want: true},
+		{name: "malformed 503", err: &relayResponseError{Status: http.StatusServiceUnavailable}, want: true},
+		{name: "malformed 504", err: &relayResponseError{Status: http.StatusGatewayTimeout}, want: true},
+		{name: "malformed 500", err: &relayResponseError{Status: http.StatusInternalServerError}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := transientRelayFailure(test.err); got != test.want {
+				t.Fatalf("transientRelayFailure() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestGHRelayClientCancellationInterruptsRetryBackoff(t *testing.T) {
+	useTestRelayRetryDelays(t, time.Minute)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	client, calls := newRelayTestClient(t, func(int64) (int, string) {
+		time.AfterFunc(20*time.Millisecond, cancel)
+		return http.StatusInternalServerError, `{"error":{"code":"internal_error","message":"Internal error","request_id":"cancel-request"}}`
+	})
+
+	_, err := client.do(ctx, ghAPIRequest{method: "GET", path: "/repos/openclaw/octopool"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("calls = %d", got)
+	}
+}
+
+func TestGHRelayClientRejectsNonGETRequest(t *testing.T) {
+	client := ghRelayClient{token: "token", baseURL: "http://127.0.0.1", pool: "maintainers"}
+	_, err := client.do(t.Context(), ghAPIRequest{method: "POST", path: "/repos/openclaw/octopool"})
+	if err == nil || err.Error() != `relay client requires GET, got "POST"` {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestGHRelayClientDoesNotRetryStructuralFallback(t *testing.T) {
+	client, calls := newRelayTestClient(t, func(int64) (int, string) {
+		return http.StatusFailedDependency, `{"error":{"code":"fallback_local","message":"Run locally","details":{"reason":"route_denied"}}}`
+	})
+
 	_, err := client.do(t.Context(), ghAPIRequest{method: "GET", path: "/repos/openclaw/openclaw"})
 	if !isLocalFallback(err) {
 		t.Fatalf("expected local fallback, got %v", err)
@@ -90,15 +213,10 @@ func TestGHRelayClientDoesNotRetryStructuralFallback(t *testing.T) {
 
 func TestGHRelayClientRetriesDisabledByEnv(t *testing.T) {
 	t.Setenv("OCTOPOOL_RELAY_RETRIES", "0")
-	var calls atomic.Int64
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		calls.Add(1)
-		w.WriteHeader(http.StatusFailedDependency)
-		_, _ = w.Write([]byte(`{"error":{"code":"fallback_local","message":"Run locally","details":{"reason":"identities_cooling_down"}}}`))
-	}))
-	t.Cleanup(server.Close)
+	client, calls := newRelayTestClient(t, func(int64) (int, string) {
+		return http.StatusFailedDependency, `{"error":{"code":"fallback_local","message":"Run locally","details":{"reason":"identities_cooling_down"}}}`
+	})
 
-	client := ghRelayClient{token: "token", baseURL: server.URL, pool: "maintainers"}
 	_, err := client.do(t.Context(), ghAPIRequest{method: "GET", path: "/repos/openclaw/openclaw"})
 	if !isLocalFallback(err) {
 		t.Fatalf("expected local fallback, got %v", err)
@@ -153,4 +271,26 @@ func TestTransientFallbackReasons(t *testing.T) {
 	if transientFallbackReason("route_denied") {
 		t.Fatal("route_denied must not retry; it always resolves locally")
 	}
+}
+
+func useTestRelayRetryDelays(t *testing.T, delays ...time.Duration) {
+	t.Helper()
+	restore := relayRetryDelays
+	relayRetryDelays = delays
+	t.Cleanup(func() { relayRetryDelays = restore })
+}
+
+func newRelayTestClient(
+	t *testing.T,
+	respond func(call int64) (status int, body string),
+) (ghRelayClient, *atomic.Int64) {
+	t.Helper()
+	calls := &atomic.Int64{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		status, body := respond(calls.Add(1))
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+	return ghRelayClient{token: "token", baseURL: server.URL, pool: "maintainers"}, calls
 }

--- a/cmd/octopool/gh_top_watch.go
+++ b/cmd/octopool/gh_top_watch.go
@@ -71,6 +71,12 @@ func retryWatchTick(ctx context.Context, backoff *watchBackoff, poll func() erro
 		if shouldRunRealGH(err) {
 			return err
 		}
+		// The relay client already exhausted its typed response retry policy.
+		// Watch retries remain for transport, parse, and operation-level failures.
+		var relay *relayResponseError
+		if errors.As(err, &relay) {
+			return err
+		}
 		if attempt+1 < watchMaxErrors {
 			if sleepErr := backoff.sleep(ctx); sleepErr != nil {
 				return sleepErr

--- a/cmd/octopool/gh_top_watch.go
+++ b/cmd/octopool/gh_top_watch.go
@@ -17,7 +17,7 @@ const (
 	watchMaxErrors   = 3
 )
 
-var watchSleep = func(ctx context.Context, duration time.Duration) error {
+var sleepContext = func(ctx context.Context, duration time.Duration) error {
 	timer := time.NewTimer(duration)
 	defer timer.Stop()
 	select {
@@ -53,7 +53,7 @@ func newWatchBackoff(requested time.Duration) watchBackoff {
 }
 
 func (backoff *watchBackoff) sleep(ctx context.Context) error {
-	if err := watchSleep(ctx, backoff.current); err != nil {
+	if err := sleepContext(ctx, backoff.current); err != nil {
 		return err
 	}
 	backoff.current = min(backoff.current*2, backoff.limit)

--- a/cmd/octopool/gh_top_watch_test.go
+++ b/cmd/octopool/gh_top_watch_test.go
@@ -651,13 +651,13 @@ func TestWatchFallbackOnlyBeforeProgress(t *testing.T) {
 
 func recordWatchSleeps(t *testing.T) *[]time.Duration {
 	t.Helper()
-	original := watchSleep
+	original := sleepContext
 	durations := []time.Duration{}
-	watchSleep = func(_ context.Context, duration time.Duration) error {
+	sleepContext = func(_ context.Context, duration time.Duration) error {
 		durations = append(durations, duration)
 		return nil
 	}
-	t.Cleanup(func() { watchSleep = original })
+	t.Cleanup(func() { sleepContext = original })
 	return &durations
 }
 

--- a/cmd/octopool/gh_top_watch_test.go
+++ b/cmd/octopool/gh_top_watch_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"net/http"
 	"reflect"
 	"strings"
 	"testing"
@@ -636,6 +637,26 @@ func TestWatchTickBailsImmediatelyOnDeterministicRefusal(t *testing.T) {
 	}
 	if len(*sleeps) != 0 {
 		t.Fatalf("sleeps=%v, want none before deterministic refusal surfaces", *sleeps)
+	}
+}
+
+func TestWatchTickBailsImmediatelyOnTypedRelayError(t *testing.T) {
+	sleeps := recordWatchSleeps(t)
+	backoff := newWatchBackoff(30 * time.Second)
+	calls := 0
+	want := &relayResponseError{
+		Status:   http.StatusInternalServerError,
+		apiError: apiError{Code: "internal_error", RequestID: "request-final"},
+	}
+	err := retryWatchTick(t.Context(), &backoff, func() error {
+		calls++
+		return want
+	})
+	if err != want || calls != 1 {
+		t.Fatalf("err=%v calls=%d, want final typed relay error once", err, calls)
+	}
+	if len(*sleeps) != 0 {
+		t.Fatalf("sleeps=%v, want none after client retry exhaustion", *sleeps)
 	}
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -328,9 +328,11 @@ These are dev/CI escape hatches, not the everyday UX:
   `fallback_local`, useful for proving relay/cache coverage.
 - `OCTOPOOL_RELAY_RETRIES` — how many times transient pool-exhaustion fallbacks
   (`identities_cooling_down`, `identity_pool_depleted`, `github_identity_depleted`,
-  `github_rate_limited`, `relay_overloaded`) are retried against the relay (1s, then 3s
-  backoff) before the CLI
-  falls back to real `gh`. Default `2`; `0` disables retries.
+  `github_rate_limited`, `relay_overloaded`), relay `5xx internal_error` responses, and
+  malformed 502/503/504 gateway responses are retried against the relay (1s, then 3s for
+  subsequent retries). Exhausted transient fallbacks may delegate to real `gh`; exhausted
+  service errors remain failures instead of spending local GitHub quota. Default `2`; `0`
+  disables retries.
 - `OCTOPOOL_ADMIN_TOKEN` — admin token for `octopool admin`.
 - `OCTOPOOL_ALLOW_INSECURE_LOGIN=1` — permit non-HTTPS login for local dev.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -209,6 +209,9 @@ failures occur before audit context exists. Bodies, credentials, and raw tokens 
   locally without contacting Octopool.
 - Safe requests contact Octopool first and delegate only on explicit `fallback_local` or
   stale/invalid Octopool auth. `OCTOPOOL_NO_FALLBACK` disables delegation.
+- The canonical relay client loop retries selected transient pool fallbacks and
+  `5xx internal_error` responses plus malformed 502/503/504 gateway responses with bounded
+  backoff; exhausted service failures do not delegate to local GitHub quota.
 - Relay envelopes require a known body encoding; upstream status and CLI exit semantics are
   preserved.
 - Bounded pagination delegates instead of returning partial PR details/checks/issue lists.

--- a/src/http.ts
+++ b/src/http.ts
@@ -66,6 +66,49 @@ export function errorResponse(error: unknown, requestId?: string): Response {
   );
 }
 
+const MAX_UNEXPECTED_ERROR_FRAMES = 5;
+const MAX_STACK_SCAN_CHARS = 8_192;
+const STACK_LOCATION = /\.([cm]?[jt]sx?):(\d{1,8}):(\d{1,6})\)?\s*$/;
+
+function safeErrorName(error: Error): string {
+  if (error instanceof TypeError) return "TypeError";
+  if (error instanceof RangeError) return "RangeError";
+  if (error instanceof ReferenceError) return "ReferenceError";
+  if (error instanceof SyntaxError) return "SyntaxError";
+  if (error instanceof URIError) return "URIError";
+  if (error instanceof EvalError) return "EvalError";
+  return "Error";
+}
+
+function safeErrorFrames(error: Error): { extension: string; line: number; column: number }[] {
+  let stack: unknown;
+  try {
+    stack = error.stack;
+  } catch {
+    return [];
+  }
+  if (typeof stack !== "string") {
+    return [];
+  }
+  const frames: { extension: string; line: number; column: number }[] = [];
+  for (const rawLine of stack.slice(0, MAX_STACK_SCAN_CHARS).split("\n")) {
+    const match = STACK_LOCATION.exec(rawLine);
+    if (match?.[1] === undefined || match[2] === undefined || match[3] === undefined) {
+      continue;
+    }
+    const line = Number(match[2]);
+    const column = Number(match[3]);
+    if (line < 1 || column < 1) {
+      continue;
+    }
+    frames.push({ extension: match[1], line, column });
+    if (frames.length === MAX_UNEXPECTED_ERROR_FRAMES) {
+      break;
+    }
+  }
+  return frames;
+}
+
 export function logUnexpectedWorkerError(
   request: Request,
   requestId: string,
@@ -74,21 +117,13 @@ export function logUnexpectedWorkerError(
   if (error instanceof HttpError || backendOverloadedError(error) !== undefined) {
     return;
   }
-  const detail =
-    error instanceof Error
-      ? {
-          name: error.name,
-          // Exception messages can embed request URLs or response bodies. Stack frames retain
-          // actionable source locations without logging the message line.
-          ...(error.stack === undefined
-            ? {}
-            : { stack: error.stack.split("\n").slice(1).join("\n") }),
-        }
-      : {
-          name: "NonErrorThrown",
-          type: typeof error,
-        };
-  // request_id is the safe join key to the existing D1 audit route/client/cache metadata.
+  const frames = error instanceof Error ? safeErrorFrames(error) : [];
+  const detail = {
+    name: error instanceof Error ? safeErrorName(error) : "NonErrorThrown",
+    ...(error instanceof Error ? {} : { type: typeof error }),
+    ...(frames.length === 0 ? {} : { frames }),
+  };
+  // request_id is always client-visible; relay-owned failures also join D1 audit metadata.
   console.error({
     event: "octopool.worker.unexpected_exception",
     code: "internal_error",

--- a/src/http.ts
+++ b/src/http.ts
@@ -66,6 +66,39 @@ export function errorResponse(error: unknown, requestId?: string): Response {
   );
 }
 
+export function logUnexpectedWorkerError(
+  request: Request,
+  requestId: string,
+  error: unknown,
+): void {
+  if (error instanceof HttpError || backendOverloadedError(error) !== undefined) {
+    return;
+  }
+  const detail =
+    error instanceof Error
+      ? {
+          name: error.name,
+          // Exception messages can embed request URLs or response bodies. Stack frames retain
+          // actionable source locations without logging the message line.
+          ...(error.stack === undefined
+            ? {}
+            : { stack: error.stack.split("\n").slice(1).join("\n") }),
+        }
+      : {
+          name: "NonErrorThrown",
+          type: typeof error,
+        };
+  // request_id is the safe join key to the existing D1 audit route/client/cache metadata.
+  console.error({
+    event: "octopool.worker.unexpected_exception",
+    code: "internal_error",
+    request_id: requestId,
+    method: request.method,
+    pathname: new URL(request.url).pathname,
+    error: detail,
+  });
+}
+
 export async function parseJsonObject(request: Request): Promise<JsonObject> {
   const contentType = request.headers.get("content-type") ?? "";
   if (!contentType.includes("application/json")) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { errorResponse } from "./http";
+import { errorResponse, logUnexpectedWorkerError } from "./http";
 import { runScheduledMaintenance } from "./maintenance";
 import { PoolCoordinator } from "./pool-coordinator";
 import { routeRequest } from "./router";
@@ -17,6 +17,7 @@ export default {
     try {
       return secureResponse(request, await routeRequest(request, env, ctx, requestId));
     } catch (error) {
+      logUnexpectedWorkerError(request, requestId, error);
       if (shouldUseWebError(request)) {
         return secureResponse(request, webErrorResponse(error, requestId));
       }

--- a/test/e2e/worker-errors.test.ts
+++ b/test/e2e/worker-errors.test.ts
@@ -9,12 +9,10 @@ describe("Worker error boundary", () => {
     const headerSecret = "header-secret-marker";
     const bodySecret = "body-secret-marker";
     const logged = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    vi.stubGlobal(
-      "fetch",
-      vi
-        .fn<typeof fetch>()
-        .mockRejectedValue(new Error(`failure ${querySecret} ${headerSecret} ${bodySecret}`)),
-    );
+    const failure = new Error(`synthetic failure\n${querySecret}\n${headerSecret}\n${bodySecret}`);
+    failure.name = `CustomError-${querySecret}`;
+    failure.stack = `${failure.stack ?? ""}\n    at ${headerSecret} (/tmp/${bodySecret}.ts:999:7)\n${querySecret}`;
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockRejectedValue(failure));
 
     const response = await callWorker(`/v1/github/request?debug=${querySecret}`, {
       method: "POST",
@@ -38,7 +36,7 @@ describe("Worker error boundary", () => {
       request_id: string;
       method: string;
       pathname: string;
-      error: { name: string; stack?: string };
+      error: { name: string; frames?: { extension: string; line: number; column: number }[] };
     };
     expect(event).toMatchObject({
       event: "octopool.worker.unexpected_exception",
@@ -48,7 +46,12 @@ describe("Worker error boundary", () => {
       error: { name: "Error" },
     });
     expect(event.request_id).toBeTruthy();
-    expect(event.error.stack).toContain("worker-errors.test.ts");
+    expect(event.error.frames?.length).toBeGreaterThan(0);
+    expect(event.error.frames?.[0]).toEqual({
+      extension: "ts",
+      line: expect.any(Number),
+      column: expect.any(Number),
+    });
     const serializedEvent = JSON.stringify(event);
     expect(serializedEvent).not.toContain(querySecret);
     expect(serializedEvent).not.toContain(headerSecret);

--- a/test/e2e/worker-errors.test.ts
+++ b/test/e2e/worker-errors.test.ts
@@ -1,0 +1,84 @@
+import { env } from "cloudflare:workers";
+import { describe, expect, it, vi } from "vitest";
+import { CALLER_TOKEN, callWorker, POOL, seedPool } from "./harness";
+
+describe("Worker error boundary", () => {
+  it("logs one correlated safe diagnostic and keeps unexpected errors redacted", async () => {
+    await seedPool();
+    const querySecret = "query-secret-marker";
+    const headerSecret = "header-secret-marker";
+    const bodySecret = "body-secret-marker";
+    const logged = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn<typeof fetch>()
+        .mockRejectedValue(new Error(`failure ${querySecret} ${headerSecret} ${bodySecret}`)),
+    );
+
+    const response = await callWorker(`/v1/github/request?debug=${querySecret}`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_TOKEN}`,
+        "content-type": "application/json",
+        "x-secret-like": headerSecret,
+      },
+      body: JSON.stringify({
+        pool: POOL,
+        method: "GET",
+        path: "/repos/openclaw/octopool",
+        ignored_secret_marker: bodySecret,
+      }),
+    });
+
+    expect(logged).toHaveBeenCalledTimes(1);
+    const event = logged.mock.calls[0]?.[0] as {
+      event: string;
+      code: string;
+      request_id: string;
+      method: string;
+      pathname: string;
+      error: { name: string; stack?: string };
+    };
+    expect(event).toMatchObject({
+      event: "octopool.worker.unexpected_exception",
+      code: "internal_error",
+      method: "POST",
+      pathname: "/v1/github/request",
+      error: { name: "Error" },
+    });
+    expect(event.request_id).toBeTruthy();
+    expect(event.error.stack).toContain("worker-errors.test.ts");
+    const serializedEvent = JSON.stringify(event);
+    expect(serializedEvent).not.toContain(querySecret);
+    expect(serializedEvent).not.toContain(headerSecret);
+    expect(serializedEvent).not.toContain(bodySecret);
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "internal_error",
+        message: "Internal error",
+        request_id: event.request_id,
+      },
+    });
+    expect(
+      await env.DB.prepare("SELECT status, error_code FROM audit_events WHERE request_id = ?")
+        .bind(event.request_id)
+        .first(),
+    ).toEqual({ status: 500, error_code: "internal_error" });
+  });
+
+  it("does not log expected HttpError responses", async () => {
+    const logged = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const response = await callWorker("/v1/github/request", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ pool: POOL, method: "POST", path: "/user" }),
+    });
+
+    expect(logged).not.toHaveBeenCalled();
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({ error: { code: "method_denied" } });
+  });
+});

--- a/test/web-routing.test.ts
+++ b/test/web-routing.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { discoveryResponse } from "../src/discovery";
 import { PROXY_HOST_HEADER, PROXY_SECRET_HEADER } from "../src/hosts";
-import { errorResponse, HttpError } from "../src/http";
+import { errorResponse, HttpError, logUnexpectedWorkerError } from "../src/http";
 import { rootResponse } from "../src/landing";
 import proxyWorker from "../src/openclaw-proxy";
 import { publicWebHostRedirect } from "../src/web-routing";
@@ -124,10 +124,17 @@ describe("web routing helpers", () => {
   });
 
   it("reports backend overload as a typed retryable error, not internal_error", async () => {
-    const response = errorResponse(
-      new Error("D1_ERROR: D1 DB is overloaded. Requests queued for too long."),
+    const error = new Error("D1_ERROR: D1 DB is overloaded. Requests queued for too long.");
+    const logged = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    logUnexpectedWorkerError(
+      new Request("https://octopool.dev/v1/pools/maintainers/health"),
       "req-overload",
+      error,
     );
+    expect(logged).not.toHaveBeenCalled();
+    logged.mockRestore();
+
+    const response = errorResponse(error, "req-overload");
 
     expect(response.status).toBe(503);
     await expect(response.json()).resolves.toMatchObject({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where safe `gh` reads routed through Octopool could fail immediately on a transient relay `internal_error`, aborting higher-level workflows even when the identical read succeeded moments later. The redacted response included a request ID, but the Worker did not emit a correlated exception diagnostic, making the underlying service failure difficult to investigate.

## Why This Change Was Made

The canonical relay client now parses every non-2xx response into one typed error and owns bounded retry policy for transient pool exhaustion, `internal_error`, and malformed gateway 502/503/504 responses. Exhausted service errors remain failures and never fall back to local GitHub quota. Unexpected Worker exceptions emit one safe structured diagnostic keyed by the same public request ID as the existing audit row, without logging request queries, headers, bodies, credentials, response bodies, or exception message lines.

## User Impact

Maintainer scripts and ordinary cached `gh` reads recover automatically from short Octopool service interruptions. Persistent failures remain explicit, include the final request ID, and can now be traced from the client error to safe Worker logs and audit metadata.

## Evidence

- `pnpm check`
  - 25 unit files / 214 tests passed
  - 12 E2E files / 80 tests passed
  - TypeScript build, Go tests, and `go vet` passed
- Focused Go relay-client suite passed.
- Focused Worker error-boundary suite passed: 2 tests.
- Built-candidate black-box proof:
  - two `500 internal_error` responses followed by `200` produced exactly three relay calls and exited successfully;
  - persistent `internal_error` exhausted three attempts, exposed the final request ID, and did not invoke a sentinel real-`gh` binary;
  - typed non-transient `503` made one relay call and was not retried;
  - an authenticated production read with local fallback disabled returned `openclaw/octopool`.
- Isolated autoreview and added-content secret scan completed with no actionable findings.
