### PR TITLE
fix: active watches stop on authorized fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Keep megabyte-class response bodies (paged run lists, check-run sweeps) out of the shared D1 cache — they stay per-colo edge-cached — so write bursts no longer queue the D1 primary into "overloaded" failures.
 - Report Cloudflare backend overload (D1/Durable Object request queues backing up) as typed `relay_overloaded` — `424 fallback_local` on the relay so the shim backs off and delegates to real `gh` — instead of an untyped `internal_error` 500 that dead-ended paged `gh api` bursts.
 - Retry transient relay `internal_error` and malformed 502/503/504 responses without falling back to local GitHub quota, preserve correlated request IDs in CLI failures, and log unexpected Worker exceptions safely for diagnosis.
+- Continue active `gh run watch` and `gh pr checks --watch` commands through real `gh` only when the relay explicitly requests local fallback, with a visible one-way handoff and exact child exit status.
 
 ### Changes
 

--- a/cmd/octopool/cli_e2e_test.go
+++ b/cmd/octopool/cli_e2e_test.go
@@ -3,12 +3,14 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -132,6 +134,92 @@ func TestCLIEndToEndRelayAndFallback(t *testing.T) {
 			t.Fatalf("err=%v stdout=%q stderr=%q", disabled.err, disabled.stdout, disabled.stderr)
 		}
 	})
+
+	const boundary = "octopool: relay requested local fallback (relay_overloaded); continuing watch with real gh\n"
+	for _, command := range []struct {
+		name     string
+		args     []string
+		exitCode int
+		serve    func(*testing.T, map[string]any, http.ResponseWriter)
+	}{
+		{
+			name:     "run watch exit 0",
+			args:     []string{"gh", "run", "watch", "42", "-R", "openclaw/octopool", "--exit-status", "-i", "5"},
+			exitCode: 0,
+			serve: func(t *testing.T, body map[string]any, w http.ResponseWriter) {
+				headers, _ := body["headers"].(map[string]any)
+				if headers["cache-control"] == "max-age=0" {
+					writeCLIFallback(t, w, "relay_overloaded")
+					return
+				}
+				writeCLIEnvelope(t, w, map[string]any{"status": "completed", "conclusion": "success", "run_attempt": 1})
+			},
+		},
+		{
+			name:     "pr checks watch exit 7",
+			args:     []string{"gh", "pr", "checks", "7", "-R", "openclaw/octopool", "--watch", "--interval=5"},
+			exitCode: 7,
+			serve: func(t *testing.T, body map[string]any, w http.ResponseWriter) {
+				path := body["path"].(string)
+				switch {
+				case strings.HasSuffix(path, "/pulls/7"):
+					headers, _ := body["headers"].(map[string]any)
+					if headers["cache-control"] == "max-age=0" {
+						writeCLIFallback(t, w, "relay_overloaded")
+						return
+					}
+					writeCLIEnvelope(t, w, map[string]any{"head": map[string]any{"sha": "abc1234"}})
+				case strings.HasSuffix(path, "/check-runs"):
+					writeCLIEnvelope(t, w, map[string]any{"total_count": 1, "check_runs": []map[string]any{{"name": "CI", "status": "completed", "conclusion": "success"}}})
+				case strings.HasSuffix(path, "/status"):
+					writeCLIEnvelope(t, w, map[string]any{"total_count": 0, "statuses": []any{}})
+				default:
+					t.Fatalf("unexpected path %q", path)
+				}
+			},
+		},
+	} {
+		t.Run(command.name, func(t *testing.T) {
+			fake := fakeGHExit(t, command.exitCode)
+			server := cliRelayServer(t, func(w http.ResponseWriter, r *http.Request) {
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				command.serve(t, body, w)
+			})
+			result := runCLI(t, bin, server.URL, map[string]string{
+				"OCTOPOOL_GH_PATH":       fake,
+				"OCTOPOOL_RELAY_RETRIES": "0",
+			}, command.args...)
+			if command.exitCode == 0 {
+				if result.err != nil {
+					t.Fatalf("err=%v stdout=%q stderr=%q", result.err, result.stdout, result.stderr)
+				}
+			} else {
+				var exitErr *exec.ExitError
+				if !errors.As(result.err, &exitErr) || exitErr.ExitCode() != command.exitCode {
+					t.Fatalf("err=%v, want exit %d", result.err, command.exitCode)
+				}
+			}
+			wantArgv := strings.Join(floorGHWatchDelegateArgs(command.args[1:]), " ")
+			wantChild := fakeGHArgvPrefix + wantArgv
+			if strings.Count(result.stdout, fakeGHArgvPrefix) != 1 || !strings.Contains(result.stdout, wantChild) {
+				t.Fatalf("stdout=%q, want one %q", result.stdout, wantChild)
+			}
+			if result.stderr != boundary || strings.Contains(result.stderr, "error: exit status") {
+				t.Fatalf("stderr=%q", result.stderr)
+			}
+			progress := strings.Index(result.stdout, "Watching run")
+			if strings.HasPrefix(command.name, "pr") {
+				progress = strings.Index(result.stdout, "checks:")
+			}
+			if child := strings.Index(result.stdout, fakeGHArgvPrefix); progress < 0 || child <= progress {
+				t.Fatalf("stdout ordering=%q", result.stdout)
+			}
+		})
+	}
 }
 
 func TestGHArgvNames(t *testing.T) {
@@ -214,6 +302,17 @@ func writeCLIEnvelope(t *testing.T, w http.ResponseWriter, body any) {
 	}
 }
 
+func writeCLIFallback(t *testing.T, w http.ResponseWriter, reason string) {
+	t.Helper()
+	w.WriteHeader(http.StatusFailedDependency)
+	response := apiErrorResponse{Error: apiError{
+		Code: "fallback_local", Message: "Run locally", Details: apiErrorDetails{FallbackReason: reason},
+	}}
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		t.Errorf("write CLI fallback: %v", err)
+	}
+}
+
 func fakeGH(t *testing.T) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), executableName("fake-gh"))
@@ -221,6 +320,23 @@ func fakeGH(t *testing.T) string {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell fixture is Unix-only")
 	}
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+const fakeGHArgvPrefix = "octopool-fake-gh-argv:"
+
+func fakeGHExit(t *testing.T, exitCode int) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-only")
+	}
+	path := filepath.Join(t.TempDir(), executableName("fake-gh"))
+	content := `#!/bin/sh
+printf '` + fakeGHArgvPrefix + `%s\n' "$*"
+exit ` + strconv.Itoa(exitCode) + "\n"
 	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/octopool/gh.go
+++ b/cmd/octopool/gh.go
@@ -32,6 +32,20 @@ func runGH(ctx context.Context, args []string, stdout io.Writer, stderr io.Write
 			return result.err
 		case ghDelegate:
 			return execRealGH(ctx, floorGHWatchDelegateArgs(args), stdout, stderr)
+		case ghHandoffAfterOutput:
+			var handoff watchFallbackHandoffError
+			if !errors.As(result.err, &handoff) {
+				return errors.New("invalid gh watch handoff outcome")
+			}
+			if envDefault("OCTOPOOL_NO_FALLBACK", "") != "" {
+				return handoff.fallback
+			}
+			fmt.Fprintf(
+				stderr,
+				"octopool: relay requested local fallback (%s); continuing watch with real gh\n",
+				watchSafeText(handoff.fallback.Reason),
+			)
+			return execRealGH(ctx, floorGHWatchDelegateArgs(args), stdout, stderr)
 		default:
 			return errors.New("invalid gh dispatch outcome")
 		}

--- a/cmd/octopool/gh_fallback.go
+++ b/cmd/octopool/gh_fallback.go
@@ -14,6 +14,7 @@ import (
 
 type localFallbackError struct {
 	Reason string
+	Relay  *relayResponseError
 }
 
 func (err localFallbackError) Error() string {
@@ -28,6 +29,14 @@ func isLocalFallback(err error) bool {
 	return errors.As(err, &fallback)
 }
 
+func explicitRelayFallback(err error) (localFallbackError, bool) {
+	var fallback localFallbackError
+	if !errors.As(err, &fallback) || fallback.Relay == nil || fallback.Relay.Code != "fallback_local" {
+		return localFallbackError{}, false
+	}
+	return fallback, true
+}
+
 func shouldRunRealGH(err error) bool {
 	return isLocalFallback(err) || errors.Is(err, errOctopoolNotLoggedIn)
 }
@@ -35,9 +44,9 @@ func shouldRunRealGH(err error) bool {
 func localFallbackFromRelayError(relay *relayResponseError) (localFallbackError, bool) {
 	switch relay.Code {
 	case "fallback_local":
-		return localFallbackError{Reason: relayFallbackReason(relay)}, true
+		return localFallbackError{Reason: relayFallbackReason(relay), Relay: relay}, true
 	case "missing_auth", "invalid_auth":
-		return localFallbackError{Reason: "octopool auth unavailable"}, true
+		return localFallbackError{Reason: "octopool auth unavailable", Relay: relay}, true
 	default:
 		return localFallbackError{}, false
 	}

--- a/cmd/octopool/gh_relay_client_test.go
+++ b/cmd/octopool/gh_relay_client_test.go
@@ -27,6 +27,9 @@ func TestParseLocalFallback(t *testing.T) {
 	if err.Reason != "route_denied" {
 		t.Fatalf("reason = %q", err.Reason)
 	}
+	if err.Relay != relay || err.Relay.Code != "fallback_local" {
+		t.Fatal("decoded fallback_local must retain explicit relay provenance")
+	}
 }
 
 func TestParseRelayResponseErrorRedactsMalformedBody(t *testing.T) {
@@ -65,6 +68,13 @@ func TestGHRelayClientInvalidAuthUsesLocalFallback(t *testing.T) {
 	_, err := client.do(t.Context(), ghAPIRequest{method: "GET", path: "/repos/openclaw/openclaw"})
 	if !isLocalFallback(err) {
 		t.Fatalf("expected local fallback, got %v", err)
+	}
+	if _, explicit := explicitRelayFallback(err); explicit {
+		t.Fatal("auth reinterpretation must not gain explicit relay fallback provenance")
+	}
+	var fallback localFallbackError
+	if !errors.As(err, &fallback) || fallback.Relay == nil || fallback.Relay.Code != "invalid_auth" {
+		t.Fatalf("auth fallback provenance = %#v", fallback.Relay)
 	}
 	if got := calls.Load(); got != 1 {
 		t.Fatalf("calls = %d", got)

--- a/cmd/octopool/gh_test_helpers_test.go
+++ b/cmd/octopool/gh_test_helpers_test.go
@@ -10,6 +10,7 @@ import (
 type relayTestResponse struct {
 	Body    any
 	Headers map[string]string
+	Status  int
 }
 
 func relayTestServer(t *testing.T, responseBody func(map[string]any) any) {
@@ -37,6 +38,16 @@ func relayTestServer(t *testing.T, responseBody func(map[string]any) any) {
 		}
 		fixture := responseBody(body)
 		if response, ok := fixture.(relayTestResponse); ok {
+			if response.Status != 0 {
+				for key, value := range response.Headers {
+					w.Header().Set(key, value)
+				}
+				w.WriteHeader(response.Status)
+				if err := json.NewEncoder(w).Encode(response.Body); err != nil {
+					t.Errorf("write relay error fixture: %v", err)
+				}
+				return
+			}
 			fixture = response.Body
 			envelope.Headers = response.Headers
 		}

--- a/cmd/octopool/gh_top.go
+++ b/cmd/octopool/gh_top.go
@@ -17,6 +17,7 @@ const (
 	ghDelegate ghAction = iota
 	ghComplete
 	ghFail
+	ghHandoffAfterOutput
 )
 
 type ghResult struct {

--- a/cmd/octopool/gh_top_watch.go
+++ b/cmd/octopool/gh_top_watch.go
@@ -47,6 +47,25 @@ type watchBackoff struct {
 	limit   time.Duration
 }
 
+type watchFallbackHandoffError struct {
+	fallback localFallbackError
+}
+
+func (err watchFallbackHandoffError) Error() string {
+	return err.fallback.Error()
+}
+
+func ghWatchCompleted(err error) ghResult {
+	if err == nil {
+		return ghResult{action: ghComplete}
+	}
+	var handoff watchFallbackHandoffError
+	if errors.As(err, &handoff) {
+		return ghResult{action: ghHandoffAfterOutput, err: handoff}
+	}
+	return ghFailed(err)
+}
+
 func newWatchBackoff(requested time.Duration) watchBackoff {
 	start := max(requested, watchMinInterval)
 	return watchBackoff{current: start, limit: max(watchMaxInterval, start)}
@@ -96,7 +115,7 @@ func handleGHRunWatch(ctx context.Context, args []string, stdout io.Writer) ghRe
 		return ghDelegated()
 	}
 	opts.repo = repo
-	return ghCompleted(relayRunWatch(ctx, stdout, opts))
+	return ghWatchCompleted(relayRunWatch(ctx, stdout, opts))
 }
 
 func parseGHRunWatchOptions(args []string) (ghRunWatchOptions, bool) {
@@ -209,7 +228,7 @@ func relayRunWatch(ctx context.Context, stdout io.Writer, opts ghRunWatchOptions
 			}
 			attempt, ok := positiveJSONInt(confirmed["run_attempt"])
 			if !ok {
-				return localFallbackError{Reason: "workflow run response did not include run_attempt"}
+				return watchError(localFallbackError{Reason: "workflow run response did not include run_attempt"}, progressPrinted)
 			}
 			jobs, err := relayWatchRunJobs(ctx, client, opts.repo, opts.id, attempt, &backoff)
 			if err != nil {
@@ -335,7 +354,7 @@ func handleGHPRChecksWatch(ctx context.Context, args []string, stdout io.Writer)
 		return ghDelegated()
 	}
 	opts.repo = repo
-	return ghCompleted(relayPRChecksWatch(ctx, stdout, opts))
+	return ghWatchCompleted(relayPRChecksWatch(ctx, stdout, opts))
 }
 
 func parseGHPRChecksWatchOptions(args []string) (ghPRChecksWatchOptions, bool) {
@@ -563,7 +582,13 @@ func bodySafeText(raw string) string {
 }
 
 func watchError(err error, progressPrinted bool) error {
-	if progressPrinted && shouldRunRealGH(err) {
+	if !progressPrinted {
+		return err
+	}
+	if fallback, ok := explicitRelayFallback(err); ok {
+		return watchFallbackHandoffError{fallback: fallback}
+	}
+	if shouldRunRealGH(err) {
 		return errors.New(err.Error())
 	}
 	return err

--- a/cmd/octopool/gh_top_watch_test.go
+++ b/cmd/octopool/gh_top_watch_test.go
@@ -660,14 +660,148 @@ func TestWatchTickBailsImmediatelyOnTypedRelayError(t *testing.T) {
 	}
 }
 
-func TestWatchFallbackOnlyBeforeProgress(t *testing.T) {
-	fallback := localFallbackError{Reason: "route denied"}
-	if err := watchError(fallback, false); !shouldRunRealGH(err) {
-		t.Fatalf("first-tick error should preserve fallback: %v", err)
+func TestWatchErrorClassification(t *testing.T) {
+	explicitRelay := &relayResponseError{
+		Status: http.StatusFailedDependency,
+		apiError: apiError{
+			Code: "fallback_local", Details: apiErrorDetails{FallbackReason: "relay_overloaded"},
+		},
 	}
-	if err := watchError(fallback, true); shouldRunRealGH(err) || err.Error() != fallback.Error() {
-		t.Fatalf("post-progress error should fail locally: %v", err)
+	explicit, _ := localFallbackFromRelayError(explicitRelay)
+	auth, _ := localFallbackFromRelayError(&relayResponseError{
+		Status:   http.StatusUnauthorized,
+		apiError: apiError{Code: "invalid_auth"},
+	})
+	for _, test := range []struct {
+		name     string
+		err      error
+		progress bool
+		action   ghAction
+	}{
+		{name: "explicit before progress", err: explicit, action: ghFail},
+		{name: "explicit after progress", err: explicit, progress: true, action: ghHandoffAfterOutput},
+		{name: "auth after progress", err: auth, progress: true, action: ghFail},
+		{name: "local fallback after progress", err: localFallbackError{Reason: "pagination_exhausted"}, progress: true, action: ghFail},
+		{name: "service error after progress", err: &relayResponseError{Status: http.StatusServiceUnavailable, apiError: apiError{Code: "admin_unconfigured"}}, progress: true, action: ghFail},
+		{name: "transport error after progress", err: errors.New("connection reset"), progress: true, action: ghFail},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result := ghWatchCompleted(watchError(test.err, test.progress))
+			if result.action != test.action {
+				t.Fatalf("action=%v, want %v; err=%v", result.action, test.action, result.err)
+			}
+		})
 	}
+}
+
+func TestGHWatchExplicitRelayFallbackBeforeProgressDelegates(t *testing.T) {
+	t.Setenv("OCTOPOOL_RELAY_RETRIES", "0")
+	t.Setenv("OCTOPOOL_GH_PATH", fakeGHExit(t, 0))
+	relayTestServer(t, func(map[string]any) any { return relayFallbackFixture("relay_overloaded") })
+	var stdout, stderr bytes.Buffer
+	if err := runGH(t.Context(), []string{"run", "watch", "42", "-R", "openclaw/octopool"}, &stdout, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(stdout.String(), fakeGHArgvPrefix) != 1 {
+		t.Fatalf("stdout=%q, want one real-gh invocation", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "Watching run") ||
+		!strings.Contains(stderr.String(), "falling back to real gh") ||
+		strings.Contains(stderr.String(), "continuing watch") {
+		t.Fatalf("stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
+func TestGHWatchNoFallbackBlocksBeforeAndAfterProgress(t *testing.T) {
+	for _, afterProgress := range []bool{false, true} {
+		name := "before progress"
+		if afterProgress {
+			name = "after progress"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("OCTOPOOL_RELAY_RETRIES", "0")
+			t.Setenv("OCTOPOOL_NO_FALLBACK", "1")
+			t.Setenv("OCTOPOOL_GH_PATH", fakeGHExit(t, 0))
+			recordWatchSleeps(t)
+			calls := 0
+			relayTestServer(t, func(map[string]any) any {
+				calls++
+				if !afterProgress || calls > 1 {
+					return relayFallbackFixture("relay_overloaded")
+				}
+				return map[string]any{"status": "completed", "conclusion": "success", "run_attempt": 1}
+			})
+			var stdout, stderr bytes.Buffer
+			err := runGH(t.Context(), []string{"run", "watch", "42", "-R", "openclaw/octopool"}, &stdout, &stderr)
+			if err == nil || strings.Contains(stdout.String(), fakeGHArgvPrefix) {
+				t.Fatalf("err=%v stdout=%q", err, stdout.String())
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("disabled fallback must not print a handoff: %q", stderr.String())
+			}
+		})
+	}
+}
+
+func TestGHRunWatchMissingAttemptDoesNotHandoff(t *testing.T) {
+	t.Setenv("OCTOPOOL_RELAY_RETRIES", "0")
+	t.Setenv("OCTOPOOL_GH_PATH", fakeGHExit(t, 0))
+	recordWatchSleeps(t)
+	relayTestServer(t, func(map[string]any) any {
+		return map[string]any{"status": "completed", "conclusion": "success"}
+	})
+	var stdout, stderr bytes.Buffer
+	err := runGH(t.Context(), []string{"run", "watch", "42", "-R", "openclaw/octopool"}, &stdout, &stderr)
+	if err == nil || strings.Contains(stdout.String(), fakeGHArgvPrefix) {
+		t.Fatalf("err=%v stdout=%q", err, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Watching run") || stderr.Len() != 0 {
+		t.Fatalf("stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
+func TestGHPRChecksWatchAuthFailureDoesNotHandoff(t *testing.T) {
+	t.Setenv("OCTOPOOL_RELAY_RETRIES", "0")
+	t.Setenv("OCTOPOOL_GH_PATH", fakeGHExit(t, 0))
+	recordWatchSleeps(t)
+	relayTestServer(t, func(body map[string]any) any {
+		path := body["path"].(string)
+		switch {
+		case strings.HasSuffix(path, "/pulls/7"):
+			headers, _ := body["headers"].(map[string]any)
+			if headers["cache-control"] == "max-age=0" {
+				return relayErrorFixture(http.StatusUnauthorized, apiError{
+					Code: "invalid_auth", Message: "Invalid caller token",
+				})
+			}
+			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+		case strings.HasSuffix(path, "/check-runs"):
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"name": "CI", "status": "completed", "conclusion": "success"}}}
+		case strings.HasSuffix(path, "/status"):
+			return map[string]any{"total_count": 0, "statuses": []any{}}
+		default:
+			t.Fatalf("unexpected path %q", path)
+			return nil
+		}
+	})
+	var stdout, stderr bytes.Buffer
+	err := runGH(t.Context(), []string{"pr", "checks", "7", "-R", "openclaw/octopool", "--watch"}, &stdout, &stderr)
+	if err == nil || strings.Contains(stdout.String(), fakeGHArgvPrefix) {
+		t.Fatalf("err=%v stdout=%q", err, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "checks:") {
+		t.Fatalf("expected progress before confirmation failure: %q", stdout.String())
+	}
+}
+
+func relayFallbackFixture(reason string) relayTestResponse {
+	return relayErrorFixture(http.StatusFailedDependency, apiError{
+		Code: "fallback_local", Message: "Run locally", Details: apiErrorDetails{FallbackReason: reason},
+	})
+}
+
+func relayErrorFixture(status int, apiErr apiError) relayTestResponse {
+	return relayTestResponse{Status: status, Body: apiErrorResponse{Error: apiErr}}
 }
 
 func recordWatchSleeps(t *testing.T) *[]time.Duration {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -182,8 +182,13 @@ verified PR head SHA, allowing file pages to share a five-minute state-scoped ca
 head-SHA lookup sends `cache-control: max-age=60` so concurrent CI-polling sessions share
 one upstream PR read at most 60 seconds old, and the check/status reads for that SHA use
 the normal cache TTLs. Native `gh run watch` and `gh pr checks --watch` polling also stays
-on the relay, floors intervals at 30 seconds, and backs off to 120 seconds. Ask for raw
-`gh api` conditional requests only when instant freshness matters more than quota.
+on the relay, floors intervals at 30 seconds, and backs off to 120 seconds. If the relay
+explicitly returns `fallback_local` during an active watch, the shim prints one handoff
+boundary and continues the original command with real `gh`; real `gh` then owns output and
+the exact exit status. Its first snapshot may repeat the last relay-rendered state. Client-side
+incompleteness, auth reinterpretation, transport/decode failures, and ordinary relay service
+errors remain terminal after progress and do not spend local GitHub quota. Ask for raw `gh api`
+conditional requests only when instant freshness matters more than quota.
 `--jq` runs after `--json` filtering, matching the usual agent workflow for small
 machine-readable reads.
 
@@ -325,7 +330,7 @@ These are dev/CI escape hatches, not the everyday UX:
 - `OCTOPOOL_POOL` — pool id (default `maintainers`).
 - `OCTOPOOL_GH_PATH` — path to the real `gh` binary.
 - `OCTOPOOL_NO_FALLBACK=1` — fail instead of running real `gh` after Octopool returns
-  `fallback_local`, useful for proving relay/cache coverage.
+  `fallback_local`, including during an active watch, useful for proving relay/cache coverage.
 - `OCTOPOOL_RELAY_RETRIES` — how many times transient pool-exhaustion fallbacks
   (`identities_cooling_down`, `identity_pool_depleted`, `github_identity_depleted`,
   `github_rate_limited`, `relay_overloaded`), relay `5xx internal_error` responses, and


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where relay-backed `gh run watch` and `gh pr checks --watch` stopped after printing progress when Octopool explicitly authorized local fallback, such as `relay_overloaded`. The watch layer intentionally erased fallback identity after output to avoid two renderers, so a valid server-directed fallback became an operator-visible dead end.

## Why This Change Was Made

Only a decoded relay response whose code is exactly `fallback_local` may continue an active watch through real `gh`. Relay provenance is retained separately from auth reinterpretation and client-generated limitations. The watch produces a closed handoff result, and top-level dispatch prints one visible transition, applies the existing 30-second interval floor, invokes real `gh` once, and transfers output plus final exit-status ownership to that child.

Before-progress fallback behavior is unchanged. Missing auth, local pagination/shape failures, `internal_error`, typed service errors, transport failures, and decode failures remain terminal after progress and do not consume local GitHub quota. `OCTOPOOL_NO_FALLBACK` continues to block all handoffs.

## User Impact

Active watches survive a server-authorized overload or fallback instead of exiting. Users see a clear one-way handoff boundary; real `gh` may repeat one current-state snapshot, then owns all subsequent rendering and the exact command exit status.

## Evidence

- Exact committed-tree `pnpm check` passed:
  - 25 unit files / 230 tests
  - 14 Workerd E2E files / 87 tests
  - route/SQL generation, formatting, lint, TypeScript build, Go tests, and `go vet`
- Built-binary source-blind proof:
  - `gh run watch` printed relay progress, handed off once with `-i 30`, and exited 0 with a successful child;
  - `gh pr checks --watch` printed check progress, handed off once with `--interval=30`, and preserved child exit 7 without an extra wrapper error;
  - auth reinterpretation and typed service errors after progress did not invoke real `gh`;
  - `OCTOPOOL_NO_FALLBACK` blocked explicit fallback before and after progress.
- Focused tests cover explicit relay provenance, missing `run_attempt`, PR confirmation failure, before-progress behavior, argument flooring, transition ordering, and exact child ownership.
- Isolated autoreview and added-content secret scan completed with no actionable findings.

No release or package publication is included. After this PR lands, the authorized deployment will exercise the live relay-to-real-gh handoff together with the previously landed cache-fill coordination repair.
