### PR TITLE
infra: move the D1 primary and pool coordinator to Western North America

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changes
 
+- Move the primary data region to Western North America: new `wnam` D1 database (config, tokens, identities, proofs, and audit history migrated; cache rebuilt) and a relocated pool coordinator, cutting ~140ms of transatlantic latency from every D1/coordinator round trip for US callers.
 - Redesign the operator dashboard as an editorial ledger: serif display type, hairline-rule sections, tick-marked rate gauges with low-headroom coloring, and right-aligned tabular numerals.
 
 ## 0.5.5 - 2026-08-08

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -49,11 +49,17 @@ because `octopool.dev` lives in a different Cloudflare account from the authorit
 ### 2. Create the data plane
 
 ```sh
-wrangler d1 create octopool
+# pick the location hint nearest your callers (e.g. wnam, enam, weur);
+# D1 location is fixed at creation and cannot be changed later
+wrangler d1 create octopool --location wnam
 # copy the printed database_id into wrangler.jsonc d1_databases[].database_id
 
 wrangler d1 migrations apply octopool --remote
 ```
+
+The pool coordinator's location hint in `src/pool-coordinator.ts`
+(`poolCoordinatorStub`) should match the D1 location so per-request coordinator
+calls do not cross regions.
 
 The `PoolCoordinator` Durable Object class is provisioned by the migration tag in
 `wrangler.jsonc` on first `wrangler deploy` — no separate step.

--- a/src/dashboard-data.ts
+++ b/src/dashboard-data.ts
@@ -6,6 +6,7 @@ import {
   type CacheTotalsRow,
   type UsageAggregateRow,
 } from "./metrics";
+import { poolCoordinatorStub } from "./pool-coordinator";
 import { requireDashboardAdmin } from "./web-session";
 
 export async function dashboardData(request: Request, env: Env): Promise<Response> {
@@ -15,7 +16,7 @@ export async function dashboardData(request: Request, env: Env): Promise<Respons
     throw new HttpError(400, "pool_invalid", "Pool id is invalid");
   }
   const operator = await requireDashboardAdmin(request, env, pool);
-  const coordinator = env.POOL_COORDINATOR.getByName(`pool:${pool}`);
+  const coordinator = poolCoordinatorStub(env, pool);
   const [
     identities,
     cache,

--- a/src/pool-coordinator.ts
+++ b/src/pool-coordinator.ts
@@ -15,6 +15,16 @@ type RateRow = {
 
 const CACHE_FILL_LEASE_MS = 8_000;
 
+// The coordinator must live near the D1 primary (WNAM since the 2026-08 region
+// move) or every selectIdentity/recordResult hop re-adds the cross-region
+// latency the migration removed. Location hints only apply when an object is
+// first created, so the name carries a generation suffix that retires the
+// EU-born instance; its state is all short-TTL coordination data, safe to drop.
+export function poolCoordinatorStub(env: Env, pool: string): DurableObjectStub<PoolCoordinator> {
+  const id = env.POOL_COORDINATOR.idFromName(`pool:${pool}@wnam`);
+  return env.POOL_COORDINATOR.get(id, { locationHint: "wnam" });
+}
+
 export class PoolCoordinator extends DurableObject<Env> {
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -21,7 +21,7 @@ import { HttpError, jsonResponse, parseJsonObject } from "./http";
 import { isRecord } from "./object";
 import { githubResponseLocalFallbackReason, localFallbackError } from "./local-fallback";
 import { classifyRoute, normalizeRouteKey, validateRelayRequest } from "./policy";
-import type { PoolCoordinator } from "./pool-coordinator";
+import { poolCoordinatorStub, type PoolCoordinator } from "./pool-coordinator";
 import { verifyPRStateHint, verifyPRStateHintLive } from "./pr-state";
 import {
   anonymousGitHubResponseProvesPublicRepo,
@@ -158,7 +158,7 @@ async function relayGitHubRequest(
     callerId: caller.id,
     callerTokenId: caller.caller_token_id,
     clientName: caller.client_name,
-    coordinator: env.POOL_COORDINATOR.getByName(`pool:${relayRequest.pool}`),
+    coordinator: poolCoordinatorStub(env, relayRequest.pool),
   };
   let active: ActiveRelay | undefined;
   try {

--- a/test/e2e/worker.test.ts
+++ b/test/e2e/worker.test.ts
@@ -2,6 +2,7 @@ import { env } from "cloudflare:workers";
 import { runInDurableObject } from "cloudflare:test";
 import { describe, expect, it, vi } from "vitest";
 import { PoolCoordinator } from "../../src/index";
+import { poolCoordinatorStub } from "../../src/pool-coordinator";
 import { deleteEdgeJSON } from "../../src/edge-cache";
 import type { CoordinatorSnapshot } from "../../src/types";
 import {
@@ -214,7 +215,7 @@ describe("Worker end-to-end relay", () => {
     expect(tokens).toContain("test-primary-token");
     expect(tokens).toContain("test-secondary-token");
 
-    const coordinator = env.POOL_COORDINATOR.getByName(`pool:${POOL}`);
+    const coordinator = poolCoordinatorStub(env, POOL);
     const snapshot = await runInDurableObject(
       coordinator,
       (instance: PoolCoordinator): CoordinatorSnapshot => instance.snapshot(),

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -26,8 +26,8 @@
   "d1_databases": [
     {
       "binding": "DB",
-      "database_name": "octopool",
-      "database_id": "28122808-8a3c-4524-a1c0-70b5984744b7",
+      "database_name": "octopool-wnam",
+      "database_id": "a4b252b5-2553-4896-b33a-14689a2152be",
     },
   ],
   "r2_buckets": [


### PR DESCRIPTION
## What Problem This Solves

Third act of the overload work (#44 typed fallback, #46 write cap): the D1 primary lives in LHR (WEUR) while every current caller is US-west, so each of the several sequential D1 round trips per relay request pays ~140ms of transatlantic latency. That both slows every miss/auth path and shrinks the headroom before D1's request queue backs up into `overloaded`.

## Why This Change Was Made

Cloudflare fixes D1 and Durable Object locations at creation — there is no in-place move — so this is a create-and-migrate. A new `octopool-wnam` database was created with `--location wnam` (confirmed placed in region WNAM), all 13 migrations applied, and the durable data imported: pools, callers, caller tokens, identities, identity scopes, public-repo proofs, PR-state proofs, public API rates, dashboard sessions, and all 617,701 audit rows. The cache table is intentionally not migrated — it rebuilds itself. The pool coordinator DO cannot be relocated either, so `poolCoordinatorStub` mints a generation-suffixed object name (`pool:<pool>@wnam`) with a `wnam` location hint; the retired instance held only short-TTL coordination state (10s leases, 8s cache-fill claims, ≤2min cooldowns), safe to drop. Self-host docs now tell operators to pick a location hint near their callers and keep the coordinator hint matched.

## User Impact

Every cache miss, auth check, and coordinator hop for US callers drops from transatlantic to single-digit-ms round trips, and D1 gets far more headroom before paged bursts can queue it into overload. Trade-off: if European callers join the pool later, they inherit the latency penalty this removes for US callers; read replication would then be the complement.

## Evidence

- `wrangler d1 create octopool-wnam --location wnam` → "Successfully created DB 'octopool-wnam' in region WNAM"; migrations 0001–0013 applied clean.
- Data import verified by row counts on the new DB: 2 callers, 14 caller tokens, 2 identities, 1 pool, 2 sessions, 617,701 audit rows (matches source, exported live).
- `pnpm test` (25 files, 217 tests), `go test ./...`, `pnpm build` typecheck, lint, format all green; Codex autoreview clean.
- Post-deploy verification planned: query meta shows `served_by_region: WNAM`, live shim requests succeed, dashboard loads, and a paged burst replay stays fast.
