### PR TITLE
fix: read merge-gate PR fields live and surface cached decision reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixes
 
+- Read merge-gate PR fields live instead of from the shared cache: `gh pr view --json` reads containing `headRefOid`, `baseRefOid`, `state`, `merged`, `mergedAt`, `mergeable`, `mergeStateStatus`, or `closedAt` now send `cache-control: max-age=0`. A cached PR entry stays fresh for two minutes while the PR is open, so right after a push it reported the previous head SHA and right after a merge it still reported the PR as open — and `git push` never reaches the relay, so the entry cannot be invalidated when the branch moves.
+- Announce cached decision reads: PR, issue, run, and checks routes served from the shared cache print one stderr line naming the route, hit or stale, and when it refreshes, leaving stdout clean for `--json`/`--jq`. Silence with `OCTOPOOL_QUIET_CACHE=1`.
+- Add `OCTOPOOL_FRESH=1` to force `cache-control: max-age=0` on every relayed read, and relay an explicit `cache-control` header from `gh api` instead of delegating to local `gh`, so a raw live read no longer spends the caller's own GitHub quota.
 - Treat malformed shared-cache rows as misses instead of surfacing relay 500s.
 - Fall through to the exact GitHub API when embedded page data is incomplete instead of serving a possibly partial list.
 - Target the configured `DB` binding in Wrangler D1 migration and local cache-proof commands so renamed databases keep working with current Wrangler releases.

--- a/cmd/octopool/cli_config.go
+++ b/cmd/octopool/cli_config.go
@@ -18,6 +18,29 @@ func envDefault(name string, fallback string) string {
 	return value
 }
 
+// Escape hatch for callers that must read GitHub's current state (a gate, a
+// post-merge confirmation) rather than a shared cache entry that can be up to
+// its route TTL old.
+func freshReadRequested() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("OCTOPOOL_FRESH"))) {
+	case "1", "true", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+// Opt-out for callers that know their reads are cached and do not want the
+// per-request note (dashboards, tight polling loops).
+func quietCacheNotices() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("OCTOPOOL_QUIET_CACHE"))) {
+	case "1", "true", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
 func requiredEnv(name string) (string, error) {
 	value := strings.TrimSpace(os.Getenv(name))
 	if value == "" {

--- a/cmd/octopool/gh_api.go
+++ b/cmd/octopool/gh_api.go
@@ -109,12 +109,19 @@ func parseGHAPIArgs(args []string) (ghAPIRequest, bool, error) {
 	if !strings.HasPrefix(request.path, "/") {
 		request.path = "/" + request.path
 	}
+	if freshReadRequested() {
+		if _, set := request.headers["cache-control"]; !set {
+			request.headers["cache-control"] = "max-age=0"
+		}
+	}
 	return request, request.method != "GET", nil
 }
 
 func safeRelayHeader(header string) bool {
 	switch header {
-	case "accept", "x-github-api-version", "if-none-match", "if-modified-since":
+	// cache-control carries no credentials and is how a caller asks the relay
+	// for a live read instead of a shared cache entry.
+	case "accept", "x-github-api-version", "if-none-match", "if-modified-since", "cache-control":
 		return true
 	default:
 		return false

--- a/cmd/octopool/gh_fresh_read_test.go
+++ b/cmd/octopool/gh_fresh_read_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+// A merge-gate field must never be answered from the shared cache: right after
+// a push or a merge the cached copy still reports the previous head SHA or an
+// open PR, and callers read that as current fact.
+func TestPRViewGateFieldsRequestLiveRead(t *testing.T) {
+	for _, field := range []string{"headRefOid", "state", "merged", "mergeable"} {
+		t.Run(field, func(t *testing.T) {
+			var seen map[string]any
+			relayTestServer(t, func(body map[string]any) any {
+				headers, _ := body["headers"].(map[string]any)
+				seen = headers
+				return map[string]any{
+					"number":   7,
+					"state":    "open",
+					"merged":   false,
+					"html_url": "https://github.com/openclaw/octopool/pull/7",
+					"head":     map[string]any{"sha": "0123456789abcdef0123456789abcdef01234567"},
+				}
+			})
+			var out bytes.Buffer
+			result := handleGHPR(t.Context(), []string{
+				"view", "7", "-R", "openclaw/octopool", "--json", "number," + field,
+			}, &out)
+			if result.err != nil || result.action != ghComplete {
+				t.Fatalf("action=%v err=%v", result.action, result.err)
+			}
+			if seen["cache-control"] != "max-age=0" {
+				t.Fatalf("%s read headers = %#v, want cache-control max-age=0", field, seen)
+			}
+		})
+	}
+}
+
+// Fields that describe the PR itself rather than its current gate state stay on
+// the shared cache; that is the whole point of the relay.
+func TestPRViewStableFieldsStayCached(t *testing.T) {
+	var seen map[string]any
+	relayTestServer(t, func(body map[string]any) any {
+		seen, _ = body["headers"].(map[string]any)
+		return map[string]any{
+			"number":   7,
+			"title":    "cached read",
+			"html_url": "https://github.com/openclaw/octopool/pull/7",
+		}
+	})
+	var out bytes.Buffer
+	result := handleGHPR(t.Context(), []string{
+		"view", "7", "-R", "openclaw/octopool", "--json", "number,title",
+	}, &out)
+	if result.err != nil || result.action != ghComplete {
+		t.Fatalf("action=%v err=%v", result.action, result.err)
+	}
+	if _, forced := seen["cache-control"]; forced {
+		t.Fatalf("stable-field read headers = %#v, want no cache-control", seen)
+	}
+}
+
+// OCTOPOOL_FRESH is the escape hatch for raw `gh api`, where the CLI cannot see
+// which fields the caller is about to act on.
+func TestGHAPIFreshEnvForcesLiveRead(t *testing.T) {
+	t.Setenv("OCTOPOOL_FRESH", "1")
+	request, delegate, err := parseGHAPIArgs([]string{"repos/openclaw/octopool/pulls/7"})
+	if err != nil || delegate {
+		t.Fatalf("delegate=%v err=%v", delegate, err)
+	}
+	if request.headers["cache-control"] != "max-age=0" {
+		t.Fatalf("headers = %#v, want cache-control max-age=0", request.headers)
+	}
+}
+
+// An explicit cache-control from the caller must reach the relay instead of
+// forcing a local `gh` fallback that spends the caller's own quota.
+func TestGHAPICacheControlHeaderRelays(t *testing.T) {
+	request, delegate, err := parseGHAPIArgs([]string{
+		"repos/openclaw/octopool/pulls/7", "-H", "cache-control: max-age=0",
+	})
+	if err != nil || delegate {
+		t.Fatalf("delegate=%v err=%v", delegate, err)
+	}
+	if request.headers["cache-control"] != "max-age=0" {
+		t.Fatalf("headers = %#v, want relayed cache-control", request.headers)
+	}
+}
+
+func TestVolatileRouteKindCoversDecisionRoutes(t *testing.T) {
+	for _, kind := range []string{"pr_view", "run_view", "checks", "status"} {
+		if !volatileRouteKind(kind) {
+			t.Fatalf("%s should be treated as volatile", kind)
+		}
+	}
+	for _, kind := range []string{"repo_view", "user_view", "license_view"} {
+		if volatileRouteKind(kind) {
+			t.Fatalf("%s should not be treated as volatile", kind)
+		}
+	}
+}

--- a/cmd/octopool/gh_relay.go
+++ b/cmd/octopool/gh_relay.go
@@ -19,6 +19,64 @@ type relayEnvelope struct {
 	Headers      map[string]string `json:"headers"`
 	Body         json.RawMessage   `json:"body"`
 	BodyEncoding string            `json:"body_encoding"`
+	Relay        relayMeta         `json:"relay"`
+}
+
+type relayMeta struct {
+	Cache          string `json:"cache"`
+	CacheExpiresAt string `json:"cache_expires_at"`
+	RouteKind      string `json:"route_kind"`
+}
+
+// Routes whose body states something the caller is likely acting on right now
+// (which SHA is at the head, whether the PR merged, whether CI finished). A
+// cache hit here is correct but can trail a push or merge by the route TTL, and
+// silently reads as current fact.
+func volatileRouteKind(kind string) bool {
+	switch kind {
+	case "pr_view", "pr_list", "issue_view", "issue_list", "run_view", "run_list",
+		"checks", "check_suites", "status", "status_list", "jobs", "job", "commit_view", "ref_view":
+		return true
+	default:
+		return false
+	}
+}
+
+// One line, on stderr, so `--json` consumers keep a clean stdout. Without it a
+// cached answer is indistinguishable from a live one, which is how a stale head
+// SHA or a "still open" merged PR reads as truth.
+func noteCachedRead(envelope relayEnvelope) {
+	if freshReadRequested() || quietCacheNotices() {
+		return
+	}
+	if envelope.Relay.Cache != "hit" && envelope.Relay.Cache != "stale" {
+		return
+	}
+	if !volatileRouteKind(envelope.Relay.RouteKind) {
+		return
+	}
+	fmt.Fprintf(
+		os.Stderr,
+		"octopool: %s served from shared cache (%s)%s; set OCTOPOOL_FRESH=1 for a live read\n",
+		envelope.Relay.RouteKind,
+		envelope.Relay.Cache,
+		cacheExpirySuffix(envelope.Relay.CacheExpiresAt),
+	)
+}
+
+func cacheExpirySuffix(expiresAt string) string {
+	if expiresAt == "" {
+		return ""
+	}
+	expires, err := time.Parse(time.RFC3339, strings.Replace(strings.TrimSpace(expiresAt), " ", "T", 1))
+	if err != nil {
+		return ""
+	}
+	remaining := time.Until(expires).Round(time.Second)
+	if remaining <= 0 {
+		return ""
+	}
+	return fmt.Sprintf(", refreshes in %s", remaining)
 }
 
 var errOctopoolNotLoggedIn = errors.New("not logged in; run: octopool login")
@@ -158,6 +216,7 @@ func (client ghRelayClient) doOnce(ctx context.Context, request ghAPIRequest) (r
 	if err := json.Unmarshal(out, &envelope); err != nil {
 		return relayEnvelope{}, err
 	}
+	noteCachedRead(envelope)
 	return envelope, nil
 }
 

--- a/cmd/octopool/gh_top_json.go
+++ b/cmd/octopool/gh_top_json.go
@@ -29,10 +29,17 @@ func supportedJSONFields(opts ghTopOptions, supported map[string]bool) bool {
 }
 
 func publicShapeHeaders(opts ghTopOptions, supported map[string]bool, shape string) map[string]string {
+	headers := map[string]string{}
 	if supportedJSONFields(opts, supported) {
-		return map[string]string{"x-octopool-public-shape": shape}
+		headers["x-octopool-public-shape"] = shape
 	}
-	return nil
+	if needsLivePRRead(opts.json) || freshReadRequested() {
+		headers["cache-control"] = "max-age=0"
+	}
+	if len(headers) == 0 {
+		return nil
+	}
+	return headers
 }
 
 func envelopeBodyBytes(envelope relayEnvelope) ([]byte, error) {

--- a/cmd/octopool/gh_top_pr.go
+++ b/cmd/octopool/gh_top_pr.go
@@ -17,6 +17,20 @@ func supportedPRListState(state string) bool {
 	}
 }
 
+// Fields whose value is a merge-gate decision: a stale answer here reads as a
+// confident fact ("branch still at the old SHA", "PR still open") seconds after
+// a push or merge, so these reads skip the shared cache.
+func needsLivePRRead(fields []string) bool {
+	for _, field := range fields {
+		switch field {
+		case "headRefOid", "baseRefOid", "state", "merged", "mergedAt", "mergeable",
+			"mergeStateStatus", "closedAt":
+			return true
+		}
+	}
+	return false
+}
+
 func needsHydratedPR(fields []string) bool {
 	for _, field := range fields {
 		switch field {
@@ -118,7 +132,7 @@ func relayHydratedPRView(ctx context.Context, stdout io.Writer, repo string, num
 		return err
 	}
 	headers := hydratedPRViewHeaders(opts)
-	if hasJSONField(opts.json, "files") {
+	if hasJSONField(opts.json, "files") || needsLivePRRead(opts.json) || freshReadRequested() {
 		if headers == nil {
 			headers = map[string]string{}
 		}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -320,6 +320,33 @@ state-aware PR subresource cache probes.
 
 Admin provisioning. Requires an admin token. See [Admin & provisioning](admin.md).
 
+## Cache freshness
+
+Shared cache hits are the point of the relay, but a cached answer describes the state at
+fill time, not now. A PR read stays fresh for two minutes while the PR is open, so directly
+after a `git push` the cached copy still reports the previous head SHA, and directly after a
+merge it still reports the PR as open. Nothing about the response looks different, which is
+how a stale answer gets read as current fact.
+
+Three things keep that honest:
+
+- **Gate fields read live.** `gh pr view --json` reads that include `headRefOid`,
+  `baseRefOid`, `state`, `merged`, `mergedAt`, `mergeable`, `mergeStateStatus`, or
+  `closedAt` send `cache-control: max-age=0` automatically. These are the values callers
+  branch on, so they always come from GitHub. Descriptive fields (`title`, `body`, `labels`,
+  `author`) stay cached.
+- **Cached decision reads announce themselves.** When a PR, issue, run, or checks route is
+  served from the shared cache, the CLI prints one line to stderr naming the route, whether
+  it was a hit or a stale serve, and when it refreshes. stdout stays untouched, so `--json`
+  and `--jq` consumers are unaffected. Silence it with `OCTOPOOL_QUIET_CACHE=1`.
+- **Anything can be forced live.** `OCTOPOOL_FRESH=1` applies `max-age=0` to every relayed
+  read, and `gh api -H "cache-control: max-age=0"` now relays instead of falling back to
+  local `gh`, so a raw API read can be made live without spending your own token quota.
+
+Note that `git push` never passes through Octopool, so the relay cannot invalidate a PR
+entry when a branch moves. That is why the gate fields read live rather than relying on
+invalidation.
+
 ## Token and URL safety
 
 - A saved caller token is only sent to the saved Octopool URL. Overriding `--url` (or
@@ -338,6 +365,12 @@ These are dev/CI escape hatches, not the everyday UX:
 - `OCTOPOOL_TOKEN` — caller token override (required to use a non-saved URL).
 - `OCTOPOOL_POOL` — pool id (default `maintainers`).
 - `OCTOPOOL_GH_PATH` — path to the real `gh` binary.
+- `OCTOPOOL_FRESH=1` — send `cache-control: max-age=0` on every relayed read, so answers
+  come from GitHub instead of the shared cache. Use it right after a `git push` or a merge,
+  when a cached answer would still describe the previous state. Costs pool quota; leave it
+  off for ordinary reads.
+- `OCTOPOOL_QUIET_CACHE=1` — suppress the one-line stderr note printed when a
+  decision-shaped route (PR/issue/run/checks) is served from the shared cache.
 - `OCTOPOOL_NO_FALLBACK=1` — fail instead of running real `gh` after Octopool returns
   `fallback_local`, including during an active watch, useful for proving relay/cache coverage.
 - `OCTOPOOL_RELAY_RETRIES` — how many times transient pool-exhaustion fallbacks


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where callers acting on a PR's current state would read stale values as current fact. A `pr_view` entry stays cached for two minutes while the PR is open, and nothing in the response distinguishes a cached answer from a live one. Right after a `git push`, `gh pr view --json headRefOid` reports the previous head SHA; right after a merge, the same PR still reports `state=open merged=false`. Both look authoritative.

This bit a real landing flow: a branch was force-pushed, `gh` kept reporting the old SHA, and the merge was reported as not-merged for two minutes after it had actually landed — each time sending the operator to double-check with `git ls-remote`.

Invalidation cannot solve it. `git push` never passes through Octopool, so the relay has no way to know a branch moved.

## Why This Change Was Made

Three complementary changes, none of which give up the cache hit rate that makes the relay worth running:

- **Gate fields read live.** `gh pr view --json` reads containing `headRefOid`, `baseRefOid`, `state`, `merged`, `mergedAt`, `mergeable`, `mergeStateStatus`, or `closedAt` send `cache-control: max-age=0`, extending the pattern `--json files` already used. Descriptive fields (`title`, `body`, `labels`, `author`) stay cached.
- **Cached decision reads announce themselves.** The CLI's `relayEnvelope` decoded only `status`/`headers`/`body`/`body_encoding` and silently discarded the `relay` block the server already sends, which carries `cache: hit|stale` and `cache_expires_at`. It now decodes that metadata and prints one stderr line for PR, issue, run, and checks routes served from cache. stdout is untouched, so `--json`/`--jq` consumers are unaffected.
- **Anything can be forced live.** `OCTOPOOL_FRESH=1` applies `max-age=0` to every relayed read. `gh api -H "cache-control: max-age=0"` now relays instead of rejecting the header and falling back to local `gh` — previously the only way to get a guaranteed-fresh raw read was to spend your own token quota.

Non-goal: server-side cache policy is unchanged. This is entirely about which reads opt out and whether the caller can tell.

## User Impact

Merge gates stop lying. A read of `headRefOid`, `state`, or `merged` always reflects GitHub now, so post-push and post-merge checks are trustworthy without a `git ls-remote` cross-check. Every other cached read behaves as before, and when one of those could mislead, it says so on stderr with the route, whether it was a hit or a stale serve, and when it refreshes. `OCTOPOOL_QUIET_CACHE=1` silences the note; `OCTOPOOL_FRESH=1` forces live reads.

Quota impact is small: gate reads are rare compared with the polling loops the cache exists to absorb.

## Evidence

Live against the production relay (`openclaw/openclaw#122976`, a PR that had just merged):

```
# repeated descriptive read -> cache hit, now visible on stderr
$ octopool gh pr view 122976 -R openclaw/openclaw --json number,title
{"number":122976,"title":"feat(slack): unify the native progress turn into one streamed message"}
octopool: pr_view served from shared cache (hit); set OCTOPOOL_FRESH=1 for a live read

# gate fields -> live read, correct post-merge state, no cache note
$ octopool gh pr view 122976 -R openclaw/openclaw --json number,headRefOid
{"headRefOid":"e766f31a260a6167e1d739e3167304d1a532a284","number":122976}

$ octopool gh pr view 122976 -R openclaw/openclaw --json number,state,merged
{"merged":true,"number":122976,"state":"closed"}
```

`e766f31a260…` is the branch's true final SHA and `closed`/`true` the true merge state — the exact values the cached path was reporting incorrectly during that landing.

Tests: full `go test ./cmd/...` green, including five new cases covering gate fields forcing `max-age=0`, descriptive fields staying cached, `OCTOPOOL_FRESH=1` on raw `gh api`, an explicit `cache-control` header relaying instead of delegating, and the volatile-route classification. `go vet` and `gofmt` clean; docs site test passes.

Docs: new "Cache freshness" section in `docs/cli.md` explaining the tradeoff and both env vars.
