### PR TITLE
fix: edge-only cache fills duplicate cross-colo reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Make cache fills outcome-aware at the pool coordinator: followers wake on confirmed shared, edge-only, or failed publication, cold colos reacquire serially without polling D1, and renewable fenced ownership prevents valid upstream work from outliving its lease.
 - Keep megabyte-class response bodies (paged run lists, check-run sweeps) out of the shared D1 cache — they stay per-colo edge-cached — so write bursts no longer queue the D1 primary into "overloaded" failures.
 - Report Cloudflare backend overload (D1/Durable Object request queues backing up) as typed `relay_overloaded` — `424 fallback_local` on the relay so the shim backs off and delegates to real `gh` — instead of an untyped `internal_error` 500 that dead-ended paged `gh api` bursts.
 - Retry transient relay `internal_error` and malformed 502/503/504 responses without falling back to local GitHub quota, preserve correlated request IDs in CLI failures, and log unexpected Worker exceptions safely for diagnosis.

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -60,7 +60,10 @@ Bodies whose serialized JSON exceeds 256 KiB (paged run lists, check-run sweeps)
 stored only in the data-center-local edge cache, not in D1: megabyte-class row writes
 were the dominant cause of `D1 DB is overloaded` queueing under paged bursts. Oversized
 entries lose cross-colo sharing and D1 stale fallback but keep the hot same-client
-repoll pattern warm.
+repoll pattern warm. A same-colo follower serves the confirmed edge publication directly;
+a follower in a cold colo reacquires coordinator ownership and performs one serialized
+takeover fill. This can produce one fill per cold colo, but never overlapping ownerless
+upstream requests.
 
 Cacheable requests can instead bound acceptable staleness with a
 `cache-control: max-age=N` header. A fresh entry older than `N` seconds is treated as a
@@ -243,11 +246,17 @@ get up to an hour; immutable-ish commit views can get up to a day. Stale serves 
 the public-repo guard and active-identity check before returning.
 
 Cache publication is awaited before returning a miss response, closing the response/write
-race for immediate repeat reads. Concurrent identical misses also claim a short pool-scoped
-fill lease in the Durable Object; followers wait for the leader's publication and serve
-the resulting hit instead of duplicating the GitHub request. Public-repository proof
-refreshes use the same coordinator pattern, so simultaneous expired-proof checks share one
-GitHub request. Audit writes remain deferred.
+race for immediate repeat reads. Concurrent identical misses acquire renewable,
+token-fenced ownership in the pool Durable Object. Followers wait on coordinator completion,
+not Cache API or D1 polling. `shared` completion triggers one edge+D1 read; `edge_only`
+triggers one local-edge read; an absent promised result, `failed` publication, owner expiry,
+or Durable Object recovery returns to atomic acquisition before any upstream work. Owners
+renew while valid upstream calls run, verify ownership immediately before publication, and
+complete before audit work; stale tokens cannot publish completion or release a newer owner.
+Public-repository proof refreshes use the same acquisition, renewal, completion, and fencing
+lifecycle on the pool coordinator colocated with the D1 primary, reporting `shared` only after
+confirmed D1 persistence. Edge-only publication remains local to the serving colo. Audit writes
+remain deferred.
 An hourly scheduled task deletes cache entries after each entry's route-specific
 `stale_expires_at` deadline in bounded batches, preserving every configured stale-serving
 window while keeping D1 growth bounded. R2 expiry is handled by the operator-configured

--- a/docs/identities.md
+++ b/docs/identities.md
@@ -51,7 +51,8 @@ keeps four SQLite tables in DO storage:
 - `leases` — sticky route→identity binding, 10s TTL.
 - `rate_states` — last seen `remaining`/`reset_at` per identity and resource bucket.
 - `cooldowns` — per identity, scoped to `*`, `resource:<r>`, or a route key.
-- `cache_fills` — 8s ownership leases that coalesce concurrent identical cache misses.
+- `cache_fills` — renewable, token-fenced ownership for concurrent identical cache misses;
+  completion wakes followers with the confirmed publication outcome.
 
 `selectIdentity` logic:
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -68,7 +68,8 @@ Durable Object partition key: `pool:<pool_id>`.
    normalized route/cache key.
 4. For cacheable routes, read the edge cache then D1. Validate cached identity eligibility
    and public-repository proof before serving.
-5. Claim an 8-second cache-fill lease. Followers wait briefly and reuse the leader's result.
+5. Acquire renewable, token-fenced cache-fill ownership. Followers wait on coordinator
+   completion (`shared`, `edge_only`, or `failed`) rather than polling cache storage.
 6. Try an exact token-free adapter: anonymous API, public page/raw content, or Git smart HTTP.
 7. Establish public-repository proof from the direct response or the explicit guard.
 8. If the route requires credentials, select a scoped identity through the pool coordinator,
@@ -77,7 +78,8 @@ Durable Object partition key: `pool:<pool_id>`.
 10. Return the relay envelope; asynchronously record the authenticated/validated outcome.
 11. If a safe read cannot be served, return `424 fallback_local` with a reason. The CLI
     reruns the original command with real `gh` unless local fallback is disabled.
-12. Always release an owned cache-fill lease.
+12. Complete the owned fill immediately after publication; every other owned exit completes
+    `failed`, while lost/stale tokens cannot release a newer owner.
 
 Conditional, log, large-payload, `rate_limit`, and otherwise non-cacheable requests bypass
 cache. A `cache-control: max-age=N` request directive instead treats fresh entries older
@@ -182,7 +184,7 @@ PoolCoordinator SQLite tables:
 - `leases`: 10-second route-to-identity bindings.
 - `rate_states`: last GitHub remaining/reset state by identity/resource.
 - `cooldowns`: global/resource/route exclusions.
-- `cache_fills`: 8-second ownership leases for duplicate misses.
+- `cache_fills`: renewable, token-fenced ownership for duplicate misses and follower wake-up.
 
 Runtime SQL lives in `sql/queries/*.sql`, is validated against `migrations/` and
 `sql/schema/coordinator.sql`, and generates `src/generated/sql.ts`. Secret values are not

--- a/sql/queries/coordinator.sql
+++ b/sql/queries/coordinator.sql
@@ -105,7 +105,15 @@ ON CONFLICT(cache_key) DO UPDATE SET
   owner_token = excluded.owner_token,
   expires_at = excluded.expires_at;
 
--- name: DeleteCacheFill :exec
+-- name: RenewCacheFill :exec
+UPDATE cache_fills
+SET expires_at = ?3
+WHERE cache_key = ?1
+  AND owner_token = ?2
+  AND expires_at > ?4;
+
+-- name: CompleteCacheFill :exec
 DELETE FROM cache_fills
 WHERE cache_key = ?1
-  AND owner_token = ?2;
+  AND owner_token = ?2
+  AND expires_at > ?3;

--- a/src/cache-coalesce.ts
+++ b/src/cache-coalesce.ts
@@ -1,58 +1,59 @@
-import { readGitHubCache, type CachedGitHubResponse } from "./cache";
-import type { PoolCoordinator } from "./pool-coordinator";
-
-const CACHE_FILL_WAIT_MS = 4_000;
-const CACHE_FILL_POLL_MS = 100;
-
-type CacheFillCoordinator = Pick<
-  DurableObjectStub<PoolCoordinator>,
-  "claimCacheFill" | "finishCacheFill"
->;
+import {
+  readEdgeGitHubCache,
+  readGitHubCacheWithSource,
+  type CachedGitHubResponse,
+  type GitHubCacheRead,
+} from "./cache";
+import {
+  acquireOwnedCacheFill,
+  type CacheFillCoordinator,
+  type OwnedCacheFill,
+} from "./cache-fill";
 
 export async function coalesceGitHubCacheMiss(
   env: Env,
   coordinator: CacheFillCoordinator,
   cacheKey: string,
   options: {
-    waitMs?: number;
-    pollMs?: number;
+    ctx?: ExecutionContext;
     maxAgeSeconds?: number;
-    sleep?: (ms: number) => Promise<void>;
+    acceptCached?: (cached: CachedGitHubResponse) => Promise<boolean>;
+    readShared?: () => Promise<GitHubCacheRead | undefined>;
+    readEdge?: () => Promise<CachedGitHubResponse | undefined>;
   } = {},
-): Promise<{ leaseToken?: string; cached?: CachedGitHubResponse }> {
-  const leaseToken = await coordinator.claimCacheFill(cacheKey);
-  if (leaseToken !== null) {
-    return { leaseToken };
-  }
-  const waitMs = options.waitMs ?? CACHE_FILL_WAIT_MS;
-  const pollMs = options.pollMs ?? CACHE_FILL_POLL_MS;
-  const wait = options.sleep ?? sleep;
-  const deadline = Date.now() + waitMs;
-  while (Date.now() < deadline) {
-    await wait(pollMs);
-    const cached = await readGitHubCache(env, cacheKey, undefined, options.maxAgeSeconds);
-    if (cached !== undefined) {
+): Promise<{ owner?: OwnedCacheFill; cached?: CachedGitHubResponse }> {
+  const readShared =
+    options.readShared ??
+    (() => readGitHubCacheWithSource(env, cacheKey, options.ctx, options.maxAgeSeconds));
+  const readEdge = options.readEdge ?? (() => readEdgeGitHubCache(cacheKey, options.maxAgeSeconds));
+  const accepted = options.acceptCached ?? (async () => true);
+
+  for (;;) {
+    const acquisition = await acquireOwnedCacheFill(coordinator, cacheKey);
+    if (acquisition.kind === "owner") {
+      try {
+        const rechecked = await readShared();
+        if (rechecked !== undefined && (await accepted(rechecked.cached))) {
+          await acquisition.owner.complete(rechecked.source === "shared" ? "shared" : "edge_only");
+          return { cached: rechecked.cached };
+        }
+        return { owner: acquisition.owner };
+      } catch (error) {
+        await acquisition.owner.fail();
+        throw error;
+      }
+    }
+
+    let cached: CachedGitHubResponse | undefined;
+    if (acquisition.kind === "completed" && acquisition.outcome === "shared") {
+      cached = (await readShared())?.cached;
+    } else if (acquisition.kind === "completed" && acquisition.outcome === "edge_only") {
+      cached = await readEdge();
+    }
+    if (cached !== undefined && (await accepted(cached))) {
       return { cached };
     }
+    // Failed publication, owner expiry, or an unexpectedly absent completed
+    // result always returns to the coordinator before any upstream work.
   }
-  return {};
-}
-
-export async function finishGitHubCacheFill(
-  coordinator: CacheFillCoordinator,
-  cacheKey: string,
-  leaseToken: string | undefined,
-): Promise<void> {
-  if (leaseToken === undefined) {
-    return;
-  }
-  try {
-    await coordinator.finishCacheFill(cacheKey, leaseToken);
-  } catch (error) {
-    console.error("github cache fill cleanup failed", error);
-  }
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/cache-fill.ts
+++ b/src/cache-fill.ts
@@ -1,0 +1,156 @@
+export type CacheFillOutcome = "shared" | "edge_only" | "failed";
+
+export type CacheFillAcquisition =
+  | { kind: "owner"; token: string }
+  | { kind: "completed"; outcome: CacheFillOutcome }
+  | { kind: "retry" };
+
+type Awaitable<T> = T | Promise<T>;
+
+export interface CacheFillCoordinator {
+  acquireCacheFill(cacheKey: string): Awaitable<CacheFillAcquisition>;
+  renewCacheFill(cacheKey: string, ownerToken: string): Awaitable<boolean>;
+  completeCacheFill(
+    cacheKey: string,
+    ownerToken: string,
+    outcome: CacheFillOutcome,
+  ): Awaitable<boolean>;
+}
+
+const CACHE_FILL_RENEW_MS = 3_000;
+
+export type OwnedCacheFill = {
+  readonly token: string;
+  renew(): Promise<boolean>;
+  complete(outcome: CacheFillOutcome): Promise<boolean>;
+  fail(): Promise<boolean>;
+  publish(publisher: () => Promise<CacheFillOutcome>): Promise<CacheFillOutcome | undefined>;
+};
+
+export async function acquireOwnedCacheFill(
+  coordinator: CacheFillCoordinator,
+  cacheKey: string,
+): Promise<
+  { kind: "owner"; owner: OwnedCacheFill } | Exclude<CacheFillAcquisition, { kind: "owner" }>
+> {
+  let acquisition: CacheFillAcquisition;
+  try {
+    acquisition = await coordinator.acquireCacheFill(cacheKey);
+  } catch {
+    // A Durable Object restart rejects its in-memory waiting RPCs. Re-entering
+    // the durable acquisition state either waits on the surviving owner or
+    // returns retry at its persisted expiry.
+    acquisition = await coordinator.acquireCacheFill(cacheKey);
+  }
+  if (acquisition.kind !== "owner") {
+    return acquisition;
+  }
+  return {
+    kind: "owner",
+    owner: startOwnedCacheFill(coordinator, cacheKey, acquisition.token),
+  };
+}
+
+function startOwnedCacheFill(
+  coordinator: CacheFillCoordinator,
+  cacheKey: string,
+  token: string,
+): OwnedCacheFill {
+  let active = true;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let renewal: Promise<boolean> | undefined;
+
+  const clearTimer = (): void => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+  const deactivate = (): void => {
+    active = false;
+    clearTimer();
+  };
+  const scheduleRenewal = (): void => {
+    clearTimer();
+    if (!active) {
+      return;
+    }
+    timer = setTimeout(() => {
+      timer = undefined;
+      void renew();
+    }, CACHE_FILL_RENEW_MS);
+  };
+  const renew = (): Promise<boolean> => {
+    if (!active) {
+      return Promise.resolve(false);
+    }
+    clearTimer();
+    if (renewal !== undefined) {
+      return renewal;
+    }
+    const current = (async () => {
+      try {
+        return await coordinator.renewCacheFill(cacheKey, token);
+      } catch (error) {
+        console.error("cache fill renewal failed", error);
+        return false;
+      }
+    })();
+    renewal = current;
+    void current.then((renewed) => {
+      if (renewal === current) {
+        renewal = undefined;
+      }
+      if (!renewed) {
+        deactivate();
+      } else if (active) {
+        scheduleRenewal();
+      }
+    });
+    return current;
+  };
+  const complete = async (outcome: CacheFillOutcome): Promise<boolean> => {
+    if (!active) {
+      return false;
+    }
+    clearTimer();
+    const pending = renewal;
+    if (pending !== undefined && !(await pending)) {
+      return false;
+    }
+    if (!active) {
+      return false;
+    }
+    deactivate();
+    try {
+      return await coordinator.completeCacheFill(cacheKey, token, outcome);
+    } catch (error) {
+      console.error("cache fill completion failed", error);
+      return false;
+    }
+  };
+  const publish = async (
+    publisher: () => Promise<CacheFillOutcome>,
+  ): Promise<CacheFillOutcome | undefined> => {
+    if (!(await renew())) {
+      return undefined;
+    }
+    try {
+      const outcome = await publisher();
+      await complete(outcome);
+      return outcome;
+    } catch (error) {
+      await complete("failed");
+      throw error;
+    }
+  };
+
+  scheduleRenewal();
+  return {
+    token,
+    renew,
+    complete,
+    fail: () => complete("failed"),
+    publish,
+  };
+}

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -10,6 +10,7 @@ import { defaultGitHubJSONAccept } from "./github-response";
 import { PUBLIC_SHAPES } from "./github-public-shapes";
 import { isRecord } from "./object";
 import { parseSQLiteTimestamp, sqliteTimestamp } from "./sqlite-time";
+import type { CacheFillOutcome } from "./cache-fill";
 import type { GitHubRelayResponse, Identity, RelayRequest, RouteInfo } from "./types";
 
 const TERMINAL_CI_TTL_SECONDS = 3_600;
@@ -38,6 +39,11 @@ export type CachedGitHubResponse = GitHubRelayResponse & {
   identity?: Pick<Identity, "id" | "kind">;
   created_at: string;
   expires_at: string;
+};
+
+export type GitHubCacheRead = {
+  cached: CachedGitHubResponse;
+  source: "edge" | "shared";
 };
 
 export function githubCacheRevalidationHeaders(
@@ -96,6 +102,34 @@ export async function readGitHubCache(
   ctx?: ExecutionContext,
   maxAgeSeconds?: number,
 ): Promise<CachedGitHubResponse | undefined> {
+  return (await readGitHubCacheWithSource(env, cacheKey, ctx, maxAgeSeconds))?.cached;
+}
+
+export async function readGitHubCacheWithSource(
+  env: Env,
+  cacheKey: string,
+  ctx?: ExecutionContext,
+  maxAgeSeconds?: number,
+): Promise<GitHubCacheRead | undefined> {
+  const edge = await readEdgeGitHubCache(cacheKey, maxAgeSeconds);
+  if (edge !== undefined) {
+    return { cached: edge, source: "edge" };
+  }
+  const row = await env.DB.prepare(queries.readGitHubCache).bind(cacheKey).first<CacheRow>();
+  const cached = cacheRowResponse(row);
+  if (cached === undefined || !withinRequestedMaxAge(cached, maxAgeSeconds)) {
+    return undefined;
+  }
+  if (ctx !== undefined) {
+    ctx.waitUntil(writeEdgeCachedResponse(cacheKey, cached));
+  }
+  return { cached, source: "shared" };
+}
+
+export async function readEdgeGitHubCache(
+  cacheKey: string,
+  maxAgeSeconds?: number,
+): Promise<CachedGitHubResponse | undefined> {
   const edge = await readEdgeJSON<CachedGitHubResponse>(EDGE_CACHE_NAMESPACE, cacheKey);
   if (edge !== undefined) {
     if (freshCachedResponse(edge)) {
@@ -108,15 +142,7 @@ export async function readGitHubCache(
       await deleteEdgeJSON(EDGE_CACHE_NAMESPACE, cacheKey);
     }
   }
-  const row = await env.DB.prepare(queries.readGitHubCache).bind(cacheKey).first<CacheRow>();
-  const cached = cacheRowResponse(row);
-  if (cached === undefined || !withinRequestedMaxAge(cached, maxAgeSeconds)) {
-    return undefined;
-  }
-  if (ctx !== undefined) {
-    ctx.waitUntil(writeEdgeCachedResponse(cacheKey, cached));
-  }
-  return cached;
+  return undefined;
 }
 
 function withinRequestedMaxAge(cached: CachedGitHubResponse, maxAgeSeconds?: number): boolean {
@@ -195,9 +221,9 @@ export async function writeGitHubCache(
   route: RouteInfo,
   response: GitHubRelayResponse,
   identity?: Identity,
-): Promise<void> {
+): Promise<CacheFillOutcome> {
   if (response.status < 200 || response.status >= 300) {
-    return;
+    return "failed";
   }
   const ttlSeconds = cacheTTLSeconds(route, response);
   const staleSeconds = staleCacheSeconds(route, ttlSeconds);
@@ -212,34 +238,42 @@ export async function writeGitHubCache(
     ...(identity === undefined ? {} : { identity: { id: identity.id, kind: identity.kind } }),
   };
   const bodyJson = JSON.stringify(response.body);
-  const writes: Promise<unknown>[] = [writeEdgeCachedResponse(cacheKey, cached)];
+  const edgeWrite = writeEdgeCachedResponse(cacheKey, cached);
+  let sharedWrite = Promise.resolve(false);
   // UTF-8 bytes, not String.length: UTF-16 code units undercount multibyte
   // content by up to 3x, which would let Unicode-heavy rows past the cap.
   if (new TextEncoder().encode(bodyJson).byteLength <= MAX_D1_CACHE_BODY_BYTES) {
-    writes.push(
-      env.DB.prepare(queries.writeGitHubCache)
-        .bind(
-          cacheKey,
-          request.pool,
-          request.method,
-          request.path,
-          JSON.stringify(stableRecord(request.query ?? {})),
-          JSON.stringify(stableRecord(cacheVaryHeaders(request.headers))),
-          route.routeKey,
-          route.kind,
-          response.status,
-          JSON.stringify(response.headers),
-          bodyJson,
-          response.body_encoding ?? "json",
-          identity?.id ?? null,
-          identity?.kind ?? null,
-          expiresAt,
-          staleExpiresAt,
-        )
-        .run(),
-    );
+    sharedWrite = env.DB.prepare(queries.writeGitHubCache)
+      .bind(
+        cacheKey,
+        request.pool,
+        request.method,
+        request.path,
+        JSON.stringify(stableRecord(request.query ?? {})),
+        JSON.stringify(stableRecord(cacheVaryHeaders(request.headers))),
+        route.routeKey,
+        route.kind,
+        response.status,
+        JSON.stringify(response.headers),
+        bodyJson,
+        response.body_encoding ?? "json",
+        identity?.id ?? null,
+        identity?.kind ?? null,
+        expiresAt,
+        staleExpiresAt,
+      )
+      .run()
+      .then(() => true)
+      .catch((error: unknown) => {
+        console.error("github shared cache write failed", error);
+        return false;
+      });
   }
-  await Promise.all(writes);
+  const [edgePublished, sharedPublished] = await Promise.all([edgeWrite, sharedWrite]);
+  if (sharedPublished) {
+    return "shared";
+  }
+  return edgePublished ? "edge_only" : "failed";
 }
 
 function freshCachedResponse(cached: CachedGitHubResponse): boolean {
@@ -256,7 +290,7 @@ function freshCachedResponse(cached: CachedGitHubResponse): boolean {
   return Number.isFinite(expiresAt) && expiresAt > Date.now();
 }
 
-function writeEdgeCachedResponse(cacheKey: string, cached: CachedGitHubResponse): Promise<void> {
+function writeEdgeCachedResponse(cacheKey: string, cached: CachedGitHubResponse): Promise<boolean> {
   const expiresAt = parseSQLiteTimestamp(cached.expires_at);
   const ttlSeconds = Math.floor((expiresAt - Date.now()) / 1000);
   return writeEdgeJSON(EDGE_CACHE_NAMESPACE, cacheKey, cached, ttlSeconds);

--- a/src/edge-cache.ts
+++ b/src/edge-cache.ts
@@ -27,10 +27,10 @@ export async function writeEdgeJSON(
   key: string,
   value: unknown,
   ttlSeconds: number,
-): Promise<void> {
+): Promise<boolean> {
   const cache = defaultEdgeCache();
   if (cache === undefined || ttlSeconds <= 0) {
-    return;
+    return false;
   }
   try {
     await cache.put(
@@ -41,8 +41,10 @@ export async function writeEdgeJSON(
         },
       }),
     );
-  } catch {
-    // The D1 cache remains authoritative when an edge cache operation fails.
+    return true;
+  } catch (error) {
+    console.error("edge cache write failed", { namespace, error });
+    return false;
   }
 }
 

--- a/src/generated/sql.ts
+++ b/src/generated/sql.ts
@@ -31,7 +31,10 @@ export const queries = {
   getCacheFill: "SELECT owner_token, expires_at\nFROM cache_fills\nWHERE cache_key = ?",
   upsertCacheFill:
     "INSERT INTO cache_fills (cache_key, owner_token, expires_at)\nVALUES (?1, ?2, ?3)\nON CONFLICT(cache_key) DO UPDATE SET\n  owner_token = excluded.owner_token,\n  expires_at = excluded.expires_at",
-  deleteCacheFill: "DELETE FROM cache_fills\nWHERE cache_key = ?1\n  AND owner_token = ?2",
+  renewCacheFill:
+    "UPDATE cache_fills\nSET expires_at = ?3\nWHERE cache_key = ?1\n  AND owner_token = ?2\n  AND expires_at > ?4",
+  completeCacheFill:
+    "DELETE FROM cache_fills\nWHERE cache_key = ?1\n  AND owner_token = ?2\n  AND expires_at > ?3",
   authenticateCaller:
     "SELECT callers.id, callers.name, callers.github_login, callers.org_login, callers.org_verified_at,\n       caller_tokens.id AS caller_token_id, caller_tokens.client_name\nFROM caller_tokens\nJOIN callers ON callers.id = caller_tokens.caller_id\nJOIN caller_pools ON caller_pools.caller_id = callers.id\nWHERE caller_tokens.token_hash = ?1\n  AND callers.status = 'active'\n  AND caller_pools.pool_id = ?2\nLIMIT 1",
   updateCallerOrgVerifiedAt:

--- a/src/pool-coordinator.ts
+++ b/src/pool-coordinator.ts
@@ -1,4 +1,5 @@
 import { DurableObject } from "cloudflare:workers";
+import type { CacheFillAcquisition, CacheFillOutcome } from "./cache-fill";
 import { queries } from "./generated/sql";
 import type { CoordinatorSnapshot, RecordResult, SelectionRequest, SelectionResult } from "./types";
 
@@ -25,7 +26,22 @@ export function poolCoordinatorStub(env: Env, pool: string): DurableObjectStub<P
   return env.POOL_COORDINATOR.get(id, { locationHint: "wnam" });
 }
 
+type CacheFillRow = {
+  owner_token: string;
+  expires_at: number;
+};
+
+type CacheFillWaiterGroup = {
+  ownerToken: string;
+  expiresAt: number;
+  completion: Promise<Exclude<CacheFillAcquisition, { kind: "owner" }>>;
+  resolve(result: Exclude<CacheFillAcquisition, { kind: "owner" }>): void;
+  timer?: ReturnType<typeof setTimeout>;
+};
+
 export class PoolCoordinator extends DurableObject<Env> {
+  private readonly cacheFillWaiters = new Map<string, CacheFillWaiterGroup>();
+
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
     this.ctx.blockConcurrencyWhile(async () => {
@@ -41,13 +57,14 @@ export class PoolCoordinator extends DurableObject<Env> {
     });
   }
 
-  claimCacheFill(cacheKey: string): string | null {
+  acquireCacheFill(cacheKey: string): Promise<CacheFillAcquisition> | CacheFillAcquisition {
     const now = Date.now();
-    const fill = this.ctx.storage.sql
-      .exec<{ owner_token: string; expires_at: number }>(queries.getCacheFill, cacheKey)
-      .toArray()[0];
+    const fill = this.cacheFill(cacheKey);
     if (fill !== undefined && fill.expires_at > now) {
-      return null;
+      return this.waitForCacheFill(cacheKey, fill);
+    }
+    if (fill !== undefined) {
+      this.wakeCacheFill(cacheKey, fill.owner_token, { kind: "retry" });
     }
     const ownerToken = crypto.randomUUID();
     this.ctx.storage.sql.exec(
@@ -56,11 +73,38 @@ export class PoolCoordinator extends DurableObject<Env> {
       ownerToken,
       now + CACHE_FILL_LEASE_MS,
     );
-    return ownerToken;
+    return { kind: "owner", token: ownerToken };
   }
 
-  finishCacheFill(cacheKey: string, ownerToken: string): void {
-    this.ctx.storage.sql.exec(queries.deleteCacheFill, cacheKey, ownerToken);
+  renewCacheFill(cacheKey: string, ownerToken: string): boolean {
+    const now = Date.now();
+    const expiresAt = now + CACHE_FILL_LEASE_MS;
+    const updated = this.ctx.storage.sql.exec(
+      queries.renewCacheFill,
+      cacheKey,
+      ownerToken,
+      expiresAt,
+      now,
+    );
+    if (updated.rowsWritten === 0) {
+      return false;
+    }
+    this.extendCacheFillWaiter(cacheKey, ownerToken, expiresAt);
+    return true;
+  }
+
+  completeCacheFill(cacheKey: string, ownerToken: string, outcome: CacheFillOutcome): boolean {
+    const deleted = this.ctx.storage.sql.exec(
+      queries.completeCacheFill,
+      cacheKey,
+      ownerToken,
+      Date.now(),
+    );
+    if (deleted.rowsWritten === 0) {
+      return false;
+    }
+    this.wakeCacheFill(cacheKey, ownerToken, { kind: "completed", outcome });
+    return true;
   }
 
   selectIdentity(request: SelectionRequest): SelectionResult {
@@ -173,6 +217,76 @@ export class PoolCoordinator extends DurableObject<Env> {
       .exec<RateRow>(queries.getRateState, identityId, resource)
       .toArray()[0];
     return rate !== undefined && rate.reset_at > now && rate.remaining <= 0;
+  }
+
+  private cacheFill(cacheKey: string): CacheFillRow | undefined {
+    return this.ctx.storage.sql.exec<CacheFillRow>(queries.getCacheFill, cacheKey).toArray()[0];
+  }
+
+  private waitForCacheFill(cacheKey: string, fill: CacheFillRow): Promise<CacheFillAcquisition> {
+    let group = this.cacheFillWaiters.get(cacheKey);
+    if (group === undefined || group.ownerToken !== fill.owner_token) {
+      if (group !== undefined) {
+        this.wakeCacheFill(cacheKey, group.ownerToken, { kind: "retry" });
+      }
+      let resolve!: CacheFillWaiterGroup["resolve"];
+      const completion = new Promise<Exclude<CacheFillAcquisition, { kind: "owner" }>>(
+        (complete) => {
+          resolve = complete;
+        },
+      );
+      group = {
+        ownerToken: fill.owner_token,
+        expiresAt: fill.expires_at,
+        completion,
+        resolve,
+      };
+      this.cacheFillWaiters.set(cacheKey, group);
+      this.scheduleCacheFillExpiry(cacheKey, group, fill.expires_at);
+    } else if (fill.expires_at > group.expiresAt) {
+      this.scheduleCacheFillExpiry(cacheKey, group, fill.expires_at);
+    }
+    return group.completion;
+  }
+
+  private scheduleCacheFillExpiry(
+    cacheKey: string,
+    group: CacheFillWaiterGroup,
+    expiresAt: number,
+  ): void {
+    group.expiresAt = expiresAt;
+    if (group.timer !== undefined) {
+      clearTimeout(group.timer);
+    }
+    group.timer = setTimeout(
+      () => {
+        this.wakeCacheFill(cacheKey, group.ownerToken, { kind: "retry" });
+      },
+      Math.max(1, expiresAt - Date.now()),
+    );
+  }
+
+  private extendCacheFillWaiter(cacheKey: string, ownerToken: string, expiresAt: number): void {
+    const group = this.cacheFillWaiters.get(cacheKey);
+    if (group !== undefined && group.ownerToken === ownerToken) {
+      this.scheduleCacheFillExpiry(cacheKey, group, expiresAt);
+    }
+  }
+
+  private wakeCacheFill(
+    cacheKey: string,
+    ownerToken: string,
+    result: Exclude<CacheFillAcquisition, { kind: "owner" }>,
+  ): void {
+    const group = this.cacheFillWaiters.get(cacheKey);
+    if (group === undefined || group.ownerToken !== ownerToken) {
+      return;
+    }
+    this.cacheFillWaiters.delete(cacheKey);
+    if (group.timer !== undefined) {
+      clearTimeout(group.timer);
+    }
+    group.resolve(result);
   }
 }
 

--- a/src/public-repos.ts
+++ b/src/public-repos.ts
@@ -1,9 +1,13 @@
 import { envSecret } from "./auth";
+import {
+  acquireOwnedCacheFill,
+  type CacheFillCoordinator,
+  type CacheFillOutcome,
+} from "./cache-fill";
 import { deleteEdgeJSON, readEdgeJSON, writeEdgeJSON } from "./edge-cache";
 import { queries } from "./generated/sql";
 import { parseSQLiteTimestamp, sqliteTimestamp } from "./sqlite-time";
 import { HttpError, parsePositiveInt } from "./http";
-import type { PoolCoordinator } from "./pool-coordinator";
 import { capabilitiesForRouteKind } from "./route-manifest";
 import type { RouteInfo } from "./types";
 
@@ -16,20 +20,15 @@ type PublicRepoProof = {
   expires_at: string;
 };
 
-type PublicProofCoordinator = Pick<
-  DurableObjectStub<PoolCoordinator>,
-  "claimCacheFill" | "finishCacheFill"
->;
+type PublicRepoProofSource = "edge" | "shared";
 
 const EDGE_CACHE_NAMESPACE = "public-repo-v1";
-const PROOF_WAIT_MS = 4_000;
-const PROOF_POLL_MS = 100;
 
 export async function ensurePublicGitHubRepo(
   env: Env,
   route: RouteInfo,
   cacheCreatedAt?: string,
-  coordinator?: PublicProofCoordinator,
+  coordinator?: CacheFillCoordinator,
 ): Promise<void> {
   if (route.owner === undefined || route.repo === undefined) {
     return;
@@ -38,34 +37,60 @@ export async function ensurePublicGitHubRepo(
   const repo = route.repo.toLowerCase();
   if (
     cacheCreatedAt !== undefined &&
-    (await cachedPublicGitHubRepoCovers(env, route, cacheCreatedAt, true))
+    (await coveringPublicRepoProofSource(env, route, cacheCreatedAt, { requireFresh: true })) !==
+      undefined
   ) {
     return;
   }
   const proofKey = `public-repo:${owner}/${repo}`;
   const proofStartedAt = sqliteTimestamp(new Date());
-  let leaseToken: string | undefined;
-  if (coordinator !== undefined) {
-    for (;;) {
-      const claimed = await coordinator.claimCacheFill(proofKey);
-      if (claimed !== null) {
-        leaseToken = claimed;
-        break;
+  if (coordinator === undefined) {
+    await refreshPublicGitHubRepoProof(env, owner, repo, route, cacheCreatedAt);
+    return;
+  }
+
+  for (;;) {
+    const acquisition = await acquireOwnedCacheFill(coordinator, proofKey);
+    if (acquisition.kind !== "owner") {
+      if (acquisition.kind === "completed") {
+        const source =
+          acquisition.outcome === "shared"
+            ? await coveringPublicRepoProofSource(env, route, proofStartedAt, {
+                requireFresh: true,
+              })
+            : acquisition.outcome === "edge_only"
+              ? await coveringPublicRepoProofSource(env, route, proofStartedAt, {
+                  requireFresh: true,
+                  source: "edge",
+                })
+              : undefined;
+        if (source !== undefined) {
+          return;
+        }
       }
-      if (await waitForConcurrentPublicProof(env, route, proofStartedAt)) {
+      continue;
+    }
+
+    const ownerFill = acquisition.owner;
+    try {
+      if (
+        cacheCreatedAt !== undefined &&
+        (await coveringPublicRepoProofSource(env, route, cacheCreatedAt, {
+          requireFresh: true,
+          source: "shared",
+        })) === "shared"
+      ) {
+        await ownerFill.complete("shared");
         return;
       }
-    }
-  }
-  try {
-    await refreshPublicGitHubRepoProof(env, owner, repo, route, cacheCreatedAt);
-  } finally {
-    if (coordinator !== undefined && leaseToken !== undefined) {
-      try {
-        await coordinator.finishCacheFill(proofKey, leaseToken);
-      } catch (error) {
-        console.error("public repo proof fill cleanup failed", error);
+      const outcome = await ownerFill.publish(() =>
+        refreshPublicGitHubRepoProof(env, owner, repo, route, cacheCreatedAt),
+      );
+      if (outcome !== undefined) {
+        return;
       }
+    } finally {
+      await ownerFill.fail();
     }
   }
 }
@@ -95,7 +120,7 @@ async function refreshPublicGitHubRepoProof(
   repo: string,
   route: RouteInfo,
   cacheCreatedAt?: string,
-): Promise<void> {
+): Promise<CacheFillOutcome> {
   if (route.tokenFreeOnly) {
     const pageProof = await fetchPublicRepoPageProof(env, owner, repo);
     if (pageProof === false) {
@@ -108,8 +133,7 @@ async function refreshPublicGitHubRepoProof(
         "GitHub public repository page check failed",
       );
     }
-    await storePublicRepoProof(env, owner, repo);
-    return;
+    return storePublicRepoProof(env, owner, repo);
   }
   let response = await fetchPublicRepoProof(env, owner, repo, true);
   let historicalProofEligibleResponse: Response | undefined;
@@ -125,8 +149,7 @@ async function refreshPublicGitHubRepoProof(
       throw new HttpError(403, "repo_not_public", "Octopool only relays public repositories");
     }
     if (pageProof === true) {
-      await storePublicRepoProof(env, owner, repo);
-      return;
+      return storePublicRepoProof(env, owner, repo);
     }
   }
   if (response.status === 404) {
@@ -135,11 +158,12 @@ async function refreshPublicGitHubRepoProof(
   if (!response.ok) {
     if (
       cacheCreatedAt !== undefined &&
-      (publicCheckMayUseHistoricalProof(response) ||
-        historicalProofEligibleResponse !== undefined) &&
-      (await cachedPublicGitHubRepoCovers(env, route, cacheCreatedAt))
+      (publicCheckMayUseHistoricalProof(response) || historicalProofEligibleResponse !== undefined)
     ) {
-      return;
+      const source = await coveringPublicRepoProofSource(env, route, cacheCreatedAt);
+      if (source !== undefined) {
+        return source === "shared" ? "shared" : "edge_only";
+      }
     }
     throw new HttpError(
       502,
@@ -151,7 +175,7 @@ async function refreshPublicGitHubRepoProof(
   if (body.private !== false) {
     throw new HttpError(403, "repo_not_public", "Octopool only relays public repositories");
   }
-  await storePublicRepoProof(env, owner, repo);
+  return storePublicRepoProof(env, owner, repo);
 }
 
 function fetchPublicRepoProof(
@@ -242,7 +266,11 @@ async function fetchPublicRepoPageProof(
   return undefined;
 }
 
-async function storePublicRepoProof(env: Env, owner: string, repo: string): Promise<void> {
+async function storePublicRepoProof(
+  env: Env,
+  owner: string,
+  repo: string,
+): Promise<CacheFillOutcome> {
   const ttlSeconds = parsePositiveInt(
     (env as unknown as Record<string, string | undefined>).PUBLIC_REPO_TTL_SECONDS,
     30,
@@ -252,10 +280,28 @@ async function storePublicRepoProof(env: Env, owner: string, repo: string): Prom
     checked_at: sqliteTimestamp(checkedAt),
     expires_at: sqliteTimestamp(new Date(checkedAt.getTime() + ttlSeconds * 1000)),
   };
-  await Promise.all([
-    env.DB.prepare(queries.upsertPublicRepoProof).bind(owner, repo, `+${ttlSeconds} seconds`).run(),
-    writeEdgeJSON(EDGE_CACHE_NAMESPACE, publicProofKey(owner, repo), proof, ttlSeconds),
-  ]);
+  const sharedWrite = (async () => {
+    try {
+      await env.DB.prepare(queries.upsertPublicRepoProof)
+        .bind(owner, repo, `+${ttlSeconds} seconds`)
+        .run();
+      return true;
+    } catch (error) {
+      console.error("public repo shared proof write failed", error);
+      return false;
+    }
+  })();
+  const edgeWrite = writeEdgeJSON(
+    EDGE_CACHE_NAMESPACE,
+    publicProofKey(owner, repo),
+    proof,
+    ttlSeconds,
+  ).catch((error: unknown) => {
+    console.error("public repo edge proof write failed", error);
+    return false;
+  });
+  const [edgePublished, sharedPublished] = await Promise.all([edgeWrite, sharedWrite]);
+  return sharedPublished ? "shared" : edgePublished ? "edge_only" : "failed";
 }
 
 function publicCheckMayRetryUnauthenticated(response: Response): boolean {
@@ -271,52 +317,50 @@ function publicCheckMayUseHistoricalProof(response: Response): boolean {
   );
 }
 
-async function cachedPublicGitHubRepoCovers(
+async function coveringPublicRepoProofSource(
   env: Env,
   route: RouteInfo,
   cacheCreatedAt: string,
-  requireFresh = false,
-): Promise<boolean> {
+  options: { requireFresh?: boolean; source?: PublicRepoProofSource } = {},
+): Promise<PublicRepoProofSource | undefined> {
   if (route.owner === undefined || route.repo === undefined) {
-    return true;
+    return "shared";
   }
   const owner = route.owner.toLowerCase();
   const repo = route.repo.toLowerCase();
   const edgeKey = publicProofKey(owner, repo);
-  const edge = await readEdgeJSON<PublicRepoProof>(EDGE_CACHE_NAMESPACE, edgeKey);
-  if (edge !== undefined) {
-    if (publicProofCovers(edge, cacheCreatedAt)) {
-      return true;
+  if (options.source !== "shared") {
+    const edge = await readEdgeJSON<PublicRepoProof>(EDGE_CACHE_NAMESPACE, edgeKey);
+    if (edge !== undefined) {
+      if (publicProofCovers(edge, cacheCreatedAt)) {
+        return "edge";
+      }
+      await deleteEdgeJSON(EDGE_CACHE_NAMESPACE, edgeKey);
     }
-    await deleteEdgeJSON(EDGE_CACHE_NAMESPACE, edgeKey);
+    if (options.source === "edge") {
+      return undefined;
+    }
   }
-  const query = requireFresh
+  const query = options.requireFresh
     ? queries.freshCoveringPublicRepoProof
     : queries.coveringPublicRepoProof;
-  const row = await env.DB.prepare(query)
-    .bind(owner, repo, cacheCreatedAt)
-    .first<PublicRepoProof>();
+  const row = await readD1PublicRepoProof(env, query, owner, repo, cacheCreatedAt);
   if (row === null || !publicProofCovers(row, cacheCreatedAt)) {
-    return false;
+    return undefined;
   }
   const ttlSeconds = Math.floor((parseSQLiteTimestamp(row.expires_at) - Date.now()) / 1000);
   await writeEdgeJSON(EDGE_CACHE_NAMESPACE, edgeKey, row, ttlSeconds);
-  return true;
+  return "shared";
 }
 
-async function waitForConcurrentPublicProof(
+function readD1PublicRepoProof(
   env: Env,
-  route: RouteInfo,
-  proofStartedAt: string,
-): Promise<boolean> {
-  const deadline = Date.now() + PROOF_WAIT_MS;
-  while (Date.now() < deadline) {
-    await sleep(PROOF_POLL_MS);
-    if (await cachedPublicGitHubRepoCovers(env, route, proofStartedAt, true)) {
-      return true;
-    }
-  }
-  return false;
+  query: string,
+  owner: string,
+  repo: string,
+  cacheCreatedAt: string,
+): Promise<PublicRepoProof | null> {
+  return env.DB.prepare(query).bind(owner, repo, cacheCreatedAt).first<PublicRepoProof>();
 }
 
 function publicProofCovers(proof: PublicRepoProof, cacheCreatedAt: string): boolean {
@@ -334,8 +378,4 @@ function publicProofCovers(proof: PublicRepoProof, cacheCreatedAt: string): bool
 
 function publicProofKey(owner: string, repo: string): string {
   return `${owner}/${repo}`;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -9,7 +9,8 @@ import {
   shouldUseGitHubCache,
   writeGitHubCache,
 } from "./cache";
-import { coalesceGitHubCacheMiss, finishGitHubCacheFill } from "./cache-coalesce";
+import { coalesceGitHubCacheMiss } from "./cache-coalesce";
+import type { CacheFillOutcome, OwnedCacheFill } from "./cache-fill";
 import { insertAudit, loadIdentities, loadPoolPolicy } from "./db";
 import { callGitHub, callPublicGitHub, probeGitHubLog } from "./github";
 import { supportsAnonymousGitHubAPI } from "./github-public-api";
@@ -91,7 +92,7 @@ type ActiveRelay = RelayBase & {
   sharedCacheKey: string | undefined;
   cacheKey: string | undefined;
   attemptedIdentityCacheKeys: { cacheKey: string; identity: Pick<Identity, "id" | "kind"> }[];
-  cacheFillToken: string | undefined;
+  cacheFill: OwnedCacheFill | undefined;
   cacheStatus: "miss" | "bypass";
   cacheable: boolean;
   identity: Identity | undefined;
@@ -167,9 +168,7 @@ async function relayGitHubRequest(
   } catch (error) {
     return await handleRelayError(base, active, error);
   } finally {
-    if (active?.cacheKey !== undefined) {
-      await finishGitHubCacheFill(active.coordinator, active.cacheKey, active.cacheFillToken);
-    }
+    await active?.cacheFill?.fail();
   }
 }
 
@@ -209,7 +208,7 @@ async function prepareRelay(
     sharedCacheKey: cacheKey,
     cacheKey,
     attemptedIdentityCacheKeys: [],
-    cacheFillToken: undefined,
+    cacheFill: undefined,
     cacheStatus: cacheKey === undefined ? "bypass" : "miss",
     cacheable: cacheKey !== undefined,
     identity: undefined,
@@ -340,26 +339,20 @@ async function coalesceRelayCacheMiss(
   if (state.cacheKey === undefined) {
     return undefined;
   }
-  const fill = await coalesceGitHubCacheMiss(
-    state.env,
-    state.coordinator,
-    state.cacheKey,
-    state.maxAgeSeconds === undefined ? {} : { maxAgeSeconds: state.maxAgeSeconds },
-  );
-  state.cacheFillToken = fill.leaseToken;
-  if (
-    fill.cached === undefined ||
-    !(await cachedResponseAvailable(
-      state.env,
-      state.request.pool,
-      state.route,
-      fill.cached,
-      state.coordinator,
-      state.identity,
-    ))
-  ) {
-    return undefined;
-  }
+  const fill = await coalesceGitHubCacheMiss(state.env, state.coordinator, state.cacheKey, {
+    ctx: state.ctx,
+    ...(state.maxAgeSeconds === undefined ? {} : { maxAgeSeconds: state.maxAgeSeconds }),
+    acceptCached: (cached) =>
+      cachedResponseAvailable(
+        state.env,
+        state.request.pool,
+        state.route,
+        cached,
+        state.coordinator,
+        state.identity,
+      ),
+  });
+  state.cacheFill = fill.owner;
   return fill.cached;
 }
 
@@ -367,8 +360,7 @@ async function revalidateStaleRelayCache(state: ActiveRelay): Promise<Response |
   try {
     return await attemptStaleRelayCacheRevalidation(state);
   } catch {
-    await restoreAfterFailedRevalidation(state);
-    return undefined;
+    return restoreSharedCacheFill(state);
   }
 }
 
@@ -391,7 +383,7 @@ async function attemptStaleRelayCacheRevalidation(
 
   const usesTokenFreeAPI = supportsAnonymousGitHubAPI(state.request, state.route);
   if (usesTokenFreeAPI || capabilities.fallback === "github_public") {
-    if (state.cacheFillToken === undefined) {
+    if (state.cacheFill === undefined) {
       const coalesced = await coalesceRelayCacheMiss(state);
       if (coalesced !== undefined) {
         return serveCachedGitHubResponse(
@@ -400,7 +392,7 @@ async function attemptStaleRelayCacheRevalidation(
           cachedResponseParams(state, coalesced, "hit", { coalesced: true }),
         );
       }
-      if (state.cacheFillToken === undefined) {
+      if (state.cacheFill === undefined) {
         return restoreSharedCacheFill(state);
       }
     }
@@ -445,25 +437,13 @@ async function attemptStaleRelayCacheRevalidation(
   await switchRelayCacheKey(state, identityCacheKey);
   const coalesced = await coalesceRelayCacheMiss(state);
   if (coalesced !== undefined) {
-    if (
-      await cachedResponseAvailable(
-        state.env,
-        state.request.pool,
-        state.route,
-        coalesced,
-        state.coordinator,
-        identity,
-      )
-    ) {
-      return serveCachedGitHubResponse(
-        state.env,
-        state.ctx,
-        cachedResponseParams(state, coalesced, "hit", { coalesced: true }),
-      );
-    }
-    return restoreSharedCacheFill(state);
+    return serveCachedGitHubResponse(
+      state.env,
+      state.ctx,
+      cachedResponseParams(state, coalesced, "hit", { coalesced: true }),
+    );
   }
-  if (state.cacheFillToken === undefined) {
+  if (state.cacheFill === undefined) {
     return restoreSharedCacheFill(state);
   }
   const github = await callRevalidationAPI(state, candidates[0]!, false, identity);
@@ -587,29 +567,6 @@ async function finishRevalidation(
   });
 }
 
-async function restoreAfterFailedRevalidation(state: ActiveRelay): Promise<void> {
-  if (
-    state.identity === undefined &&
-    state.cacheKey === state.sharedCacheKey &&
-    (state.cacheKey === undefined || state.cacheFillToken !== undefined)
-  ) {
-    return;
-  }
-  try {
-    state.identity = undefined;
-    await switchRelayCacheKey(state, state.sharedCacheKey);
-    if (state.cacheKey !== undefined && state.cacheFillToken === undefined) {
-      state.cacheFillToken = (await state.coordinator.claimCacheFill(state.cacheKey)) ?? undefined;
-    }
-  } catch {
-    state.identity = undefined;
-    state.cacheKey = state.sharedCacheKey;
-    state.cacheFillToken = undefined;
-    state.cacheStatus = state.sharedCacheKey === undefined ? "bypass" : "miss";
-    state.cacheable = state.sharedCacheKey !== undefined;
-  }
-}
-
 async function restoreSharedCacheFill(state: ActiveRelay): Promise<Response | undefined> {
   const coalesced = await restoreSharedCacheFillState(state);
   if (coalesced === undefined) {
@@ -636,11 +593,11 @@ async function restoreSharedCacheFillState(
   state: ActiveRelay,
 ): Promise<CachedGitHubResponse | undefined> {
   state.identity = undefined;
-  if (state.cacheKey === state.sharedCacheKey && state.cacheKey !== undefined) {
-    await finishGitHubCacheFill(state.coordinator, state.cacheKey, state.cacheFillToken);
-    state.cacheFillToken = undefined;
-  } else {
+  if (state.cacheKey !== state.sharedCacheKey) {
     await switchRelayCacheKey(state, state.sharedCacheKey);
+  }
+  if (state.cacheKey === undefined || state.cacheFill !== undefined) {
+    return undefined;
   }
   return coalesceRelayCacheMiss(state);
 }
@@ -759,10 +716,10 @@ async function switchRelayCacheKey(
     return;
   }
   if (state.cacheKey !== undefined) {
-    await finishGitHubCacheFill(state.coordinator, state.cacheKey, state.cacheFillToken);
+    await state.cacheFill?.fail();
   }
   state.cacheKey = cacheKey;
-  state.cacheFillToken = undefined;
+  state.cacheFill = undefined;
   state.cacheStatus = cacheKey === undefined ? "bypass" : "miss";
   state.cacheable = cacheKey !== undefined;
 }
@@ -773,15 +730,23 @@ async function finalizeRelaySuccess(state: ActiveRelay, result: RelaySuccess): P
   if (completedRunJobsResponse(result.github)) {
     state.route = await proveRunAttemptCompleted(state);
   }
-  if (state.cacheKey !== undefined) {
-    await publishGitHubCache(
-      state.env,
-      state.cacheKey,
-      state.cacheRequest,
-      state.route,
-      result.github,
-      result.identity,
+  const cacheKey = state.cacheKey;
+  if (cacheKey !== undefined) {
+    const owner = state.cacheFill;
+    if (owner === undefined) {
+      throw new Error("cache fill upstream work completed without ownership");
+    }
+    await owner.publish(() =>
+      publishGitHubCache(
+        state.env,
+        cacheKey,
+        state.cacheRequest,
+        state.route,
+        result.github,
+        result.identity,
+      ),
     );
+    state.cacheFill = undefined;
   }
   if (
     !state.runListExactFallback &&
@@ -1126,11 +1091,12 @@ async function publishGitHubCache(
   route: Parameters<typeof writeGitHubCache>[3],
   response: Parameters<typeof writeGitHubCache>[4],
   identity?: Identity,
-): Promise<void> {
+): Promise<CacheFillOutcome> {
   try {
-    await writeGitHubCache(env, cacheKey, request, route, response, identity);
+    return await writeGitHubCache(env, cacheKey, request, route, response, identity);
   } catch (error) {
     console.error("github cache write failed", error);
+    return "failed";
   }
 }
 

--- a/test/cache-coalesce.test.ts
+++ b/test/cache-coalesce.test.ts
@@ -1,128 +1,203 @@
 import { describe, expect, it, vi } from "vitest";
-import { coalesceGitHubCacheMiss, finishGitHubCacheFill } from "../src/cache-coalesce";
+import { coalesceGitHubCacheMiss } from "../src/cache-coalesce";
+import { acquireOwnedCacheFill } from "../src/cache-fill";
+import type { GitHubCacheRead } from "../src/cache";
+import { fakeCacheFillCoordinator } from "./cache-fill-test-support";
 
 describe("cache miss coalescing", () => {
-  it("lets the first request lead the fill", async () => {
-    const coordinator = {
-      claimCacheFill: vi.fn(async () => "lease-token"),
-      finishCacheFill: vi.fn(async () => undefined),
-    };
-    const result = await coalesceGitHubCacheMiss(env([]), coordinator as never, "cache-key");
+  it("rechecks the cache after becoming the owner", async () => {
+    const coordinator = fakeCacheFillCoordinator([{ kind: "owner", token: "leader" }]);
+    const readShared = vi.fn(async () => undefined);
 
-    expect(result).toEqual({ leaseToken: "lease-token" });
-    expect(coordinator.claimCacheFill).toHaveBeenCalledWith("cache-key");
-  });
-
-  it("waits for a concurrent leader to publish", async () => {
-    const coordinator = {
-      claimCacheFill: vi.fn(async () => null),
-      finishCacheFill: vi.fn(async () => undefined),
-    };
-    const cached = {
-      status: 200,
-      response_headers_json: "{}",
-      body_json: '{"status":"completed"}',
-      body_encoding: "json",
-      identity_id: null,
-      identity_kind: null,
-      created_at: "2026-06-14 00:00:00",
-      expires_at: "2026-06-14 01:00:00",
-    };
-    const result = await coalesceGitHubCacheMiss(
-      env([null, cached]),
-      coordinator as never,
-      "cache-key",
-      {
-        waitMs: 10,
-        pollMs: 1,
-        sleep: async () => undefined,
-      },
-    );
-
-    expect(result).toMatchObject({
-      cached: { status: 200, body: { status: "completed" } },
+    const result = await coalesceGitHubCacheMiss({} as Env, coordinator, "cache-key", {
+      readShared,
     });
+
+    expect(result.owner?.token).toBe("leader");
+    expect(readShared).toHaveBeenCalledOnce();
+    await result.owner?.fail();
+    expect(coordinator.completeCacheFill).toHaveBeenCalledWith("cache-key", "leader", "failed");
   });
 
-  it("ignores published entries older than the requested max-age while waiting", async () => {
-    const coordinator = {
-      claimCacheFill: vi.fn(async () => null),
-      finishCacheFill: vi.fn(async () => undefined),
-    };
-    const aged = {
-      status: 200,
-      response_headers_json: "{}",
-      body_json: '{"head":{"sha":"old"}}',
-      body_encoding: "json",
-      identity_id: null,
-      identity_kind: null,
-      created_at: sqliteUTC(Date.now() - 60_000),
-      expires_at: sqliteUTC(Date.now() + 60_000),
-    };
-    const result = await coalesceGitHubCacheMiss(
-      env([aged, aged, aged]),
-      coordinator as never,
-      "cache-key",
-      {
-        waitMs: 3,
-        pollMs: 1,
-        maxAgeSeconds: 20,
-        sleep: async () => undefined,
+  it.each([
+    {
+      name: "shared-cache recheck",
+      readShared: async () => {
+        throw new Error("recheck failed");
       },
-    );
+      acceptCached: undefined,
+    },
+    {
+      name: "cached acceptance",
+      readShared: async () => sharedRead(),
+      acceptCached: async () => {
+        throw new Error("acceptance failed");
+      },
+    },
+  ])("fails an acquired owner when $name throws", async ({ readShared, acceptCached }) => {
+    vi.useFakeTimers();
+    try {
+      const coordinator = fakeCacheFillCoordinator([{ kind: "owner", token: "leader" }]);
+      await expect(
+        coalesceGitHubCacheMiss({} as Env, coordinator, "cache-key", {
+          readShared,
+          ...(acceptCached === undefined ? {} : { acceptCached }),
+        }),
+      ).rejects.toThrow();
 
-    expect(result).toEqual({});
+      expect(coordinator.completeCacheFill).toHaveBeenCalledWith("cache-key", "leader", "failed");
+      await vi.advanceTimersByTimeAsync(6_000);
+      expect(coordinator.renewCacheFill).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
-  it("only releases fills owned by the current request", async () => {
-    const coordinator = {
-      claimCacheFill: vi.fn(async () => "leader-token"),
-      finishCacheFill: vi.fn(async () => undefined),
-    };
+  it("rereads the shared cache once after completion", async () => {
+    const coordinator = fakeCacheFillCoordinator([{ kind: "completed", outcome: "shared" }]);
+    const readShared = vi.fn(async () => sharedRead());
+    const readEdge = vi.fn(async () => undefined);
 
-    await finishGitHubCacheFill(coordinator as never, "leader", "leader-token");
-    await finishGitHubCacheFill(coordinator as never, "follower", undefined);
+    const result = await coalesceGitHubCacheMiss({} as Env, coordinator, "cache-key", {
+      readShared,
+      readEdge,
+    });
 
-    expect(coordinator.finishCacheFill).toHaveBeenCalledTimes(1);
-    expect(coordinator.finishCacheFill).toHaveBeenCalledWith("leader", "leader-token");
+    expect(result.cached).toMatchObject({ body: { status: "completed" } });
+    expect(readShared).toHaveBeenCalledOnce();
+    expect(readEdge).not.toHaveBeenCalled();
+    expect(coordinator.acquireCacheFill).toHaveBeenCalledOnce();
   });
 
-  it("does not replace relay failures when cleanup fails", async () => {
-    const coordinator = {
-      claimCacheFill: vi.fn(async () => "lease-token"),
-      finishCacheFill: vi.fn(async () => {
-        throw new Error("coordinator unavailable");
-      }),
-    };
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  it("serves an edge-only completion from the same colo without D1", async () => {
+    const coordinator = fakeCacheFillCoordinator([{ kind: "completed", outcome: "edge_only" }]);
+    const readShared = vi.fn(async () => undefined);
+    const readEdge = vi.fn(async () => sharedRead().cached);
 
-    await expect(
-      finishGitHubCacheFill(coordinator as never, "cache-key", "lease-token"),
-    ).resolves.toBeUndefined();
-    expect(consoleError).toHaveBeenCalledWith(
-      "github cache fill cleanup failed",
-      expect.any(Error),
-    );
-    consoleError.mockRestore();
+    const result = await coalesceGitHubCacheMiss({} as Env, coordinator, "cache-key", {
+      readShared,
+      readEdge,
+    });
+
+    expect(result.cached).toMatchObject({ body: { status: "completed" } });
+    expect(readEdge).toHaveBeenCalledOnce();
+    expect(readShared).not.toHaveBeenCalled();
+  });
+
+  it("reacquires immediately after an edge-only remote-colo miss", async () => {
+    const coordinator = fakeCacheFillCoordinator([
+      { kind: "completed", outcome: "edge_only" },
+      { kind: "owner", token: "takeover" },
+    ]);
+    const readShared = vi.fn(async () => undefined);
+    const readEdge = vi.fn(async () => undefined);
+
+    const result = await coalesceGitHubCacheMiss({} as Env, coordinator, "cache-key", {
+      readShared,
+      readEdge,
+    });
+
+    expect(result.owner?.token).toBe("takeover");
+    expect(readEdge).toHaveBeenCalledOnce();
+    expect(readShared).toHaveBeenCalledOnce();
+    expect(coordinator.acquireCacheFill).toHaveBeenCalledTimes(2);
+    await result.owner?.fail();
+  });
+
+  it("does not read either cache as a completion channel after failed publication", async () => {
+    const coordinator = fakeCacheFillCoordinator([
+      { kind: "completed", outcome: "failed" },
+      { kind: "owner", token: "retry-owner" },
+    ]);
+    const readShared = vi.fn(async () => undefined);
+    const readEdge = vi.fn(async () => undefined);
+
+    const result = await coalesceGitHubCacheMiss({} as Env, coordinator, "cache-key", {
+      readShared,
+      readEdge,
+    });
+
+    expect(result.owner?.token).toBe("retry-owner");
+    expect(readShared).toHaveBeenCalledOnce();
+    expect(readEdge).not.toHaveBeenCalled();
+    await result.owner?.fail();
+  });
+
+  it("blocks stale completion after renewal loss", async () => {
+    vi.useFakeTimers();
+    try {
+      const coordinator = fakeCacheFillCoordinator([{ kind: "owner", token: "lost-owner" }]);
+      coordinator.renewCacheFill.mockResolvedValueOnce(false);
+      const acquisition = await acquireOwnedCacheFill(coordinator, "cache-key");
+      expect(acquisition.kind).toBe("owner");
+      if (acquisition.kind !== "owner") {
+        return;
+      }
+
+      await expect(acquisition.owner.renew()).resolves.toBe(false);
+      await expect(acquisition.owner.complete("shared")).resolves.toBe(false);
+      await vi.advanceTimersByTimeAsync(6_000);
+      expect(coordinator.renewCacheFill).toHaveBeenCalledOnce();
+      expect(coordinator.completeCacheFill).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reuses one in-flight final renewal and leaves no queued timer after publication", async () => {
+    vi.useFakeTimers();
+    try {
+      const coordinator = fakeCacheFillCoordinator([{ kind: "owner", token: "leader" }]);
+      let resolveRenewal!: (renewed: boolean) => void;
+      const renewal = new Promise<boolean>((resolve) => {
+        resolveRenewal = resolve;
+      });
+      coordinator.renewCacheFill.mockReturnValue(renewal);
+      const acquisition = await acquireOwnedCacheFill(coordinator, "cache-key");
+      expect(acquisition.kind).toBe("owner");
+      if (acquisition.kind !== "owner") {
+        return;
+      }
+
+      const explicitRenewal = acquisition.owner.renew();
+      const publication = acquisition.owner.publish(async () => "shared");
+      expect(coordinator.renewCacheFill).toHaveBeenCalledOnce();
+      resolveRenewal(true);
+      await expect(explicitRenewal).resolves.toBe(true);
+      await expect(publication).resolves.toBe("shared");
+      expect(coordinator.completeCacheFill).toHaveBeenCalledWith("cache-key", "leader", "shared");
+
+      await vi.advanceTimersByTimeAsync(6_000);
+      expect(coordinator.renewCacheFill).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("re-enters acquisition after a waiting RPC is reset", async () => {
+    const coordinator = fakeCacheFillCoordinator([{ kind: "owner", token: "recovered-owner" }]);
+    coordinator.acquireCacheFill.mockRejectedValueOnce(new Error("Durable Object reset"));
+
+    const result = await coalesceGitHubCacheMiss({} as Env, coordinator, "cache-key", {
+      readShared: async () => undefined,
+    });
+
+    expect(result.owner?.token).toBe("recovered-owner");
+    expect(coordinator.acquireCacheFill).toHaveBeenCalledTimes(2);
+    await result.owner?.fail();
   });
 });
 
-function sqliteUTC(ms: number): string {
-  return new Date(ms)
-    .toISOString()
-    .replace("T", " ")
-    .replace(/\.\d{3}Z$/, "");
-}
-
-function env(rows: unknown[]): Env {
-  let index = 0;
+function sharedRead(): GitHubCacheRead {
   return {
-    DB: {
-      prepare: () => ({
-        bind: () => ({
-          first: async () => rows[index++] ?? null,
-        }),
-      }),
+    source: "shared",
+    cached: {
+      status: 200,
+      headers: {},
+      body: { status: "completed" },
+      body_encoding: "json",
+      created_at: "2026-08-09 00:00:00",
+      expires_at: "2026-08-09 01:00:00",
     },
-  } as unknown as Env;
+  };
 }

--- a/test/cache-fill-test-support.ts
+++ b/test/cache-fill-test-support.ts
@@ -1,0 +1,17 @@
+import { vi } from "vitest";
+import type { CacheFillAcquisition, CacheFillCoordinator } from "../src/cache-fill";
+
+export function fakeCacheFillCoordinator(acquisitions: CacheFillAcquisition[]) {
+  let index = 0;
+  return {
+    acquireCacheFill: vi.fn(async () => {
+      const acquisition = acquisitions[index++];
+      if (acquisition === undefined) {
+        throw new Error("unexpected cache-fill acquisition");
+      }
+      return acquisition;
+    }),
+    renewCacheFill: vi.fn(async () => true),
+    completeCacheFill: vi.fn(async () => true),
+  } satisfies CacheFillCoordinator;
+}

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -676,7 +676,9 @@ describe("github cache policy", () => {
       },
     } as unknown as Env;
 
-    await writeGitHubCache(env, "cache-key", request, route, response({ number: 42 }));
+    await expect(
+      writeGitHubCache(env, "cache-key", request, route, response({ number: 42 })),
+    ).resolves.toBe("shared");
 
     expect(run).toHaveBeenCalledOnce();
     expect(put).toHaveBeenCalledOnce();
@@ -713,25 +715,91 @@ describe("github cache policy", () => {
       },
     } as unknown as Env;
 
-    await writeGitHubCache(
-      env,
-      "cache-key",
-      request,
-      route,
-      response({ blob: "x".repeat(300_000) }),
-    );
+    await expect(
+      writeGitHubCache(env, "cache-key", request, route, response({ blob: "x".repeat(300_000) })),
+    ).resolves.toBe("edge_only");
 
     // 120k CJK chars pass a UTF-16 code-unit count but exceed the cap in UTF-8 bytes.
-    await writeGitHubCache(
-      env,
-      "cache-key-multibyte",
-      request,
-      route,
-      response({ blob: "语".repeat(120_000) }),
-    );
+    await expect(
+      writeGitHubCache(
+        env,
+        "cache-key-multibyte",
+        request,
+        route,
+        response({ blob: "语".repeat(120_000) }),
+      ),
+    ).resolves.toBe("edge_only");
 
     expect(run).not.toHaveBeenCalled();
     expect(put).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports failed when an edge-only cache put rejects", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.stubGlobal("caches", {
+      default: {
+        match: vi.fn(async () => undefined),
+        put: vi.fn(async () => {
+          throw new Error("cache put rejected");
+        }),
+        delete: vi.fn(async () => true),
+      },
+    });
+    const run = vi.fn(async () => ({}));
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/openclaw/pulls/42",
+    });
+    const route = classifyRoute(request, policy);
+    const env = {
+      DB: { prepare: () => ({ bind: () => ({ run }) }) },
+    } as unknown as Env;
+
+    await expect(
+      writeGitHubCache(env, "cache-key", request, route, response({ blob: "x".repeat(300_000) })),
+    ).resolves.toBe("failed");
+    expect(run).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(
+      "edge cache write failed",
+      expect.objectContaining({ namespace: "github-v1" }),
+    );
+  });
+
+  it("reports edge-only when D1 fails after a confirmed edge publication", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.stubGlobal("caches", {
+      default: {
+        match: vi.fn(async () => undefined),
+        put: vi.fn(async () => undefined),
+        delete: vi.fn(async () => true),
+      },
+    });
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/openclaw/pulls/42",
+    });
+    const route = classifyRoute(request, policy);
+    const env = {
+      DB: {
+        prepare: () => ({
+          bind: () => ({
+            run: async () => {
+              throw new Error("D1 unavailable");
+            },
+          }),
+        }),
+      },
+    } as unknown as Env;
+
+    await expect(
+      writeGitHubCache(env, "cache-key", request, route, response({ number: 42 })),
+    ).resolves.toBe("edge_only");
+    expect(consoleError).toHaveBeenCalledWith(
+      "github shared cache write failed",
+      expect.any(Error),
+    );
   });
 
   it("serves only stale cache rows inside the route grace window", async () => {

--- a/test/e2e/cache-fill-behavior.test.ts
+++ b/test/e2e/cache-fill-behavior.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from "vitest";
+import { bearer, jsonResponse, relay, seedPool } from "./harness";
+
+const PATH = "/repos/openclaw/octopool/pulls/42";
+const OPTIONS = { headers: { accept: "application/vnd.github.diff" } };
+
+describe("Worker end-to-end cache-fill outcomes", () => {
+  it("wakes shared followers for one cache reread without duplicate upstream work", async () => {
+    const { responses, upstream } = await concurrentFill("small shared body", true);
+
+    expect(responses.map(({ status }) => status)).toEqual([200, 200]);
+    expect(upstream.calls()).toBe(1);
+    expect(upstream.maxConcurrent()).toBe(1);
+    expect(await responses[1]!.json()).toMatchObject({ relay: { cache: "hit" } });
+  });
+
+  it("serves an edge-only completion in the same colo", async () => {
+    const { responses, upstream } = await concurrentFill("x".repeat(300_000), true);
+
+    expect(responses.map(({ status }) => status)).toEqual([200, 200]);
+    expect(upstream.calls()).toBe(1);
+    expect(await responses[1]!.json()).toMatchObject({ relay: { cache: "hit" } });
+  });
+
+  it("serializes one takeover after an edge-only remote-colo miss", async () => {
+    const { responses, upstream } = await concurrentFill("x".repeat(300_000), false);
+
+    expect(responses.map(({ status }) => status)).toEqual([200, 200]);
+    expect(upstream.calls()).toBe(2);
+    expect(upstream.maxConcurrent()).toBe(1);
+    expect(await responses[1]!.json()).toMatchObject({ relay: { cache: "miss" } });
+  });
+
+  it("wakes a follower promptly when the leader throws", async () => {
+    await seedPool();
+    const cache = edgeCache(true);
+    vi.stubGlobal("caches", { default: cache.default });
+    const upstream = gatedDiffUpstream("recovered", { failFirst: true });
+    vi.stubGlobal("fetch", upstream.fetch);
+
+    const leader = relay(PATH, undefined, OPTIONS);
+    await upstream.started;
+    const follower = relay(PATH, undefined, OPTIONS);
+    await cache.waitForGitHubMatches(3);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    upstream.release();
+    const followerResponse = await Promise.race([
+      follower,
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("follower stayed blocked")), 2_000),
+      ),
+    ]);
+    await leader.catch(() => undefined);
+
+    expect(followerResponse.status).toBe(200);
+    expect(upstream.calls()).toBe(2);
+  });
+
+  it("keeps upstream work beyond the old eight-second lease exclusively owned", async () => {
+    await seedPool();
+    const cache = edgeCache(true);
+    vi.stubGlobal("caches", { default: cache.default });
+    const upstream = gatedDiffUpstream("renewed shared body");
+    vi.stubGlobal("fetch", upstream.fetch);
+
+    const leader = relay(PATH, undefined, OPTIONS);
+    await upstream.started;
+    const follower = relay(PATH, undefined, OPTIONS);
+    await cache.waitForGitHubMatches(3);
+    await new Promise((resolve) => setTimeout(resolve, 8_500));
+
+    expect(upstream.calls()).toBe(1);
+    expect(upstream.maxConcurrent()).toBe(1);
+    upstream.release();
+    const responses = await Promise.all([leader, follower]);
+    expect(responses.map(({ status }) => status)).toEqual([200, 200]);
+    expect(upstream.calls()).toBe(1);
+  }, 15_000);
+});
+
+async function concurrentFill(body: string, githubEntriesVisible: boolean) {
+  await seedPool();
+  const cache = edgeCache(githubEntriesVisible);
+  vi.stubGlobal("caches", { default: cache.default });
+  const upstream = gatedDiffUpstream(body);
+  vi.stubGlobal("fetch", upstream.fetch);
+
+  const leader = relay(PATH, undefined, OPTIONS);
+  await upstream.started;
+  const follower = relay(PATH, undefined, OPTIONS);
+  await cache.waitForGitHubMatches(3);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  upstream.release();
+  return { responses: await Promise.all([leader, follower]), upstream };
+}
+
+function gatedDiffUpstream(body: string, options: { failFirst?: boolean } = {}) {
+  let active = 0;
+  let maximum = 0;
+  let count = 0;
+  let release!: () => void;
+  let markStarted!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve;
+  });
+  const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+    const request = new Request(input, init);
+    if (bearer(request) === "test-org-token") {
+      return jsonResponse({ private: false });
+    }
+    if (bearer(request) !== "test-primary-token") {
+      return new Response("unavailable", { status: 503 });
+    }
+    count++;
+    active++;
+    maximum = Math.max(maximum, active);
+    if (count === 1) {
+      markStarted();
+      await gate;
+      if (options.failFirst === true) {
+        active--;
+        throw new Error("leader failed");
+      }
+    }
+    active--;
+    return new Response(body, { headers: { "content-type": "text/plain" } });
+  });
+  return {
+    fetch: fetchMock,
+    started,
+    release,
+    calls: () => count,
+    maxConcurrent: () => maximum,
+  };
+}
+
+function edgeCache(githubEntriesVisible: boolean) {
+  const entries = new Map<string, Response>();
+  let githubMatches = 0;
+  const matchWaiters = new Set<() => void>();
+  const defaultCache = {
+    match: vi.fn(async (request: Request) => {
+      if (request.url.includes("/github-v1/")) {
+        githubMatches++;
+        for (const wake of matchWaiters) {
+          wake();
+        }
+      }
+      if (!githubEntriesVisible && request.url.includes("/github-v1/")) {
+        return undefined;
+      }
+      return entries.get(request.url)?.clone();
+    }),
+    put: vi.fn(async (request: Request, response: Response) => {
+      entries.set(request.url, response.clone());
+    }),
+    delete: vi.fn(async (request: Request) => entries.delete(request.url)),
+  };
+  return {
+    default: defaultCache,
+    async waitForGitHubMatches(count: number): Promise<void> {
+      while (githubMatches < count) {
+        await new Promise<void>((resolve) => {
+          matchWaiters.add(resolve);
+        });
+        matchWaiters.clear();
+      }
+    },
+  };
+}

--- a/test/e2e/cache-fill-protocol.test.ts
+++ b/test/e2e/cache-fill-protocol.test.ts
@@ -1,0 +1,49 @@
+import { env } from "cloudflare:workers";
+import { describe, expect, it } from "vitest";
+import { poolCoordinatorStub } from "../../src/pool-coordinator";
+
+describe("PoolCoordinator cache-fill protocol", () => {
+  it("allows completion RPC to wake a waiting acquisition", async () => {
+    const coordinator = poolCoordinatorStub(env, "cache-fill-wakeup");
+    const leader = await coordinator.acquireCacheFill("key");
+    expect(leader.kind).toBe("owner");
+    if (leader.kind !== "owner") {
+      return;
+    }
+
+    const followers = [coordinator.acquireCacheFill("key"), coordinator.acquireCacheFill("key")];
+    expect(await coordinator.completeCacheFill("key", leader.token, "shared")).toBe(true);
+
+    await expect(Promise.all(followers)).resolves.toEqual([
+      { kind: "completed", outcome: "shared" },
+      { kind: "completed", outcome: "shared" },
+    ]);
+  });
+
+  it("rejects stale tokens after expiry without releasing a newer owner", async () => {
+    const coordinator = poolCoordinatorStub(env, "cache-fill-fencing");
+    const stale = await coordinator.acquireCacheFill("key");
+    expect(stale.kind).toBe("owner");
+    if (stale.kind !== "owner") {
+      return;
+    }
+    const staleFollower = coordinator.acquireCacheFill("key");
+
+    await new Promise((resolve) => setTimeout(resolve, 8_100));
+    const current = await coordinator.acquireCacheFill("key");
+    expect(current.kind).toBe("owner");
+    if (current.kind !== "owner") {
+      return;
+    }
+
+    await expect(staleFollower).resolves.toEqual({ kind: "retry" });
+    expect(await coordinator.renewCacheFill("key", stale.token)).toBe(false);
+    expect(await coordinator.completeCacheFill("key", stale.token, "shared")).toBe(false);
+    expect(await coordinator.completeCacheFill("key", "wrong-token", "failed")).toBe(false);
+    expect(await coordinator.renewCacheFill("key", current.token)).toBe(true);
+
+    const currentFollower = coordinator.acquireCacheFill("key");
+    expect(await coordinator.completeCacheFill("key", current.token, "failed")).toBe(true);
+    await expect(currentFollower).resolves.toEqual({ kind: "completed", outcome: "failed" });
+  }, 15_000);
+});

--- a/test/public-repos.test.ts
+++ b/test/public-repos.test.ts
@@ -5,6 +5,7 @@ import {
   recordPublicGitHubRepo,
 } from "../src/public-repos";
 import type { RouteInfo } from "../src/types";
+import { fakeCacheFillCoordinator } from "./cache-fill-test-support";
 
 describe("public repo guard", () => {
   afterEach(() => {
@@ -168,6 +169,7 @@ describe("public repo guard", () => {
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(first).toHaveBeenCalledTimes(2);
   });
 
   it.each([
@@ -279,10 +281,7 @@ describe("public repo guard", () => {
   it("coalesces a concurrent public proof refresh through the pool coordinator", async () => {
     const fetchMock = vi.fn(async () => Response.json({ private: false }));
     vi.stubGlobal("fetch", fetchMock);
-    const coordinator = {
-      claimCacheFill: vi.fn(async () => null),
-      finishCacheFill: vi.fn(async () => undefined),
-    };
+    const coordinator = fakeCacheFillCoordinator([{ kind: "completed", outcome: "shared" }]);
     const database = {
       prepare: vi.fn(() => ({
         bind: vi.fn(() => ({
@@ -296,12 +295,12 @@ describe("public repo guard", () => {
       { ...env(), DB: database } as unknown as Env,
       route(),
       undefined,
-      coordinator as never,
+      coordinator,
     );
 
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(coordinator.claimCacheFill).toHaveBeenCalledWith("public-repo:openclaw/octopool");
-    expect(coordinator.finishCacheFill).not.toHaveBeenCalled();
+    expect(coordinator.acquireCacheFill).toHaveBeenCalledWith("public-repo:openclaw/octopool");
+    expect(coordinator.completeCacheFill).not.toHaveBeenCalled();
   });
 
   it("releases a public proof fill after the leader refreshes it", async () => {
@@ -309,30 +308,124 @@ describe("public repo guard", () => {
       "fetch",
       vi.fn(async () => Response.json({ private: false })),
     );
-    const coordinator = {
-      claimCacheFill: vi.fn(async () => "proof-lease"),
-      finishCacheFill: vi.fn(async () => undefined),
-    };
+    const coordinator = fakeCacheFillCoordinator([{ kind: "owner", token: "proof-lease" }]);
 
-    await ensurePublicGitHubRepo(env(), route(), undefined, coordinator as never);
+    await ensurePublicGitHubRepo(env(), route(), undefined, coordinator);
 
-    expect(coordinator.finishCacheFill).toHaveBeenCalledWith(
+    expect(coordinator.completeCacheFill).toHaveBeenCalledWith(
       "public-repo:openclaw/octopool",
       "proof-lease",
+      "shared",
     );
   });
 
-  it("reclaims an expired public proof lease before refreshing", async () => {
-    vi.useFakeTimers();
+  it("fails an acquired owner when its D1 recheck throws", async () => {
+    const coordinator = fakeCacheFillCoordinator([{ kind: "owner", token: "proof-lease" }]);
+    const first = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockRejectedValueOnce(new Error("D1 recheck failed"));
+    const database = {
+      prepare: vi.fn(() => ({ bind: vi.fn(() => ({ first })) })),
+    };
+
+    await expect(
+      ensurePublicGitHubRepo(
+        { ...env(), DB: database } as unknown as Env,
+        route(),
+        sqliteUTC(Date.now() - 1_000),
+        coordinator,
+      ),
+    ).rejects.toThrow("D1 recheck failed");
+    expect(coordinator.completeCacheFill).toHaveBeenCalledWith(
+      "public-repo:openclaw/octopool",
+      "proof-lease",
+      "failed",
+    );
+  });
+
+  it("completes a public proof fill as failed when D1 persistence fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ private: false })),
+    );
+    const coordinator = fakeCacheFillCoordinator([{ kind: "owner", token: "proof-lease" }]);
+    const database = {
+      prepare: vi.fn(() => ({
+        bind: vi.fn(() => ({
+          first: vi.fn(async () => null),
+          run: vi.fn(async () => {
+            throw new Error("D1 unavailable");
+          }),
+        })),
+      })),
+    };
+
+    await expect(
+      ensurePublicGitHubRepo(
+        { ...env(), DB: database } as unknown as Env,
+        route(),
+        undefined,
+        coordinator,
+      ),
+    ).resolves.toBeUndefined();
+    expect(coordinator.completeCacheFill).toHaveBeenCalledWith(
+      "public-repo:openclaw/octopool",
+      "proof-lease",
+      "failed",
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      "public repo shared proof write failed",
+      expect.any(Error),
+    );
+  });
+
+  it("publishes edge-only when D1 persistence fails after the local edge write", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ private: false })),
+    );
+    vi.stubGlobal("caches", {
+      default: {
+        match: vi.fn(async () => undefined),
+        put: vi.fn(async () => undefined),
+        delete: vi.fn(async () => true),
+      },
+    });
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const coordinator = fakeCacheFillCoordinator([{ kind: "owner", token: "proof-lease" }]);
+    const database = {
+      prepare: vi.fn(() => ({
+        bind: vi.fn(() => ({
+          run: vi.fn(async () => {
+            throw new Error("D1 unavailable");
+          }),
+        })),
+      })),
+    };
+
+    await ensurePublicGitHubRepo(
+      { ...env(), DB: database } as unknown as Env,
+      route(),
+      undefined,
+      coordinator,
+    );
+
+    expect(coordinator.completeCacheFill).toHaveBeenCalledWith(
+      "public-repo:openclaw/octopool",
+      "proof-lease",
+      "edge_only",
+    );
+  });
+
+  it("retries coordinator ownership before refreshing an expired public proof", async () => {
     const fetchMock = vi.fn(async () => Response.json({ private: false }));
     vi.stubGlobal("fetch", fetchMock);
-    const coordinator = {
-      claimCacheFill: vi
-        .fn<() => Promise<string | null>>()
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce("replacement-lease"),
-      finishCacheFill: vi.fn(async () => undefined),
-    };
+    const coordinator = fakeCacheFillCoordinator([
+      { kind: "retry" },
+      { kind: "owner", token: "replacement-lease" },
+    ]);
     const database = {
       prepare: vi.fn((query: string) => ({
         bind: vi.fn(() => ({
@@ -343,21 +436,109 @@ describe("public repo guard", () => {
       })),
     };
 
-    const pending = ensurePublicGitHubRepo(
+    await ensurePublicGitHubRepo(
       { ...env(), DB: database } as unknown as Env,
       route(),
       undefined,
-      coordinator as never,
+      coordinator,
     );
-    await vi.advanceTimersByTimeAsync(4_100);
-    await pending;
 
-    expect(coordinator.claimCacheFill).toHaveBeenCalledTimes(2);
+    expect(coordinator.acquireCacheFill).toHaveBeenCalledTimes(2);
     expect(fetchMock).toHaveBeenCalledOnce();
-    expect(coordinator.finishCacheFill).toHaveBeenCalledWith(
+    expect(coordinator.completeCacheFill).toHaveBeenCalledWith(
       "public-repo:openclaw/octopool",
       "replacement-lease",
+      "shared",
     );
+  });
+
+  it("reacquires when final renewal loses ownership before proof publication", async () => {
+    const fetchMock = vi.fn(async () => Response.json({ private: false }));
+    vi.stubGlobal("fetch", fetchMock);
+    const coordinator = fakeCacheFillCoordinator([
+      { kind: "owner", token: "lost-owner" },
+      { kind: "owner", token: "replacement-owner" },
+    ]);
+    coordinator.renewCacheFill.mockResolvedValueOnce(false).mockResolvedValue(true);
+
+    await ensurePublicGitHubRepo(env(), route(), undefined, coordinator);
+
+    expect(coordinator.acquireCacheFill).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(coordinator.completeCacheFill).toHaveBeenCalledTimes(1);
+    expect(coordinator.completeCacheFill).toHaveBeenCalledWith(
+      "public-repo:openclaw/octopool",
+      "replacement-owner",
+      "shared",
+    );
+  });
+
+  it("serves an edge-only completion in the same colo without a second D1 read", async () => {
+    const edgeMatch = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(Response.json(proof()));
+    vi.stubGlobal("caches", {
+      default: {
+        match: edgeMatch,
+        put: vi.fn(async () => undefined),
+        delete: vi.fn(async () => true),
+      },
+    });
+    const first = vi.fn(async () => null);
+    const coordinator = fakeCacheFillCoordinator([{ kind: "completed", outcome: "edge_only" }]);
+
+    await ensurePublicGitHubRepo(
+      {
+        ...env(),
+        DB: { prepare: vi.fn(() => ({ bind: vi.fn(() => ({ first })) })) },
+      } as unknown as Env,
+      route(),
+      sqliteUTC(Date.now() - 1_000),
+      coordinator,
+    );
+
+    expect(first).toHaveBeenCalledOnce();
+    expect(edgeMatch).toHaveBeenCalledTimes(2);
+    expect(coordinator.acquireCacheFill).toHaveBeenCalledOnce();
+  });
+
+  it("reacquires after an edge-only completion misses in the local colo", async () => {
+    vi.stubGlobal("caches", {
+      default: {
+        match: vi.fn(async () => undefined),
+        put: vi.fn(async () => undefined),
+        delete: vi.fn(async () => true),
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ private: false })),
+    );
+    const coordinator = fakeCacheFillCoordinator([
+      { kind: "completed", outcome: "edge_only" },
+      { kind: "owner", token: "takeover" },
+    ]);
+    const first = vi.fn(async () => null);
+    const run = vi.fn(async () => ({}));
+
+    await ensurePublicGitHubRepo(
+      {
+        ...env(),
+        DB: { prepare: vi.fn(() => ({ bind: vi.fn(() => ({ first, run })) })) },
+      } as unknown as Env,
+      route(),
+      sqliteUTC(Date.now() - 1_000),
+      coordinator,
+    );
+
+    expect(coordinator.acquireCacheFill).toHaveBeenCalledTimes(2);
+    expect(coordinator.completeCacheFill).toHaveBeenCalledWith(
+      "public-repo:openclaw/octopool",
+      "takeover",
+      "shared",
+    );
+    expect(run).toHaveBeenCalledOnce();
   });
 
   it("serves a covering public proof from the edge without reading D1", async () => {
@@ -399,7 +580,7 @@ describe("public repo guard", () => {
       recordPublicGitHubRepo({ ...env(), DB: database } as unknown as Env, route()),
     ).resolves.toBeUndefined();
     expect(consoleError).toHaveBeenCalledWith(
-      "public repo proof persistence failed",
+      "public repo shared proof write failed",
       expect.any(Error),
     );
     consoleError.mockRestore();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an oversized GitHub response cached only in one Cloudflare colo could leave followers in other colos polling D1 for a row that intentionally did not exist. After four seconds those followers proceeded upstream without owning the still-active global fill lease, amplifying D1 reads and allowing overlapping duplicate GitHub work.

## Why This Change Was Made

The per-pool Durable Object now owns the complete cache-fill lifecycle: acquisition, renewable token-fenced ownership, follower waiting, and completion outcomes (`shared`, `edge_only`, or `failed`). Followers wait on coordinator completion instead of polling D1. A remote follower that cannot see an edge-only result atomically reacquires ownership before performing one serialized fill. Cache and public-repository-proof publication now report which storage tier actually succeeded, and edge-only publication failure is no longer treated as success.

This keeps the 256 KiB D1 body cap from #46 and intentionally does not add an R2 body tier, D1 marker schema, or public protocol change.

## User Impact

Concurrent maintainer reads no longer create a D1 polling burst or overlap upstream GitHub requests when a large response is edge-only. Long-running fills remain exclusively owned beyond the old eight-second lease, failed leaders wake followers promptly, and stale owners cannot publish or release a newer owner.

## Evidence

- Exact committed-tree `pnpm check` passed:
  - 25 unit files / 230 tests
  - 14 Workerd E2E files / 87 tests
  - route and SQL generation, formatting, lint, TypeScript build, Go tests, and `go vet`
- Focused runtime behavior:
  - shared completion wakes followers with one upstream request;
  - same-colo edge-only completion serves the local hit;
  - simulated remote-colo edge miss performs one serialized takeover with maximum upstream concurrency of 1;
  - leader exception wakes a follower promptly;
  - an 8.5-second fill remains exclusively owned through renewal;
  - expired/stale tokens cannot renew, complete, or release a newer owner.
- Publication tests cover UTF-8 D1 cap preservation, Cache API rejection, D1 failure, and public-proof edge/shared outcomes.
- Isolated autoreview and added-content secret scan completed with no actionable findings.

Real multi-colo deployment behavior will be exercised after this and the queued active-watch fallback PR are both landed, before the authorized Worker deployment is considered complete. No release or package publication is included.
