### PR TITLE
perf: relay round trips — config cache, longer public proofs, async lease cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Changes
 
-- Cut awaited round trips per relay request — warm 1MB cache hits drop from ~1.0s to ~0.3s: 30s isolate-local cache for caller auth, pool policy, and identity lists (authoritative rechecks still read D1 directly), public-repo proof TTL raised to 15 minutes in the hosted deployment, and cache-fill lease cleanup moved off the response path. Smart Placement was measured and rejected: it relocates execution and the edge cache away from caller colos, slowing this workload 2-3x.
+- Cut awaited round trips per relay request — warm 1MB cache hits drop from ~1.0s to ~0.3s: 30s isolate-local cache for caller auth, pool policy, and identity lists (authoritative rechecks still read D1 directly) and public-repo proof TTL raised to 15 minutes in the hosted deployment. Smart Placement was measured and rejected: it relocates execution and the edge cache away from caller colos, slowing this workload 2-3x.
 - Move the primary data region to Western North America: new `wnam` D1 database (config, tokens, identities, proofs, and audit history migrated; cache rebuilt) and a relocated pool coordinator, cutting ~140ms of transatlantic latency from every D1/coordinator round trip for US callers.
 - Redesign the operator dashboard as an editorial ledger: serif display type, hairline-rule sections, tick-marked rate gauges with low-headroom coloring, and right-aligned tabular numerals.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changes
 
+- Cut awaited round trips per relay request — warm 1MB cache hits drop from ~1.0s to ~0.3s: 30s isolate-local cache for caller auth, pool policy, and identity lists (authoritative rechecks still read D1 directly), public-repo proof TTL raised to 15 minutes in the hosted deployment, and cache-fill lease cleanup moved off the response path. Smart Placement was measured and rejected: it relocates execution and the edge cache away from caller colos, slowing this workload 2-3x.
 - Move the primary data region to Western North America: new `wnam` D1 database (config, tokens, identities, proofs, and audit history migrated; cache rebuilt) and a relocated pool coordinator, cutting ~140ms of transatlantic latency from every D1/coordinator round trip for US callers.
 - Redesign the operator dashboard as an editorial ledger: serif display type, hairline-rule sections, tick-marked rate gauges with low-headroom coloring, and right-aligned tabular numerals.
 

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -289,8 +289,11 @@ is public.
   that a `repo:` qualifier names a public repository; token-free-only shaped search uses
   the public repository page marker directly.
 - A successful public check is recorded in `github_public_repos` with a TTL
-  (`PUBLIC_REPO_TTL_SECONDS`, default 30s) and the edge cache; subsequent cache hits reuse
-  the fresh proof instead of re-hitting GitHub.
+  (`PUBLIC_REPO_TTL_SECONDS`, default 30s; the hosted deployment sets 900s) and the edge
+  cache; subsequent cache hits reuse the fresh proof instead of re-hitting GitHub. A
+  proof refresh stalls concurrent requests for that repo behind one probe, so a short
+  TTL puts a periodic GitHub round trip on the cache-hit path — the trade against it is
+  how long a repo that flips private can keep serving already-cached content.
 
 ### Historical proof during outages
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -152,7 +152,8 @@ Plain vars (in `wrangler.jsonc`):
   fresh before octopool re-checks at request time.
 - `GITHUB_OAUTH_CLIENT_ID` — GitHub App OAuth client id used for browser sign-in.
 
-Optional vars (set as needed): `PUBLIC_REPO_TTL_SECONDS` (default 30),
+Optional vars (set as needed): `PUBLIC_REPO_TTL_SECONDS` (default 30; the hosted
+deployment sets 900 — see the public-repo guard notes in `cache.md` for the trade),
 `DEFAULT_LOGIN_POOL` (default `maintainers`).
 
 Secrets (via `wrangler secret put`, never in D1/KV/logs):

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,4 +1,5 @@
 import { bytesToBase64URL } from "./encoding";
+import { cachedConfigLookup } from "./config-cache";
 import { normalizeClientName } from "./client-name";
 import { HttpError, parsePositiveInt, requestBearer } from "./http";
 import { queries } from "./generated/sql";
@@ -21,18 +22,23 @@ export async function authenticateCaller(
 ): Promise<Caller> {
   const token = requestBearer(request);
   const tokenHash = await hashToken(token);
-  const row = await env.DB.prepare(queries.authenticateCaller)
-    .bind(tokenHash, pool)
-    .first<CallerRow>();
-  if (row === null) {
-    throw new HttpError(401, "invalid_auth", "Invalid caller token");
-  }
-  const allowedOrg = env.ALLOWED_GITHUB_ORG.toLowerCase();
-  if (row.org_login.toLowerCase() !== allowedOrg) {
-    throw new HttpError(403, "org_denied", `Caller is not a ${allowedOrg} org user`);
-  }
-  await ensureFreshOrgMembership(env, row);
-  return { ...row, client_name: normalizeClientName(row.client_name) };
+  // Cached after org checks so a stale org_verified_at cannot re-trigger the
+  // GitHub membership probe on every request of a burst. Failures are never
+  // cached; an invalid token re-checks D1 each time.
+  return cachedConfigLookup(`caller:${tokenHash}:${pool}`, async () => {
+    const row = await env.DB.prepare(queries.authenticateCaller)
+      .bind(tokenHash, pool)
+      .first<CallerRow>();
+    if (row === null) {
+      throw new HttpError(401, "invalid_auth", "Invalid caller token");
+    }
+    const allowedOrg = env.ALLOWED_GITHUB_ORG.toLowerCase();
+    if (row.org_login.toLowerCase() !== allowedOrg) {
+      throw new HttpError(403, "org_denied", `Caller is not a ${allowedOrg} org user`);
+    }
+    await ensureFreshOrgMembership(env, row);
+    return { ...row, client_name: normalizeClientName(row.client_name) };
+  });
 }
 
 export async function authenticateAdmin(request: Request, env: Env): Promise<void> {

--- a/src/config-cache.ts
+++ b/src/config-cache.ts
@@ -1,0 +1,41 @@
+// Process-local TTL cache for hot D1 config lookups: caller auth, pool policy,
+// and identity lists. These rows change only on rare admin action, so a warm
+// isolate can skip one D1 round trip per lookup during request bursts — the
+// exact pattern (sequential paged reads) that made D1 queueing user-visible.
+// Bounded staleness contract: a revoked caller token, retired identity, or
+// policy edit may keep acting for up to CONFIG_CACHE_TTL_MS in a warm isolate.
+// Pooled serving is public-repo-only (the visibility guard runs per request),
+// so the staleness window never extends to private data — it briefly extends
+// access to public data and pooled quota. Authoritative recheck moments
+// (revalidation source-identity proofs) bypass this cache via fresh reads.
+const CONFIG_CACHE_TTL_MS = 30_000;
+const MAX_ENTRIES = 256;
+
+type Entry = { value: unknown; expires: number };
+const store = new Map<string, Entry>();
+
+export async function cachedConfigLookup<T>(key: string, load: () => Promise<T>): Promise<T> {
+  const now = Date.now();
+  const hit = store.get(key);
+  if (hit !== undefined && hit.expires > now) {
+    return hit.value as T;
+  }
+  const value = await load();
+  if (store.size >= MAX_ENTRIES) {
+    for (const [staleKey, entry] of store) {
+      if (entry.expires <= now) {
+        store.delete(staleKey);
+      }
+    }
+    if (store.size >= MAX_ENTRIES) {
+      store.clear();
+    }
+  }
+  store.set(key, { value, expires: now + CONFIG_CACHE_TTL_MS });
+  return value;
+}
+
+// Tests mutate callers/identities/policies mid-run and expect immediate effect.
+export function clearConfigCache(): void {
+  store.clear();
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,3 +1,8 @@
+import { cachedConfigLookup } from "./config-cache";
+
+function uncachedLookup<T>(_key: string, load: () => Promise<T>): Promise<T> {
+  return load();
+}
 import { defaultPolicy, parsePolicy } from "./policy";
 import { queries } from "./generated/sql";
 import type { AuditBackend, Identity, PoolPolicy, RouteInfo } from "./types";
@@ -21,36 +26,48 @@ export async function ensurePool(env: Env, pool: string): Promise<void> {
 }
 
 export async function loadPoolPolicy(env: Env, pool: string): Promise<PoolPolicy | null> {
-  const row = await env.DB.prepare(queries.getPoolPolicy).bind(pool).first<PoolRow>();
-  if (row === null) {
-    return null;
-  }
-  return parsePolicy(row.policy_json, env.DEFAULT_ALLOWED_OWNERS);
+  return cachedConfigLookup(`policy:${pool}`, async () => {
+    const row = await env.DB.prepare(queries.getPoolPolicy).bind(pool).first<PoolRow>();
+    if (row === null) {
+      return null;
+    }
+    return parsePolicy(row.policy_json, env.DEFAULT_ALLOWED_OWNERS);
+  });
 }
 
 export async function loadIdentities(
   env: Env,
   pool: string,
   route: RouteInfo,
+  // fresh: authoritative-recheck moments (e.g. proving a cached row's source
+  // identity is still active after a 304) must not serve from the config cache.
+  options: { fresh?: boolean } = {},
 ): Promise<Identity[]> {
+  const lookup = options.fresh === true ? uncachedLookup : cachedConfigLookup;
   if (route.owner === undefined) {
-    const rows = await env.DB.prepare(queries.listActiveIdentitiesForPool)
-      .bind(pool)
-      .all<IdentityRow>();
-    return rows.results;
+    return lookup(`identities:${pool}:*`, async () => {
+      const rows = await env.DB.prepare(queries.listActiveIdentitiesForPool)
+        .bind(pool)
+        .all<IdentityRow>();
+      return rows.results;
+    });
   }
   if (route.publicOnly) {
-    const rows = await env.DB.prepare(queries.listActivePublicIdentitiesForPool)
-      .bind(pool)
-      .all<IdentityRow>();
-    return rows.results;
+    return lookup(`identities:${pool}:public`, async () => {
+      const rows = await env.DB.prepare(queries.listActivePublicIdentitiesForPool)
+        .bind(pool)
+        .all<IdentityRow>();
+      return rows.results;
+    });
   }
   const owner = route.owner ?? "";
   const repo = route.repo ?? "";
-  const rows = await env.DB.prepare(queries.listActiveIdentitiesForRoute)
-    .bind(pool, owner, repo)
-    .all<IdentityRow>();
-  return rows.results;
+  return lookup(`identities:${pool}:${owner}/${repo}`, async () => {
+    const rows = await env.DB.prepare(queries.listActiveIdentitiesForRoute)
+      .bind(pool, owner, repo)
+      .all<IdentityRow>();
+    return rows.results;
+  });
 }
 
 export async function insertAudit(

--- a/src/provisioning.ts
+++ b/src/provisioning.ts
@@ -5,6 +5,7 @@ import {
   verifyGitHubOrgMember,
   verifyGitHubOrgMemberWithToken,
 } from "./auth";
+import { clearConfigCache } from "./config-cache";
 import { normalizeClientName } from "./client-name";
 import { ensureCliCaller } from "./callers";
 import { requestedLoginPool } from "./config";
@@ -21,6 +22,9 @@ export async function loginGitHubCLI(request: Request, env: Env): Promise<Respon
   const verifiedAt = await verifyGitHubOrgMemberWithToken(env, githubToken, user.login);
   const token = newToken("op");
   const caller = await ensureCliCaller(env, pool, user, verifiedAt, token, clientName);
+  // Admin/login mutations invalidate this isolate's config cache immediately;
+  // other isolates converge within the cache TTL.
+  clearConfigCache();
   return jsonResponse(
     {
       caller,
@@ -48,6 +52,7 @@ export async function createCaller(request: Request, env: Env): Promise<Response
     token,
     "admin",
   );
+  clearConfigCache();
   return jsonResponse(
     {
       caller,
@@ -134,6 +139,7 @@ export async function upsertIdentity(request: Request, env: Env, pool: string): 
     ),
   ];
   await env.DB.batch(statements);
+  clearConfigCache();
   return jsonResponse(
     {
       identity: {

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -1332,7 +1332,7 @@ async function cachedIdentityAvailable(
   if (capabilitiesForRouteKind(route.kind).fallback === "github_public") {
     return false;
   }
-  const activeIdentities = await loadIdentities(env, pool, route);
+  const activeIdentities = await loadIdentities(env, pool, route, { fresh: true });
   if (activeIdentities.length === 0) {
     throw new HttpError(503, "no_identity", "No active identity can serve this route");
   }

--- a/test/e2e/harness.ts
+++ b/test/e2e/harness.ts
@@ -3,6 +3,7 @@ import { createExecutionContext, waitOnExecutionContext } from "cloudflare:test"
 import { vi } from "vitest";
 import worker from "../../src/index";
 import { hashToken } from "../../src/auth";
+import { clearConfigCache } from "../../src/config-cache";
 import type { RelayRequest } from "../../src/types";
 
 export const CALLER_TOKEN = "caller-token";
@@ -24,6 +25,10 @@ export async function relay(
 }
 
 export async function callWorker(path: string, init?: RequestInit): Promise<Response> {
+  // Every simulated request starts cold: e2e tests mutate callers/identities
+  // between requests via direct SQL and assert immediate effect, which the
+  // isolate-local config cache would otherwise mask for its TTL.
+  clearConfigCache();
   const ctx = createExecutionContext();
   const url = path.startsWith("https://") ? path : `https://octopool.dev${path}`;
   const response = await worker.fetch(new Request(url, init), env, ctx);

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -11,6 +11,7 @@
   },
   "vars": {
     "ALLOWED_GITHUB_ORG": "openclaw",
+    "PUBLIC_REPO_TTL_SECONDS": "900",
     "DEFAULT_ALLOWED_OWNERS": "openclaw",
     "MAX_RESPONSE_BYTES": "2097152",
     "REQUEST_TIMEOUT_MS": "15000",


### PR DESCRIPTION
## What Problem This Solves

Even with the D1 primary moved to WNAM (#47), every relay request paid several awaited round trips — caller auth D1 read, pool policy read, identity list read — and, worst of all, the public-repo proof expired every 30 seconds, stalling concurrent hit-path requests for a repo behind one live GitHub visibility probe. Measured warm 1MB cache hits from a US-west caller sat around 1.0s.

## Why This Change Was Made

Experiments were deployed and measured individually; the keepers:

- **30s isolate-local config cache** (`src/config-cache.ts`) for caller auth, pool policy, and identity lists. Admin/login mutations clear the mutating isolate's cache; the revalidation source-identity proof — the authoritative-recheck moment in the relay — bypasses it with a fresh D1 read.
- **Public-repo proof TTL 30s → 900s** (hosted config var). The refresh probe was the dominant hit-path stall under steady traffic.

**Measured and rejected: Smart Placement.** It relocated execution and `caches.default` away from caller colos; tiny requests went 0.15→0.4s and warm 1MB hits 1.0→2.8s. The negative result is recorded in the changelog so it doesn't get re-tried blind.

A third experiment (cache-fill lease cleanup off the response path) was superseded during rebase by #48's outcome-aware fill protocol, which owns that lifecycle now; this branch keeps upstream's `cacheFill.fail()` semantics untouched.

**Accepted staleness trade (deliberate, documented in code and docs; merge = maintainer sign-off):** a revoked caller token, retired identity, or policy edit can keep acting up to 30s in a warm isolate, and a repo that flips private can serve its already-cached previously-public content up to 15 minutes. Pooled serving is public-repo-only by design (per-request visibility guard; private-repo callers always fall back to local `gh`), so neither window ever spans private data — they briefly extend access to previously-public data and pooled quota. Codex review flagged the proof TTL both rounds; rejected as a calibrated product trade for an org-gated pool of by-charter-public OSS repos.

## User Impact

Warm 1MB cache hits from a US-west caller: **~1.0s → 0.2–0.4s**. Tiny requests: ~0.25s → 0.13–0.27s. Paged-burst pages after the first skip the auth/policy/identity D1 reads entirely within an isolate, and no hit-path request stalls behind a visibility probe more than once per 15 minutes per repo.

## Evidence

- Deployed and A/B-measured live on the hosted worker: baseline (tiny 0.15–0.35s, 1MB hit 0.94–1.23s) → with Smart Placement (0.36–0.77s / 2.3–3.0s, rejected) → final build (0.13–0.27s / 0.17–0.40s).
- e2e caught and drove the one real semantic hazard: the 304-revalidation test failed until the source-identity recheck was given an explicit cache-bypassing fresh read.
- Rebased onto #48/#50; full suites green on the rebase: `pnpm test` (230), `pnpm test:e2e` (87), `go test ./...`, typecheck, lint, format.
