### PR TITLE
De-duplicate proof queries, pagination adapters, public transports, and CLI plumbing

### DIFF
--- a/cmd/octopool/cli_config.go
+++ b/cmd/octopool/cli_config.go
@@ -48,17 +48,43 @@ func defaultAuthPool(auth authFile) string {
 	return envDefault("OCTOPOOL_POOL", firstNonEmpty(auth.Pool, "maintainers"))
 }
 
-func applyAuthFlagDefaults(fs *flag.FlagSet, auth authFile, baseURL *string, pool *string) {
+type callerRequestFlags struct {
+	baseURL  *string
+	pool     *string
+	tokenEnv *string
+}
+
+func newCallerRequestFlags(fs *flag.FlagSet) callerRequestFlags {
+	return callerRequestFlags{
+		baseURL:  fs.String("url", defaultAuthURL(authFile{}), "Octopool base URL"),
+		pool:     fs.String("pool", defaultAuthPool(authFile{}), "pool id"),
+		tokenEnv: fs.String("token-env", "OCTOPOOL_TOKEN", "caller token env var"),
+	}
+}
+
+func (flags callerRequestFlags) applyAuth(fs *flag.FlagSet) (authFile, error) {
+	auth, err := loadAuth()
+	if err != nil {
+		return authFile{}, err
+	}
 	set := map[string]bool{}
 	fs.Visit(func(item *flag.Flag) {
 		set[item.Name] = true
 	})
 	if !set["url"] {
-		*baseURL = defaultAuthURL(auth)
+		*flags.baseURL = defaultAuthURL(auth)
 	}
 	if !set["pool"] {
-		*pool = defaultAuthPool(auth)
+		*flags.pool = defaultAuthPool(auth)
 	}
+	return auth, nil
+}
+
+func (flags callerRequestFlags) authorize(auth authFile) (string, error) {
+	if err := validateAuthURLForRequest(auth, *flags.baseURL, *flags.tokenEnv); err != nil {
+		return "", err
+	}
+	return callerToken(*flags.tokenEnv)
 }
 
 func validateAuthURLForRequest(auth authFile, effectiveURL string, tokenEnvName string) error {

--- a/cmd/octopool/command_health.go
+++ b/cmd/octopool/command_health.go
@@ -9,25 +9,19 @@ import (
 func runHealth(ctx context.Context, args []string, stdout io.Writer) error {
 	fs := flag.NewFlagSet("health", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	url := fs.String("url", defaultAuthURL(authFile{}), "Octopool base URL")
-	pool := fs.String("pool", defaultAuthPool(authFile{}), "pool id")
-	tokenEnv := fs.String("token-env", "OCTOPOOL_TOKEN", "caller token env var")
+	requestFlags := newCallerRequestFlags(fs)
 	if handled, err := parseCommandFlags(fs, args, stdout, "usage: octopool health [flags]"); err != nil {
 		return err
 	} else if handled {
 		return nil
 	}
-	auth, err := loadAuth()
+	auth, err := requestFlags.applyAuth(fs)
 	if err != nil {
 		return err
 	}
-	applyAuthFlagDefaults(fs, auth, url, pool)
-	if err := validateAuthURLForRequest(auth, *url, *tokenEnv); err != nil {
-		return err
-	}
-	token, err := callerToken(*tokenEnv)
+	token, err := requestFlags.authorize(auth)
 	if err != nil {
 		return err
 	}
-	return getJSON(ctx, stdout, apiURL(*url, "/v1/pools/"+urlPath(*pool)+"/health"), token)
+	return getJSON(ctx, stdout, apiURL(*requestFlags.baseURL, "/v1/pools/"+urlPath(*requestFlags.pool)+"/health"), token)
 }

--- a/cmd/octopool/command_request.go
+++ b/cmd/octopool/command_request.go
@@ -11,9 +11,7 @@ import (
 func runRequest(ctx context.Context, args []string, stdout io.Writer) error {
 	fs := flag.NewFlagSet("request", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	url := fs.String("url", defaultAuthURL(authFile{}), "Octopool base URL")
-	pool := fs.String("pool", defaultAuthPool(authFile{}), "pool id")
-	tokenEnv := fs.String("token-env", "OCTOPOOL_TOKEN", "caller token env var")
+	requestFlags := newCallerRequestFlags(fs)
 	method := fs.String("method", "GET", "GitHub method")
 	path := fs.String("path", "", "GitHub API path")
 	queryValues := multiFlag{}
@@ -27,23 +25,19 @@ func runRequest(ctx context.Context, args []string, stdout io.Writer) error {
 	} else if handled {
 		return nil
 	}
-	auth, err := loadAuth()
+	auth, err := requestFlags.applyAuth(fs)
 	if err != nil {
 		return err
 	}
-	applyAuthFlagDefaults(fs, auth, url, pool)
 	if *path == "" {
 		return errors.New("--path is required")
 	}
-	if err := validateAuthURLForRequest(auth, *url, *tokenEnv); err != nil {
-		return err
-	}
-	token, err := callerToken(*tokenEnv)
+	token, err := requestFlags.authorize(auth)
 	if err != nil {
 		return err
 	}
 	body := map[string]any{
-		"pool":   *pool,
+		"pool":   *requestFlags.pool,
 		"method": strings.ToUpper(*method),
 		"path":   *path,
 	}
@@ -56,7 +50,7 @@ func runRequest(ctx context.Context, args []string, stdout io.Writer) error {
 	if len(routeHintValues) > 0 {
 		body["route_hint"] = valuesMap(routeHintValues)
 	}
-	return postJSON(ctx, stdout, apiURL(*url, "/v1/github/request"), token, body)
+	return postJSON(ctx, stdout, apiURL(*requestFlags.baseURL, "/v1/github/request"), token, body)
 }
 
 type multiFlag []string

--- a/cmd/octopool/gh_top_checks.go
+++ b/cmd/octopool/gh_top_checks.go
@@ -165,41 +165,13 @@ func prCheckItemsForSHAWithHeaders(
 }
 
 func checkRunItems(envelope relayEnvelope) ([]any, int, error) {
-	body, err := envelopeBodyBytes(envelope)
-	if err != nil {
-		return nil, 0, err
-	}
-	var response map[string]any
-	if err := json.Unmarshal(body, &response); err != nil {
-		return nil, 0, err
-	}
-	items, ok := response["check_runs"].([]any)
-	if !ok {
-		return nil, 0, errors.New("check-runs response did not include check_runs")
-	}
-	total := len(items)
-	if value, ok := response["total_count"].(float64); ok {
-		total = int(value)
-	}
-	return items, total, nil
+	return envelopeCollectionPage(envelope, "check_runs")
 }
 
 func statusItems(envelope relayEnvelope) ([]any, int, error) {
-	body, err := envelopeBodyBytes(envelope)
+	rawItems, total, err := envelopeCollectionPage(envelope, "statuses")
 	if err != nil {
 		return nil, 0, err
-	}
-	var response map[string]any
-	if err := json.Unmarshal(body, &response); err != nil {
-		return nil, 0, err
-	}
-	rawItems, ok := response["statuses"].([]any)
-	if !ok {
-		return nil, 0, errors.New("status response did not include statuses")
-	}
-	total := len(rawItems)
-	if value, ok := response["total_count"].(float64); ok {
-		total = int(value)
 	}
 	items := make([]any, 0, len(rawItems))
 	for _, raw := range rawItems {

--- a/cmd/octopool/gh_top_json.go
+++ b/cmd/octopool/gh_top_json.go
@@ -43,6 +43,31 @@ func envelopeBodyBytes(envelope relayEnvelope) ([]byte, error) {
 	return bytes.TrimSpace(body), err
 }
 
+func envelopeCollectionPage(envelope relayEnvelope, key string) ([]any, int, error) {
+	body, err := envelopeBodyBytes(envelope)
+	if err != nil {
+		return nil, 0, err
+	}
+	var response map[string]any
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, 0, err
+	}
+	items, ok := response[key].([]any)
+	if !ok {
+		labels := map[string]string{
+			"check_runs": "check-runs",
+			"statuses":   "status",
+			"jobs":       "workflow jobs",
+		}
+		return nil, 0, fmt.Errorf("%s response did not include %s", labels[key], key)
+	}
+	total := len(items)
+	if value, ok := response["total_count"].(float64); ok {
+		total = int(value)
+	}
+	return items, total, nil
+}
+
 func filterJSONFields(raw []byte, fields []string, fieldMap map[string][]string) ([]byte, error) {
 	var value any
 	if err := json.Unmarshal(raw, &value); err != nil {

--- a/cmd/octopool/gh_top_run.go
+++ b/cmd/octopool/gh_top_run.go
@@ -157,21 +157,9 @@ func runJobs(envelope relayEnvelope) ([]any, error) {
 }
 
 func runJobsPage(envelope relayEnvelope) ([]any, int, error) {
-	body, err := envelopeBodyBytes(envelope)
+	rawJobs, total, err := envelopeCollectionPage(envelope, "jobs")
 	if err != nil {
 		return nil, 0, err
-	}
-	var response map[string]any
-	if err := json.Unmarshal(body, &response); err != nil {
-		return nil, 0, err
-	}
-	rawJobs, ok := response["jobs"].([]any)
-	if !ok {
-		return nil, 0, errors.New("workflow jobs response did not include jobs")
-	}
-	total := len(rawJobs)
-	if value, ok := response["total_count"].(float64); ok {
-		total = int(value)
 	}
 	jobs := make([]any, 0, len(rawJobs))
 	for _, rawJob := range rawJobs {

--- a/cmd/octopool/stats.go
+++ b/cmd/octopool/stats.go
@@ -95,9 +95,7 @@ type statsCache struct {
 func runStats(ctx context.Context, args []string, stdout io.Writer) error {
 	fs := flag.NewFlagSet("stats", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	baseURL := fs.String("url", defaultAuthURL(authFile{}), "Octopool base URL")
-	pool := fs.String("pool", defaultAuthPool(authFile{}), "pool id")
-	tokenEnv := fs.String("token-env", "OCTOPOOL_TOKEN", "caller token env var")
+	requestFlags := newCallerRequestFlags(fs)
 	since := fs.String("since", "24h", "stats window, e.g. 30m, 24h, 7d")
 	jsonOutput := fs.Bool("json", false, "print raw JSON")
 	if handled, err := parseCommandFlags(fs, args, stdout, "usage: octopool stats [flags]"); err != nil {
@@ -105,15 +103,11 @@ func runStats(ctx context.Context, args []string, stdout io.Writer) error {
 	} else if handled {
 		return nil
 	}
-	auth, err := loadAuth()
+	auth, err := requestFlags.applyAuth(fs)
 	if err != nil {
 		return err
 	}
-	applyAuthFlagDefaults(fs, auth, baseURL, pool)
-	if err := validateAuthURLForRequest(auth, *baseURL, *tokenEnv); err != nil {
-		return err
-	}
-	token, err := callerToken(*tokenEnv)
+	token, err := requestFlags.authorize(auth)
 	if err != nil {
 		return err
 	}
@@ -121,7 +115,7 @@ func runStats(ctx context.Context, args []string, stdout io.Writer) error {
 	if strings.TrimSpace(*since) != "" {
 		query.Set("since", strings.TrimSpace(*since))
 	}
-	endpoint := apiURL(*baseURL, "/v1/pools/"+urlPath(*pool)+"/stats")
+	endpoint := apiURL(*requestFlags.baseURL, "/v1/pools/"+urlPath(*requestFlags.pool)+"/stats")
 	if encoded := query.Encode(); encoded != "" {
 		endpoint += "?" + encoded
 	}

--- a/sql/queries/d1.sql
+++ b/sql/queries/d1.sql
@@ -419,16 +419,6 @@ WHERE lower(owner) = ?1
   AND expires_at > CURRENT_TIMESTAMP
 LIMIT 1;
 
--- name: FreshCoveringPublicRepoProof :one
-SELECT checked_at, expires_at
-FROM github_public_repos
-WHERE lower(owner) = ?1
-  AND lower(repo) = ?2
-  AND is_public = 1
-  AND checked_at >= datetime(?3, '-5 seconds')
-  AND expires_at > CURRENT_TIMESTAMP
-LIMIT 1;
-
 -- name: FreshNegativePublicRepoProof :one
 SELECT checked_at, expires_at, is_public
 FROM github_public_repos

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -406,23 +406,11 @@ function completedRun(response?: GitHubRelayResponse): boolean {
 }
 
 function completedRunList(response?: GitHubRelayResponse): boolean {
-  if (!isRecord(response?.body) || !Array.isArray(response.body.workflow_runs)) {
-    return false;
-  }
-  return (
-    response.body.workflow_runs.length > 0 &&
-    response.body.workflow_runs.every((item) => isRecord(item) && item.status === "completed")
-  );
+  return completedCollection(response, "workflow_runs");
 }
 
 function completedJobs(response?: GitHubRelayResponse): boolean {
-  if (!isRecord(response?.body) || !Array.isArray(response.body.jobs)) {
-    return false;
-  }
-  return (
-    response.body.jobs.length > 0 &&
-    response.body.jobs.every((item) => isRecord(item) && item.status === "completed")
-  );
+  return completedCollection(response, "jobs");
 }
 
 function completedJob(response?: GitHubRelayResponse): boolean {
@@ -430,23 +418,19 @@ function completedJob(response?: GitHubRelayResponse): boolean {
 }
 
 function completedChecks(response?: GitHubRelayResponse): boolean {
-  if (!isRecord(response?.body) || !Array.isArray(response.body.check_runs)) {
-    return false;
-  }
-  return (
-    response.body.check_runs.length > 0 &&
-    response.body.check_runs.every((item) => isRecord(item) && item.status === "completed")
-  );
+  return completedCollection(response, "check_runs");
 }
 
 function completedCheckSuites(response?: GitHubRelayResponse): boolean {
-  if (!isRecord(response?.body) || !Array.isArray(response.body.check_suites)) {
+  return completedCollection(response, "check_suites");
+}
+
+function completedCollection(response: GitHubRelayResponse | undefined, key: string): boolean {
+  if (!isRecord(response?.body) || !Array.isArray(response.body[key])) {
     return false;
   }
-  return (
-    response.body.check_suites.length > 0 &&
-    response.body.check_suites.every((item) => isRecord(item) && item.status === "completed")
-  );
+  const items = response.body[key];
+  return items.length > 0 && items.every((item) => isRecord(item) && item.status === "completed");
 }
 
 function completedStatus(response?: GitHubRelayResponse): boolean {

--- a/src/generated/sql.ts
+++ b/src/generated/sql.ts
@@ -118,8 +118,6 @@ export const queries = {
     "INSERT INTO github_public_repos (owner, repo, is_public, checked_at, expires_at)\nVALUES (?1, ?2, ?3, CURRENT_TIMESTAMP, datetime(CURRENT_TIMESTAMP, ?4))\nON CONFLICT(owner, repo) DO UPDATE SET\n  is_public = excluded.is_public,\n  checked_at = excluded.checked_at,\n  expires_at = excluded.expires_at",
   coveringPublicRepoProof:
     "SELECT checked_at, expires_at\nFROM github_public_repos\nWHERE lower(owner) = ?1\n  AND lower(repo) = ?2\n  AND is_public = 1\n  AND checked_at >= datetime(?3, '-5 seconds')\n  AND expires_at > CURRENT_TIMESTAMP\nLIMIT 1",
-  freshCoveringPublicRepoProof:
-    "SELECT checked_at, expires_at\nFROM github_public_repos\nWHERE lower(owner) = ?1\n  AND lower(repo) = ?2\n  AND is_public = 1\n  AND checked_at >= datetime(?3, '-5 seconds')\n  AND expires_at > CURRENT_TIMESTAMP\nLIMIT 1",
   freshNegativePublicRepoProof:
     "SELECT checked_at, expires_at, is_public\nFROM github_public_repos\nWHERE lower(owner) = ?1\n  AND lower(repo) = ?2\n  AND is_public = 0\n  AND expires_at > CURRENT_TIMESTAMP\nLIMIT 1",
   freshPRStateProof:

--- a/src/github-public-actions.ts
+++ b/src/github-public-actions.ts
@@ -1,6 +1,14 @@
 import { responseCapBytes } from "./github-limits";
 import { decodeURIComponentSafe, encodedPathSegments } from "./github-path";
-import { parseJSONBytes, publicJSONResponse, scalarQuery } from "./github-public-utils";
+import {
+  boundedPageSize,
+  firstPageQuery,
+  htmlWebRequest,
+  parseJSONBytes,
+  publicJSONResponse,
+  scalarQuery,
+  validScalarQuery,
+} from "./github-public-utils";
 import { defaultGitHubJSONAccept } from "./github-response";
 import {
   parseActionsJobGroupsJSON,
@@ -72,36 +80,30 @@ function actionsRunListRequest(
   if (query.search !== "") {
     url.searchParams.set("query", query.search);
   }
-  return {
-    url: url.toString(),
-    headers: { accept: "text/html", "user-agent": "octopool" },
-    capBytes: responseCapBytes(env),
-    usesApiQuota: false,
-    payload: async (body, headers, status) => {
-      const parsed = parseActionsRunListHTML(
-        new TextDecoder().decode(body),
-        route.owner!,
-        route.repo!,
-      );
-      if (parsed === undefined) {
-        return undefined;
-      }
-      if (parsed.workflow_runs.length < Math.min(parsed.total_count, query.perPage)) {
-        return undefined;
-      }
-      parsed.workflow_runs = parsed.workflow_runs.slice(0, query.perPage);
-      const runs = await Promise.all(
-        parsed.workflow_runs.map((run) =>
-          isFullGitSHA(run.head_sha) ? run : enrichActionsRun(env, route, run),
-        ),
-      );
-      if (runs.some((run) => run === undefined)) {
-        return undefined;
-      }
-      parsed.workflow_runs = runs as Record<string, unknown>[];
-      return publicJSONResponse(headers, status, parsed);
-    },
-  };
+  return htmlWebRequest(env, url.toString(), async (body, headers, status) => {
+    const parsed = parseActionsRunListHTML(
+      new TextDecoder().decode(body),
+      route.owner!,
+      route.repo!,
+    );
+    if (parsed === undefined) {
+      return undefined;
+    }
+    if (parsed.workflow_runs.length < Math.min(parsed.total_count, query.perPage)) {
+      return undefined;
+    }
+    parsed.workflow_runs = parsed.workflow_runs.slice(0, query.perPage);
+    const runs = await Promise.all(
+      parsed.workflow_runs.map((run) =>
+        isFullGitSHA(run.head_sha) ? run : enrichActionsRun(env, route, run),
+      ),
+    );
+    if (runs.some((run) => run === undefined)) {
+      return undefined;
+    }
+    parsed.workflow_runs = runs as Record<string, unknown>[];
+    return publicJSONResponse(headers, status, parsed);
+  });
 }
 
 function actionsRunRequest(
@@ -118,8 +120,9 @@ function actionsRunRequest(
   if (id === undefined) {
     return undefined;
   }
-  return {
-    url: `https://github.com/${encodedPathSegments([
+  return htmlWebRequest(
+    env,
+    `https://github.com/${encodedPathSegments([
       route.owner!,
       route.repo!,
       "actions",
@@ -127,10 +130,7 @@ function actionsRunRequest(
       id,
       ...(attempt === undefined ? [] : ["attempts", attempt]),
     ])}`,
-    headers: { accept: "text/html", "user-agent": "octopool" },
-    capBytes: responseCapBytes(env),
-    usesApiQuota: false,
-    payload: async (body, headers, status) => {
+    async (body, headers, status) => {
       const parsed = parseActionsRunHTML(
         new TextDecoder().decode(body),
         route.owner!,
@@ -141,7 +141,7 @@ function actionsRunRequest(
         parsed === undefined ? undefined : await completeActionsRunSHA(env, route, parsed);
       return complete === undefined ? undefined : publicJSONResponse(headers, status, complete);
     },
-  };
+  );
 }
 
 function actionsRunJobsRequest(
@@ -196,16 +196,11 @@ function actionsListQuery(
   query: Record<string, string | string[]> | undefined,
 ): { perPage: number; search: string } | undefined {
   const allowed = new Set(["per_page", "page", "branch", "status"]);
-  if (
-    Object.entries(query ?? {}).some(
-      ([key, value]) => !allowed.has(key) || Array.isArray(value) || value === "",
-    ) ||
-    (scalarQuery(query, "page") !== undefined && scalarQuery(query, "page") !== "1")
-  ) {
+  if (!validScalarQuery(query, allowed) || !firstPageQuery(query)) {
     return undefined;
   }
-  const perPage = Number(scalarQuery(query, "per_page") ?? "25");
-  if (!Number.isInteger(perPage) || perPage < 1 || perPage > 25) {
+  const perPage = boundedPageSize(query?.per_page, { defaultValue: 25, max: 25 });
+  if (perPage === undefined) {
     return undefined;
   }
   if (scalarQuery(query, "branch") !== undefined || scalarQuery(query, "status") !== undefined) {
@@ -219,16 +214,14 @@ function actionsJobsQuery(
 ): { perPage: number } | undefined {
   const allowed = new Set(["per_page", "page", "filter"]);
   if (
-    Object.entries(query ?? {}).some(
-      ([key, value]) => !allowed.has(key) || Array.isArray(value) || value === "",
-    ) ||
-    (scalarQuery(query, "page") !== undefined && scalarQuery(query, "page") !== "1") ||
+    !validScalarQuery(query, allowed) ||
+    !firstPageQuery(query) ||
     (scalarQuery(query, "filter") !== undefined && scalarQuery(query, "filter") !== "latest")
   ) {
     return undefined;
   }
-  const perPage = Number(scalarQuery(query, "per_page") ?? "30");
-  return Number.isInteger(perPage) && perPage >= 1 && perPage <= 100 ? { perPage } : undefined;
+  const perPage = boundedPageSize(query?.per_page, { defaultValue: 30 });
+  return perPage === undefined ? undefined : { perPage };
 }
 
 async function enrichActionsRun(

--- a/src/github-public-content.ts
+++ b/src/github-public-content.ts
@@ -1,7 +1,12 @@
 import { bytesToBase64 } from "./encoding";
 import { responseCapBytes } from "./github-limits";
 import { encodedPathSegments, safeRelativePath } from "./github-path";
-import { decodePathStrict, publicResponseHeaders, scalarQuery } from "./github-public-utils";
+import {
+  decodePathStrict,
+  publicJSONResponse,
+  publicResponseHeaders,
+  scalarQuery,
+} from "./github-public-utils";
 import { defaultGitHubJSONAccept } from "./github-response";
 import type { WebRequest } from "./github-web-types";
 import type { RelayRequest, RouteInfo } from "./types";
@@ -90,30 +95,24 @@ export function rawContentRequest(
       const apiPath = `/repos/${route.owner}/${route.repo}/contents/${contentPath}`;
       const apiURL = `https://api.github.com${apiPath}?ref=${encodeURIComponent(ref)}`;
       const htmlURL = `https://github.com/${encodedPathSegments([route.owner!, route.repo!, "blob", ref, contentPath])}`;
-      return {
-        status,
-        headers: publicResponseHeaders(headers, "application/json"),
-        body: {
-          type: "file",
-          encoding: "base64",
-          name: contentPath.split("/").at(-1) ?? contentPath,
-          path: contentPath,
-          sha,
-          size: body.byteLength,
-          content: bytesToBase64(body),
-          url: apiURL,
-          html_url: htmlURL,
-          git_url: `https://api.github.com/repos/${route.owner}/${route.repo}/git/blobs/${sha}`,
-          download_url: rawURL,
-          _links: {
-            self: apiURL,
-            git: `https://api.github.com/repos/${route.owner}/${route.repo}/git/blobs/${sha}`,
-            html: htmlURL,
-          },
+      return publicJSONResponse(headers, status, {
+        type: "file",
+        encoding: "base64",
+        name: contentPath.split("/").at(-1) ?? contentPath,
+        path: contentPath,
+        sha,
+        size: body.byteLength,
+        content: bytesToBase64(body),
+        url: apiURL,
+        html_url: htmlURL,
+        git_url: `https://api.github.com/repos/${route.owner}/${route.repo}/git/blobs/${sha}`,
+        download_url: rawURL,
+        _links: {
+          self: apiURL,
+          git: `https://api.github.com/repos/${route.owner}/${route.repo}/git/blobs/${sha}`,
+          html: htmlURL,
         },
-        body_encoding: "json",
-        backend: "web",
-      };
+      });
     },
   };
 }

--- a/src/github-public-git.ts
+++ b/src/github-public-git.ts
@@ -1,8 +1,8 @@
 import { responseCapBytes } from "./github-limits";
 import { gitRefResponse, parseGitUploadPackAdvertisement } from "./github-git";
 import { encodedPathSegments, safeRelativePath } from "./github-path";
-import { defaultGitHubJSONAccept, githubResponseHeaders } from "./github-response";
-import { decodePathStrict } from "./github-public-utils";
+import { defaultGitHubJSONAccept } from "./github-response";
+import { decodePathStrict, publicJSONResponse } from "./github-public-utils";
 import { parseRepositoryNodeIDHTML } from "./github-html";
 import { fetchPublicPage } from "./github-web-transport";
 import type { WebRequest } from "./github-web-types";
@@ -69,18 +69,7 @@ export function gitRefRequest(
               requested,
               route.kind === "git_matching_refs",
             );
-      return parsed === undefined
-        ? undefined
-        : {
-            status,
-            headers: githubResponseHeaders(headers, {
-              contentType: "application/json",
-              includeCacheControl: true,
-            }),
-            body: parsed,
-            body_encoding: "json",
-            backend: "web",
-          };
+      return parsed === undefined ? undefined : publicJSONResponse(headers, status, parsed);
     },
   };
 }

--- a/src/github-public-pages.ts
+++ b/src/github-public-pages.ts
@@ -1,6 +1,14 @@
 import { responseCapBytes } from "./github-limits";
 import { encodedPathSegments } from "./github-path";
-import { decodePathStrict, publicResponseHeaders, scalarQuery } from "./github-public-utils";
+import {
+  boundedPageSize,
+  decodePathStrict,
+  firstPageQuery,
+  htmlWebRequest,
+  publicJSONResponse,
+  scalarQuery,
+  validScalarQuery,
+} from "./github-public-utils";
 import { defaultGitHubJSONAccept } from "./github-response";
 import {
   parseIssueHTML,
@@ -106,61 +114,35 @@ export function summaryPageRequest(
     url = new URL(
       `https://github.com/${encodedPathSegments([route.owner, route.repo, "actions"])}`,
     );
-    return {
-      url: url.toString(),
-      headers: { accept: "text/html", "user-agent": "octopool" },
-      capBytes: responseCapBytes(env),
-      usesApiQuota: false,
-      payload: async (body, headers, status) => {
-        const html = new TextDecoder().decode(body);
-        const workflows = await completeWorkflowList(env, route, html);
-        if (workflows === undefined) {
-          return undefined;
-        }
-        const bodyValue =
-          route.kind === "workflow_view"
-            ? workflows.find(
-                (workflow) =>
-                  String(workflow.id) === workflowRef ||
-                  workflow.path === `.github/workflows/${workflowRef}`,
-              )
-            : {
-                total_count: workflows.length,
-                workflows: workflows.slice(0, query.perPage),
-              };
-        if (bodyValue === undefined) {
-          return undefined;
-        }
-        return {
-          status,
-          headers: publicResponseHeaders(headers, "application/json"),
-          body: bodyValue,
-          body_encoding: "json",
-          backend: "web",
-        };
-      },
-    };
+    return htmlWebRequest(env, url.toString(), async (body, headers, status) => {
+      const html = new TextDecoder().decode(body);
+      const workflows = await completeWorkflowList(env, route, html);
+      if (workflows === undefined) {
+        return undefined;
+      }
+      const bodyValue =
+        route.kind === "workflow_view"
+          ? workflows.find(
+              (workflow) =>
+                String(workflow.id) === workflowRef ||
+                workflow.path === `.github/workflows/${workflowRef}`,
+            )
+          : {
+              total_count: workflows.length,
+              workflows: workflows.slice(0, query.perPage),
+            };
+      if (bodyValue === undefined) {
+        return undefined;
+      }
+      return publicJSONResponse(headers, status, bodyValue);
+    });
   } else {
     return undefined;
   }
-  return {
-    url: url.toString(),
-    headers: { accept: "text/html", "user-agent": "octopool" },
-    capBytes: responseCapBytes(env),
-    usesApiQuota: false,
-    payload: (body, headers, status) => {
-      const parsed = parse(new TextDecoder().decode(body));
-      return parsed === undefined
-        ? undefined
-        : {
-            status,
-            headers: publicResponseHeaders(headers, "application/json"),
-            body: parsed,
-            body_encoding: "json",
-            backend: "web",
-          };
-    },
-  };
+  return htmlWebRequest(env, url.toString(), (body, headers, status) => {
+    const parsed = parse(new TextDecoder().decode(body));
+    return parsed === undefined ? undefined : publicJSONResponse(headers, status, parsed);
+  });
 }
 
 async function completeWorkflowList(
@@ -210,11 +192,7 @@ function issueListPageQuery(
     kind === "issue"
       ? new Set(["per_page", "page", "state", "creator", "assignee", "labels"])
       : new Set(["per_page", "page", "state"]);
-  if (
-    Object.entries(query ?? {}).some(
-      ([key, value]) => !allowed.has(key) || Array.isArray(value) || value === "",
-    )
-  ) {
+  if (!validScalarQuery(query, allowed)) {
     return undefined;
   }
   const pageQuery = simplePageQuery(query, allowed);
@@ -257,16 +235,11 @@ function simplePageQuery(
   query: Record<string, string | string[]> | undefined,
   allowed = new Set(["per_page", "page"]),
 ): { perPage: number } | undefined {
-  if (
-    Object.entries(query ?? {}).some(
-      ([key, value]) => !allowed.has(key) || Array.isArray(value) || value === "",
-    ) ||
-    (scalarQuery(query, "page") !== undefined && scalarQuery(query, "page") !== "1")
-  ) {
+  if (!validScalarQuery(query, allowed) || !firstPageQuery(query)) {
     return undefined;
   }
-  const perPage = Number(scalarQuery(query, "per_page") ?? "30");
-  return Number.isInteger(perPage) && perPage >= 1 && perPage <= 100 ? { perPage } : undefined;
+  const perPage = boundedPageSize(query?.per_page, { defaultValue: 30 });
+  return perPage === undefined ? undefined : { perPage };
 }
 
 function searchQualifier(key: string, value: string): string | undefined {
@@ -317,27 +290,13 @@ export function releasePageRequest(
   } else {
     return undefined;
   }
-  return {
-    url,
-    headers: { accept: "text/html", "user-agent": "octopool" },
-    capBytes: responseCapBytes(env),
-    usesApiQuota: false,
-    payload: (body, headers, status, responseURL) => {
-      const parsed = parseReleaseHTML(
-        new TextDecoder().decode(body),
-        route.owner!,
-        route.repo!,
-        responseURL,
-      );
-      return parsed === undefined
-        ? undefined
-        : {
-            status,
-            headers: publicResponseHeaders(headers, "application/json"),
-            body: parsed,
-            body_encoding: "json",
-            backend: "web",
-          };
-    },
-  };
+  return htmlWebRequest(env, url, (body, headers, status, responseURL) => {
+    const parsed = parseReleaseHTML(
+      new TextDecoder().decode(body),
+      route.owner!,
+      route.repo!,
+      responseURL,
+    );
+    return parsed === undefined ? undefined : publicJSONResponse(headers, status, parsed);
+  });
 }

--- a/src/github-public-utils.ts
+++ b/src/github-public-utils.ts
@@ -1,4 +1,6 @@
+import { responseCapBytes } from "./github-limits";
 import { githubResponseHeaders } from "./github-response";
+import type { WebRequest } from "./github-web-types";
 import type { GitHubRelayResponse } from "./types";
 
 export function scalarQuery(
@@ -7,6 +9,35 @@ export function scalarQuery(
 ): string | undefined {
   const value = query?.[key];
   return typeof value === "string" && value !== "" ? value : undefined;
+}
+
+export function validScalarQuery(
+  query: Record<string, string | string[]> | undefined,
+  allowed: ReadonlySet<string>,
+): boolean {
+  return !Object.entries(query ?? {}).some(
+    ([key, value]) => !allowed.has(key) || Array.isArray(value) || value === "",
+  );
+}
+
+export function firstPageQuery(query: Record<string, string | string[]> | undefined): boolean {
+  const page = scalarQuery(query, "page");
+  return page === undefined || page === "1";
+}
+
+export function boundedPageSize(
+  value: string | string[] | undefined,
+  options: { defaultValue?: number; max?: number; strict?: boolean } = {},
+): number | undefined {
+  if (value === undefined) {
+    return options.defaultValue;
+  }
+  if (Array.isArray(value) || (options.strict === true && !/^[1-9][0-9]*$/.test(value))) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  const max = options.max ?? 100;
+  return Number.isInteger(parsed) && parsed >= 1 && parsed <= max ? parsed : undefined;
 }
 
 export function decodePathStrict(value: string): string | undefined {
@@ -44,5 +75,15 @@ export function publicJSONResponse(
     body,
     body_encoding: bodyEncoding,
     backend: "web",
+  };
+}
+
+export function htmlWebRequest(env: Env, url: string, payload: WebRequest["payload"]): WebRequest {
+  return {
+    url,
+    headers: { accept: "text/html", "user-agent": "octopool" },
+    capBytes: responseCapBytes(env),
+    usesApiQuota: false,
+    payload,
   };
 }

--- a/src/public-repos.ts
+++ b/src/public-repos.ts
@@ -39,10 +39,7 @@ export async function ensurePublicGitHubRepo(
   const edgeProof = await rejectFreshNegativePublicRepoProof(env, owner, repo);
   if (
     cacheCreatedAt !== undefined &&
-    (await coveringPublicRepoProofSource(env, route, cacheCreatedAt, {
-      requireFresh: true,
-      edgeProof,
-    })) !== undefined
+    (await coveringPublicRepoProofSource(env, route, cacheCreatedAt, { edgeProof })) !== undefined
   ) {
     return;
   }
@@ -61,12 +58,10 @@ export async function ensurePublicGitHubRepo(
         const source =
           acquisition.outcome === "shared"
             ? await coveringPublicRepoProofSource(env, route, proofStartedAt, {
-                requireFresh: true,
                 edgeProof: completedEdgeProof,
               })
             : acquisition.outcome === "edge_only"
               ? await coveringPublicRepoProofSource(env, route, proofStartedAt, {
-                  requireFresh: true,
                   source: "edge",
                   edgeProof: completedEdgeProof,
                 })
@@ -83,7 +78,6 @@ export async function ensurePublicGitHubRepo(
       if (
         cacheCreatedAt !== undefined &&
         (await coveringPublicRepoProofSource(env, route, cacheCreatedAt, {
-          requireFresh: true,
           source: "shared",
         })) === "shared"
       ) {
@@ -338,7 +332,6 @@ async function coveringPublicRepoProofSource(
   route: RouteInfo,
   cacheCreatedAt: string,
   options: {
-    requireFresh?: boolean;
     source?: PublicRepoProofSource;
     edgeProof?: PublicRepoProof | undefined;
   } = {},
@@ -362,10 +355,13 @@ async function coveringPublicRepoProofSource(
       return undefined;
     }
   }
-  const query = options.requireFresh
-    ? queries.freshCoveringPublicRepoProof
-    : queries.coveringPublicRepoProof;
-  const row = await readD1PublicRepoProof(env, query, owner, repo, cacheCreatedAt);
+  const row = await readD1PublicRepoProof(
+    env,
+    queries.coveringPublicRepoProof,
+    owner,
+    repo,
+    cacheCreatedAt,
+  );
   if (row === null || !publicProofCovers(row, cacheCreatedAt)) {
     return undefined;
   }

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -492,9 +492,7 @@ async function callRevalidationAPI(
       const response = await callAnonymousGitHubAPI(state.env, request, state.route);
       return response === undefined
         ? undefined
-        : completeRunJobsSuperset(response, state.runJobsSuperset, (pageRequest) =>
-            callAnonymousGitHubAPI(state.env, pageRequest, state.route),
-          );
+        : completeRunJobsSuperset(response, state.runJobsSuperset, anonymousRunJobsPage(state));
     }
     if (identity !== undefined) {
       state.paginatedIdentityRateRecorded = false;
@@ -502,17 +500,11 @@ async function callRevalidationAPI(
         state.route,
         await callGitHub(state.env, identity, request, state.route),
       );
-      return completeRunJobsSuperset(response, state.runJobsSuperset, async (pageRequest) => {
-        await recordFirstPaginatedIdentityRate(state, identity, response);
-        const page = sanitizeGitHubResponse(
-          state.route,
-          await callGitHub(state.env, identity, pageRequest, state.route),
-        );
-        await state.coordinator.recordResult(
-          coordinatorResult(state, identity, page.status, rateFromHeaders(page.headers)),
-        );
-        return page;
-      });
+      return completeRunJobsSuperset(
+        response,
+        state.runJobsSuperset,
+        identityRunJobsPage(state, identity, response),
+      );
     }
     return sanitizeGitHubResponse(
       state.route,
@@ -632,9 +624,7 @@ async function callTokenFreeBackend(state: ActiveRelay): Promise<Response | unde
   }
   const completed =
     response.backend === "github"
-      ? await completeRunJobsSuperset(response, state.runJobsSuperset, (pageRequest) =>
-          callAnonymousGitHubAPI(state.env, pageRequest, state.route),
-        )
+      ? await completeRunJobsSuperset(response, state.runJobsSuperset, anonymousRunJobsPage(state))
       : response;
   const github = sanitizeGitHubResponse(state.route, completed);
   if (anonymousGitHubResponseProvesPublicRepo(state.route)) {
@@ -722,17 +712,7 @@ async function callIdentityPool(state: ActiveRelay): Promise<Response> {
     const github = await completeRunJobsSuperset(
       firstPage,
       state.runJobsSuperset,
-      async (pageRequest) => {
-        await recordFirstPaginatedIdentityRate(state, identity, firstPage);
-        const page = sanitizeGitHubResponse(
-          state.route,
-          await callGitHub(state.env, identity, pageRequest, state.route),
-        );
-        await state.coordinator.recordResult(
-          coordinatorResult(state, identity, page.status, rateFromHeaders(page.headers)),
-        );
-        return page;
-      },
+      identityRunJobsPage(state, identity, firstPage),
     );
     const rate = rateFromHeaders(github.headers);
     const identityFallback = githubResponseLocalFallbackReason(github.status, rate);
@@ -912,6 +892,30 @@ async function recordFirstPaginatedIdentityRate(
     coordinatorResult(state, identity, response.status, rateFromHeaders(response.headers)),
   );
   state.paginatedIdentityRateRecorded = true;
+}
+
+function anonymousRunJobsPage(
+  state: ActiveRelay,
+): (request: RelayRequest) => Promise<GitHubRelayResponse | undefined> {
+  return (request) => callAnonymousGitHubAPI(state.env, request, state.route);
+}
+
+function identityRunJobsPage(
+  state: ActiveRelay,
+  identity: Identity,
+  firstPage: GitHubRelayResponse,
+): (request: RelayRequest) => Promise<GitHubRelayResponse> {
+  return async (request) => {
+    await recordFirstPaginatedIdentityRate(state, identity, firstPage);
+    const page = sanitizeGitHubResponse(
+      state.route,
+      await callGitHub(state.env, identity, request, state.route),
+    );
+    await state.coordinator.recordResult(
+      coordinatorResult(state, identity, page.status, rateFromHeaders(page.headers)),
+    );
+    return page;
+  };
 }
 
 async function handleRelayError(

--- a/src/run-jobs-superset.ts
+++ b/src/run-jobs-superset.ts
@@ -1,4 +1,5 @@
 import { PUBLIC_SHAPES } from "./github-public-shapes";
+import { boundedPageSize, firstPageQuery, validScalarQuery } from "./github-public-utils";
 import { isRecord } from "./object";
 import type { GitHubRelayResponse, RelayRequest, RouteInfo } from "./types";
 
@@ -25,15 +26,13 @@ export function runJobsSupersetView(
   const query = request.query ?? {};
   const allowed = new Set(["filter", "page", "per_page"]);
   if (
-    Object.entries(query).some(
-      ([key, value]) => !allowed.has(key) || Array.isArray(value) || value === "",
-    ) ||
-    (query.page !== undefined && query.page !== "1") ||
+    !validScalarQuery(query, allowed) ||
+    !firstPageQuery(query) ||
     (query.filter !== undefined && query.filter !== "latest")
   ) {
     return undefined;
   }
-  const limit = pageSize(query.per_page);
+  const limit = boundedPageSize(query.per_page, { strict: true });
   if (query.per_page !== undefined && limit === undefined) {
     return undefined;
   }
@@ -138,14 +137,4 @@ export function filterRunJobsSuperset(
       jobs: response.body.jobs.slice(0, view.limit),
     },
   };
-}
-
-function pageSize(value: string | string[] | undefined): number | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (Array.isArray(value) || !/^(?:[1-9]|[1-9][0-9]|100)$/.test(value)) {
-    return undefined;
-  }
-  return Number(value);
 }

--- a/src/run-list-superset.ts
+++ b/src/run-list-superset.ts
@@ -1,4 +1,5 @@
 import { PUBLIC_SHAPES } from "./github-public-shapes";
+import { boundedPageSize, firstPageQuery, validScalarQuery } from "./github-public-utils";
 import { isRecord } from "./object";
 import type { GitHubRelayResponse, RelayRequest, RouteInfo } from "./types";
 
@@ -42,7 +43,7 @@ export function runListShapeView(request: RelayRequest, route: RouteInfo): RunLi
   if (limit === undefined) {
     return undefined;
   }
-  const perPage = boundedPageSize(request.query.per_page);
+  const perPage = boundedPageSize(request.query.per_page, { strict: true });
   return { limit: Math.min(perPage ?? MAX_PAGE_SIZE, limit) };
 }
 
@@ -71,16 +72,11 @@ export function runListSupersetView(
   }
   const query = request.query ?? {};
   const allowed = new Set(["branch", "status", "page", "per_page", "limit"]);
-  if (
-    Object.entries(query).some(
-      ([key, value]) => !allowed.has(key) || Array.isArray(value) || value === "",
-    ) ||
-    (query.page !== undefined && query.page !== "1")
-  ) {
+  if (!validScalarQuery(query, allowed) || !firstPageQuery(query)) {
     return undefined;
   }
-  const perPage = boundedPageSize(query.per_page);
-  const limit = boundedPageSize(query.limit);
+  const perPage = boundedPageSize(query.per_page, { strict: true });
+  const limit = boundedPageSize(query.limit, { strict: true });
   if (
     (query.per_page !== undefined && perPage === undefined) ||
     (query.limit !== undefined && limit === undefined) ||
@@ -181,14 +177,4 @@ function cappedPageSize(value: string | string[] | undefined): number | undefine
   }
   const parsed = Number(value);
   return Number.isSafeInteger(parsed) ? Math.min(parsed, MAX_PAGE_SIZE) : undefined;
-}
-
-function boundedPageSize(value: string | string[] | undefined): number | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (Array.isArray(value) || !/^(?:[1-9]|[1-9][0-9]|100)$/.test(value)) {
-    return undefined;
-  }
-  return Number(value);
 }

--- a/test/public-repos.test.ts
+++ b/test/public-repos.test.ts
@@ -336,7 +336,7 @@ describe("public repo guard", () => {
 
   it("filters negative rows out of both shared covering-proof queries", () => {
     expect(queries.coveringPublicRepoProof).toContain("AND is_public = 1");
-    expect(queries.freshCoveringPublicRepoProof).toContain("AND is_public = 1");
+    expect(queries.coveringPublicRepoProof).toContain("AND is_public = 1");
   });
 
   it("re-checks GitHub after a negative proof expires", async () => {
@@ -411,7 +411,7 @@ describe("public repo guard", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(prepare).toHaveBeenCalledWith(queries.freshNegativePublicRepoProof);
-    expect(prepare).toHaveBeenCalledWith(queries.freshCoveringPublicRepoProof);
+    expect(prepare).toHaveBeenCalledWith(queries.coveringPublicRepoProof);
     expect(prepare).toHaveBeenCalledWith(queries.coveringPublicRepoProof);
   });
 


### PR DESCRIPTION
Behavior-preserving de-duplication pass over the worker and CLI, scoped by a read-only whole-codebase survey (TS + Go + SQL), with each finding verified against unchanged test behavior. Net −62 LOC.

## What was consolidated

- **Twin SQL queries**: `FreshCoveringPublicRepoProof` was byte-identical to `CoveringPublicRepoProof` — a vestige of the 0.5.1 outage-fallback fix that made both reject expired proofs. The twin and its `requireFresh` plumbing are gone.
- **Run-jobs pagination adapters**: `callRevalidationAPI` and `callIdentityPool` each carried copies of the anonymous and identity page-fetch closures (including per-page sanitize + coordinator rate recording). Now two shared factories.
- **Public transport construction**: the five `github-public-*` modules rebuilt HTML `WebRequest` literals and JSON responses by hand; now one factory + the existing response helper.
- **Query validation**: scalar-key and 1–100 page-size checks shared between the page parsers and both superset modules; route-specific defaults stay local.
- **CLI flag lifecycle**: `health`/`request`/`stats` each registered url/pool/token-env flags and repeated the load-auth → apply-defaults → validate-URL → resolve-token sequence; now `callerRequestFlags`, preserving flag names, defaults, and validation order exactly.
- **Go envelope decoding**: one keyed collection-page decoder replaces three copies across check-run/status/run-jobs readers.
- **Cache completion predicates**: four identical all-`completed` array checks collapsed into one keyed helper.

## What was deliberately NOT done

- Parallelizing stale-cache candidate reads (a survey finding) was **rejected during implementation**: `serveStaleRelayCache` early-exits on the first usable candidate in priority order, so `Promise.all` would change semantics. The survey misread the loop.
- Unifying the run-jobs and run-list superset modules: they differ materially in completion, filtering, and fallback semantics.
- No dead-export sweep: the one production-unused export is an intentional e2e seam.

## Proof

`pnpm check` green: 246 unit, 98 e2e, Go tests + vet — all tests unchanged except two identifier references to the deleted query name. Codex autoreview clean (0.98). No changelog entry (internal-only).
