### PR TITLE
Skip the relay for gh api placeholder paths; relay annotated tag objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Scope permission and SSO 403 cooldowns to the failed route so an identity with remaining quota can continue serving unrelated routes.
 - Follow up to three authenticated or anonymous API pages for shaped Actions job reads so matrix runs with up to 300 jobs share one complete cached superset instead of falling back locally after the first 100.
 - Fall back from public release pages to the anonymous GitHub API while keeping every release route barred from pooled identities, preventing draft releases from entering shared caches.
+- Run `gh api` paths containing GitHub CLI repository-context placeholder segments directly through real `gh`, avoiding guaranteed relay-denial round trips.
 
 ### Changes
 
@@ -24,6 +25,7 @@
 - Cut awaited round trips per relay request — warm 1MB cache hits drop from ~1.0s to ~0.3s: 30s isolate-local cache for caller auth, pool policy, and identity lists (authoritative rechecks still read D1 directly) and public-repo proof TTL raised to 15 minutes in the hosted deployment. Smart Placement was measured and rejected: it relocates execution and the edge cache away from caller colos, slowing this workload 2-3x.
 - Move the primary data region to Western North America: new `wnam` D1 database (config, tokens, identities, proofs, and audit history migrated; cache rebuilt) and a relocated pool coordinator, cutting ~140ms of transatlantic latency from every D1/coordinator round trip for US callers.
 - Redesign the operator dashboard as an editorial ledger: serif display type, hairline-rule sections, tick-marked rate gauges with low-headroom coloring, and right-aligned tabular numerals.
+- Add cacheable anonymous and pooled fallback coverage for immutable annotated tag objects through `GET /repos/{owner}/{repo}/git/tags/{sha}`.
 
 ## 0.5.5 - 2026-08-08
 

--- a/cmd/octopool/gh_api.go
+++ b/cmd/octopool/gh_api.go
@@ -159,9 +159,20 @@ func safeRelayPath(path string) bool {
 		!strings.Contains(path, "\\") &&
 		!strings.Contains(path, "?") &&
 		!strings.Contains(path, "#") &&
+		!hasGHPlaceholderSegment(path) &&
 		!hasDotSegment(path) &&
 		!strings.Contains(lower, "%2e") &&
 		!strings.Contains(lower, "%5c")
+}
+
+func hasGHPlaceholderSegment(path string) bool {
+	for _, segment := range strings.Split(path, "/") {
+		if len(segment) >= 2 && segment[0] == ':' &&
+			(segment[1] >= 'A' && segment[1] <= 'Z' || segment[1] >= 'a' && segment[1] <= 'z') {
+			return true
+		}
+	}
+	return false
 }
 
 func hasDotSegment(path string) bool {

--- a/cmd/octopool/gh_api_test.go
+++ b/cmd/octopool/gh_api_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
 
 func TestParseGHAPIArgs(t *testing.T) {
 	request, fallback, err := parseGHAPIArgs([]string{
@@ -185,5 +190,51 @@ func TestParseGHAPIArgsFallsBackForMutation(t *testing.T) {
 	}
 	if !fallback {
 		t.Fatal("expected fallback")
+	}
+}
+
+func TestRunGHAPIPlaceholderPathExecutesLocallyWithoutRelay(t *testing.T) {
+	requests := 0
+	relayTestServer(t, func(map[string]any) any {
+		requests++
+		return nil
+	})
+	t.Setenv("OCTOPOOL_GH_PATH", fakeGH(t))
+
+	var out bytes.Buffer
+	if err := runGH(t.Context(), []string{"api", "repos/:owner/:repo"}, &out, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 0 {
+		t.Fatalf("relay requests = %d, want 0", requests)
+	}
+	if !strings.HasPrefix(out.String(), "real-gh:api repos/:owner/:repo") {
+		t.Fatalf("output = %q, want real gh execution", out.String())
+	}
+}
+
+func TestRunGHAPIColonOutsidePlaceholderSegmentRelays(t *testing.T) {
+	requests := 0
+	relayTestServer(t, func(body map[string]any) any {
+		requests++
+		query, _ := body["query"].(map[string]any)
+		if body["path"] != "/repos/openclaw/octopool/contents/README.md" || query["ref"] != "heads/foo:bar" {
+			t.Fatalf("relay body = %#v", body)
+		}
+		return map[string]any{"relayed": true}
+	})
+	t.Setenv("OCTOPOOL_GH_PATH", fakeGH(t))
+
+	var out bytes.Buffer
+	if err := runGH(t.Context(), []string{
+		"api", "repos/openclaw/octopool/contents/README.md?ref=heads/foo:bar",
+	}, &out, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 1 {
+		t.Fatalf("relay requests = %d, want 1", requests)
+	}
+	if strings.Contains(out.String(), "real-gh:") || !strings.Contains(out.String(), `"relayed":true`) {
+		t.Fatalf("output = %q, want relay response", out.String())
 	}
 }

--- a/cmd/octopool/routes_generated.go
+++ b/cmd/octopool/routes_generated.go
@@ -122,6 +122,7 @@ var relayQueryPathPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`^/repos/(?:[A-Za-z0-9_.-]+)/(?:[A-Za-z0-9_.-]+)/stats/punch_card$`),
 	regexp.MustCompile(`^/repos/(?:[A-Za-z0-9_.-]+)/(?:[A-Za-z0-9_.-]+)/git/blobs/(?:[0-9A-Fa-f]{7,64})$`),
 	regexp.MustCompile(`^/repos/(?:[A-Za-z0-9_.-]+)/(?:[A-Za-z0-9_.-]+)/git/commits/(?:[0-9A-Fa-f]{7,64})$`),
+	regexp.MustCompile(`^/repos/(?:[A-Za-z0-9_.-]+)/(?:[A-Za-z0-9_.-]+)/git/tags/(?:[0-9A-Fa-f]{7,64})$`),
 	regexp.MustCompile(`^/repos/(?:[A-Za-z0-9_.-]+)/(?:[A-Za-z0-9_.-]+)/git/trees/(?:[0-9A-Fa-f]{7,64})$`),
 	regexp.MustCompile(`^/repos/(?:[A-Za-z0-9_.-]+)/(?:[A-Za-z0-9_.-]+)/git/ref/(?:.+)$`),
 	regexp.MustCompile(`^/repos/(?:[A-Za-z0-9_.-]+)/(?:[A-Za-z0-9_.-]+)/git/matching-refs/(?:.+)$`),

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -220,6 +220,7 @@ following read-only shapes are enabled. A safe CLI-shaped request outside this s
 - `repo_stats_punch_card`
 - `git_blob`
 - `git_commit`
+- `git_tag`
 - `git_tree`
 - `git_ref`
 - `git_matching_refs`

--- a/docs/token-free.md
+++ b/docs/token-free.md
@@ -236,6 +236,7 @@ GET /repos/{owner}/{repo}/stats/participation
 GET /repos/{owner}/{repo}/stats/punch_card
 GET /repos/{owner}/{repo}/git/blobs/{sha}
 GET /repos/{owner}/{repo}/git/commits/{sha}
+GET /repos/{owner}/{repo}/git/tags/{sha}
 GET /repos/{owner}/{repo}/git/trees/{sha}
 GET /repos/{owner}/{repo}/git/ref/{ref}
 GET /repos/{owner}/{repo}/git/matching-refs/{ref}

--- a/src/cache-policy.ts
+++ b/src/cache-policy.ts
@@ -120,6 +120,7 @@ function freshCacheStrategy(kind: RouteKind): CacheFreshStrategy {
     case "commit_view":
     case "git_blob":
     case "git_commit":
+    case "git_tag":
     case "git_tree":
       return staticCache(86_400);
     case "release_latest":
@@ -287,6 +288,7 @@ function staleCacheSeconds(kind: RouteKind): number {
     case "commit_view":
     case "git_blob":
     case "git_commit":
+    case "git_tag":
     case "git_tree":
       return 86_400;
     case "run_artifacts":

--- a/src/route-manifest.ts
+++ b/src/route-manifest.ts
@@ -134,7 +134,7 @@ function normalizeRouteKeyTemplate(template: string): string {
     .replace(/\/actions\/jobs\/\{id\}/g, "/actions/jobs/:id")
     .replace(/\/check-runs\/\{id\}/g, "/check-runs/:id")
     .replace(/\/milestones\/\{id\}/g, "/milestones/:id")
-    .replace(/\/git\/(blobs|commits|trees)\/\{sha\}/g, "/git/$1/:sha")
+    .replace(/\/git\/(blobs|commits|tags|trees)\/\{sha\}/g, "/git/$1/:sha")
     .replace(/\/git\/ref\/\{gitRef\}/g, "/git/ref/:ref")
     .replace(/\/git\/matching-refs\/\{gitRef\}/g, "/git/matching-refs/:ref")
     .replace(/\/actions\/workflows\/\{workflow\}\/runs/g, "/actions/workflows/:workflow/runs")
@@ -299,6 +299,7 @@ export const ROUTES = [
   route("/repos/{owner}/{repo}/stats/punch_card", "repo_stats_punch_card"),
   route("/repos/{owner}/{repo}/git/blobs/{sha}", "git_blob"),
   route("/repos/{owner}/{repo}/git/commits/{sha}", "git_commit"),
+  route("/repos/{owner}/{repo}/git/tags/{sha}", "git_tag"),
   route("/repos/{owner}/{repo}/git/trees/{sha}", "git_tree"),
   route("/repos/{owner}/{repo}/git/ref/{gitRef}", "git_ref"),
   route("/repos/{owner}/{repo}/git/matching-refs/{gitRef}", "git_matching_refs"),

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -539,6 +539,18 @@ describe("github cache policy", () => {
       policy,
     );
     expect(cacheTTLSeconds(gitRef, response({ ref: "refs/heads/main" }))).toBe(120);
+
+    const gitTag = classifyRoute(
+      validateRelayRequest({
+        pool: "maintainers",
+        method: "GET",
+        path: "/repos/openclaw/openclaw/git/tags/0123456789abcdef0123456789abcdef01234567",
+      }),
+      policy,
+    );
+    expect(gitTag.kind).toBe("git_tag");
+    expect(cacheTTLSeconds(gitTag, response({ tag: "v1.2.3" }))).toBe(86_400);
+    expect(staleCacheSeconds(gitTag, 86_400)).toBe(86_400);
   });
 
   it("caps ref-named commit route TTLs because refs move", () => {

--- a/test/route-manifest.test.ts
+++ b/test/route-manifest.test.ts
@@ -4,8 +4,8 @@ import { ROUTES } from "../src/route-manifest";
 
 describe("route manifest", () => {
   it("has unique route identities and patterns", () => {
-    expect(ROUTES).toHaveLength(119);
-    expect(new Set(ROUTES.map((route) => route.kind)).size).toBe(115);
+    expect(ROUTES).toHaveLength(120);
+    expect(new Set(ROUTES.map((route) => route.kind)).size).toBe(116);
     expect(new Set(ROUTES.map((route) => route.id)).size).toBe(ROUTES.length);
     expect(new Set(ROUTES.map((route) => route.pattern.source)).size).toBe(ROUTES.length);
   });
@@ -21,7 +21,7 @@ describe("route manifest", () => {
   });
 
   it("defines backend eligibility on every concrete route", () => {
-    expect(ROUTES.filter((route) => route.capabilities.publicApi)).toHaveLength(115);
+    expect(ROUTES.filter((route) => route.capabilities.publicApi)).toHaveLength(116);
     expect(ROUTES.filter((route) => route.capabilities.fallback === "local")).toHaveLength(27);
     expect(ROUTES.filter((route) => route.capabilities.fallback === "github_public")).toHaveLength(
       1,
@@ -30,7 +30,26 @@ describe("route manifest", () => {
       ROUTES.filter(
         (route) => route.capabilities.publicApi || route.capabilities.fallback !== "pool",
       ),
-    ).toHaveLength(116);
+    ).toHaveLength(117);
+  });
+
+  it("routes annotated tag objects through the immutable Git object policy", () => {
+    const route = ROUTES.find((candidate) => candidate.kind === "git_tag");
+    expect(route).toMatchObject({
+      template: "/repos/{owner}/{repo}/git/tags/{sha}",
+      routeKeyTemplate: "/repos/{owner}/{repo}/git/tags/:sha",
+      cacheable: true,
+      capabilities: {
+        publicApi: true,
+        fallback: "pool",
+        anonymousRepoProof: true,
+      },
+    });
+    expect(route?.pattern.test("/repos/openclaw/octopool/git/tags/0123456789abcdef")).toBe(true);
+    expect(cachePolicyForRouteKind("git_tag")).toEqual({
+      fresh: { kind: "static", seconds: 86_400 },
+      staleSeconds: 86_400,
+    });
   });
 
   it("splits SHA-shaped and ref-named commit paths onto distinct routes", () => {


### PR DESCRIPTION
Two coverage fixes from a 7-day fleet traffic analysis.

**`gh api` placeholder paths skip the relay.** gh substitutes `:owner`/`:repo`-style placeholders from the local repository context — the shim forwarded them literally, so the relay could never match them: **505 guaranteed `route_denied` round trips in 7 days**, each followed by the local run that would have happened anyway. Detection is segment-scoped (`:` + ASCII letter at segment start), so colons in refs and query values still relay; both directions pinned by test.

**Annotated tag objects are now relayed.** `GET /repos/{owner}/{repo}/git/tags/{sha}` joins its siblings (`git_commit`/`git_blob`/`git_tree`) as `git_tag` with the same immutable 24h cache tier, anonymous-API-first.

Proof: `pnpm check` green — 254 unit, 98 e2e, Go tests + vet. Codex autoreview clean (0.99).
