### PR TITLE
perf: paged read bursts overload D1 with megabyte cache rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Keep megabyte-class response bodies (paged run lists, check-run sweeps) out of the shared D1 cache — they stay per-colo edge-cached — so write bursts no longer queue the D1 primary into "overloaded" failures.
 - Report Cloudflare backend overload (D1/Durable Object request queues backing up) as typed `relay_overloaded` — `424 fallback_local` on the relay so the shim backs off and delegates to real `gh` — instead of an untyped `internal_error` 500 that dead-ended paged `gh api` bursts.
 
 ### Changes

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -56,6 +56,12 @@ Only successful `2xx` responses on cacheable routes are stored. The edge + D1 ca
   dedicated R2 cache described below), or
 - the request carries a conditional header (`if-none-match` / `if-modified-since`).
 
+Bodies whose serialized JSON exceeds 256 KiB (paged run lists, check-run sweeps) are
+stored only in the data-center-local edge cache, not in D1: megabyte-class row writes
+were the dominant cause of `D1 DB is overloaded` queueing under paged bursts. Oversized
+entries lose cross-colo sharing and D1 stale fallback but keep the hot same-client
+repoll pattern warm.
+
 Cacheable requests can instead bound acceptable staleness with a
 `cache-control: max-age=N` header. A fresh entry older than `N` seconds is treated as a
 miss and refetched, and the refill writes through to the shared cache, so concurrent

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -15,6 +15,12 @@ import type { GitHubRelayResponse, Identity, RelayRequest, RouteInfo } from "./t
 const TERMINAL_CI_TTL_SECONDS = 3_600;
 const TERMINAL_CI_TTL_DETECTION_SECONDS = 1_800;
 const EDGE_CACHE_NAMESPACE = "github-v1";
+// Megabyte-class bodies (paged run lists, check-run sweeps) are the dominant D1
+// write cost and the trigger for "D1 DB is overloaded" queueing under bursts.
+// The per-colo edge cache still serves the hot same-client repoll pattern, so
+// oversized bodies stay edge-only; they lose cross-colo sharing and D1 stale
+// fallback, which is the accepted tradeoff for keeping the primary responsive.
+const MAX_D1_CACHE_BODY_BYTES = 262_144;
 
 type CacheRow = {
   status: number;
@@ -205,29 +211,35 @@ export async function writeGitHubCache(
     expires_at: expiresAt,
     ...(identity === undefined ? {} : { identity: { id: identity.id, kind: identity.kind } }),
   };
-  await Promise.all([
-    env.DB.prepare(queries.writeGitHubCache)
-      .bind(
-        cacheKey,
-        request.pool,
-        request.method,
-        request.path,
-        JSON.stringify(stableRecord(request.query ?? {})),
-        JSON.stringify(stableRecord(cacheVaryHeaders(request.headers))),
-        route.routeKey,
-        route.kind,
-        response.status,
-        JSON.stringify(response.headers),
-        JSON.stringify(response.body),
-        response.body_encoding ?? "json",
-        identity?.id ?? null,
-        identity?.kind ?? null,
-        expiresAt,
-        staleExpiresAt,
-      )
-      .run(),
-    writeEdgeCachedResponse(cacheKey, cached),
-  ]);
+  const bodyJson = JSON.stringify(response.body);
+  const writes: Promise<unknown>[] = [writeEdgeCachedResponse(cacheKey, cached)];
+  // UTF-8 bytes, not String.length: UTF-16 code units undercount multibyte
+  // content by up to 3x, which would let Unicode-heavy rows past the cap.
+  if (new TextEncoder().encode(bodyJson).byteLength <= MAX_D1_CACHE_BODY_BYTES) {
+    writes.push(
+      env.DB.prepare(queries.writeGitHubCache)
+        .bind(
+          cacheKey,
+          request.pool,
+          request.method,
+          request.path,
+          JSON.stringify(stableRecord(request.query ?? {})),
+          JSON.stringify(stableRecord(cacheVaryHeaders(request.headers))),
+          route.routeKey,
+          route.kind,
+          response.status,
+          JSON.stringify(response.headers),
+          bodyJson,
+          response.body_encoding ?? "json",
+          identity?.id ?? null,
+          identity?.kind ?? null,
+          expiresAt,
+          staleExpiresAt,
+        )
+        .run(),
+    );
+  }
+  await Promise.all(writes);
 }
 
 function freshCachedResponse(cached: CachedGitHubResponse): boolean {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -689,6 +689,51 @@ describe("github cache policy", () => {
     });
   });
 
+  it("keeps oversized bodies out of D1 while still writing the edge cache", async () => {
+    const put = vi.fn(async () => undefined);
+    vi.stubGlobal("caches", {
+      default: {
+        match: vi.fn(async () => undefined),
+        put,
+        delete: vi.fn(async () => true),
+      },
+    });
+    const run = vi.fn(async () => ({}));
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/openclaw/pulls/42",
+    });
+    const route = classifyRoute(request, policy);
+    const env = {
+      DB: {
+        prepare: () => ({
+          bind: () => ({ run }),
+        }),
+      },
+    } as unknown as Env;
+
+    await writeGitHubCache(
+      env,
+      "cache-key",
+      request,
+      route,
+      response({ blob: "x".repeat(300_000) }),
+    );
+
+    // 120k CJK chars pass a UTF-16 code-unit count but exceed the cap in UTF-8 bytes.
+    await writeGitHubCache(
+      env,
+      "cache-key-multibyte",
+      request,
+      route,
+      response({ blob: "语".repeat(120_000) }),
+    );
+
+    expect(run).not.toHaveBeenCalled();
+    expect(put).toHaveBeenCalledTimes(2);
+  });
+
   it("serves only stale cache rows inside the route grace window", async () => {
     const route = classifyRoute(
       validateRelayRequest({


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #44. That PR made D1 overload fail gracefully (typed `relay_overloaded` fallback); this one attacks the overload itself so the fallback fires far less often. Bursts of paged Actions reads cache 0.3–1.3MB response bodies as single rows in the shared D1 database (`run_list` rows average ~270KB; `commit_check_runs` ~186KB; live DB is 711MB), and those megabyte-class serialized writes queue the single D1 primary into `D1 DB is overloaded. Requests queued for too long.`

## Why This Change Was Made

D1 cache writes are now capped at 256KiB of serialized UTF-8 body. Oversized bodies stay in the per-colo edge cache only, which still serves the hot pattern that actually repeats — the same client re-polling the same query (`watch-pr-ci`, `prepare-run` hosted-gates paging). The accepted tradeoff, documented in `docs/cache.md`: oversized entries lose cross-colo sharing and D1 stale fallback. The size gate measures UTF-8 bytes via `TextEncoder`, not `String.length`, so Unicode-heavy bodies can't slip past the cap at 2–3× the limit.

## User Impact

Paged `gh api` bursts through the shim stop tipping D1 into minutes-long overload windows, so callers hit the relay cache instead of falling back to their local `gh` quota. No behavior change for responses under 256KiB.

## Evidence

- Overload mechanism proven in #44's investigation: `wrangler tail` captured `D1_ERROR: D1 DB is overloaded. Requests queued for too long.` during a reproduced paged burst; per-table D1 stats show the large-body route kinds dominating cache bytes (`commit_check_runs` 69MB/379 rows, `run_jobs` 62MB/1283, `run_list` 13MB/49).
- New unit tests: oversized ASCII body and a multibyte body that passes a UTF-16 code-unit count but exceeds the cap in UTF-8 bytes — both skip D1 while still writing the edge cache.
- `pnpm test` (25 files, 217 tests), `go test ./...`, `pnpm build` typecheck, lint, format all green; Codex autoreview clean after addressing its byte-vs-code-unit finding.
