### PR TITLE
fix: keep PR JSON lifecycle state consistent across field subsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Normalize `gh pr view --json state` to `OPEN`, `CLOSED`, or `MERGED` across public-page and REST reads, keeping draft status separate and field subsets and `--jq` projections consistent.
 - Harden GitHub HTML text extraction and docs table-of-contents generation so malformed tag fragments cannot survive text conversion.
 
 ## 0.5.6 - 2026-08-13

--- a/cmd/octopool/gh_top_pr.go
+++ b/cmd/octopool/gh_top_pr.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"strconv"
 	"strings"
@@ -25,16 +26,6 @@ func needsLivePRRead(fields []string) bool {
 		switch field {
 		case "headRefOid", "baseRefOid", "state", "merged", "mergedAt", "mergeable",
 			"mergeStateStatus", "closedAt":
-			return true
-		}
-	}
-	return false
-}
-
-func needsHydratedPR(fields []string) bool {
-	for _, field := range fields {
-		switch field {
-		case "files", "commits", "comments", "reviews":
 			return true
 		}
 	}
@@ -64,14 +55,7 @@ func handleGHPR(ctx context.Context, args []string, stdout io.Writer) ghResult {
 		if !machineReadable(opts) || !supportedJSONFields(opts, supportedPRFields) {
 			return ghDelegated()
 		}
-		if needsHydratedPR(opts.json) {
-			return ghCompleted(relayHydratedPRView(ctx, stdout, repo, number, opts))
-		}
-		return ghCompleted(relayTop(ctx, stdout, ghAPIRequest{
-			method:  "GET",
-			path:    repoPath(repo, "pulls", number),
-			headers: publicShapeHeaders(opts, supportedPublicPRViewFields, publicShapePullRequestSummary),
-		}, opts, fieldMapPR))
+		return ghCompleted(relayPRView(ctx, stdout, repo, number, opts))
 	case "list":
 		repo, ok := repoOnly(opts)
 		if !ok || !supportedPRListState(opts.state) || limitOverOnePage(opts) || opts.author != "" || opts.assignee != "" || len(opts.labels) > 0 {
@@ -126,21 +110,25 @@ func handleGHPR(ctx context.Context, args []string, stdout io.Writer) ghResult {
 	}
 }
 
-func relayHydratedPRView(ctx context.Context, stdout io.Writer, repo string, number string, opts ghTopOptions) error {
-	client, err := newGHRelayClient()
-	if err != nil {
-		return err
-	}
-	headers := hydratedPRViewHeaders(opts)
+func relayPRView(ctx context.Context, stdout io.Writer, repo string, number string, opts ghTopOptions) error {
+	headers := prViewHeaders(opts)
 	if hasJSONField(opts.json, "files") || needsLivePRRead(opts.json) || freshReadRequested() {
 		if headers == nil {
 			headers = map[string]string{}
 		}
 		headers["cache-control"] = "max-age=0"
 	}
-	prEnvelope, err := client.do(ctx, ghAPIRequest{
+	request := ghAPIRequest{
 		method: "GET", path: repoPath(repo, "pulls", number), headers: headers,
-	})
+	}
+	if !safeRelayRequest(request) {
+		return errors.New("internal error: top-level gh command built an unsupported relay request")
+	}
+	client, err := newGHRelayClient()
+	if err != nil {
+		return err
+	}
+	prEnvelope, err := client.do(ctx, request)
 	if err != nil {
 		return err
 	}
@@ -152,6 +140,7 @@ func relayHydratedPRView(ctx context.Context, stdout io.Writer, repo string, num
 	if err := json.Unmarshal(body, &pr); err != nil {
 		return err
 	}
+	normalizePRViewState(pr)
 	filesHeadSHA := ""
 	for _, field := range opts.json {
 		switch field {
@@ -212,9 +201,29 @@ func relayHydratedPRView(ctx context.Context, stdout io.Writer, repo string, num
 	return writeBytes(ctx, stdout, filtered, opts.jq)
 }
 
-func hydratedPRViewHeaders(opts ghTopOptions) map[string]string {
+func normalizePRViewState(pr map[string]any) {
+	state, ok := pr["state"].(string)
+	if !ok {
+		return
+	}
+	state = strings.ToUpper(state)
+	merged, _ := pr["merged"].(bool)
+	switch {
+	case merged || firstString(pr, "merged_at") != "" || state == "MERGED":
+		state = "MERGED"
+	case firstString(pr, "closed_at") != "" || state == "CLOSED":
+		state = "CLOSED"
+	case state == "DRAFT":
+		// pr-summary-v1 includes the page's display state, including in existing cache entries.
+		state = "OPEN"
+	}
+	pr["state"] = state
+}
+
+func prViewHeaders(opts ghTopOptions) map[string]string {
 	for _, field := range opts.json {
-		if needsHydratedPR([]string{field}) {
+		switch field {
+		case "files", "commits", "comments", "reviews":
 			continue
 		}
 		if !supportedPublicPRViewFields[field] {

--- a/cmd/octopool/gh_top_pr_state_test.go
+++ b/cmd/octopool/gh_top_pr_state_test.go
@@ -1,0 +1,273 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const prStateTestHead = "96b73e3bc5c058b57ca73ee3337ec351c3c727df"
+const prStateTestTime = "2026-08-27T04:41:05Z"
+
+func TestCLIEndToEndPRViewLifecycleProjection(t *testing.T) {
+	if testing.Short() || !jqAvailable() {
+		t.Skip("builds and executes the CLI binary with jq")
+	}
+	bin := buildCLIBinary(t)
+	server := cliRelayServer(t, func(w http.ResponseWriter, r *http.Request) {
+		request := decodeCLIRequest(t, w, r)
+		if request == nil {
+			return
+		}
+		headers, _ := request["headers"].(map[string]any)
+		pr := map[string]any{
+			"state": "open", "draft": true, "head": map[string]any{"sha": prStateTestHead},
+			"updated_at": prStateTestTime, "merged_at": nil,
+		}
+		if headers["x-octopool-public-shape"] == "pr-summary-v1" {
+			pr["state"] = "DRAFT"
+			delete(pr, "draft")
+			delete(pr, "updated_at")
+		}
+		writeCLIEnvelope(t, w, pr)
+	})
+	for _, fields := range []string{"state,headRefOid", "state,headRefOid,isDraft,updatedAt"} {
+		t.Run(fields, func(t *testing.T) {
+			result := runCLI(t, bin, server.URL, map[string]string{
+				"OCTOPOOL_NO_FALLBACK": "1", "OCTOPOOL_FRESH": "1",
+			}, "gh", "pr", "view", "1025", "--repo", "openclaw/clawsweeper", "--json", fields, "--jq", ".")
+			if result.err != nil {
+				t.Fatalf("err=%v stdout=%q stderr=%q", result.err, result.stdout, result.stderr)
+			}
+			var got map[string]any
+			if err := json.Unmarshal([]byte(result.stdout), &got); err != nil {
+				t.Fatal(err)
+			}
+			want := map[string]any{"state": "OPEN", "headRefOid": prStateTestHead}
+			if strings.Contains(fields, "isDraft") {
+				want["isDraft"] = true
+				want["updatedAt"] = prStateTestTime
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("projection = %#v, want %#v", got, want)
+			}
+		})
+	}
+}
+
+func TestNormalizePRViewState(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		pr   map[string]any
+		want any
+	}{
+		{"merged flag", map[string]any{"state": "closed", "merged": true}, "MERGED"},
+		{"merge timestamp", map[string]any{"state": "closed", "merged_at": prStateTestTime}, "MERGED"},
+		{"page merged", map[string]any{"state": "MERGED"}, "MERGED"},
+		{"closed draft display", map[string]any{"state": "DRAFT", "closed_at": prStateTestTime}, "CLOSED"},
+		{"draft does not reopen", map[string]any{"state": "closed", "draft": true}, "CLOSED"},
+		{"no lifecycle requested", map[string]any{"head": map[string]any{"sha": prStateTestHead}}, nil},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			normalizePRViewState(test.pr)
+			if test.pr["state"] != test.want {
+				t.Errorf("state = %v, want %v", test.pr["state"], test.want)
+			}
+		})
+	}
+}
+
+func TestRunGHPRViewLifecycleProjection(t *testing.T) {
+	for _, lifecycle := range []struct {
+		name, webState, restState, wantState string
+		draft, closed, merged                bool
+	}{
+		{"draft", "DRAFT", "open", "OPEN", true, false, false},
+		{"open", "OPEN", "open", "OPEN", false, false, false},
+		{"closed", "CLOSED", "closed", "CLOSED", false, true, false},
+		{"closed-draft", "CLOSED", "closed", "CLOSED", true, true, false},
+		{"merged", "MERGED", "closed", "MERGED", false, true, true},
+	} {
+		t.Run(lifecycle.name, func(t *testing.T) {
+			for _, transport := range []string{"web", "rest"} {
+				t.Run(transport, func(t *testing.T) {
+					for _, fields := range []string{
+						"state", "state,headRefOid", "state,isDraft", "state,headRefOid,isDraft",
+						"state,updatedAt", "state,headRefOid,updatedAt", "state,isDraft,updatedAt",
+						"state,headRefOid,isDraft,updatedAt", "isDraft,state,headRefOid",
+						"isDraft", "headRefOid", "headRefOid,isDraft",
+						"state,comments", "state,headRefOid,comments", "state,isDraft,comments",
+						"state,headRefOid,isDraft,comments",
+					} {
+						t.Run(fields, func(t *testing.T) {
+							// REST may also serve a public shape after a page parser misses.
+							wantShape := !strings.Contains(fields, "isDraft") && !strings.Contains(fields, "updatedAt")
+							prCalls, commentCalls := 0, 0
+							relayTestServer(t, func(request map[string]any) any {
+								if request["path"] == "/repos/openclaw/clawsweeper/issues/1025/comments" {
+									commentCalls++
+									return []any{}
+								}
+								if request["path"] != "/repos/openclaw/clawsweeper/pulls/1025" {
+									t.Fatalf("unexpected path: %v", request["path"])
+								}
+								prCalls++
+								headers, _ := request["headers"].(map[string]any)
+								shape, _ := headers["x-octopool-public-shape"].(string)
+								if (wantShape && shape != "pr-summary-v1") || (!wantShape && shape != "") {
+									t.Fatalf("shape = %q, want public shape = %v", shape, wantShape)
+								}
+								pr := map[string]any{
+									"state": lifecycle.restState, "draft": lifecycle.draft, "merged": lifecycle.merged,
+									"head": map[string]any{"sha": prStateTestHead}, "updated_at": prStateTestTime,
+									"closed_at": nil, "merged_at": nil,
+								}
+								if lifecycle.closed {
+									pr["closed_at"] = prStateTestTime
+								}
+								if lifecycle.merged {
+									pr["merged_at"] = prStateTestTime
+								}
+								if wantShape && transport == "web" {
+									pr["state"] = lifecycle.webState
+									delete(pr, "draft")
+									delete(pr, "merged")
+									delete(pr, "updated_at")
+								}
+								return pr
+							})
+							var out bytes.Buffer
+							result := handleGHPR(t.Context(), []string{
+								"view", "1025", "--repo", "openclaw/clawsweeper", "--json", fields,
+							}, &out)
+							if result.err != nil || result.action != ghComplete {
+								t.Fatalf("action=%v err=%v", result.action, result.err)
+							}
+							var got map[string]any
+							if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+								t.Fatal(err)
+							}
+							all := map[string]any{
+								"state": lifecycle.wantState, "isDraft": lifecycle.draft,
+								"headRefOid": prStateTestHead, "updatedAt": prStateTestTime, "comments": []any{},
+							}
+							want := map[string]any{}
+							for _, field := range strings.Split(fields, ",") {
+								want[field] = all[field]
+							}
+							if !reflect.DeepEqual(got, want) {
+								t.Errorf("projection = %#v, want %#v", got, want)
+							}
+							wantComments := 0
+							if strings.Contains(fields, "comments") {
+								wantComments = 1
+							}
+							if prCalls != 1 || commentCalls != wantComments {
+								t.Errorf("requests: PR=%d comments=%d, want 1/%d", prCalls, commentCalls, wantComments)
+							}
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestRunGHPRViewLifecycleJQ(t *testing.T) {
+	if !jqAvailable() {
+		t.Skip("jq is not installed")
+	}
+	for _, fields := range []string{"state,headRefOid", "state,headRefOid,isDraft,updatedAt"} {
+		for _, jq := range []string{".", ".state", "has(\"isDraft\")", "has(\"merged_at\")"} {
+			t.Run(fields+"/"+jq, func(t *testing.T) {
+				expanded := strings.Contains(fields, "isDraft")
+				relayTestServer(t, func(request map[string]any) any {
+					if expanded {
+						return map[string]any{
+							"state": "open", "draft": true, "head": map[string]any{"sha": prStateTestHead},
+							"updated_at": prStateTestTime, "merged_at": nil,
+						}
+					}
+					return map[string]any{"state": "DRAFT", "head": map[string]any{"sha": prStateTestHead}, "merged_at": nil}
+				})
+				var out bytes.Buffer
+				result := handleGHPR(t.Context(), []string{
+					"view", "1025", "--repo", "openclaw/clawsweeper", "--json", fields, "--jq", jq,
+				}, &out)
+				if result.err != nil || result.action != ghComplete {
+					t.Fatalf("action=%v err=%v", result.action, result.err)
+				}
+				want := "OPEN\n"
+				switch jq {
+				case ".":
+					var got map[string]any
+					if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+						t.Fatal(err)
+					}
+					want := map[string]any{"state": "OPEN", "headRefOid": prStateTestHead}
+					if expanded {
+						want["isDraft"] = true
+						want["updatedAt"] = prStateTestTime
+					}
+					if !reflect.DeepEqual(got, want) {
+						t.Errorf("projection = %#v, want %#v", got, want)
+					}
+					return
+				case "has(\"isDraft\")":
+					want = "false\n"
+					if expanded {
+						want = "true\n"
+					}
+				case "has(\"merged_at\")":
+					want = "false\n"
+				}
+				if out.String() != want {
+					t.Errorf("jq output = %q, want %q", out.String(), want)
+				}
+			})
+		}
+	}
+}
+
+func TestRunGHPRStatePreservesOtherContracts(t *testing.T) {
+	for _, state := range []string{"open", "closed"} {
+		t.Run(state, func(t *testing.T) {
+			pr := map[string]any{"state": state, "draft": true, "merged_at": nil}
+			relayTestServer(t, func(request map[string]any) any {
+				if request["path"] == "/search/issues" {
+					return map[string]any{"items": []any{pr}}
+				}
+				return pr
+			})
+			var out bytes.Buffer
+			if err := runGH(t.Context(), []string{"api", "repos/openclaw/clawsweeper/pulls/1025"}, &out, &bytes.Buffer{}); err != nil {
+				t.Fatal(err)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, pr) {
+				t.Errorf("raw REST = %#v, want %#v", got, pr)
+			}
+			out.Reset()
+			result := handleGHSearch(t.Context(), []string{"prs", "cache", "-R", "openclaw/clawsweeper", "--json", "state"}, &out)
+			if result.err != nil || result.action != ghComplete {
+				t.Fatalf("action=%v err=%v", result.action, result.err)
+			}
+			if want := "[{\"state\":\"" + state + "\"}]\n"; out.String() != want {
+				t.Errorf("search = %q, want %q", out.String(), want)
+			}
+			wantHuman := "DRAFT"
+			if state == "closed" {
+				wantHuman = "CLOSED"
+			}
+			if got := humanPRState(pr); got != wantHuman {
+				t.Errorf("human state = %q, want %q", got, wantHuman)
+			}
+		})
+	}
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -167,6 +167,11 @@ human-format reads. Supported `--json` fields are intentionally conservative. Co
 `gh` field names are mapped where the REST API uses different
 names, such as `url`, `author`, `headRefName`, `headRefOid`, `baseRefName`,
 `baseRefOid`, `isDraft`, `databaseId`, `workflowName`, and `nameWithOwner`.
+`gh pr view --json state` returns the GraphQL lifecycle `OPEN`, `CLOSED`, or `MERGED`
+regardless of the other requested fields or whether the relay uses a public page or REST.
+Draft status is separate: an open draft has `state: "OPEN"` and `isDraft: true` when
+requested. This conversion happens before field filtering and `--jq`; raw `gh api` REST
+states, PR search states, and human-format `DRAFT` display remain unchanged.
 Run views also support the nested `jobs` field; Octopool composes its job/step metadata from
 the cache, exact API responses, or bounded public GitHub pages.
 `gh search issues|prs` is translated to a repo-scoped, cacheable GitHub Search request

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -101,17 +101,20 @@ describe("github cache policy", () => {
     );
   });
 
-  it("keeps public summary shapes separate from exact REST cache entries", async () => {
+  it.each([
+    ["/repos/openclaw/openclaw/actions/runs", "actions-summary-v1"],
+    ["/repos/openclaw/openclaw/pulls/85341", "pr-summary-v1"],
+  ])("keeps %s public summaries separate from exact REST cache entries", async (path, shape) => {
     const summary = validateRelayRequest({
       pool: "maintainers",
       method: "GET",
-      path: "/repos/openclaw/openclaw/actions/runs",
-      headers: { "x-octopool-public-shape": "actions-summary-v1" },
+      path,
+      headers: { "x-octopool-public-shape": shape },
     });
     const exact = validateRelayRequest({
       pool: "maintainers",
       method: "GET",
-      path: "/repos/openclaw/openclaw/actions/runs",
+      path,
     });
     const route = classifyRoute(summary, policy);
 

--- a/test/github-web.test.ts
+++ b/test/github-web.test.ts
@@ -844,6 +844,71 @@ describe("github web provider", () => {
     });
   });
 
+  it.each([
+    ["draft", "DRAFT", "open", true, null, null],
+    ["open", "OPEN", "open", false, null, null],
+    ["closed", "CLOSED", "closed", false, "2026-08-27T04:41:05Z", null],
+    ["closed draft", "CLOSED", "closed", true, "2026-08-27T04:41:05Z", null],
+    ["merged", "MERGED", "closed", false, "2026-08-27T04:41:05Z", "2026-08-27T04:41:05Z"],
+  ])(
+    "preserves source states for %s PR summaries and exact REST reads",
+    async (_name, webState, restState, draft, closedAt, mergedAt) => {
+      const headSha = "96b73e3bc5c058b57ca73ee3337ec351c3c727df";
+      const rest = {
+        state: restState,
+        draft,
+        closed_at: closedAt,
+        merged_at: mergedAt,
+        head: { sha: headSha },
+      };
+      const fetchMock = vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url === "https://github.com/openclaw/octopool/pull/11") {
+          return new Response(
+            pullRequestPage({
+              number: 11,
+              relayId: "PR_fixture",
+              title: "Lifecycle fixture",
+              state: webState,
+              createdTime: "2026-08-26T00:00:00Z",
+              closedTime: closedAt,
+              mergedTime: mergedAt,
+              headBranch: "fix",
+              headSha,
+              baseBranch: "main",
+            }),
+          );
+        }
+        expect(url).toBe("https://api.github.com/repos/openclaw/octopool/pulls/11");
+        return Response.json(rest);
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      const summary = validateRelayRequest({
+        pool: "maintainers",
+        method: "GET",
+        path: "/repos/openclaw/octopool/pulls/11",
+        headers: { "x-octopool-public-shape": "pr-summary-v1" },
+      });
+      const exact = validateRelayRequest({
+        pool: "maintainers",
+        method: "GET",
+        path: summary.path,
+      });
+      const web = await callGitHubWeb(env(), summary, classifyRoute(summary, policy));
+      // The CLI owns GraphQL lifecycle projection; the relay caches source-shaped data.
+      expect(web?.body).toMatchObject({
+        state: webState,
+        closed_at: closedAt,
+        merged_at: mergedAt,
+        head: { sha: headSha },
+      });
+      expect(web?.body).not.toHaveProperty("draft");
+      const api = await callGitHubWeb(env(), exact, classifyRoute(exact, policy));
+      expect(api?.body).toEqual(rest);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    },
+  );
+
   it("prefers embedded issue and PR lists when the whole result fits", async () => {
     const issueNode = {
       __typename: "Issue",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where callers of `gh pr view --json` receive different lifecycle states for the same unchanged draft PR depending on the requested fields. A minimal projection could report `DRAFT`, while adding `isDraft` or `updatedAt` reported lowercase `open`; native `gh` reports `OPEN` with draft status separate. Exact lifecycle prechecks could therefore reject an open PR.

## Why This Change Was Made

Public-page summaries carry display states and REST responses carry lowercase lifecycle states. Normalize both in the PR-view CLI adapter before field filtering and `--jq`, sharing the existing hydration path rather than adding consumer workarounds. Preserve raw REST, search, human-display, freshness, and head-consistency contracts.

## User Impact

PR-view JSON consistently reports `OPEN`, `CLOSED`, or `MERGED`, independently of the requested field subset or response source. Draft status remains in `isDraft`; closed drafts stay closed and merged PRs take precedence.

## Evidence

- Reproduced both inconsistent outputs with bounded fresh relay-only reads, and verified the native schema with one targeted diagnostic. A newly built CLI returns `OPEN` for both original field sets through the live relay; the expanded result matches native `gh` at the same head and update time.
- Added deterministic field-subset, source-path, draft/open/closed/closed-draft/merged, hydration, `--jq`, and compiled-CLI regressions. The new regression failed before the fix.
- Local validation: 277 unit tests and 99 Worker end-to-end tests passed, along with route/SQL consistency, formatting, lint, and TypeScript checks. The complete Go suite and Go vet pass without exclusions using Go 1.26.6, matching the repository's Go 1.26 toolchain. Default Go 1.27 has a separate pre-existing `TestResolveGHPathSkipsCopiedGoShim` failure reproduced on unchanged source; it is not introduced by this patch.
- Independent Codex autoreview reported no accepted/actionable findings.

This is a source-only CLI fix; no installation, deployment, or release is included.
