### PR TITLE
Add a client filter to pool stats (server + CLI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Changes
 
+- Add a caller-scoped `client` filter to the stats API and `octopool stats` so operators can inspect route-level behavior for any of their own clients.
 - Cut awaited round trips per relay request — warm 1MB cache hits drop from ~1.0s to ~0.3s: 30s isolate-local cache for caller auth, pool policy, and identity lists (authoritative rechecks still read D1 directly) and public-repo proof TTL raised to 15 minutes in the hosted deployment. Smart Placement was measured and rejected: it relocates execution and the edge cache away from caller colos, slowing this workload 2-3x.
 - Move the primary data region to Western North America: new `wnam` D1 database (config, tokens, identities, proofs, and audit history migrated; cache rebuilt) and a relocated pool coordinator, cutting ~140ms of transatlantic latency from every D1/coordinator round trip for US callers.
 - Redesign the operator dashboard as an editorial ledger: serif display type, hairline-rule sections, tick-marked rate gauges with low-headroom coloring, and right-aligned tabular numerals.

--- a/cmd/octopool/command_e2e_test.go
+++ b/cmd/octopool/command_e2e_test.go
@@ -36,6 +36,35 @@ func TestCLIEndToEndServiceCommands(t *testing.T) {
 		}
 	})
 
+	t.Run("stats client filter", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet || r.URL.Path != "/v1/pools/maintainers/stats" {
+				http.Error(w, "unexpected stats request", http.StatusBadRequest)
+				t.Errorf("request = %s %s", r.Method, r.URL.Path)
+				return
+			}
+			if r.URL.Query().Get("since") != "24h" || r.URL.Query().Get("client") != "ci-runner" {
+				http.Error(w, "unexpected stats query", http.StatusBadRequest)
+				t.Errorf("query = %q", r.URL.RawQuery)
+				return
+			}
+			writeCommandJSON(t, w, map[string]any{
+				"pool":          "maintainers",
+				"operator":      map[string]any{"client_name": "test-mac"},
+				"client_filter": "ci-runner",
+				"client_usage":  map[string]any{"requests": 3, "saved_github_requests": 2, "backend_requests": 1},
+			})
+		}))
+		t.Cleanup(server.Close)
+
+		result := runCLI(t, bin, server.URL, nil, "stats", "-client", "ci-runner")
+		if result.err != nil ||
+			!strings.Contains(result.stdout, "client: test-mac\nclient filter: ci-runner\n") ||
+			!strings.Contains(result.stdout, "ci-runner: 3 requests, 2 saved, 1 backend") {
+			t.Fatalf("err=%v stdout=%q stderr=%q", result.err, result.stdout, result.stderr)
+		}
+	})
+
 	t.Run("request forwards options", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodPost || r.URL.Path != "/v1/github/request" {

--- a/cmd/octopool/stats.go
+++ b/cmd/octopool/stats.go
@@ -16,6 +16,7 @@ type statsResponse struct {
 	Pool            string                `json:"pool"`
 	Window          statsWindow           `json:"window"`
 	Operator        statsOperator         `json:"operator"`
+	ClientFilter    string                `json:"client_filter"`
 	PoolUsage       statsAggregate        `json:"pool_usage"`
 	CallerUsage     statsAggregate        `json:"caller_usage"`
 	ClientUsage     statsAggregate        `json:"client_usage"`
@@ -97,6 +98,7 @@ func runStats(ctx context.Context, args []string, stdout io.Writer) error {
 	fs.SetOutput(io.Discard)
 	requestFlags := newCallerRequestFlags(fs)
 	since := fs.String("since", "24h", "stats window, e.g. 30m, 24h, 7d")
+	client := fs.String("client", "", "client name to filter client usage and routes")
 	jsonOutput := fs.Bool("json", false, "print raw JSON")
 	if handled, err := parseCommandFlags(fs, args, stdout, "usage: octopool stats [flags]"); err != nil {
 		return err
@@ -114,6 +116,9 @@ func runStats(ctx context.Context, args []string, stdout io.Writer) error {
 	query := url.Values{}
 	if strings.TrimSpace(*since) != "" {
 		query.Set("since", strings.TrimSpace(*since))
+	}
+	if strings.TrimSpace(*client) != "" {
+		query.Set("client", strings.TrimSpace(*client))
 	}
 	endpoint := apiURL(*requestFlags.baseURL, "/v1/pools/"+urlPath(*requestFlags.pool)+"/stats")
 	if encoded := query.Encode(); encoded != "" {
@@ -147,6 +152,13 @@ func renderStats(w io.Writer, stats statsResponse) error {
 		"window: " + firstNonEmpty(stats.Window.Label, "24h"),
 		fmt.Sprintf("operator: %s", firstNonEmpty(stats.Operator.GitHubLogin, "unknown")),
 		fmt.Sprintf("client: %s", firstNonEmpty(stats.Operator.ClientName, "legacy")),
+	}
+	clientUsageLabel := "this client"
+	if stats.ClientFilter != "" {
+		lines = append(lines, "client filter: "+stats.ClientFilter)
+		clientUsageLabel = stats.ClientFilter
+	}
+	lines = append(lines,
 		fmt.Sprintf(
 			"requests: %s (%s service errors, %s local fallbacks)",
 			intFmt(stats.PoolUsage.Requests),
@@ -180,7 +192,8 @@ func renderStats(w io.Writer, stats statsResponse) error {
 			percent(stats.CallerUsage.CacheHitRate),
 		),
 		fmt.Sprintf(
-			"this client: %s requests, %s saved, %s backend",
+			"%s: %s requests, %s saved, %s backend",
+			clientUsageLabel,
 			intFmt(stats.ClientUsage.Requests),
 			intFmt(stats.ClientUsage.SavedGitHubCalls),
 			intFmt(stats.ClientUsage.BackendRequests),
@@ -192,7 +205,7 @@ func renderStats(w io.Writer, stats statsResponse) error {
 			intFmt(stats.Cache.ExpiredEntries),
 			byteFmt(stats.Cache.BodyBytes),
 		),
-	}
+	)
 	for _, line := range lines {
 		if _, err := fmt.Fprintln(w, line); err != nil {
 			return err

--- a/cmd/octopool/stats_test.go
+++ b/cmd/octopool/stats_test.go
@@ -114,3 +114,26 @@ func TestRenderStatsNoRoutes(t *testing.T) {
 		t.Fatalf("missing empty routes:\n%s", got)
 	}
 }
+
+func TestRenderStatsClientFilter(t *testing.T) {
+	var out bytes.Buffer
+	stats := statsResponse{
+		Pool:         "maintainers",
+		Operator:     statsOperator{ClientName: "steipete-mbp"},
+		ClientFilter: "ci-runner",
+		ClientUsage:  statsAggregate{Requests: 4, SavedGitHubCalls: 1, BackendRequests: 3},
+	}
+	if err := renderStats(&out, stats); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "client: steipete-mbp\nclient filter: ci-runner\n") {
+		t.Fatalf("missing client filter after calling client:\n%s", got)
+	}
+	if !strings.Contains(got, "ci-runner: 4 requests, 1 saved, 3 backend") {
+		t.Fatalf("missing filtered usage label:\n%s", got)
+	}
+	if strings.Contains(got, "this client:") {
+		t.Fatalf("unexpected unfiltered usage label:\n%s", got)
+	}
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -263,7 +263,7 @@ is not stored by Octopool; retry the same login command after reset instead of r
 Fetches `GET /v1/pools/<pool>/health` using the stored token. Returns identity counts and
 policy version.
 
-### `octopool stats [--pool <id>] [--since 24h] [--json]`
+### `octopool stats [--pool <id>] [--since 24h] [--client <name>] [--json]`
 
 Fetches `GET /v1/pools/<pool>/stats` using the stored token. The default human output
 shows the pool request count, service errors, expected local fallbacks, raw and
@@ -274,6 +274,9 @@ route and bounded source (`github_web`, anonymous `github_api`, or `github_ident
 groups local delegation by fallback reason. No request bodies, query values, or credentials
 enter these aggregates.
 `--since` accepts `30m`, `24h`, or `7d` style windows, capped at 30 days.
+`--client` filters `client_usage` and `client_routes` to that named client while retaining
+the authenticated caller's scope. Human output identifies both the calling client and the
+filter; JSON includes `client_filter` only when the filter is active.
 
 ```sh
 octopool stats
@@ -299,6 +302,12 @@ Use `--json` for dashboards or scripts that want the raw aggregate:
 
 ```sh
 octopool stats --since 7d --json
+```
+
+Filter the client-specific aggregates without changing the calling client identity:
+
+```sh
+octopool stats -client ci-runner
 ```
 
 ### `octopool request --path <p> [--method GET] [--query k=v] [--header k=v] [--route-hint k=v]`

--- a/src/client-name.ts
+++ b/src/client-name.ts
@@ -1,6 +1,23 @@
+import { HttpError } from "./http";
+
 export function normalizeClientName(value: string): string {
   const trimmed = value.trim();
   return trimmed.length > ".local".length && trimmed.toLowerCase().endsWith(".local")
     ? trimmed.slice(0, -".local".length)
     : trimmed;
+}
+
+export function parseClientName(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new HttpError(400, "client_name_invalid", "client_name must be a string");
+  }
+  const clientName = normalizeClientName(value);
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/.test(clientName)) {
+    throw new HttpError(
+      400,
+      "client_name_invalid",
+      "client_name must be 1-80 hostname-safe characters",
+    );
+  }
+  return clientName;
 }

--- a/src/provisioning.ts
+++ b/src/provisioning.ts
@@ -6,7 +6,7 @@ import {
   verifyGitHubOrgMemberWithToken,
 } from "./auth";
 import { clearConfigCache } from "./config-cache";
-import { normalizeClientName } from "./client-name";
+import { parseClientName } from "./client-name";
 import { ensureCliCaller } from "./callers";
 import { requestedLoginPool } from "./config";
 import { ensurePool } from "./db";
@@ -16,7 +16,7 @@ import { HttpError, jsonResponse, parseJsonObject, requireString } from "./http"
 export async function loginGitHubCLI(request: Request, env: Env): Promise<Response> {
   const body = await parseJsonObject(request);
   const githubToken = requireString(body.github_token, "github_token");
-  const clientName = parseClientName(body.client_name);
+  const clientName = body.client_name === undefined ? "legacy" : parseClientName(body.client_name);
   const pool = requestedLoginPool(env, body.pool);
   const user = await githubUserFromToken(env, githubToken);
   const verifiedAt = await verifyGitHubOrgMemberWithToken(env, githubToken, user.login);
@@ -60,24 +60,6 @@ export async function createCaller(request: Request, env: Env): Promise<Response
     },
     201,
   );
-}
-
-function parseClientName(value: unknown): string {
-  if (value === undefined) {
-    return "legacy";
-  }
-  if (typeof value !== "string") {
-    throw new HttpError(400, "client_name_invalid", "client_name must be a string");
-  }
-  const clientName = normalizeClientName(value);
-  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/.test(clientName)) {
-    throw new HttpError(
-      400,
-      "client_name_invalid",
-      "client_name must be 1-80 hostname-safe characters",
-    );
-  }
-  return clientName;
 }
 
 export async function upsertIdentity(request: Request, env: Env, pool: string): Promise<Response> {

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,4 +1,5 @@
 import { authenticateAdmin, authenticateCaller } from "./auth";
+import { parseClientName } from "./client-name";
 import { defaultLoginPool } from "./config";
 import { dashboardData } from "./dashboard-data";
 import { dashboardResponse } from "./dashboard";
@@ -77,7 +78,9 @@ export async function routeRequest(
     const pool = routeParam(url.pathname, /^\/v1\/pools\/(?<pool>[^/]+)\/stats$/, "pool");
     const caller = await authenticateCaller(request, env, pool);
     const window = parseStatsWindow(url.searchParams.get("since"));
-    return jsonResponse(await poolStats(env, pool, caller, window));
+    const rawClientFilter = url.searchParams.get("client");
+    const clientFilter = rawClientFilter === null ? undefined : parseClientName(rawClientFilter);
+    return jsonResponse(await poolStats(env, pool, caller, window, clientFilter));
   }
   if (request.method === "GET" && /^\/v1\/pools\/[^/]+\/health$/.test(url.pathname)) {
     const pool = routeParam(url.pathname, /^\/v1\/pools\/(?<pool>[^/]+)\/health$/, "pool");

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -62,7 +62,14 @@ export function parseStatsWindow(raw: string | null): StatsWindow {
   return { label: `${amount}${unit}`, seconds };
 }
 
-export async function poolStats(env: Env, pool: string, caller: Caller, window: StatsWindow) {
+export async function poolStats(
+  env: Env,
+  pool: string,
+  caller: Caller,
+  window: StatsWindow,
+  clientFilter?: string,
+) {
+  const statsClientName = clientFilter ?? caller.client_name;
   const [
     poolUsage,
     callerUsage,
@@ -77,10 +84,10 @@ export async function poolStats(env: Env, pool: string, caller: Caller, window: 
   ] = await Promise.all([
     aggregateUsage(env, pool, window.seconds),
     aggregateUsage(env, pool, window.seconds, caller.id),
-    aggregateUsage(env, pool, window.seconds, caller.id, caller.client_name),
+    aggregateUsage(env, pool, window.seconds, caller.id, statsClientName),
     routeUsage(env, pool, window.seconds),
     routeUsage(env, pool, window.seconds, caller.id),
-    routeUsage(env, pool, window.seconds, caller.id, caller.client_name),
+    routeUsage(env, pool, window.seconds, caller.id, statsClientName),
     loadClientUsage(env, pool, window.seconds, caller.id),
     loadBackendUsage(env, pool, window.seconds),
     loadFallbackReasons(env, pool, window.seconds),
@@ -94,6 +101,7 @@ export async function poolStats(env: Env, pool: string, caller: Caller, window: 
       github_login: caller.github_login,
       client_name: caller.client_name,
     },
+    ...(clientFilter === undefined ? {} : { client_filter: clientFilter }),
     pool_usage: poolUsage,
     caller_usage: callerUsage,
     client_usage: currentClientUsage,

--- a/test/client-name.test.ts
+++ b/test/client-name.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normalizeClientName } from "../src/client-name";
+import { normalizeClientName, parseClientName } from "../src/client-name";
 
 describe("client name normalization", () => {
   it.each([
@@ -11,4 +11,19 @@ describe("client name normalization", () => {
   ])("normalizes %s to %s", (input, expected) => {
     expect(normalizeClientName(input)).toBe(expected);
   });
+});
+
+describe("client name validation", () => {
+  it("returns normalized hostname-safe names", () => {
+    expect(parseClientName("  ci-runner.local  ")).toBe("ci-runner");
+  });
+
+  it.each(["", "not a hostname", "-leading-dash", "a".repeat(81)])(
+    "rejects invalid name %j",
+    (input) => {
+      expect(() => parseClientName(input)).toThrowError(
+        expect.objectContaining({ status: 400, code: "client_name_invalid" }),
+      );
+    },
+  );
 });

--- a/test/e2e/worker.test.ts
+++ b/test/e2e/worker.test.ts
@@ -47,12 +47,14 @@ type UsageEnvelope = {
 type StatsEnvelope = {
   pool: string;
   operator: { github_login: string; client_name: string };
+  client_filter?: string;
   pool_usage: UsageEnvelope;
   caller_usage: UsageEnvelope;
   client_usage: UsageEnvelope;
   clients: (UsageEnvelope & { client_name: string })[];
   routes: (UsageEnvelope & { route_kind: string })[];
   caller_routes: (UsageEnvelope & { route_kind: string })[];
+  client_routes: (UsageEnvelope & { route_kind: string })[];
   backends: { backend: string; route_kind: string; requests: number }[];
   fallback_reasons: { reason: string; route_kind: string; requests: number }[];
   cache: { total_entries: number };
@@ -679,14 +681,27 @@ describe("Worker end-to-end relay", () => {
 });
 
 describe("Worker end-to-end read models", () => {
-  it("isolates pool and caller stats through the canonical usage queries", async () => {
+  it("filters client stats within the authenticated caller", async () => {
     await seedPool();
     await seedCaller("other", "other-token", "other");
+    await env.DB.prepare(
+      "INSERT INTO caller_tokens (id, caller_id, token_hash, client_name) VALUES (?, ?, ?, ?)",
+    )
+      .bind("caller-ci-token", "caller", "unused-ci-hash", "ci-runner")
+      .run();
     await seedAudit("request-1", "caller", "repo_view", "miss", 200, {
       backend: "github_web",
     });
     await seedAudit("request-2", "caller", "repo_view", "hit", 200);
-    await seedAudit("request-3", "other", "actions_log", "unknown", 424, {
+    await seedAudit("request-3", "caller", "workflow_run_list", "miss", 200, {
+      callerTokenId: "caller-ci-token",
+      clientName: "ci-runner",
+    });
+    await seedAudit("request-4", "caller", "workflow_run_list", "hit", 200, {
+      callerTokenId: "caller-ci-token",
+      clientName: "ci-runner",
+    });
+    await seedAudit("request-5", "other", "actions_log", "unknown", 424, {
       errorCode: "fallback_local",
       fallbackReason: "owner_denied",
       cacheable: 0,
@@ -701,18 +716,18 @@ describe("Worker end-to-end read models", () => {
       pool: POOL,
       operator: { github_login: "caller", client_name: "test-mac" },
       pool_usage: {
-        requests: 3,
+        requests: 5,
         errors: 1,
         fallbacks: 1,
-        cache_hits: 1,
-        cache_misses: 1,
+        cache_hits: 2,
+        cache_misses: 2,
       },
       caller_usage: {
-        requests: 2,
+        requests: 4,
         errors: 0,
         fallbacks: 0,
-        cache_hits: 1,
-        cache_misses: 1,
+        cache_hits: 2,
+        cache_misses: 2,
       },
       client_usage: {
         requests: 2,
@@ -723,13 +738,25 @@ describe("Worker end-to-end read models", () => {
       },
       cache: { total_entries: 0 },
     });
+    expect(body).not.toHaveProperty("client_filter");
     expect(body.pool_usage.eligible_cache_hit_rate).toBe(0.5);
     expect(body.caller_usage.eligible_cache_hit_rate).toBe(0.5);
-    expect(body.clients).toEqual([
-      expect.objectContaining({ client_name: "test-mac", requests: 2 }),
+    expect(body.clients).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ client_name: "ci-runner", requests: 2 }),
+        expect.objectContaining({ client_name: "test-mac", requests: 2 }),
+      ]),
+    );
+    expect(body.routes.map(({ route_kind }) => route_kind)).toEqual([
+      "repo_view",
+      "workflow_run_list",
+      "actions_log",
     ]);
-    expect(body.routes.map(({ route_kind }) => route_kind)).toEqual(["repo_view", "actions_log"]);
     expect(body.caller_routes).toEqual([
+      expect.objectContaining({ route_kind: "repo_view", requests: 2 }),
+      expect.objectContaining({ route_kind: "workflow_run_list", requests: 2 }),
+    ]);
+    expect(body.client_routes).toEqual([
       expect.objectContaining({ route_kind: "repo_view", requests: 2 }),
     ]);
     expect(body.backends).toEqual([
@@ -738,6 +765,42 @@ describe("Worker end-to-end read models", () => {
     expect(body.fallback_reasons).toEqual([
       expect.objectContaining({ reason: "owner_denied", route_kind: "actions_log", requests: 1 }),
     ]);
+
+    const filteredResponse = await callWorker(
+      `/v1/pools/${POOL}/stats?since=24h&client=ci-runner`,
+      { headers: { authorization: `Bearer ${CALLER_TOKEN}` } },
+    );
+    expect(filteredResponse.status).toBe(200);
+    const filtered = await filteredResponse.json<StatsEnvelope>();
+    expect(filtered).toMatchObject({
+      operator: { github_login: "caller", client_name: "test-mac" },
+      client_filter: "ci-runner",
+      client_usage: { requests: 2, cache_hits: 1, cache_misses: 1 },
+    });
+    expect(filtered.client_routes).toEqual([
+      expect.objectContaining({ route_kind: "workflow_run_list", requests: 2 }),
+    ]);
+
+    const foreignResponse = await callWorker(`/v1/pools/${POOL}/stats?since=24h&client=other-mac`, {
+      headers: { authorization: `Bearer ${CALLER_TOKEN}` },
+    });
+    expect(foreignResponse.status).toBe(200);
+    const foreign = await foreignResponse.json<StatsEnvelope>();
+    expect(foreign).toMatchObject({
+      operator: { github_login: "caller", client_name: "test-mac" },
+      client_filter: "other-mac",
+      client_usage: { requests: 0, cache_hits: 0, cache_misses: 0 },
+      client_routes: [],
+    });
+
+    const invalidResponse = await callWorker(
+      `/v1/pools/${POOL}/stats?since=24h&client=not%20a%20hostname`,
+      { headers: { authorization: `Bearer ${CALLER_TOKEN}` } },
+    );
+    expect(invalidResponse.status).toBe(400);
+    expect(await invalidResponse.json()).toMatchObject({
+      error: { code: "client_name_invalid" },
+    });
   });
 
   it("composes the authenticated dashboard from D1 and Durable Object state", async () => {

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { normalizeAggregate } from "../src/metrics";
-import { parseStatsWindow } from "../src/stats";
+import { parseStatsWindow, poolStats } from "../src/stats";
 import { HttpError } from "../src/http";
+import type { Caller } from "../src/types";
 
 describe("stats windows", () => {
   it("defaults to 24h", () => {
@@ -88,3 +89,72 @@ describe("stats aggregates", () => {
     });
   });
 });
+
+describe("client-filtered stats", () => {
+  const caller: Caller = {
+    id: "caller-id",
+    name: "Caller",
+    github_login: "caller",
+    org_login: "openclaw",
+    org_verified_at: null,
+    caller_token_id: "caller-token-id",
+    client_name: "test-mac",
+  };
+
+  it("keeps the calling client by default and emits no filter field", async () => {
+    const bindings: unknown[][] = [];
+    const response = await poolStats(statsEnv(bindings), "maintainers", caller, {
+      label: "24h",
+      seconds: 86_400,
+    });
+
+    expect(response).not.toHaveProperty("client_filter");
+    expect(clientScopedBindings(bindings)).toEqual([
+      ["maintainers", "-86400 seconds", "caller-id", "test-mac"],
+      ["maintainers", "-86400 seconds", "caller-id", "test-mac"],
+    ]);
+  });
+
+  it("binds a filtered client together with the authenticated caller id", async () => {
+    const bindings: unknown[][] = [];
+    const response = await poolStats(
+      statsEnv(bindings),
+      "maintainers",
+      caller,
+      { label: "24h", seconds: 86_400 },
+      "ci-runner",
+    );
+
+    expect(response).toMatchObject({
+      operator: { github_login: "caller", client_name: "test-mac" },
+      client_filter: "ci-runner",
+    });
+    expect(clientScopedBindings(bindings)).toEqual([
+      ["maintainers", "-86400 seconds", "caller-id", "ci-runner"],
+      ["maintainers", "-86400 seconds", "caller-id", "ci-runner"],
+    ]);
+  });
+});
+
+function statsEnv(bindings: unknown[][]): Env {
+  const prepare = vi.fn(() => ({
+    bind: (...values: unknown[]) => {
+      bindings.push(values);
+      return {
+        first: async () => null,
+        all: async () => ({ results: [] }),
+      };
+    },
+  }));
+  return { DB: { prepare } } as unknown as Env;
+}
+
+function clientScopedBindings(bindings: unknown[][]): unknown[][] {
+  return bindings.filter(
+    (values) =>
+      values.length === 4 &&
+      values[2] === "caller-id" &&
+      typeof values[3] === "string" &&
+      values[3] !== "",
+  );
+}


### PR DESCRIPTION
Adds `?client=<name>` to `GET /v1/pools/:pool/stats` and `-client <name>` to `octopool stats`, so an operator can inspect any of their own clients' route-level cache behavior without raw D1 queries — the exact gap that made this morning's clawsweeper diagnosis require direct database access.

Scope invariant: the filter always combines with the authenticated caller id in both aggregate and route queries; another caller's identically named client returns zeroed aggregates, never their data (pinned by test). Names pass the same validation as the login flow, now shared from `client-name.ts` (the login-specific `legacy` default stays at its call site). Filtered responses carry a `client_filter` field; unfiltered responses are byte-identical to today.

Proof: `pnpm check` green — 253 unit (7 new), 98 e2e, Go tests + vet. Codex autoreview clean (0.99).
