### PR TITLE
fix: harden HTML text extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Harden GitHub HTML text extraction and docs table-of-contents generation so malformed tag fragments cannot survive text conversion.
+
 ## 0.5.6 - 2026-08-13
 
 ### Fixes

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -431,10 +431,7 @@ function tocFromHtml(html) {
   const re = /<h([23]) id="([^"]+)">([\s\S]*?)<\/h[23]>/g;
   let m;
   while ((m = re.exec(html))) {
-    const text = m[3]
-      .replace(/<a class="anchor"[^>]*>.*?<\/a>/, "")
-      .replace(/<[^>]+>/g, "")
-      .trim();
+    const text = stripHtmlTags(m[3].replace(/<a class="anchor"[^>]*>.*?<\/a>/, "")).trim();
     items.push({ level: Number(m[1]), id: m[2], text });
   }
   if (items.length < 2) return "";
@@ -648,6 +645,22 @@ function escapeHtml(value) {
     /[&<>"']/g,
     (char) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[char],
   );
+}
+
+function stripHtmlTags(value) {
+  let text = "";
+  let insideTag = false;
+  // An unmatched "<" starts malformed markup; drop that tail instead of returning an active tag.
+  for (const character of value) {
+    if (character === "<") {
+      insideTag = true;
+    } else if (character === ">" && insideTag) {
+      insideTag = false;
+    } else if (!insideTag) {
+      text += character;
+    }
+  }
+  return text;
 }
 
 function escapeAttr(value) {

--- a/src/github-html-releases.ts
+++ b/src/github-html-releases.ts
@@ -1,5 +1,5 @@
 import { decodeURIComponentSafe } from "./github-path";
-import { decodeHTML, textMatch } from "./github-html-utils";
+import { decodeHTML, stripHTMLTags, textMatch } from "./github-html-utils";
 
 export function parseReleaseHTML(
   html: string,
@@ -44,22 +44,18 @@ function releaseTag(responseURL: string): string | undefined {
 }
 
 function htmlToText(value: string): string {
-  return decodeHTML(
-    value
-      .replace(/<a\b[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi, (_, href, text) => {
-        const label = String(text)
-          .replace(/<[^>]+>/g, "")
-          .trim();
-        return label === "" ? "" : `[${label}](${decodeHTML(String(href))})`;
-      })
-      .replace(/<br\s*\/?>/gi, "\n")
-      .replace(/<li\b[^>]*>/gi, "- ")
-      .replace(/<\/li>/gi, "\n")
-      .replace(/<\/(?:p|h[1-6]|ul|ol)>/gi, "\n\n")
-      .replace(/<code\b[^>]*>/gi, "`")
-      .replace(/<\/code>/gi, "`")
-      .replace(/<[^>]+>/g, ""),
-  )
+  const formatted = value
+    .replace(/<a\b[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi, (_, href, text) => {
+      const label = stripHTMLTags(String(text)).trim();
+      return label === "" ? "" : `[${label}](${decodeHTML(String(href))})`;
+    })
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<li\b[^>]*>/gi, "- ")
+    .replace(/<\/li>/gi, "\n")
+    .replace(/<\/(?:p|h[1-6]|ul|ol)>/gi, "\n\n")
+    .replace(/<code\b[^>]*>/gi, "`")
+    .replace(/<\/code>/gi, "`");
+  return decodeHTML(stripHTMLTags(formatted))
     .replace(/[ \t]+\n/g, "\n")
     .replace(/\n{3,}/g, "\n\n")
     .trim();

--- a/src/github-html-utils.ts
+++ b/src/github-html-utils.ts
@@ -1,5 +1,5 @@
 export function plainHTML(value: string): string {
-  return decodeHTML(value.replace(/<[^>]+>/g, "")).trim();
+  return decodeHTML(stripHTMLTags(value)).trim();
 }
 
 export function htmlAttribute(attributes: string, name: string): string | undefined {
@@ -9,7 +9,23 @@ export function htmlAttribute(attributes: string, name: string): string | undefi
 
 export function textMatch(input: string, pattern: RegExp): string | undefined {
   const value = pattern.exec(input)?.[1];
-  return value === undefined ? undefined : decodeHTML(value.replace(/<[^>]+>/g, "")).trim();
+  return value === undefined ? undefined : decodeHTML(stripHTMLTags(value)).trim();
+}
+
+export function stripHTMLTags(value: string): string {
+  let text = "";
+  let insideTag = false;
+  // An unmatched "<" starts malformed markup; drop that tail instead of returning an active tag.
+  for (const character of value) {
+    if (character === "<") {
+      insideTag = true;
+    } else if (character === ">" && insideTag) {
+      insideTag = false;
+    } else if (!insideTag) {
+      text += character;
+    }
+  }
+  return text;
 }
 
 export function decodeHTML(value: string): string {

--- a/test/docs-site.test.ts
+++ b/test/docs-site.test.ts
@@ -41,7 +41,10 @@ describe("docs site generator", () => {
           "",
         ].join("\n"),
       );
-      writeFileSync(path.join(tmp, "docs", "cli.md"), "# CLI\n");
+      writeFileSync(
+        path.join(tmp, "docs", "cli.md"),
+        ["# CLI", "", "## First *section*", "", "## Second `section` <script", ""].join("\n"),
+      );
 
       execFileSync("node", [path.join(root, "scripts/build-docs-site.mjs")], {
         cwd: tmp,
@@ -56,6 +59,12 @@ describe("docs site generator", () => {
         'name="twitter:description" content="Shared &lt;relay&gt; &quot;quotes&quot;"',
       );
       expect(index).not.toContain('content="Shared <relay> "quotes""');
+      const cli = readFileSync(path.join(tmp, "dist/docs-site/cli.html"), "utf8");
+      expect(cli).toContain('class="toc-l2" href="#first-section">First section</a>');
+      expect(cli).toContain(
+        'class="toc-l2" href="#second-section-script">Second section &amp;lt;script</a>',
+      );
+      expect(cli).not.toContain("<script</a>");
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/github-html-utils.test.ts
+++ b/test/github-html-utils.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { plainHTML, textMatch } from "../src/github-html-utils";
+
+describe("GitHub HTML text extraction", () => {
+  it("drops unterminated tag-like tails", () => {
+    expect(plainHTML("safe <strong>text</strong><script")).toBe("safe text");
+    expect(textMatch("title: safe <strong>text</strong><script", /^title: (.*)$/)).toBe(
+      "safe text",
+    );
+  });
+});

--- a/test/github-web.test.ts
+++ b/test/github-web.test.ts
@@ -673,7 +673,7 @@ describe("github web provider", () => {
           <nav><li class="breadcrumb-item-selected">v0.8.0</li></nav>
           <h1>0.8.0</h1>
           released this <relative-time datetime="2026-06-10T07:55:39Z"></relative-time>
-          <div data-test-selector="body-content" class="markdown-body"><h2>Fixed</h2><ul><li>Use public HTML.</li></ul></div>
+          <div data-test-selector="body-content" class="markdown-body"><h2>Fixed</h2><ul><li>Use public HTML.</li></ul><p><a href="https://example.test">Docs<script</a></p><p>Before<script</p></div>
           </div>
           <div class="Box-footer"></div>
         `),
@@ -700,7 +700,7 @@ describe("github web provider", () => {
       draft: false,
       prerelease: false,
       published_at: "2026-06-10T07:55:39Z",
-      body: "Fixed\n\n- Use public HTML.",
+      body: "Fixed\n\n- Use public HTML.\n\n[Docs](https://example.test)\n\nBefore",
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where malformed HTML tag fragments could survive text extraction in token-free GitHub summaries and generated docs navigation. GitHub CodeQL reported five high-severity incomplete multi-character sanitization alerts across these paths.

## Why This Change Was Made

Replaces regex tag removal with delimiter-state text extraction that drops unterminated tag-like tails. The GitHub HTML helpers own the shared runtime invariant, while the standalone docs builder applies the same boundary locally.

## User Impact

GitHub release, issue, PR, Actions, and workflow summaries no longer return malformed active-tag prefixes after HTML-to-text conversion. Generated docs table-of-contents labels retain their text without carrying markup fragments.

## Evidence

- `pnpm --config.verify-deps-before-run=warn check`
- 271 unit tests passed
- 99 Worker E2E tests passed
- TypeScript source and test builds passed
- `oxlint --deny-warnings` and full `oxfmt --check` passed
- `go test ./...` and `go vet ./...` passed
- `git diff --check`

CodeQL alerts addressed:

- https://github.com/openclaw/octopool/security/code-scanning/1
- https://github.com/openclaw/octopool/security/code-scanning/2
- https://github.com/openclaw/octopool/security/code-scanning/3
- https://github.com/openclaw/octopool/security/code-scanning/4
- https://github.com/openclaw/octopool/security/code-scanning/5
