### PR TITLE
test: fix copied Go shim fixtures on Go 1.27

### DIFF
--- a/cmd/octopool/gh_path_test.go
+++ b/cmd/octopool/gh_path_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"debug/buildinfo"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -110,43 +113,104 @@ func TestResolveGHPathSkipsGitcrawlShim(t *testing.T) {
 }
 
 func TestResolveGHPathSkipsCopiedGoShim(t *testing.T) {
-	dir := t.TempDir()
-	shimDir := filepath.Join(dir, "shim")
-	realDir := filepath.Join(dir, "real")
-	if err := os.Mkdir(shimDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Mkdir(realDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	self, err := os.Executable()
-	if err != nil {
-		t.Fatal(err)
-	}
-	shim := filepath.Join(shimDir, "gh.exe")
-	data, err := os.ReadFile(self)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(shim, data, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	realGH := filepath.Join(realDir, "gh.exe")
-	if err := os.WriteFile(realGH, []byte("real gh"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	for _, tt := range []struct {
+		name     string
+		module   string
+		command  string
+		wantShim bool
+	}{
+		{"octopool", "github.com/openclaw/octopool", "octopool", true},
+		{"gitcrawl", "github.com/openclaw/gitcrawl", "gitcrawl", true},
+		{"github-cli", "github.com/cli/cli/v2", "gh", false},
+		{"test-command", "github.com/openclaw/octopool", "octopool.test", false},
+		{"other-command", "github.com/openclaw/gitcrawl", "gitcrawl-helper", false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			binary := buildGHPathFixture(t, tt.module, tt.command)
+			dir := t.TempDir()
+			// Neutral names and a separate copy prevent name and same-file checks
+			// from masking the buildinfo check.
+			candidate := filepath.Join(dir, "gh.exe")
+			data, err := os.ReadFile(binary)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(candidate, data, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			info, err := buildinfo.ReadFile(candidate)
+			if err != nil {
+				t.Fatalf("read fixture buildinfo: %v", err)
+			}
+			if want := tt.module + "/cmd/" + tt.command; info.Path != want {
+				t.Fatalf("fixture buildinfo Path = %q, want %q", info.Path, want)
+			}
+			if got := ghShimPath(candidate); got != tt.wantShim {
+				t.Errorf("ghShimPath() = %v, want %v", got, tt.wantShim)
+			}
+			realGH := filepath.Join(dir, "fallback-gh.exe")
+			if err := os.WriteFile(realGH, []byte("real gh"), 0o755); err != nil {
+				t.Fatal(err)
+			}
 
-	got, err := resolveGHPathFrom(
-		"gh",
-		filepath.Join(dir, "octopool.exe"),
-		[]string{shim, realGH},
-	)
-	if err != nil {
+			want := candidate
+			if tt.wantShim {
+				want = realGH
+			}
+			got, err := resolveGHPathFrom("gh", binary, []string{candidate, realGH})
+			if err != nil || got != want {
+				t.Errorf("resolveGHPathFrom() = %q, %v; want %q, nil", got, err, want)
+			}
+			got, err = resolveGHPathFrom(candidate, binary, []string{realGH})
+			if tt.wantShim {
+				if got != "" || err == nil || !strings.Contains(err.Error(), "does not point to the real GitHub CLI") {
+					t.Errorf("explicit shim: resolveGHPathFrom() = %q, %v; want rejection", got, err)
+				}
+			} else if err != nil || got != candidate {
+				t.Errorf("explicit non-shim: resolveGHPathFrom() = %q, %v; want %q, nil", got, err, candidate)
+			}
+		})
+	}
+}
+
+func buildGHPathFixture(t *testing.T, module, command string) string {
+	t.Helper()
+	// A test executable can have a .test buildinfo Path, unlike a go build command.
+	dir := t.TempDir()
+	commandDir := filepath.Join(dir, "cmd", command)
+	if err := os.MkdirAll(commandDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if got != realGH {
-		t.Fatalf("resolveGHPathFrom() = %q, want %q", got, realGH)
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module "+module+"\n\ngo 1.26\n"), 0o644); err != nil {
+		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(commandDir, "main.go"), []byte("package main\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	binary := filepath.Join(dir, "fixture.exe")
+	goTool := executableName("go")
+	// -trimpath can leave GOROOT empty; use PATH only in that case.
+	if root := runtime.GOROOT(); root != "" {
+		goTool = filepath.Join(root, "bin", goTool)
+	}
+	goPath, err := exec.LookPath(goTool)
+	if err != nil {
+		t.Fatalf("locate Go compiler for fixture (%q): %v", goTool, err)
+	}
+	cmd := exec.CommandContext(t.Context(), goPath, "build", "-buildvcs=false", "-o", binary, "./cmd/"+command)
+	cmd.Dir = dir
+	// Ignore caller Go configuration, including workspace, flags and experiments.
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		if !strings.HasPrefix(key, "GO") && !strings.HasPrefix(key, "CGO_") {
+			cmd.Env = append(cmd.Env, entry)
+		}
+	}
+	cmd.Env = append(cmd.Env, "GOENV=off", "GO111MODULE=on", "GOWORK=off", "GOTOOLCHAIN=local", "GOPROXY=off", "GOSUMDB=off", "CGO_ENABLED=0")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build Go fixture: %v\n%s", err, out)
+	}
+	return binary
 }
 
 func TestResolveGHPathRejectsExplicitShim(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix `TestResolveGHPathSkipsCopiedGoShim` on Go 1.27 without changing production shim identification. The old fixture copied the running test executable: its build-info path is `github.com/openclaw/octopool/cmd/octopool` on Go 1.26.6, but `github.com/openclaw/octopool/cmd/octopool.test` on Go 1.27.0. A normally built Octopool command retains the production path and is already detected correctly.

Build small, dependency-free command fixtures instead, then copy them to neutral executable names and assert their metadata before testing discovery and explicit-path handling. Cover both Octopool and Gitcrawl shims, the GitHub CLI identity, and similar non-shim command paths. Keep fixture builds isolated from caller Go configuration, with compiler lookup that also works when `-trimpath` removes the embedded GOROOT.

This is a one-file test-only change; production code, installed shims, and the separate PR lifecycle normalization work are unchanged.

## Validation

- Reproduced the original failure on unchanged `5ed6d7e` with Go 1.27.0 darwin/arm64.
- Exact isolated regression, focused path tests, and `-trimpath` regression pass.
- Full uncached Go suite and `go vet ./...` pass on Go 1.27.0 and Go 1.26.6; the `-trimpath` regression passes on both.
- Fixture generation also passes with deliberately invalid inherited Go workspace, flags, environment, experiment, module, toolchain, OS, and architecture settings.
- Live-tested freshly built normal and stripped Octopool binaries against the actual GitHub CLI 2.98.0 in disposable HOME/config/PATH directories. All eight scenarios pass: skipping two copied shims, invoking a copied shim directly, rejecting an explicit copied shim, and accepting the explicit real CLI, for both builds. No credentials, installed-shim changes, or relay calls were needed.
- Independent Codex autoreview completed with no actionable findings.
