### PR TITLE
fix: preserve Actions run metadata ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Validate Actions run/attempt ownership and summary commit links, reject ambiguous or mismatched patch expansion, and fall back to historical REST heads instead of mutable PR heads; retire contaminated Actions summary cache entries with a server-controlled representation generation, including existing clients and run-list supersets.
+- Validate Actions run/attempt ownership and summary commit links with standard HTML DOM parsing, reject malformed regions and ambiguous or mismatched patch expansion, and fall back to historical REST heads instead of mutable PR heads; retire contaminated Actions summary cache entries with a server-controlled representation generation, including existing clients and run-list supersets.
 - Forward `OCTOPOOL_FRESH=1` on top-level run metadata and jobs hydration through shared relay request construction, preserving explicit cache-control headers and ordinary caching.
 
 ## 0.5.7 - 2026-08-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.5.8 - Unreleased
 
+### Fixes
+
+- Validate Actions run/attempt ownership and summary commit links, reject ambiguous or mismatched patch expansion, and fall back to historical REST heads instead of mutable PR heads; retire contaminated Actions summary cache entries with a server-controlled representation generation, including existing clients and run-list supersets.
+- Forward `OCTOPOOL_FRESH=1` on top-level run metadata and jobs hydration through shared relay request construction, preserving explicit cache-control headers and ordinary caching.
+
 ## 0.5.7 - 2026-08-26
 
 ### Fixes

--- a/cmd/octopool/gh_relay.go
+++ b/cmd/octopool/gh_relay.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"strconv"
 	"strings"
@@ -191,6 +192,14 @@ func transientRelayFailure(err error) bool {
 }
 
 func (client ghRelayClient) doOnce(ctx context.Context, request ghAPIRequest) (relayEnvelope, error) {
+	headers := request.headers
+	if _, explicit := headers["cache-control"]; freshReadRequested() && !explicit {
+		headers = maps.Clone(headers)
+		if headers == nil {
+			headers = make(map[string]string)
+		}
+		headers["cache-control"] = "max-age=0"
+	}
 	body := map[string]any{
 		"pool":   client.pool,
 		"method": request.method,
@@ -199,8 +208,8 @@ func (client ghRelayClient) doOnce(ctx context.Context, request ghAPIRequest) (r
 	if len(request.query) > 0 {
 		body["query"] = request.query
 	}
-	if len(request.headers) > 0 {
-		body["headers"] = request.headers
+	if len(headers) > 0 {
+		body["headers"] = headers
 	}
 	if len(request.routeHint) > 0 {
 		body["route_hint"] = request.routeHint

--- a/cmd/octopool/gh_run_ownership_test.go
+++ b/cmd/octopool/gh_run_ownership_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"maps"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestRunOwnershipFreshAndHistoricalHead(t *testing.T) {
+	for _, id := range []string{"33167365292", "33167365221"} {
+		for _, fresh := range []bool{false, true} {
+			t.Run(id+"/fresh="+strconv.FormatBool(fresh), func(t *testing.T) {
+				t.Setenv("OCTOPOOL_FRESH", "0")
+				if fresh {
+					t.Setenv("OCTOPOOL_FRESH", "1")
+				}
+				const head = "224a80eeebec678db6646ef888f5bbc89caf63c4"
+				var paths []string
+				relayTestServer(t, func(body map[string]any) any {
+					path := body["path"].(string)
+					paths = append(paths, path)
+					headers, _ := body["headers"].(map[string]any)
+					if fresh && headers["cache-control"] != "max-age=0" {
+						t.Errorf("%s headers=%v, want max-age=0", path, headers)
+					}
+					if !fresh && headers["cache-control"] != nil {
+						t.Errorf("ordinary %s read bypasses cache: %v", path, headers)
+					}
+					if strings.HasSuffix(path, "/jobs") {
+						return map[string]any{"total_count": 0, "jobs": []any{}}
+					}
+					numericID, _ := strconv.ParseInt(id, 10, 64)
+					return map[string]any{"id": numericID, "head_sha": head, "head_branch": "fixture-branch", "event": "pull_request", "name": "CI", "run_attempt": 1, "pull_requests": []any{map[string]any{"head": map[string]any{"sha": "9999999999999999999999999999999999999999"}}}}
+				})
+				var out bytes.Buffer
+				result := handleGHRun(t.Context(), []string{"view", id, "-R", "openclaw/Peekaboo", "--json", "databaseId,headSha,headBranch,event,workflowName,jobs"}, &out)
+				if result.err != nil || result.action != ghComplete {
+					t.Fatalf("result=%+v", result)
+				}
+				var got map[string]any
+				if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+					t.Fatal(err)
+				}
+				if got["headSha"] != head {
+					t.Fatalf("historical head mapping=%v", got)
+				}
+				if len(paths) != 2 || paths[1] != "/repos/openclaw/Peekaboo/actions/runs/"+id+"/attempts/1/jobs" {
+					t.Fatalf("paths=%v", paths)
+				}
+			})
+		}
+	}
+}
+
+func TestRelayFreshPreservesExplicitHeadersAndCallerMap(t *testing.T) {
+	t.Setenv("OCTOPOOL_FRESH", "1")
+	var seen map[string]any
+	relayTestServer(t, func(body map[string]any) any { seen, _ = body["headers"].(map[string]any); return map[string]any{} })
+	client, err := newGHRelayClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, headers := range []map[string]string{nil, {"x-octopool-public-shape": "actions-summary-v1"}, {"cache-control": "max-age=60"}, {"cache-control": ""}} {
+		before := maps.Clone(headers)
+		_, err := client.do(t.Context(), ghAPIRequest{method: "GET", path: "/repos/openclaw/Peekaboo/actions/runs/33167365292", headers: headers})
+		if err != nil {
+			t.Fatal(err)
+		}
+		want, explicit := headers["cache-control"]
+		if !explicit {
+			want = "max-age=0"
+		}
+		if seen["cache-control"] != want {
+			t.Errorf("headers=%v want cache-control=%q", seen, want)
+		}
+		if !maps.Equal(headers, before) {
+			t.Errorf("mutated caller headers: before=%v after=%v", before, headers)
+		}
+	}
+	request, delegate, err := parseGHAPIArgs([]string{"repos/openclaw/Peekaboo/actions/runs/33167365292", "-H", "Cache-Control: max-age=60"})
+	if err != nil || delegate {
+		t.Fatalf("delegate=%v err=%v", delegate, err)
+	}
+	if _, err := client.do(t.Context(), request); err != nil {
+		t.Fatal(err)
+	}
+	if seen["cache-control"] != "max-age=60" {
+		t.Fatalf("raw explicit headers=%v", seen)
+	}
+}

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -35,6 +35,14 @@ Default pagination
 media types and non-default query values still produce distinct entries. The key is
 pool-scoped, so pools never share cache entries.
 
+Actions summaries also include a server-controlled representation generation
+(`actions-summary-owned-v2`) in this common key. Run views, attempt-qualified views,
+and repository/workflow run lists, including canonical supersets and identity-specific
+entries, cannot reuse summaries cached before the ownership fix. Existing
+`actions-summary-v1` clients keep the same wire format but miss those old entries in
+edge, D1, stale fallback, fill coalescing, and conditional revalidation. Raw REST and
+unrelated shapes keep their existing keys; no cache purge is needed.
+
 PR file-list routes may include a validated
 `route_hint.pr_head_sha` or closed/merged `route_hint.pr_state` discriminator. Clients
 that already know the current PR state can use that to avoid mixing entries across head
@@ -115,6 +123,19 @@ The main transport classes are:
 Anonymous API rate snapshots are recorded by GitHub resource from API responses.
 When a public-page/raw/Git parser cannot satisfy a request, Octopool falls back to the
 anonymous API in the same request cycle.
+
+Actions run pages must identify the requested repository and run in both the summary
+region and embedded job navigation, with a matching attempt when requested. The head
+SHA must come from a commit link inside that run's summary; document titles and links
+elsewhere cannot supply it. List cards end at their own closing element, so a following
+card or region cannot lend its SHA. Missing or conflicting ownership falls back to exact
+anonymous REST, then the existing pool path. In particular, title-only pages use REST's
+historical top-level `head_sha`, never the mutable `pull_requests[].head.sha`.
+
+An abbreviated summary commit link can still expand without API quota, but only from
+a single well-formed patch with a full 40-character SHA matching that abbreviation.
+Merge patch series, mismatched headers, and ambiguous or incomplete patches fall back
+to REST. This deliberately uses more API reads for pages that cannot prove ownership.
 
 Successful web reads are cached in the same D1 table with no source identity. A cached
 web hit still re-checks that public proof covers the entry before returning it.

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -132,6 +132,17 @@ card or region cannot lend its SHA. Missing or conflicting ownership falls back 
 anonymous REST, then the existing pool path. In particular, title-only pages use REST's
 historical top-level `head_sha`, never the mutable `pull_requests[].head.sha`.
 
+These ownership regions use parse5's HTML DOM and source locations, not markup
+stripping or regular-expression boundaries. Scripts, comments, styles, templates,
+raw-text elements, and foreign content cannot supply commit links. Embedded job
+navigation is read only as JSON from its unique script element. HTML element and
+attribute names follow browser case rules, and entities are decoded only by the
+HTML parser. Parse errors, inferred or overlapping ownership boundaries, unusual
+element names, and duplicate identity evidence fall back to REST. Only bare
+fragments with an implicit document scaffold may omit the doctype; full documents
+must declare it. This conservative policy can increase API fallback for malformed
+or changed GitHub markup.
+
 An abbreviated summary commit link can still expand without API quota, but only from
 a single well-formed patch with a full 40-character SHA matching that abbreviation.
 Merge patch series, mismatched headers, and ambiguous or incomplete patches fall back

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -344,9 +344,11 @@ Three things keep that honest:
   served from the shared cache, the CLI prints one line to stderr naming the route, whether
   it was a hit or a stale serve, and when it refreshes. stdout stays untouched, so `--json`
   and `--jq` consumers are unaffected. Silence it with `OCTOPOOL_QUIET_CACHE=1`.
-- **Anything can be forced live.** `OCTOPOOL_FRESH=1` applies `max-age=0` to every relayed
-  read, and `gh api -H "cache-control: max-age=0"` now relays instead of falling back to
-  local `gh`, so a raw API read can be made live without spending your own token quota.
+- **Anything can request a live read.** `OCTOPOOL_FRESH=1` applies `max-age=0` at shared
+  relay request construction, including top-level `run view` and every jobs hydration
+  request. An explicit `cache-control` header retains precedence, including headers
+  passed through `gh api -H`. Ordinary reads retain caching. The relay's existing bounded
+  stale fallback still applies when upstream backends are unavailable.
 
 Note that `git push` never passes through Octopool, so the relay cannot invalidate a PR
 entry when a branch moves. That is why the gate fields read live rather than relying on
@@ -370,10 +372,10 @@ These are dev/CI escape hatches, not the everyday UX:
 - `OCTOPOOL_TOKEN` — caller token override (required to use a non-saved URL).
 - `OCTOPOOL_POOL` — pool id (default `maintainers`).
 - `OCTOPOOL_GH_PATH` — path to the real `gh` binary.
-- `OCTOPOOL_FRESH=1` — send `cache-control: max-age=0` on every relayed read, so answers
-  come from GitHub instead of the shared cache. Use it right after a `git push` or a merge,
-  when a cached answer would still describe the previous state. Costs pool quota; leave it
-  off for ordinary reads.
+- `OCTOPOOL_FRESH=1` — default every relayed read to `cache-control: max-age=0`, including
+  run metadata and jobs; explicit cache-control headers take precedence. Use it right after
+  a `git push` or a merge, when a cached answer could describe the previous state. It can
+  cost API quota; leave it off for ordinary reads. Bounded stale outage fallback is unchanged.
 - `OCTOPOOL_QUIET_CACHE=1` — suppress the one-line stderr note printed when a
   decision-shaped route (PR/issue/run/checks) is served from the shared cache.
 - `OCTOPOOL_NO_FALLBACK=1` — fail instead of running real `gh` after Octopool returns

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "test:e2e:cli-worker": "sh test/cli-worker-e2e.sh",
     "types": "wrangler types"
   },
+  "dependencies": {
+    "parse5": "8.0.1"
+  },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.21.0",
     "@types/node": "^26.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,10 @@ overrides:
 importers:
 
   .:
+    dependencies:
+      parse5:
+        specifier: 8.0.1
+        version: 8.0.1
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.21.0
@@ -991,6 +995,10 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
@@ -1142,6 +1150,9 @@ packages:
         optional: true
       vite-plus:
         optional: true
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -1936,6 +1947,8 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  entities@8.0.0: {}
+
   error-stack-parser-es@1.0.5: {}
 
   es-module-lexer@2.3.1: {}
@@ -2098,6 +2111,10 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.78.0
       '@oxlint/binding-win32-ia32-msvc': 1.78.0
       '@oxlint/binding-win32-x64-msvc': 1.78.0
+
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
 
   path-to-regexp@6.3.0: {}
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -74,6 +74,11 @@ export async function githubCacheKey(
     headers: stableRecord(cacheVaryHeaders(request.headers)),
     route_key: route.routeKey,
     state: cacheStateDiscriminator(route),
+    // Retire contaminated page shapes for existing clients in every cache/fill path.
+    ...(request.headers?.["x-octopool-public-shape"] === PUBLIC_SHAPES.actionsSummary &&
+    ["run_view", "run_list", "workflow_run_list"].includes(route.kind)
+      ? { representation: "actions-summary-owned-v2" }
+      : {}),
     ...(identity === undefined ? {} : { identity: `${identity.kind}:${identity.id}` }),
   };
   return hashToken(JSON.stringify(stable));

--- a/src/github-html-actions.ts
+++ b/src/github-html-actions.ts
@@ -1,5 +1,6 @@
+import { parse, type DefaultTreeAdapterTypes } from "parse5";
 import { decodeURIComponentSafe } from "./github-path";
-import { decodeHTML, escapeRegex, htmlAttribute, textMatch } from "./github-html-utils";
+import { escapeRegex, htmlAttribute } from "./github-html-utils";
 import { isRecord } from "./object";
 
 type RunState = {
@@ -20,47 +21,46 @@ export function parseActionsRunListHTML(
   owner: string,
   repo: string,
 ): { total_count: number; workflow_runs: Record<string, unknown>[] } | undefined {
-  const totalMatch = /<strong>([0-9,]+) workflow runs?(?: results?)?<\/strong>/.exec(html);
-  const total = totalMatch === null ? undefined : Number(totalMatch[1]!.replaceAll(",", ""));
-  const cards = actionsDivRegions(html, (attributes) => {
-    const classes = new Set(htmlAttribute(attributes, "class")?.split(/\s+/));
-    return ["Box-row", "js-socket-channel", "js-updatable-content"].every((name) =>
-      classes.has(name),
-    );
-  });
-  if (cards === undefined) {
-    return undefined;
-  }
+  const document = actionsDocument(html);
+  if (document === undefined) return undefined;
+  const elements = actionsElements(document);
+  const totals = elements
+    .filter((element) => element.tagName === "strong")
+    .map((element) => /^([0-9,]+) workflow runs?(?: results?)?$/.exec(actionsText(element)))
+    .filter((match) => match !== null);
+  if (totals.length > 1) return undefined;
+  const total = totals[0] === undefined ? undefined : Number(totals[0][1]!.replaceAll(",", ""));
+  const cards = elements.filter(isRunCard);
+  if (!disjointRegions(cards)) return undefined;
   const runs: Record<string, unknown>[] = [];
   const runPath = `/${escapeRegex(owner)}/${escapeRegex(repo)}/actions/runs/`;
 
   for (const card of cards) {
-    const anchors = [...card.matchAll(/<a\b([^>]*)>/g)]
-      .map((match) => ({
-        href: htmlAttribute(match[1]!, "href"),
-        label: htmlAttribute(match[1]!, "aria-label"),
-      }))
-      .filter(
-        (anchor) =>
-          anchor.label !== undefined &&
-          /^\/[^/]+\/[^/]+\/actions\/runs\/[0-9]+$/.test(anchor.href ?? ""),
-      );
-    const anchor = anchors[0];
-    const idText = new RegExp(`^${runPath}([0-9]+)$`).exec(anchor?.href ?? "")?.[1];
-    if (anchors.length !== 1 || anchor?.label === undefined || idText === undefined) {
-      return undefined;
-    }
-    const state = runState(anchor.label);
+    const contents = ownedElements(card);
+    if (contents === undefined) return undefined;
+    const anchor = onlyElement(
+      contents.filter(
+        (element) =>
+          isHTMLAnchor(element) &&
+          /^\/[^/]+\/[^/]+\/actions\/runs\/[0-9]+$/.test(attribute(element, "href") ?? ""),
+      ),
+    );
+    const idText = new RegExp(`^${runPath}([0-9]+)$`).exec(attribute(anchor, "href") ?? "")?.[1];
+    const label = attribute(anchor, "aria-label");
+    if (label === undefined || idText === undefined) return undefined;
+    const state = runState(label);
     if (state === undefined) {
       return undefined;
     }
-    const title = textMatch(card, /class="[^"]*markdown-title[^"]*"[^>]*>([\s\S]*?)<\/span>/);
-    const workflow = textMatch(
-      card,
-      /<span class="text-bold"[^>]*>([\s\S]*?)<\/span>\s*#([0-9]+):/,
+    const title = onlyElement(contents.filter((element) => hasClass(element, "markdown-title")));
+    const workflow = onlyElement(
+      contents.filter((element) => element.tagName === "span" && hasClass(element, "text-bold")),
     );
-    const runNumber = /<span class="text-bold"[^>]*>[\s\S]*?<\/span>\s*#([0-9]+):/.exec(card)?.[1];
-    const createdAt = /<relative-time[\s\S]*?datetime="([^"]+)"/.exec(card)?.[1];
+    const runNumber = /^#([0-9]+):/.exec(actionsText(adjacentNode(workflow, 1)))?.[1];
+    const createdAt = attribute(
+      onlyElement(contents.filter((element) => element.tagName === "relative-time")),
+      "datetime",
+    );
     if (
       title === undefined ||
       workflow === undefined ||
@@ -70,7 +70,7 @@ export function parseActionsRunListHTML(
       return undefined;
     }
     const id = Number(idText);
-    const commit = actionsCommitSHA(card, owner, repo);
+    const commit = actionsCommitSHA(contents, owner, repo);
     if (
       commit === undefined ||
       !Number.isSafeInteger(id) ||
@@ -79,21 +79,23 @@ export function parseActionsRunListHTML(
     ) {
       return undefined;
     }
-    const branch = new RegExp(
-      `href="/${escapeRegex(owner)}/${escapeRegex(repo)}/tree/refs/heads/([^"]+)"`,
-    ).exec(card)?.[1];
-    const duration = /aria-label="Run duration"[\s\S]*?<\/svg>\s*<span>\s*([^<]+)</.exec(card)?.[1];
+    const branch = actionsRunBranch(contents, owner, repo, false);
+    if (branch === undefined) return undefined;
+    const durationIcon = onlyElement(
+      contents.filter((element) => attribute(element, "aria-label") === "Run duration"),
+    );
+    const duration = actionsText(adjacentNode(durationIcon, 1));
     runs.push({
       id,
-      name: workflow,
-      display_title: title,
+      name: actionsText(workflow),
+      display_title: actionsText(title),
       run_number: Number(runNumber),
       status: state.status,
       conclusion: state.conclusion,
       html_url: `https://github.com/${owner}/${repo}/actions/runs/${id}`,
-      head_branch: branch === undefined ? null : decodeURIComponentSafe(branch),
+      head_branch: branch.name ?? null,
       head_sha: commit.sha ?? null,
-      event: runEvent(card),
+      event: runEvent(actionsText(card)),
       created_at: createdAt,
       updated_at: addDuration(createdAt, duration) ?? createdAt,
     });
@@ -112,69 +114,108 @@ export function parseActionsRunHTML(
   id: number,
   attempt?: number,
 ): Record<string, unknown> | undefined {
+  const document = actionsDocument(html);
+  if (document === undefined) return undefined;
+  const elements = actionsElements(document);
   const runPath = `/${owner}/${repo}/actions/runs/${id}`;
-  const summaries = actionsDivRegions(
-    html,
-    (attributes) => htmlAttribute(attributes, "aria-label") === "Workflow run summary",
+  const summary = onlyElement(
+    elements.filter(
+      (element) =>
+        element.tagName === "div" && attribute(element, "aria-label") === "Workflow run summary",
+    ),
   );
-  const summary = summaries?.[0];
-  const summaryAttributes =
-    summary === undefined ? undefined : /^<div\b([^>]*)>/.exec(summary)?.[1];
-  const runAttempt = actionsRunAttempt(html, runPath);
+  const header = onlyElement(elements.filter((element) => element.tagName === "page-header"));
+  const navigation = onlyElement(
+    elements.filter(
+      (element) =>
+        element.tagName === "react-partial" &&
+        attribute(element, "partial-name") === "actions-run-jobs-list",
+    ),
+  );
   if (
     !Number.isSafeInteger(id) ||
     id <= 0 ||
-    summaries?.length !== 1 ||
     summary === undefined ||
-    summaryAttributes === undefined ||
-    htmlAttribute(summaryAttributes, "data-url") !== `${runPath}/summary_partial` ||
+    header === undefined ||
+    navigation === undefined ||
+    !disjointRegions([summary, header, navigation]) ||
+    attribute(summary, "data-url") !== `${runPath}/summary_partial`
+  ) {
+    return undefined;
+  }
+  const contents = ownedElements(summary);
+  const headerContents = ownedElements(header);
+  const runAttempt = actionsRunAttempt(navigation, runPath);
+  if (
+    contents === undefined ||
+    headerContents === undefined ||
     runAttempt === undefined ||
     (attempt !== undefined && attempt !== runAttempt)
   ) {
     return undefined;
   }
-  const pageHeaders = [...html.matchAll(/<page-header\b[^>]*>([\s\S]*?)<\/page-header>/g)];
-  const header = pageHeaders[0]?.[1];
-  if (pageHeaders.length !== 1 || header === undefined) {
-    return undefined;
-  }
-  const title = textMatch(
-    header,
-    /<h1[^>]*class="[^"]*PageHeader-title[^"]*"[\s\S]*?<span class="markdown-title"[^>]*>([\s\S]*?)<\/span>/,
+  const heading = onlyElement(
+    headerContents.filter(
+      (element) => element.tagName === "h1" && hasClass(element, "PageHeader-title"),
+    ),
   );
-  const workflow = textMatch(header, /class="PageHeader-parentLink-label"[^>]*>([\s\S]*?)<\/span>/);
-  const stateLabel =
-    /class="[^"]*actions-workflow-runs-status[^"]*"[\s\S]*?aria-label="([^"]+)"/.exec(header)?.[1];
-  const state = stateLabel === undefined ? undefined : runState(decodeHTML(stateLabel));
-  const runNumber = new RegExp(
-    `<span class="markdown-title"[\\s\\S]*?</span>\\s*<span[^>]*>\\s*#([0-9]+)`,
-  ).exec(header)?.[1];
-  const trigger = /Triggered via\s+([^<]+?)\s*<relative-time[^>]*datetime="([^"]+)"/.exec(summary);
-  const sha = actionsCommitSHA(summary, owner, repo)?.sha;
-  const branch = actionsRunBranch(summary, owner, repo);
+  const title = onlyElement(
+    actionsElements(heading).filter((element) => hasClass(element, "markdown-title")),
+  );
+  const workflow = onlyElement(
+    headerContents.filter((element) => hasClass(element, "PageHeader-parentLink-label")),
+  );
+  const statusContainer = onlyElement(
+    headerContents.filter((element) => hasClass(element, "actions-workflow-runs-status")),
+  );
+  const stateLabel = attribute(
+    onlyElement(
+      actionsElements(statusContainer).filter(
+        (element) => attribute(element, "aria-label") !== undefined,
+      ),
+    ),
+    "aria-label",
+  );
+  const state = stateLabel === undefined ? undefined : runState(stateLabel);
+  const runNumber = /^#([0-9]+)$/.exec(actionsText(adjacentNode(title, 1)))?.[1];
+  const timestamp = onlyElement(
+    contents.filter(
+      (element) =>
+        element.tagName === "relative-time" &&
+        /^Triggered via\s+/.test(actionsText(adjacentNode(element, -1))),
+    ),
+  );
+  const trigger = /^Triggered via\s+(.+)$/.exec(actionsText(adjacentNode(timestamp, -1)));
+  const createdAt = attribute(timestamp, "datetime");
+  const sha = actionsCommitSHA(contents, owner, repo)?.sha;
+  const branch = actionsRunBranch(contents, owner, repo, true);
   if (
     title === undefined ||
     workflow === undefined ||
     state === undefined ||
     runNumber === undefined ||
     trigger === null ||
-    sha === undefined
+    createdAt === undefined ||
+    sha === undefined ||
+    branch === undefined
   ) {
     return undefined;
   }
-  const duration = /Total duration[\s\S]*?class="[^"]*color-fg-default[^"]*"[^>]*>\s*([^<]+)</.exec(
-    summary,
-  )?.[1];
-  const createdAt = trigger[2]!;
+  const durationLabel = onlyElement(
+    contents.filter(
+      (element) => element.tagName === "span" && actionsText(element) === "Total duration",
+    ),
+  );
+  const duration = actionsText(adjacentNode(durationLabel, 1));
   return {
     id,
-    name: workflow,
-    display_title: title,
+    name: actionsText(workflow),
+    display_title: actionsText(title),
     run_number: Number(runNumber),
     status: state.status,
     conclusion: state.conclusion,
     html_url: `https://github.com/${owner}/${repo}/actions/runs/${id}`,
-    head_branch: branch ?? null,
+    head_branch: branch.name ?? null,
     head_sha: sha,
     event: trigger[1]!
       .trim()
@@ -285,70 +326,228 @@ export function parseActionsJobHTML(
   };
 }
 
-// Match the closing div, not the next card: following regions do not own this run's SHA.
-function actionsDivRegions(
-  html: string,
-  selected: (attributes: string) => boolean,
-): string[] | undefined {
-  const regions: string[] = [];
-  let depth = 0;
-  let start: number | undefined;
-  for (const match of html.matchAll(
-    /<!--[\s\S]*?-->|<script\b[^>]*>[\s\S]*?<\/script\s*>|<\/?div\b[^>]*>/gi,
-  )) {
-    if (!/^<\/?div\b/i.test(match[0])) {
-      continue;
-    }
-    if (match[0].startsWith("</")) {
-      if (start !== undefined && --depth === 0) {
-        regions.push(
-          html
-            .slice(start, match.index + match[0].length)
-            .replace(/<!--[\s\S]*?-->|<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, ""),
-        );
-        start = undefined;
-      }
-    } else {
-      if (selected(match[0].slice(4, -1))) {
-        if (start !== undefined) return undefined;
-        start = match.index;
-      }
-      if (start !== undefined) depth++;
+type ActionsElement = DefaultTreeAdapterTypes.Element;
+type ActionsNode = DefaultTreeAdapterTypes.Node;
+
+const HTML_NAMESPACE = "http://www.w3.org/1999/xhtml";
+const INERT_ELEMENTS = new Set([
+  "script",
+  "style",
+  "template",
+  "textarea",
+  "title",
+  "xmp",
+  "iframe",
+  "noembed",
+  "noframes",
+  "noscript",
+  "plaintext",
+]);
+
+function actionsDocument(html: string): DefaultTreeAdapterTypes.Document | undefined {
+  let invalid = false;
+  let missingDoctype = false;
+  const document = parse(html, {
+    scriptingEnabled: true,
+    sourceCodeLocationInfo: true,
+    onParseError(error) {
+      if (error.code === "missing-doctype") missingDoctype = true;
+      else invalid = true;
+    },
+  });
+  const elements = actionsElements(document);
+  // Fragments have an implicit document scaffold; full documents must declare their mode.
+  if (
+    missingDoctype &&
+    elements.some(
+      (element) =>
+        ["html", "head", "body"].includes(element.tagName) &&
+        element.sourceCodeLocation !== null &&
+        element.sourceCodeLocation !== undefined,
+    )
+  )
+    invalid = true;
+  // HTML accepts names such as `scr<!--x--` without a parse error. They are not
+  // GitHub elements and cannot provide an ownership boundary, even as ancestors.
+  if (
+    elements.some(
+      (element) =>
+        element.namespaceURI === HTML_NAMESPACE && !/^[a-z][a-z0-9-]*$/.test(element.tagName),
+    )
+  )
+    invalid = true;
+  return invalid ? undefined : document;
+}
+
+function actionsElements(root: ActionsNode | undefined): ActionsElement[] {
+  const elements: ActionsElement[] = [];
+  const pending = root !== undefined && "childNodes" in root ? [...root.childNodes].reverse() : [];
+  while (pending.length > 0) {
+    const node = pending.pop()!;
+    if (!("tagName" in node)) continue;
+    elements.push(node);
+    // Keep SVG status icons, but never traverse foreign or inert content for ownership.
+    if (node.namespaceURI === HTML_NAMESPACE && !INERT_ELEMENTS.has(node.tagName)) {
+      for (let index = node.childNodes.length - 1; index >= 0; index--)
+        pending.push(node.childNodes[index]!);
     }
   }
-  return start === undefined ? regions : undefined;
+  return elements;
+}
+
+function actionsText(root: ActionsNode | undefined): string {
+  const parts: string[] = [];
+  const pending = root === undefined ? [] : [root];
+  while (pending.length > 0) {
+    const node = pending.pop()!;
+    if ("value" in node) parts.push(node.value);
+    else if (
+      "childNodes" in node &&
+      !(
+        "tagName" in node &&
+        (node.namespaceURI !== HTML_NAMESPACE || INERT_ELEMENTS.has(node.tagName))
+      )
+    ) {
+      for (let index = node.childNodes.length - 1; index >= 0; index--)
+        pending.push(node.childNodes[index]!);
+    }
+  }
+  return parts.join("").replace(/\s+/g, " ").trim();
+}
+
+function attribute(element: ActionsElement | undefined, name: string): string | undefined {
+  return element?.attrs.find(
+    (attribute) => attribute.name === name && attribute.namespace === undefined,
+  )?.value;
+}
+
+function hasClass(element: ActionsElement, name: string): boolean {
+  return (
+    attribute(element, "class")
+      ?.split(/[\t\n\f\r ]+/)
+      .includes(name) ?? false
+  );
+}
+
+function onlyElement(elements: ActionsElement[]): ActionsElement | undefined {
+  return elements.length === 1 ? elements[0] : undefined;
+}
+
+function adjacentNode(
+  element: ActionsElement | undefined,
+  direction: 1 | -1,
+): ActionsNode | undefined {
+  const siblings = element?.parentNode?.childNodes;
+  if (element === undefined || siblings === undefined) return undefined;
+  for (
+    let index = siblings.indexOf(element) + direction;
+    index >= 0 && index < siblings.length;
+    index += direction
+  ) {
+    const node = siblings[index]!;
+    if (node.nodeName !== "#comment" && !("value" in node && node.value.trim() === "")) return node;
+  }
+  return undefined;
+}
+
+function disjointRegions(regions: ActionsElement[]): boolean {
+  const ordered = [...regions].sort(
+    (left, right) =>
+      (left.sourceCodeLocation?.startOffset ?? 0) - (right.sourceCodeLocation?.startOffset ?? 0),
+  );
+  return ordered.every((region, index) => {
+    const location = region.sourceCodeLocation;
+    return (
+      region.namespaceURI === HTML_NAMESPACE &&
+      location?.endTag !== undefined &&
+      (index === 0 || ordered[index - 1]!.sourceCodeLocation!.endOffset <= location.startOffset)
+    );
+  });
+}
+
+function ownedElements(region: ActionsElement): ActionsElement[] | undefined {
+  if (!disjointRegions([region])) return undefined;
+  const elements = actionsElements(region);
+  // parse5 can repair nesting without emitting an error. Do not use inferred closures
+  // or reparented nodes inside an ownership region as evidence.
+  for (const element of elements) {
+    const location = element.sourceCodeLocation;
+    const parent = element.parentNode;
+    const parentLocation =
+      parent !== null && "tagName" in parent ? parent.sourceCodeLocation : undefined;
+    if (
+      location === undefined ||
+      location === null ||
+      parentLocation?.startTag === undefined ||
+      location.startOffset < parentLocation.startTag.endOffset ||
+      location.endOffset > (parentLocation.endTag?.startOffset ?? parentLocation.endOffset) ||
+      (element.childNodes.length > 0 &&
+        element.namespaceURI === HTML_NAMESPACE &&
+        location.endTag === undefined)
+    )
+      return undefined;
+  }
+  return elements;
+}
+
+function isHTMLAnchor(element: ActionsElement): boolean {
+  return element.namespaceURI === HTML_NAMESPACE && element.tagName === "a";
+}
+
+function isRunCard(element: ActionsElement): boolean {
+  return (
+    element.tagName === "div" &&
+    ["Box-row", "js-socket-channel", "js-updatable-content"].every((name) =>
+      hasClass(element, name),
+    )
+  );
 }
 
 function actionsCommitSHA(
-  html: string,
+  elements: ActionsElement[],
   owner: string,
   repo: string,
 ): { sha: string | undefined } | undefined {
   const prefix = `/${owner}/${repo}/commit/`;
-  const shas = new Set<string>();
-  for (const anchor of html.matchAll(/<a\b([^>]*)>/g)) {
-    const href = htmlAttribute(anchor[1]!, "href");
+  let ownedSHA: string | undefined;
+  for (const anchor of elements.filter(isHTMLAnchor)) {
+    const href = attribute(anchor, "href");
     if (href !== undefined && /^\/[^/]+\/[^/]+\/commit\//.test(href)) {
-      if (!href.startsWith(prefix)) return undefined;
+      if (
+        !href.startsWith(prefix) ||
+        ownedSHA !== undefined ||
+        anchor.sourceCodeLocation?.endTag === undefined
+      )
+        return undefined;
       const sha = href.slice(prefix.length);
       if (!/^[0-9A-Fa-f]{7,40}$/.test(sha)) return undefined;
-      shas.add(sha.toLowerCase());
+      ownedSHA = sha.toLowerCase();
     }
   }
-  return shas.size > 1 ? undefined : { sha: [...shas][0] };
+  return { sha: ownedSHA };
 }
 
-function actionsRunAttempt(html: string, runPath: string): number | undefined {
-  const partials = [
-    ...html.matchAll(/<react-partial\b([^>]*)>([\s\S]*?)<\/react-partial>/g),
-  ].filter((match) => htmlAttribute(match[1]!, "partial-name") === "actions-run-jobs-list");
-  if (partials.length !== 1) return undefined;
-  const scripts = [...partials[0]![2]!.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/g)].filter(
-    (match) => htmlAttribute(match[1]!, "data-target") === "react-partial.embeddedData",
+function actionsRunAttempt(navigation: ActionsElement, runPath: string): number | undefined {
+  const elements = ownedElements(navigation);
+  if (elements === undefined) return undefined;
+  const script = onlyElement(
+    elements.filter(
+      (element) =>
+        element.namespaceURI === HTML_NAMESPACE &&
+        element.tagName === "script" &&
+        attribute(element, "data-target") === "react-partial.embeddedData",
+    ),
   );
-  if (scripts.length !== 1) return undefined;
+  if (
+    script?.sourceCodeLocation?.endTag === undefined ||
+    script.childNodes.some((node) => !("value" in node))
+  )
+    return undefined;
   try {
-    const data: unknown = JSON.parse(scripts[0]![2]!);
+    // Script text is JSON, never HTML and never entity-decoded.
+    const data: unknown = JSON.parse(
+      script.childNodes.map((node) => ("value" in node ? node.value : "")).join(""),
+    );
     if (!isRecord(data) || !isRecord(data.props)) return undefined;
     const props = data.props;
     if (
@@ -402,26 +601,30 @@ function collectJobSummaries(
   }
 }
 
-function actionsRunBranch(html: string, owner: string, repo: string): string | undefined {
-  const branch = new RegExp(
-    `href="/${escapeRegex(owner)}/${escapeRegex(repo)}/tree/refs/heads/([^"]+)"`,
-  ).exec(html)?.[1];
-  if (branch !== undefined) {
-    return decodeURIComponentSafe(branch);
-  }
-  for (const match of html.matchAll(/<a\b([^>]*)>/g)) {
-    const classes = htmlAttribute(match[1]!, "class")?.split(/\s+/);
-    if (!classes?.includes("branch-name")) {
-      continue;
+function actionsRunBranch(
+  elements: ActionsElement[],
+  owner: string,
+  repo: string,
+  allowTitle: boolean,
+): { name: string | undefined } | undefined {
+  const prefix = `/${owner}/${repo}/tree/refs/heads/`;
+  const names = new Set<string>();
+  for (const anchor of elements.filter(isHTMLAnchor)) {
+    const href = attribute(anchor, "href");
+    if (href?.startsWith(prefix)) {
+      names.add(decodeURIComponentSafe(href.slice(prefix.length)));
     }
-    const title = htmlAttribute(match[1]!, "title");
-    if (title === undefined) {
-      continue;
-    }
-    const separator = title.indexOf(":");
-    return separator === -1 ? title : title.slice(separator + 1);
   }
-  return undefined;
+  if (allowTitle && names.size === 0) {
+    for (const anchor of elements.filter(isHTMLAnchor)) {
+      const title = attribute(anchor, "title");
+      if (hasClass(anchor, "branch-name") && title !== undefined) {
+        const separator = title.indexOf(":");
+        names.add(separator === -1 ? title : title.slice(separator + 1));
+      }
+    }
+  }
+  return names.size > 1 ? undefined : { name: [...names][0] };
 }
 
 function firstTimestamp(items: Record<string, unknown>[], field: string): string | null {

--- a/src/github-html-actions.ts
+++ b/src/github-html-actions.ts
@@ -22,18 +22,37 @@ export function parseActionsRunListHTML(
 ): { total_count: number; workflow_runs: Record<string, unknown>[] } | undefined {
   const totalMatch = /<strong>([0-9,]+) workflow runs?(?: results?)?<\/strong>/.exec(html);
   const total = totalMatch === null ? undefined : Number(totalMatch[1]!.replaceAll(",", ""));
-  const cards = actionsRunCards(html);
+  const cards = actionsDivRegions(html, (attributes) => {
+    const classes = new Set(htmlAttribute(attributes, "class")?.split(/\s+/));
+    return ["Box-row", "js-socket-channel", "js-updatable-content"].every((name) =>
+      classes.has(name),
+    );
+  });
+  if (cards === undefined) {
+    return undefined;
+  }
   const runs: Record<string, unknown>[] = [];
   const runPath = `/${escapeRegex(owner)}/${escapeRegex(repo)}/actions/runs/`;
 
   for (const card of cards) {
-    const anchor = new RegExp(`href="${runPath}([0-9]+)"[^>]*aria-label="([^"]+)"`).exec(card);
-    if (anchor === null) {
-      continue;
+    const anchors = [...card.matchAll(/<a\b([^>]*)>/g)]
+      .map((match) => ({
+        href: htmlAttribute(match[1]!, "href"),
+        label: htmlAttribute(match[1]!, "aria-label"),
+      }))
+      .filter(
+        (anchor) =>
+          anchor.label !== undefined &&
+          /^\/[^/]+\/[^/]+\/actions\/runs\/[0-9]+$/.test(anchor.href ?? ""),
+      );
+    const anchor = anchors[0];
+    const idText = new RegExp(`^${runPath}([0-9]+)$`).exec(anchor?.href ?? "")?.[1];
+    if (anchors.length !== 1 || anchor?.label === undefined || idText === undefined) {
+      return undefined;
     }
-    const state = runState(decodeHTML(anchor[2]!));
+    const state = runState(anchor.label);
     if (state === undefined) {
-      continue;
+      return undefined;
     }
     const title = textMatch(card, /class="[^"]*markdown-title[^"]*"[^>]*>([\s\S]*?)<\/span>/);
     const workflow = textMatch(
@@ -48,12 +67,18 @@ export function parseActionsRunListHTML(
       runNumber === undefined ||
       createdAt === undefined
     ) {
-      continue;
+      return undefined;
     }
-    const id = Number(anchor[1]);
-    const sha = new RegExp(
-      `href="/${escapeRegex(owner)}/${escapeRegex(repo)}/commit/([0-9A-Fa-f]{7,64})"`,
-    ).exec(card)?.[1];
+    const id = Number(idText);
+    const commit = actionsCommitSHA(card, owner, repo);
+    if (
+      commit === undefined ||
+      !Number.isSafeInteger(id) ||
+      id <= 0 ||
+      runs.some((run) => run.id === id)
+    ) {
+      return undefined;
+    }
     const branch = new RegExp(
       `href="/${escapeRegex(owner)}/${escapeRegex(repo)}/tree/refs/heads/([^"]+)"`,
     ).exec(card)?.[1];
@@ -67,7 +92,7 @@ export function parseActionsRunListHTML(
       conclusion: state.conclusion,
       html_url: `https://github.com/${owner}/${repo}/actions/runs/${id}`,
       head_branch: branch === undefined ? null : decodeURIComponentSafe(branch),
-      head_sha: sha ?? null,
+      head_sha: commit.sha ?? null,
       event: runEvent(card),
       created_at: createdAt,
       updated_at: addDuration(createdAt, duration) ?? createdAt,
@@ -85,31 +110,48 @@ export function parseActionsRunHTML(
   owner: string,
   repo: string,
   id: number,
+  attempt?: number,
 ): Record<string, unknown> | undefined {
-  const title = textMatch(
+  const runPath = `/${owner}/${repo}/actions/runs/${id}`;
+  const summaries = actionsDivRegions(
     html,
+    (attributes) => htmlAttribute(attributes, "aria-label") === "Workflow run summary",
+  );
+  const summary = summaries?.[0];
+  const summaryAttributes =
+    summary === undefined ? undefined : /^<div\b([^>]*)>/.exec(summary)?.[1];
+  const runAttempt = actionsRunAttempt(html, runPath);
+  if (
+    !Number.isSafeInteger(id) ||
+    id <= 0 ||
+    summaries?.length !== 1 ||
+    summary === undefined ||
+    summaryAttributes === undefined ||
+    htmlAttribute(summaryAttributes, "data-url") !== `${runPath}/summary_partial` ||
+    runAttempt === undefined ||
+    (attempt !== undefined && attempt !== runAttempt)
+  ) {
+    return undefined;
+  }
+  const pageHeaders = [...html.matchAll(/<page-header\b[^>]*>([\s\S]*?)<\/page-header>/g)];
+  const header = pageHeaders[0]?.[1];
+  if (pageHeaders.length !== 1 || header === undefined) {
+    return undefined;
+  }
+  const title = textMatch(
+    header,
     /<h1[^>]*class="[^"]*PageHeader-title[^"]*"[\s\S]*?<span class="markdown-title"[^>]*>([\s\S]*?)<\/span>/,
   );
-  const workflow = textMatch(html, /class="PageHeader-parentLink-label"[^>]*>([\s\S]*?)<\/span>/);
+  const workflow = textMatch(header, /class="PageHeader-parentLink-label"[^>]*>([\s\S]*?)<\/span>/);
   const stateLabel =
-    /class="[^"]*actions-workflow-runs-status[^"]*"[\s\S]*?aria-label="([^"]+)"/.exec(html)?.[1];
+    /class="[^"]*actions-workflow-runs-status[^"]*"[\s\S]*?aria-label="([^"]+)"/.exec(header)?.[1];
   const state = stateLabel === undefined ? undefined : runState(decodeHTML(stateLabel));
   const runNumber = new RegExp(
     `<span class="markdown-title"[\\s\\S]*?</span>\\s*<span[^>]*>\\s*#([0-9]+)`,
-  ).exec(html)?.[1];
-  const trigger = /Triggered via\s+([^<]+?)\s*<relative-time[^>]*datetime="([^"]+)"/.exec(html);
-  const sha =
-    new RegExp(
-      `href="/${escapeRegex(owner)}/${escapeRegex(repo)}/commit/([0-9A-Fa-f]{7,64})"`,
-    ).exec(html)?.[1] ??
-    new RegExp(
-      `(?:\\u00b7|&#183;)\\s*${escapeRegex(owner)}/${escapeRegex(repo)}@([0-9A-Fa-f]{7,64})`,
-    ).exec(html)?.[1];
-  const branch = actionsRunBranch(html, owner, repo);
-  const runAttemptText = new RegExp(
-    `/${escapeRegex(owner)}/${escapeRegex(repo)}/actions/runs/${id}/job_groups_batch\\?attempt=([0-9]+)`,
-  ).exec(html)?.[1];
-  const runAttempt = runAttemptText === undefined ? undefined : Number(runAttemptText);
+  ).exec(header)?.[1];
+  const trigger = /Triggered via\s+([^<]+?)\s*<relative-time[^>]*datetime="([^"]+)"/.exec(summary);
+  const sha = actionsCommitSHA(summary, owner, repo)?.sha;
+  const branch = actionsRunBranch(summary, owner, repo);
   if (
     title === undefined ||
     workflow === undefined ||
@@ -121,7 +163,7 @@ export function parseActionsRunHTML(
     return undefined;
   }
   const duration = /Total duration[\s\S]*?class="[^"]*color-fg-default[^"]*"[^>]*>\s*([^<]+)</.exec(
-    html,
+    summary,
   )?.[1];
   const createdAt = trigger[2]!;
   return {
@@ -140,14 +182,36 @@ export function parseActionsRunHTML(
       .replace(/[\s-]+/g, "_"),
     created_at: createdAt,
     updated_at: addDuration(createdAt, duration) ?? createdAt,
-    ...(runAttempt !== undefined && Number.isSafeInteger(runAttempt) && runAttempt > 0
-      ? { run_attempt: runAttempt }
-      : {}),
+    run_attempt: runAttempt,
   };
 }
 
-export function parseCommitPatchSHA(patch: string): string | undefined {
-  return /^From ([0-9A-Fa-f]{40,64})\s/m.exec(patch)?.[1];
+export function parseCommitPatchSHA(patch: string, abbreviation: string): string | undefined {
+  const normalized = patch.replaceAll("\r\n", "\n");
+  const envelope = /^From ([0-9A-Fa-f]{40}) Mon Sep 17 00:00:00 2001\n/.exec(normalized);
+  const sha = envelope?.[1]?.toLowerCase();
+  if (
+    !/^[0-9A-Fa-f]{7,39}$/.test(abbreviation) ||
+    sha === undefined ||
+    !sha.startsWith(abbreviation.toLowerCase()) ||
+    [...normalized.matchAll(/^From /gm)].length !== 1
+  ) {
+    return undefined;
+  }
+  const headerEnd = normalized.indexOf("\n\n");
+  const headers = normalized.slice(envelope![0].length, headerEnd);
+  const subjects = [...headers.matchAll(/^Subject: (.+(?:\n[ \t].+)*)$/gm)];
+  if (
+    headerEnd === -1 ||
+    subjects.length !== 1 ||
+    /\b[0-9]+\/[0-9]+\b/.test(subjects[0]![1]!) ||
+    [...headers.matchAll(/^From: .+$/gm)].length !== 1 ||
+    [...headers.matchAll(/^Date: .+$/gm)].length !== 1 ||
+    !/^diff --git /m.test(normalized.slice(headerEnd + 2))
+  ) {
+    return undefined;
+  }
+  return sha;
 }
 
 export function parseActionsJobGroupsJSON(
@@ -221,22 +285,86 @@ export function parseActionsJobHTML(
   };
 }
 
-function actionsRunCards(html: string): string[] {
-  const starts: number[] = [];
-  for (const match of html.matchAll(/<div\b[^>]*class="([^"]*)"[^>]*>/g)) {
-    if (match.index === undefined) {
+// Match the closing div, not the next card: following regions do not own this run's SHA.
+function actionsDivRegions(
+  html: string,
+  selected: (attributes: string) => boolean,
+): string[] | undefined {
+  const regions: string[] = [];
+  let depth = 0;
+  let start: number | undefined;
+  for (const match of html.matchAll(
+    /<!--[\s\S]*?-->|<script\b[^>]*>[\s\S]*?<\/script\s*>|<\/?div\b[^>]*>/gi,
+  )) {
+    if (!/^<\/?div\b/i.test(match[0])) {
       continue;
     }
-    const classes = new Set(match[1]!.split(/\s+/));
-    if (
-      classes.has("Box-row") &&
-      classes.has("js-socket-channel") &&
-      classes.has("js-updatable-content")
-    ) {
-      starts.push(match.index);
+    if (match[0].startsWith("</")) {
+      if (start !== undefined && --depth === 0) {
+        regions.push(
+          html
+            .slice(start, match.index + match[0].length)
+            .replace(/<!--[\s\S]*?-->|<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, ""),
+        );
+        start = undefined;
+      }
+    } else {
+      if (selected(match[0].slice(4, -1))) {
+        if (start !== undefined) return undefined;
+        start = match.index;
+      }
+      if (start !== undefined) depth++;
     }
   }
-  return starts.map((start, index) => html.slice(start, starts[index + 1] ?? html.length));
+  return start === undefined ? regions : undefined;
+}
+
+function actionsCommitSHA(
+  html: string,
+  owner: string,
+  repo: string,
+): { sha: string | undefined } | undefined {
+  const prefix = `/${owner}/${repo}/commit/`;
+  const shas = new Set<string>();
+  for (const anchor of html.matchAll(/<a\b([^>]*)>/g)) {
+    const href = htmlAttribute(anchor[1]!, "href");
+    if (href !== undefined && /^\/[^/]+\/[^/]+\/commit\//.test(href)) {
+      if (!href.startsWith(prefix)) return undefined;
+      const sha = href.slice(prefix.length);
+      if (!/^[0-9A-Fa-f]{7,40}$/.test(sha)) return undefined;
+      shas.add(sha.toLowerCase());
+    }
+  }
+  return shas.size > 1 ? undefined : { sha: [...shas][0] };
+}
+
+function actionsRunAttempt(html: string, runPath: string): number | undefined {
+  const partials = [
+    ...html.matchAll(/<react-partial\b([^>]*)>([\s\S]*?)<\/react-partial>/g),
+  ].filter((match) => htmlAttribute(match[1]!, "partial-name") === "actions-run-jobs-list");
+  if (partials.length !== 1) return undefined;
+  const scripts = [...partials[0]![2]!.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/g)].filter(
+    (match) => htmlAttribute(match[1]!, "data-target") === "react-partial.embeddedData",
+  );
+  if (scripts.length !== 1) return undefined;
+  try {
+    const data: unknown = JSON.parse(scripts[0]![2]!);
+    if (!isRecord(data) || !isRecord(data.props)) return undefined;
+    const props = data.props;
+    if (
+      props.summaryHref !== runPath ||
+      props.summarySelected !== true ||
+      typeof props.jobGroupsFetchUrl !== "string"
+    )
+      return undefined;
+    const match = new RegExp(
+      `^${escapeRegex(runPath)}/job_groups_batch\\?attempt=([1-9][0-9]*)$`,
+    ).exec(props.jobGroupsFetchUrl);
+    const attempt = Number(match?.[1]);
+    return Number.isSafeInteger(attempt) && attempt > 0 ? attempt : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function collectJobSummaries(

--- a/src/github-public-actions.ts
+++ b/src/github-public-actions.ts
@@ -136,6 +136,7 @@ function actionsRunRequest(
         route.owner!,
         route.repo!,
         Number(id),
+        attempt === undefined ? undefined : Number(attempt),
       );
       const complete =
         parsed === undefined ? undefined : await completeActionsRunSHA(env, route, parsed);
@@ -244,9 +245,19 @@ async function enrichActionsRun(
   );
   const parsed =
     page === undefined ? undefined : parseActionsRunHTML(page, route.owner, route.repo, run.id);
-  return parsed === undefined
-    ? undefined
-    : completeActionsRunSHA(env, route, { ...run, ...parsed });
+  if (parsed === undefined) {
+    return undefined;
+  }
+  const complete = await completeActionsRunSHA(env, route, { ...run, ...parsed });
+  if (
+    complete === undefined ||
+    (typeof run.head_sha === "string" &&
+      (!isFullGitSHA(complete.head_sha) ||
+        !complete.head_sha.toLowerCase().startsWith(run.head_sha.toLowerCase())))
+  ) {
+    return undefined;
+  }
+  return complete;
 }
 
 async function completeActionsRunSHA(
@@ -271,10 +282,10 @@ async function completeActionsRunSHA(
     env,
     "text/plain",
   );
-  const sha = patch === undefined ? undefined : parseCommitPatchSHA(patch);
+  const sha = patch === undefined ? undefined : parseCommitPatchSHA(patch, run.head_sha);
   return sha === undefined ? undefined : { ...run, head_sha: sha };
 }
 
 function isFullGitSHA(value: unknown): value is string {
-  return typeof value === "string" && /^[0-9A-Fa-f]{40,64}$/.test(value);
+  return typeof value === "string" && /^[0-9A-Fa-f]{40}$/.test(value);
 }

--- a/test/actions-cache-generation.test.ts
+++ b/test/actions-cache-generation.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { githubCacheKey } from "../src/cache";
+import { classifyRoute, defaultPolicy, validateRelayRequest } from "../src/policy";
+import { runListSupersetView } from "../src/run-list-superset";
+import { legacyActionsKey } from "./fixtures/actions-legacy-cache";
+
+describe("Actions summary cache generation", () => {
+  it.each([
+    ["actions/runs/33167365292", {}],
+    ["actions/runs/33167365221/attempts/1", {}],
+    ["actions/runs", { limit: "20", branch: "main" }],
+    ["actions/runs", { limit: "100" }],
+    ["actions/workflows/ci.yml/runs", { limit: "20", status: "failure" }],
+  ])("retires legacy %s keys including canonical supersets", async (suffix, query) => {
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: `/repos/openclaw/Peekaboo/${suffix}`,
+      query,
+      headers: { "x-octopool-public-shape": "actions-summary-v1" },
+    });
+    const route = classifyRoute(request, defaultPolicy("openclaw"));
+    for (const candidate of [
+      request,
+      runListSupersetView(request, route)?.cacheRequest ?? request,
+    ]) {
+      for (const identity of [undefined, { kind: "pat" as const, id: "primary" }]) {
+        expect(await githubCacheKey(request.pool, candidate, route, identity)).not.toBe(
+          await legacyActionsKey(candidate, route, identity),
+        );
+      }
+    }
+  });
+
+  it.each([
+    ["actions/runs/33167365292", undefined],
+    ["actions/runs", undefined],
+    ["actions/workflows/ci.yml/runs", undefined],
+    ["actions/runs/33167365292/attempts/1/jobs", "actions-jobs-v1"],
+    ["pulls/651", "pr-summary-v1"],
+  ])("preserves unrelated %s (%s) keys", async (suffix, shape) => {
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: `/repos/openclaw/Peekaboo/${suffix}`,
+      headers: shape === undefined ? {} : { "x-octopool-public-shape": shape },
+    });
+    const route = classifyRoute(request, defaultPolicy("openclaw"));
+    expect(await githubCacheKey(request.pool, request, route)).toBe(
+      await legacyActionsKey(request, route),
+    );
+  });
+});

--- a/test/actions-ownership.test.ts
+++ b/test/actions-ownership.test.ts
@@ -38,7 +38,9 @@ describe("Actions run ownership", () => {
 
   it("ignores unrelated links before and after the owned summary", () => {
     const decoy = `<aside><a href="/openclaw/Peekaboo/commit/${wrongPatchHead}">unrelated</a></aside>`;
-    const html = decoy + runPage(runIDs[0], historicalHead) + decoy;
+    const html = runPage(runIDs[0], historicalHead)
+      .replace("<body>", `<body>${decoy}`)
+      .replace("</body>", `${decoy}</body>`);
     expect(parseActionsRunHTML(html, "openclaw", "Peekaboo", runIDs[0]!)).toMatchObject({
       head_sha: historicalHead,
     });
@@ -86,6 +88,259 @@ describe("Actions run ownership", () => {
       `</relative-time><!-- ${decoy} --><script>${JSON.stringify(decoy)}</script>`,
     );
     expect(parseActionsRunHTML(html, "openclaw", "Peekaboo", runIDs[0]!)).toBeUndefined();
+  });
+
+  const decoyLink = `<a href="/openclaw/Peekaboo/commit/${wrongPatchHead}">wrong</a>`;
+  const malformedMarkup = [
+    ["script end-tag attributes", `<script>const value = '${decoyLink}';</script\t\n bar>`],
+    ["uppercase script end-tag attributes", `<SCRIPT>${decoyLink}</SCRIPT data-extra>`],
+    ["style end-tag attributes", `<style>${decoyLink}</STYLE data-extra>`],
+    ["comment reconstruction", `<scr<!--x-->ipt>const value = '${decoyLink}';</scr<!--x-->ipt>`],
+    ["nested comment reconstruction", `<!-- <!-- -->${decoyLink} -->`],
+    [
+      "duplicate href",
+      `<a href="/openclaw/Peekaboo/commit/${historicalHead}" href="/other/repo/commit/${wrongPatchHead}">ambiguous</a>`,
+    ],
+    ["unclosed raw text", `<script>${decoyLink}`],
+    ["misnested formatting", `<b><i>${decoyLink}</b></i>`],
+  ];
+
+  it.each(malformedMarkup)(
+    "falls back to the historical REST head for %s",
+    async (_name, markup) => {
+      const html = runPage().replace("</relative-time>", `</relative-time>${markup}`);
+      expect(parseActionsRunHTML(html, "openclaw", "Peekaboo", runIDs[0]!)).toBeUndefined();
+      const fetchMock = vi.fn(async (input: string) =>
+        input.startsWith("https://github.com/")
+          ? new Response(html)
+          : Response.json(exactRun(runIDs[0]!)),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      expect(await readRun(runIDs[0]!)).toMatchObject({
+        backend: "github",
+        body: exactRun(runIDs[0]!),
+      });
+      expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+        `https://github.com/openclaw/Peekaboo/actions/runs/${runIDs[0]}`,
+        `https://api.github.com/repos/openclaw/Peekaboo/actions/runs/${runIDs[0]}`,
+      ]);
+    },
+  );
+
+  it.each(malformedMarkup)("rejects malformed list ownership: %s", (_name, markup) => {
+    const card = runCard(runIDs[0]!).replace("</relative-time>", `</relative-time>${markup}`);
+    expect(
+      parseActionsRunListHTML(`<strong>1 workflow run</strong>${card}`, "openclaw", "Peekaboo"),
+    ).toBeUndefined();
+  });
+
+  const inertMarkup = [
+    ["script", `<script>${JSON.stringify(decoyLink)}</script>`],
+    [
+      "script containing fake div boundaries",
+      `<script>const markup = '</div><div>${decoyLink}</div>';</script>`,
+    ],
+    ["mixed-case script", `<ScRiPt>${JSON.stringify(decoyLink)}</sCrIpT>`],
+    ["style", `<style>${decoyLink}</STYLE>`],
+    ["template", `<template>${decoyLink}</template>`],
+    ["comment", `<!-- ${decoyLink} -->`],
+    ["textarea", `<textarea>${decoyLink}</TEXTAREA>`],
+    ["title", `<title>${decoyLink}</TITLE>`],
+    ["iframe", `<iframe>${decoyLink}</IFRAME>`],
+    ["xmp", `<xmp>${decoyLink}</XMP>`],
+    ["noembed", `<noembed>${decoyLink}</NOEMBED>`],
+    ["noframes", `<noframes>${decoyLink}</NOFRAMES>`],
+    ["noscript", `<noscript>${decoyLink}</noscript>`],
+    ["foreign content", `<svg><foreignObject>${decoyLink}</foreignObject></svg>`],
+    ["escaped text", `&lt;a href="/openclaw/Peekaboo/commit/${wrongPatchHead}"&gt;wrong&lt;/a&gt;`],
+  ];
+
+  it.each(inertMarkup)(
+    "ignores fake commit links in %s without losing a safe owned head",
+    (_name, markup) => {
+      for (const head of [undefined, historicalHead]) {
+        const html = runPage(runIDs[0], head).replace(
+          "</relative-time>",
+          `</relative-time>${markup}`,
+        );
+        expect(parseActionsRunHTML(html, "openclaw", "Peekaboo", runIDs[0]!)?.head_sha).toBe(head);
+        const card = runCard(runIDs[0]!, head).replace(
+          "</relative-time>",
+          `</relative-time>${markup}`,
+        );
+        expect(
+          parseActionsRunListHTML(`<strong>1 workflow run</strong>${card}`, "openclaw", "Peekaboo")
+            ?.workflow_runs[0]?.head_sha,
+        ).toBe(head ?? null);
+      }
+    },
+  );
+
+  it("parses uppercase elements and attributes, including embedded job JSON", async () => {
+    const html = runPage(runIDs[0], historicalHead)
+      .replace(
+        /(<\/?)([a-z][a-z-]*)/g,
+        (_match, prefix: string, tag: string) => prefix + tag.toUpperCase(),
+      )
+      .replace(
+        /(class|href|aria-label|data-url|datetime|partial-name|data-target)=/g,
+        (attribute) => attribute.toUpperCase(),
+      );
+    const fetchMock = vi.fn(async () => new Response(html));
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await readRun(runIDs[0]!)).toMatchObject({
+      backend: "web",
+      body: { head_sha: historicalHead },
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("does not decode DOM text or attributes twice", () => {
+    const html = runPage(runIDs[0], historicalHead)
+      .replace(
+        '<span class="markdown-title">fixture</span>',
+        '<span class="markdown-title">&amp;lt;fixture&amp;gt; &amp; &#x1f980;</span>',
+      )
+      .replace("refs/heads/fixture-branch", "refs/heads/feature&amp;amp;branch");
+    expect(parseActionsRunHTML(html, "openclaw", "Peekaboo", runIDs[0]!)).toMatchObject({
+      display_title: "&lt;fixture&gt; & 🦀",
+      head_branch: "feature&amp;branch",
+    });
+  });
+
+  it("accepts document mode and a bare fragment, but rejects a missing document doctype", () => {
+    const html = runPage(runIDs[0], historicalHead);
+    const fragment = html.slice(html.indexOf("<page-header>"), html.indexOf("</body>"));
+    expect(parseActionsRunHTML(html, "openclaw", "Peekaboo", runIDs[0]!)?.head_sha).toBe(
+      historicalHead,
+    );
+    expect(parseActionsRunHTML(fragment, "openclaw", "Peekaboo", runIDs[0]!)?.head_sha).toBe(
+      historicalHead,
+    );
+    expect(
+      parseActionsRunHTML(html.replace("<!DOCTYPE html>", ""), "openclaw", "Peekaboo", runIDs[0]!),
+    ).toBeUndefined();
+  });
+
+  it("ignores fake list cards and totals inside inert DOM content", () => {
+    for (const tag of ["script", "style", "template", "textarea"]) {
+      const decoy = `<${tag}><strong>0 workflow runs</strong>${runCard(runIDs[1]!, wrongPatchHead)}</${tag}>`;
+      expect(parseActionsRunListHTML(decoy, "openclaw", "Peekaboo")).toBeUndefined();
+      expect(
+        parseActionsRunListHTML(
+          `${decoy}<strong>1 workflow run</strong>${runCard(runIDs[0]!, historicalHead)}`,
+          "openclaw",
+          "Peekaboo",
+        )?.workflow_runs,
+      ).toMatchObject([{ id: runIDs[0], head_sha: historicalHead }]);
+    }
+  });
+
+  it("parses uppercase list elements and attributes", () => {
+    const html = `<strong>1 workflow run</strong>${runCard(runIDs[0]!, historicalHead)}`
+      .replace(
+        /(<\/?)([a-z][a-z-]*)/g,
+        (_match, prefix: string, tag: string) => prefix + tag.toUpperCase(),
+      )
+      .replace(/(class|href|aria-label|datetime)=/g, (attribute) => attribute.toUpperCase());
+    expect(parseActionsRunListHTML(html, "openclaw", "Peekaboo")?.workflow_runs).toMatchObject([
+      { id: runIDs[0], head_sha: historicalHead },
+    ]);
+  });
+
+  it("rejects unusual ancestor names around otherwise complete ownership regions", () => {
+    const html = runPage(runIDs[0], historicalHead)
+      .replace("<body>", "<body><scr<!--x-->ipt>")
+      .replace("</body>", "</scr<!--x-->ipt></body>");
+    expect(parseActionsRunHTML(html, "openclaw", "Peekaboo", runIDs[0]!)).toBeUndefined();
+  });
+
+  it("rejects duplicate commit links even when their SHAs agree", () => {
+    for (const page of [runPage(runIDs[0], historicalHead), runCard(runIDs[0]!, historicalHead)]) {
+      const html = page.replace(
+        `</relative-time>`,
+        `</relative-time><a href="/openclaw/Peekaboo/commit/${historicalHead}">duplicate</a>`,
+      );
+      expect(parseActionsRunHTML(html, "openclaw", "Peekaboo", runIDs[0]!)).toBeUndefined();
+      expect(parseActionsRunListHTML(html, "openclaw", "Peekaboo")).toBeUndefined();
+    }
+  });
+
+  it.each(["script", "style", "template", "textarea"])(
+    "does not take a page header or job navigation from %s",
+    (tag) => {
+      for (const region of [
+        /<page-header>[\s\S]*?<\/page-header>/,
+        /<react-partial[\s\S]*?<\/react-partial>/,
+      ]) {
+        const html = runPage(runIDs[0], historicalHead).replace(
+          region,
+          (markup) => `<${tag}>${markup}</${tag}>`,
+        );
+        expect(parseActionsRunHTML(html, "openclaw", "Peekaboo", runIDs[0]!)).toBeUndefined();
+      }
+    },
+  );
+
+  it.each([
+    [
+      "duplicate summary attribute",
+      (html: string) =>
+        html.replace(
+          "data-url=",
+          'DATA-URL="/other/repo/actions/runs/1/summary_partial" data-url=',
+        ),
+    ],
+    ["unclosed summary", (html: string) => html.replace("</div>\n  </body>", "\n  </body>")],
+    [
+      "nested summary",
+      (html: string) =>
+        html.replace(
+          "<div><span>Triggered",
+          '<div aria-label="Workflow run summary"><span>Triggered',
+        ),
+    ],
+    [
+      "duplicate navigation",
+      (html: string) => html.replace(/(<react-partial[\s\S]*?<\/react-partial>)/, "$1$1"),
+    ],
+    [
+      "duplicate embedded JSON",
+      (html: string) => html.replace(/(<script[\s\S]*?<\/script>)/, "$1$1"),
+    ],
+    [
+      "duplicate page header",
+      (html: string) => html.replace(/(<page-header>[\s\S]*?<\/page-header>)/, "$1$1"),
+    ],
+    [
+      "foreign commit identity",
+      (html: string) =>
+        html.replace(`/Peekaboo/commit/${historicalHead}`, `/other/commit/${historicalHead}`),
+    ],
+  ])("rejects ambiguous DOM ownership: %s", (_name, transform) => {
+    expect(
+      parseActionsRunHTML(
+        transform(runPage(runIDs[0], historicalHead)),
+        "openclaw",
+        "Peekaboo",
+        runIDs[0]!,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("rejects nested list cards and unlabeled conflicting run links", () => {
+    for (const markup of [
+      runCard(runIDs[1]!, wrongPatchHead),
+      `<a href="/other/repo/actions/runs/1">wrong run</a>`,
+    ]) {
+      const card = runCard(runIDs[0]!, historicalHead).replace(
+        "</relative-time>",
+        `</relative-time>${markup}`,
+      );
+      expect(
+        parseActionsRunListHTML(`<strong>1 workflow run</strong>${card}`, "openclaw", "Peekaboo"),
+      ).toBeUndefined();
+    }
   });
 
   it.each([

--- a/test/actions-ownership.test.ts
+++ b/test/actions-ownership.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  parseActionsRunHTML,
+  parseActionsRunListHTML,
+  parseCommitPatchSHA,
+} from "../src/github-html-actions";
+import { callGitHubWeb } from "../src/github-web";
+import { classifyRoute, defaultPolicy, validateRelayRequest } from "../src/policy";
+import {
+  exactRun,
+  historicalHead,
+  mergePatch,
+  runCard,
+  runIDs,
+  runPage,
+  singlePatch,
+  wrongPatchHead,
+} from "./fixtures/actions-ownership";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("Actions run ownership", () => {
+  it.each(runIDs)("uses historical REST ownership for saved run %i", async (id) => {
+    const fetched: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string) => {
+        fetched.push(input);
+        if (input.endsWith(".patch")) return new Response(mergePatch);
+        if (input.startsWith("https://github.com/")) return new Response(runPage(id));
+        return Response.json(exactRun(id));
+      }),
+    );
+    const response = await readRun(id);
+    expect(response).toMatchObject({ backend: "github", body: exactRun(id) });
+    expect(fetched).toContain(`https://api.github.com/repos/openclaw/Peekaboo/actions/runs/${id}`);
+  });
+
+  it("ignores unrelated links before and after the owned summary", () => {
+    const decoy = `<aside><a href="/openclaw/Peekaboo/commit/${wrongPatchHead}">unrelated</a></aside>`;
+    const html = decoy + runPage(runIDs[0], historicalHead) + decoy;
+    expect(parseActionsRunHTML(html, "openclaw", "Peekaboo", runIDs[0]!)).toMatchObject({
+      head_sha: historicalHead,
+    });
+  });
+
+  it.each(runIDs)(
+    "rejects the real merge patch even with an owned abbreviated link for %i",
+    async (id) => {
+      const fetched: string[] = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: string) => {
+          fetched.push(input);
+          if (input.endsWith(".patch")) return new Response(mergePatch);
+          if (input.startsWith("https://github.com/")) return new Response(runPage(id, "224a80e"));
+          return Response.json(exactRun(id));
+        }),
+      );
+      expect(await readRun(id)).toMatchObject({ backend: "github", body: exactRun(id) });
+      expect(fetched).toEqual([
+        `https://github.com/openclaw/Peekaboo/actions/runs/${id}`,
+        "https://github.com/openclaw/Peekaboo/commit/224a80e.patch",
+        `https://api.github.com/repos/openclaw/Peekaboo/actions/runs/${id}`,
+      ]);
+    },
+  );
+
+  it("keeps safe single-commit expansion token-free", async () => {
+    const fetchMock = vi.fn(
+      async (input: string) =>
+        new Response(input.endsWith(".patch") ? singlePatch() : runPage(runIDs[0], "224a80e")),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await readRun(runIDs[0]!)).toMatchObject({
+      backend: "web",
+      body: { head_sha: historicalHead },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not treat comments or script strings as summary commit links", () => {
+    const decoy = `<a href="/openclaw/Peekaboo/commit/${wrongPatchHead}">wrong</a>`;
+    const html = runPage().replace(
+      "</relative-time>",
+      `</relative-time><!-- ${decoy} --><script>${JSON.stringify(decoy)}</script>`,
+    );
+    expect(parseActionsRunHTML(html, "openclaw", "Peekaboo", runIDs[0]!)).toBeUndefined();
+  });
+
+  it.each([
+    ["wrong run", runPage(runIDs[1], historicalHead)],
+    [
+      "wrong repo",
+      runPage(runIDs[0], historicalHead).replaceAll("openclaw/Peekaboo", "other/Peekaboo"),
+    ],
+    [
+      "missing identity",
+      runPage(runIDs[0], historicalHead).replace(/<react-partial[\s\S]*?<\/react-partial>/, ""),
+    ],
+    [
+      "conflicting identity",
+      runPage(runIDs[0], historicalHead)
+        .replace(`job_groups_batch?attempt=1`, `job_groups_batch?attempt=2`)
+        .replace(
+          `"summaryHref":"/openclaw/Peekaboo/actions/runs/${runIDs[0]}"`,
+          `"summaryHref":"/openclaw/Peekaboo/actions/runs/${runIDs[1]}"`,
+        ),
+    ],
+    ["ambiguous summary", runPage(runIDs[0], historicalHead) + runPage(runIDs[0], wrongPatchHead)],
+    ["missing owned head", runPage()],
+    [
+      "conflicting heads",
+      runPage(runIDs[0], historicalHead).replace(
+        "</relative-time>",
+        `</relative-time><a href="/openclaw/Peekaboo/commit/${wrongPatchHead}">wrong</a>`,
+      ),
+    ],
+    ["invalid head length", runPage(runIDs[0], "a".repeat(41))],
+    [
+      "wrong summary identity",
+      runPage(runIDs[0], historicalHead).replace(
+        `${runIDs[0]}/summary_partial`,
+        `${runIDs[1]}/summary_partial`,
+      ),
+    ],
+    [
+      "invalid embedded JSON",
+      runPage(runIDs[0], historicalHead).replace('{"props":', '{"props":invalid'),
+    ],
+    [
+      "wrong job navigation identity",
+      runPage(runIDs[0], historicalHead).replace(
+        `${runIDs[0]}/job_groups_batch`,
+        `${runIDs[1]}/job_groups_batch`,
+      ),
+    ],
+    ["zero attempt", runPage(runIDs[0], historicalHead, 0)],
+  ])("refuses %s", (_name, html) => {
+    expect(parseActionsRunHTML(html, "openclaw", "Peekaboo", runIDs[0]!)).toBeUndefined();
+  });
+
+  it("refuses a different attempt and accepts the owned attempt", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string) =>
+        input.startsWith("https://github.com/")
+          ? new Response(runPage(runIDs[0], historicalHead, 2))
+          : Response.json(exactRun(runIDs[0]!)),
+      ),
+    );
+    expect(await readRun(runIDs[0]!, 1)).toMatchObject({ backend: "github" });
+    expect(await readRun(runIDs[0]!, 2)).toMatchObject({
+      backend: "web",
+      body: { run_attempt: 2, head_sha: historicalHead },
+    });
+  });
+
+  it("does not borrow a following region's SHA for a list card", () => {
+    const html = `<strong>2 workflow runs</strong>${runCard(runIDs[0]!)}<aside><a href="/openclaw/Peekaboo/commit/${wrongPatchHead}">wrong</a></aside>${runCard(runIDs[1]!, historicalHead)}`;
+    expect(
+      parseActionsRunListHTML(html, "openclaw", "Peekaboo")?.workflow_runs.map(
+        (run) => run.head_sha,
+      ),
+    ).toEqual([null, historicalHead]);
+  });
+
+  it.each([
+    [
+      "last card's neighbor",
+      `${runCard(runIDs[0]!)}<aside><a href="/openclaw/Peekaboo/commit/${wrongPatchHead}">wrong</a></aside>`,
+      [null],
+    ],
+    [
+      "conflicting card heads",
+      runCard(runIDs[0]!, historicalHead).replace(
+        "</relative-time>",
+        `</relative-time><a href="/openclaw/Peekaboo/commit/${wrongPatchHead}">wrong</a>`,
+      ),
+      undefined,
+    ],
+    ["unclosed card", runCard(runIDs[0]!, historicalHead).replace(/<\/div>\s*$/, ""), undefined],
+    ["duplicate run", runCard(runIDs[0]!, historicalHead).repeat(2), undefined],
+    [
+      "conflicting repository identity",
+      runCard(runIDs[0]!, historicalHead).replace(
+        "</relative-time>",
+        '</relative-time><a href="/other/repo/actions/runs/1" aria-label="failed: ">other run</a>',
+      ),
+      undefined,
+    ],
+  ])("refuses borrowed or ambiguous list ownership: %s", (_name, cards, expected) => {
+    expect(
+      parseActionsRunListHTML(
+        `<strong>1 workflow run</strong>${cards}`,
+        "openclaw",
+        "Peekaboo",
+      )?.workflow_runs.map((run) => run.head_sha),
+    ).toEqual(expected);
+  });
+
+  it("rejects a list abbreviation conflicting with its owned run page", async () => {
+    const exact = { total_count: 1, workflow_runs: [exactRun(runIDs[0]!)] };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string) => {
+        if (input.startsWith("https://api.github.com/")) return Response.json(exact);
+        return new Response(
+          input.endsWith("/actions")
+            ? `<strong>1 workflow run</strong>${runCard(runIDs[0]!, "f46c055")}`
+            : runPage(runIDs[0], historicalHead),
+        );
+      }),
+    );
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/Peekaboo/actions/runs",
+      headers: { "x-octopool-public-shape": "actions-summary-v1" },
+    });
+    expect(
+      await callGitHubWeb({} as Env, request, classifyRoute(request, defaultPolicy("openclaw"))),
+    ).toMatchObject({ backend: "github", body: exact });
+  });
+
+  it.each(["actions/runs", "actions/workflows/ci.yml/runs"])(
+    "falls back for unsafe %s enrichment",
+    async (suffix) => {
+      const exact = { total_count: 2, workflow_runs: runIDs.map(exactRun) };
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: string) => {
+          if (input.startsWith("https://api.github.com/")) return Response.json(exact);
+          if (input.endsWith(".patch")) return new Response(mergePatch);
+          const id = /\/actions\/runs\/([0-9]+)$/.exec(input)?.[1];
+          return new Response(
+            id
+              ? runPage(Number(id), "224a80e")
+              : `<strong>2 workflow runs</strong>${runIDs.map((id) => runCard(id)).join("")}`,
+          );
+        }),
+      );
+      const request = validateRelayRequest({
+        pool: "maintainers",
+        method: "GET",
+        path: `/repos/openclaw/Peekaboo/${suffix}`,
+        headers: { "x-octopool-public-shape": "actions-summary-v1" },
+      });
+      expect(
+        await callGitHubWeb({} as Env, request, classifyRoute(request, defaultPolicy("openclaw"))),
+      ).toMatchObject({ backend: "github", body: exact });
+    },
+  );
+});
+
+describe("commit patch ownership", () => {
+  it("expands a single matching commit", () => {
+    expect(parseCommitPatchSHA(singlePatch(), "224a80e")).toBe(historicalHead);
+  });
+  it.each([
+    ["real merge series", mergePatch],
+    ["matching first of multiple commits", singlePatch() + singlePatch(wrongPatchHead)],
+    ["mismatching commit", singlePatch(wrongPatchHead)],
+    ["invalid length", singlePatch("a".repeat(41))],
+    ["64-character GitHub SHA", singlePatch("a".repeat(64))],
+    ["duplicate author", singlePatch().replace("Date:", "From: Other <other@example.com>\nDate:")],
+    ["duplicate subject", singlePatch().replace("Subject:", "Subject: ambiguity\nSubject:")],
+    ["missing envelope", `Subject: [PATCH] fixture\n${historicalHead}`],
+    ["incomplete headers", `From ${historicalHead} Mon Sep 17 00:00:00 2001\n`],
+    ["partial series", singlePatch().replace("[PATCH]", "[PATCH 1/3]")],
+  ])("rejects %s", (_name, patch) => {
+    expect(parseCommitPatchSHA(patch, "224a80e")).toBeUndefined();
+  });
+  it.each(["", "224a80", historicalHead, "a".repeat(41), "a".repeat(64), "224a80g"])(
+    "rejects invalid abbreviation %s",
+    (abbreviation) => {
+      expect(parseCommitPatchSHA(singlePatch(), abbreviation)).toBeUndefined();
+    },
+  );
+});
+
+async function readRun(id: number, attempt?: number) {
+  const request = validateRelayRequest({
+    pool: "maintainers",
+    method: "GET",
+    path: `/repos/openclaw/Peekaboo/actions/runs/${id}${attempt === undefined ? "" : `/attempts/${attempt}`}`,
+    headers: { "x-octopool-public-shape": "actions-summary-v1" },
+  });
+  return callGitHubWeb({} as Env, request, classifyRoute(request, defaultPolicy("openclaw")));
+}

--- a/test/actions-ownership.test.ts
+++ b/test/actions-ownership.test.ts
@@ -306,7 +306,11 @@ describe("Actions run ownership", () => {
     ],
     [
       "duplicate embedded JSON",
-      (html: string) => html.replace(/(<script[\s\S]*?<\/script>)/, "$1$1"),
+      (html: string) =>
+        html.replace(
+          "</script>",
+          '</script><script data-target="react-partial.embeddedData">{}</script>',
+        ),
     ],
     [
       "duplicate page header",

--- a/test/e2e/actions-ownership-cache.test.ts
+++ b/test/e2e/actions-ownership-cache.test.ts
@@ -1,0 +1,178 @@
+import { env } from "cloudflare:workers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { githubCacheKey, writeGitHubCache } from "../../src/cache";
+import { deleteEdgeJSON } from "../../src/edge-cache";
+import { classifyRoute, defaultPolicy, validateRelayRequest } from "../../src/policy";
+import { recordPublicGitHubRepo } from "../../src/public-repos";
+import { runListSupersetView } from "../../src/run-list-superset";
+import { legacyActionsKey } from "../fixtures/actions-legacy-cache";
+import { exactRun, historicalHead, runIDs, wrongPatchHead } from "../fixtures/actions-ownership";
+import { jsonResponse, rateHeaders, relay, seedPool } from "./harness";
+
+const headers = { "x-octopool-public-shape": "actions-summary-v1" };
+const path = `/repos/openclaw/Peekaboo/actions/runs/${runIDs[0]}`;
+type Envelope = { body: unknown; relay: { cache: string; coalesced?: boolean } };
+
+describe("Actions ownership cache migration", () => {
+  beforeEach(seedPool);
+
+  it.each([
+    [path, "edge"],
+    [path, "shared"],
+    [`${path}/attempts/1`, "edge"],
+    ["/repos/openclaw/Peekaboo/actions/runs", "shared"],
+    ["/repos/openclaw/Peekaboo/actions/workflows/ci.yml/runs", "edge"],
+  ])("ignores contaminated fresh %s in %s", async (routePath, layer) => {
+    const { request, oldKey, body } = await seedLegacy(routePath);
+    if (layer === "shared") await deleteEdgeJSON("github-v1", oldKey);
+    const upstream = mockUpstream(body);
+    const first = await relay(routePath, undefined, request);
+    expect(first.status).toBe(200);
+    expect(await first.json<Envelope>()).toMatchObject({ body, relay: { cache: "miss" } });
+    const second = await relay(routePath, undefined, request);
+    expect(await second.json<Envelope>()).toMatchObject({ body, relay: { cache: "hit" } });
+    expect(
+      upstream.mock.calls.some(([input]) => String(input).startsWith("https://api.github.com/")),
+    ).toBe(true);
+    expect(
+      await env.DB.prepare("SELECT body_json FROM github_cache_entries WHERE cache_key = ?")
+        .bind(oldKey)
+        .first(),
+    ).toMatchObject({ body_json: expect.stringContaining(wrongPatchHead) });
+  });
+
+  it("never serves a contaminated legacy stale entry during an outage", async () => {
+    const { request, oldKey } = await seedLegacy(path);
+    await expire(oldKey);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => outageResponse(new Request(input, init))),
+    );
+    const response = await relay(path, undefined, request);
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(await response.text()).not.toContain(wrongPatchHead);
+  });
+
+  it("coalesces a clean fill, revalidates only its new key, and serves only clean stale data", async () => {
+    const { request, oldKey, body, route } = await seedLegacy(path);
+    await expire(oldKey);
+    let release!: () => void;
+    let started!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const entered = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    const conditionals: (string | null)[] = [];
+    let phase: "fill" | "revalidate" | "outage" = "fill";
+    let apiCalls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        const upstream = new Request(input, init);
+        if (phase === "outage") return outageResponse(upstream);
+        if (new URL(upstream.url).hostname === "github.com")
+          return new Response("no page", { status: 404 });
+        apiCalls++;
+        conditionals.push(upstream.headers.get("if-none-match"));
+        if (phase === "fill") {
+          started();
+          await gate;
+        }
+        if (upstream.headers.has("if-none-match"))
+          return new Response(null, {
+            status: 304,
+            headers: { ...rateHeaders({ remaining: 59 }), etag: '"clean"' },
+          });
+        return jsonResponse(body, 200, { ...rateHeaders({ remaining: 59 }), etag: '"clean"' });
+      }),
+    );
+    const leader = relay(path, undefined, request);
+    await entered;
+    const follower = relay(path, undefined, request);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    release();
+    const filled = await Promise.all(
+      [leader, follower].map(async (response) => (await response).json<Envelope>()),
+    );
+    expect(filled.map((item) => item.body)).toEqual([body, body]);
+    expect(filled[1]?.relay.coalesced).toBe(true);
+    expect(apiCalls).toBe(1);
+    expect(conditionals).toEqual([null]);
+
+    const newKey = await githubCacheKey(request.pool, request, route);
+    expect(newKey).not.toBe(oldKey);
+    await expire(newKey);
+    phase = "revalidate";
+    expect(await (await relay(path, undefined, request)).json<Envelope>()).toMatchObject({
+      body,
+      relay: { cache: "hit" },
+    });
+    expect(conditionals).toEqual([null, '"clean"']);
+    await expire(newKey);
+    phase = "outage";
+    expect(await (await relay(path, undefined, request)).json<Envelope>()).toMatchObject({
+      body,
+      relay: { cache: "stale" },
+    });
+  });
+});
+
+async function seedLegacy(routePath: string) {
+  const list = routePath.endsWith("/runs");
+  const request = validateRelayRequest({
+    pool: "maintainers",
+    method: "GET",
+    path: routePath,
+    headers,
+    ...(list ? { query: { limit: "1" } } : {}),
+  });
+  const route = classifyRoute(request, defaultPolicy("openclaw"));
+  const cacheRequest = runListSupersetView(request, route)?.cacheRequest ?? request;
+  const oldKey = await legacyActionsKey(cacheRequest, route);
+  const run = exactRun(runIDs[0]!);
+  const badRun = { ...run, head_sha: wrongPatchHead };
+  const body = list ? { total_count: 1, workflow_runs: [run] } : run;
+  await recordPublicGitHubRepo(env, route);
+  await writeGitHubCache(env, oldKey, cacheRequest, route, {
+    status: 200,
+    headers: { ...rateHeaders({ remaining: 59 }), etag: '"contaminated"' },
+    body: list ? { total_count: 1, workflow_runs: [badRun] } : badRun,
+    body_encoding: "json",
+  });
+  expect(JSON.stringify(body)).toContain(historicalHead);
+  return { request, oldKey, body, route };
+}
+
+async function expire(key: string) {
+  await env.DB.prepare(
+    "UPDATE github_cache_entries SET expires_at = datetime('now', '-1 second'), stale_expires_at = datetime('now', '+1 hour') WHERE cache_key = ?",
+  )
+    .bind(key)
+    .run();
+  await deleteEdgeJSON("github-v1", key);
+}
+
+function mockUpstream(body: unknown) {
+  const upstream = vi.fn<typeof fetch>(async (input, init) => {
+    const request = new Request(input, init);
+    expect(request.headers.get("if-none-match")).toBeNull();
+    return new URL(request.url).hostname === "github.com"
+      ? new Response("no page", { status: 404 })
+      : jsonResponse(body);
+  });
+  vi.stubGlobal("fetch", upstream);
+  return upstream;
+}
+
+function outageResponse(request: Request): Response {
+  if (new URL(request.url).pathname.toLowerCase() === "/repos/openclaw/peekaboo") {
+    return jsonResponse({ private: false });
+  }
+  return jsonResponse(
+    { message: "rate limited" },
+    429,
+    rateHeaders({ remaining: 0, retryAfter: 60 }),
+  );
+}

--- a/test/e2e/cache-revalidation.test.ts
+++ b/test/e2e/cache-revalidation.test.ts
@@ -357,10 +357,16 @@ describe("Worker end-to-end cache revalidation", () => {
       revalidationStarted = resolve;
     });
     let conditionalCalls = 0;
+    let publicRepoChecks = 0;
     vi.stubGlobal(
       "fetch",
       vi.fn<typeof fetch>(async (input, init) => {
         const request = new Request(input, init);
+        if (request.url === "https://api.github.com/repos/openclaw/octopool") {
+          publicRepoChecks++;
+          return jsonResponse({ private: false });
+        }
+        expect(request.url).toBe(`https://api.github.com${RUN_PATH}`);
         if (request.headers.get("if-none-match") === '"run-v1"') {
           conditionalCalls++;
           revalidationStarted();
@@ -373,6 +379,16 @@ describe("Worker end-to-end cache revalidation", () => {
 
     await relay(RUN_PATH);
     await expireCacheEntry("run_view");
+    // Cover the original entry, but require the follower to refresh proof for the new timestamp.
+    await env.DB.prepare(
+      `UPDATE github_public_repos
+       SET checked_at = datetime(
+         (SELECT created_at FROM github_cache_entries WHERE route_kind = 'run_view' LIMIT 1),
+         '-5 seconds'
+       )
+       WHERE owner = 'openclaw' AND repo = 'octopool'`,
+    ).run();
+    await deleteEdgeJSON("public-repo-v1", "openclaw/octopool");
     const leader = relay(RUN_PATH);
     await started;
     const follower = relay(RUN_PATH);
@@ -399,6 +415,7 @@ describe("Worker end-to-end cache revalidation", () => {
     ]);
     expect(conditionalCallsBeforePublish).toBe(1);
     expect(conditionalCalls).toBe(1);
+    expect(publicRepoChecks).toBe(1);
     expect(
       await env.DB.prepare(
         "SELECT COUNT(*) AS count FROM audit_events WHERE fallback_reason = 'cache_revalidated'",

--- a/test/fixtures/actions-legacy-cache.ts
+++ b/test/fixtures/actions-legacy-cache.ts
@@ -1,0 +1,31 @@
+import { hashToken } from "../../src/auth";
+import type { RelayRequest, RouteInfo } from "../../src/types";
+
+// Freeze the pre-fix key layout independently of the production key generator.
+export function legacyActionsKey(
+  request: RelayRequest,
+  route: RouteInfo,
+  identity?: { kind: string; id: string },
+) {
+  return hashToken(
+    JSON.stringify({
+      pool: request.pool,
+      method: request.method,
+      path: request.path,
+      query: Object.fromEntries(
+        Object.entries(request.query ?? {})
+          .filter(
+            ([key, value]) =>
+              !(key === "page" && value === "1") && !(key === "per_page" && value === "30"),
+          )
+          .sort(([a], [b]) => a.localeCompare(b)),
+      ),
+      headers:
+        request.headers?.["x-octopool-public-shape"] === undefined
+          ? {}
+          : { "x-octopool-public-shape": request.headers["x-octopool-public-shape"] },
+      route_key: route.routeKey,
+      ...(identity === undefined ? {} : { identity: `${identity.kind}:${identity.id}` }),
+    }),
+  );
+}

--- a/test/fixtures/actions-ownership.ts
+++ b/test/fixtures/actions-ownership.ts
@@ -6,7 +6,7 @@ export const runIDs = [33167365292, 33167365221];
 // Sanitized structure from the two saved run pages. Neither summary contains a commit link.
 export function runPage(id = runIDs[0]!, sha?: string, attempt = 1): string {
   const path = `/openclaw/Peekaboo/actions/runs/${id}`;
-  return `<html><head><title>fixture · openclaw/Peekaboo@224a80e · GitHub</title></head><body>
+  return `<!DOCTYPE html><html><head><title>fixture · openclaw/Peekaboo@224a80e · GitHub</title></head><body>
     <page-header>
       <span class="PageHeader-parentLink-label">${id === runIDs[0] ? "CI" : "CodeQL"}</span>
       <span class="actions-workflow-runs-status"><svg aria-label="failed: "></svg></span>

--- a/test/fixtures/actions-ownership.ts
+++ b/test/fixtures/actions-ownership.ts
@@ -1,0 +1,73 @@
+export const historicalHead = "224a80eeebec678db6646ef888f5bbc89caf63c4";
+export const wrongPatchHead = "f46c055901c4fbc034cc89120cca36c87075b6bd";
+export const movingPRHead = "9999999999999999999999999999999999999999";
+export const runIDs = [33167365292, 33167365221];
+
+// Sanitized structure from the two saved run pages. Neither summary contains a commit link.
+export function runPage(id = runIDs[0]!, sha?: string, attempt = 1): string {
+  const path = `/openclaw/Peekaboo/actions/runs/${id}`;
+  return `<html><head><title>fixture · openclaw/Peekaboo@224a80e · GitHub</title></head><body>
+    <page-header>
+      <span class="PageHeader-parentLink-label">${id === runIDs[0] ? "CI" : "CodeQL"}</span>
+      <span class="actions-workflow-runs-status"><svg aria-label="failed: "></svg></span>
+      <h1 class="PageHeader-title"><span class="markdown-title">fixture</span><span>#651</span></h1>
+    </page-header>
+    <react-partial partial-name="actions-run-jobs-list">
+      <script type="application/json" data-target="react-partial.embeddedData">${JSON.stringify({
+        props: {
+          summaryHref: path,
+          summarySelected: true,
+          jobGroupsFetchUrl: `${path}/job_groups_batch?attempt=${attempt}`,
+        },
+      })}</script>
+    </react-partial>
+    <div role="region" aria-label="Workflow run summary" data-url="${path}/summary_partial">
+      <div><span>Triggered via pull request <relative-time datetime="2026-08-28T11:29:48Z"></relative-time></span>
+      <a class="branch-name" href="/openclaw/Peekaboo/tree/refs/heads/fixture-branch">fixture-branch</a>
+      ${sha === undefined ? "" : `<a href="/openclaw/Peekaboo/commit/${sha}">${sha}</a>`}
+      <span>Total duration</span><a class="h4 color-fg-default">29m 23s</a></div>
+    </div>
+  </body></html>`;
+}
+
+export function exactRun(id: number) {
+  return {
+    id,
+    head_sha: historicalHead,
+    head_branch: "fixture-branch",
+    event: "pull_request",
+    name: id === runIDs[0] ? "CI" : "CodeQL",
+    status: "completed",
+    conclusion: "failure",
+    run_attempt: 1,
+    html_url: `https://github.com/openclaw/Peekaboo/actions/runs/${id}`,
+    pull_requests: [{ number: 651, head: { sha: movingPRHead } }],
+  };
+}
+
+export function singlePatch(sha = historicalHead): string {
+  return `From ${sha} Mon Sep 17 00:00:00 2001\nFrom: Fixture <fixture@example.com>\nDate: Fri, 28 Aug 2026 11:29:48 +0000\nSubject: [PATCH] fixture\n\ndiff --git a/example b/example\n--- a/example\n+++ b/example\n@@ -1 +1 @@\n-old\n+new\n`;
+}
+
+// Exact envelope SHAs and subjects from /commit/224a80e.patch; no scraped bodies.
+export const mergePatch = [
+  [wrongPatchHead, "fix(cli): honor verify unknown exit status (#649)"],
+  ["415610c7a236a7e9c86aa4b89703720e49fdb100", "fix(cli): keep learn on injected runtime (#653)"],
+  [
+    "cb25788d6b4599e1bf1e59d7c79ffa3f9ad1828b",
+    "fix(bridge): preserve exact-window focus proof (#656)",
+  ],
+]
+  .map(([sha, subject], index) =>
+    singlePatch(sha).replace("[PATCH] fixture", `[PATCH ${index + 1}/3] ${subject}`),
+  )
+  .join("\n");
+
+export function runCard(id: number, sha?: string): string {
+  return `<div class="Box-row js-socket-channel js-updatable-content">
+    <a href="/openclaw/Peekaboo/actions/runs/${id}" aria-label="failed: Run 651 of CI. fixture"><span class="h4 markdown-title">fixture</span></a>
+    <div><span class="text-bold">CI</span> #651: pull request
+    <relative-time datetime="2026-08-28T11:29:48Z"></relative-time>
+    ${sha === undefined ? "" : `<a href="/openclaw/Peekaboo/commit/${sha}">${sha}</a>`}</div>
+  </div>`;
+}

--- a/test/github-web.test.ts
+++ b/test/github-web.test.ts
@@ -359,16 +359,24 @@ describe("github web provider", () => {
       .mockResolvedValueOnce(
         new Response(`
           <meta name="twitter:title" content="workflow-filtered &#183; openclaw/octopool@ef53e13">
+          <page-header>
           <span class="PageHeader-parentLink-label"> CI</span>
           <span class="actions-workflow-runs-status"><svg aria-label="completed successfully: "></svg></span>
           <h1 class="PageHeader-title"><span class="markdown-title">workflow-filtered</span><span>#65</span></h1>
+          </page-header>
+          <react-partial partial-name="actions-run-jobs-list"><script data-target="react-partial.embeddedData">{"props":{"summaryHref":"/openclaw/octopool/actions/runs/26906919053","summarySelected":true,"jobGroupsFetchUrl":"/openclaw/octopool/actions/runs/26906919053/job_groups_batch?attempt=1"}}</script></react-partial>
+          <div aria-label="Workflow run summary" data-url="/openclaw/octopool/actions/runs/26906919053/summary_partial">
           <span>Triggered via pull request <relative-time datetime="2026-06-03T18:14:57Z"></relative-time></span>
           <a class="branch-name" title="RomneyDa:fix/login-provisioning-guidance" href="/RomneyDa/octopool/tree/refs/heads/fix/login-provisioning-guidance">fix/login-provisioning-guidance</a>
           <span>Total duration</span><a class="h4 color-fg-default">19s</a>
+          <a href="/openclaw/octopool/commit/ef53e13">ef53e13</a>
+          </div>
         `),
       )
       .mockResolvedValueOnce(
-        new Response("From ef53e13233adb1af0730f8239d87149d60cb42ac Mon Sep 17 00:00:00 2001\n"),
+        new Response(
+          "From ef53e13233adb1af0730f8239d87149d60cb42ac Mon Sep 17 00:00:00 2001\nFrom: Fixture <fixture@example.com>\nDate: Wed, 3 Jun 2026 18:14:57 +0000\nSubject: [PATCH] fixture\n\ndiff --git a/example b/example\n",
+        ),
       );
     vi.stubGlobal("fetch", fetchMock);
     const request = validateRelayRequest({
@@ -525,14 +533,18 @@ describe("github web provider", () => {
       "fetch",
       vi.fn().mockResolvedValueOnce(
         new Response(`
+            <page-header>
             <span class="PageHeader-parentLink-label"> CI</span>
             <span class="actions-workflow-runs-status"><svg aria-label="completed successfully: "></svg></span>
             <h1 class="PageHeader-title"><span class="markdown-title">fix: harden setup</span><span>#79</span></h1>
+            </page-header>
+            <react-partial partial-name="actions-run-jobs-list"><script data-target="react-partial.embeddedData">{"props":{"summaryHref":"/openclaw/octopool/actions/runs/27328786454","summarySelected":true,"jobGroupsFetchUrl":"/openclaw/octopool/actions/runs/27328786454/job_groups_batch?attempt=2"}}</script></react-partial>
+            <div aria-label="Workflow run summary" data-url="/openclaw/octopool/actions/runs/27328786454/summary_partial">
             <span>Triggered via pull request <relative-time datetime="2026-06-11T06:38:49Z"></relative-time></span>
             <a href="/openclaw/octopool/commit/1e6a563d13924ba423febe3a4cb47eeb9d594322">1e6a563</a>
             <a class="branch-name" title="main" href="/openclaw/octopool/tree/refs/heads/main">main</a>
-            <div data-job-groups-fetch-url="/openclaw/octopool/actions/runs/27328786454/job_groups_batch?attempt=2"></div>
             <span>Total duration</span><a class="h4 color-fg-default">2m 49s</a>
+            </div>
           `),
       ),
     );
@@ -553,6 +565,7 @@ describe("github web provider", () => {
         status: "completed",
         conclusion: "success",
         run_attempt: 2,
+        head_sha: "1e6a563d13924ba423febe3a4cb47eeb9d594322",
         event: "pull_request",
       },
       backend: "web",


### PR DESCRIPTION
## Summary

Fix incorrect historical commit ownership in shaped Actions run responses. For Peekaboo runs [33167365292](https://github.com/openclaw/Peekaboo/actions/runs/33167365292) and [33167365221](https://github.com/openclaw/Peekaboo/actions/runs/33167365221), GitHub's patch for merge commit `224a80ee` is a series beginning with an unrelated commit. Octopool previously used the first patch header as the run's `headSha`.

Run metadata now requires matching repository/run/attempt ownership and summary-scoped commit links. A standards-compliant parse5 DOM replaces ad hoc HTML stripping, so script/comment/raw-text content cannot be reinterpreted as owned markup; malformed or repaired ownership regions fall back safely. Abbreviation expansion accepts only one well-formed, matching commit patch; ambiguous pages and patch series fall back to exact REST metadata. Historical top-level `head_sha` remains authoritative, not a moving nested PR head.

A server-owned Actions-summary cache generation prevents existing clients from reusing contaminated edge/D1, stale, coalesced, or revalidated entries, including run-list supersets. Shared CLI relay construction also forwards `OCTOPOOL_FRESH=1` for run metadata and jobs without mutating caller headers or overriding explicit cache-control.

The nearby coalesced-revalidation test now gives repository-visibility requests a repository response instead of run JSON. Deterministic proof aging reproduces the old fixture failure; production privacy checks are unchanged.

## Verification

- Captured both exact run responses and the actual merge patch; reproduced the old wrong SHA offline and verified the fixed rejection/fallback behavior.
- 383 TypeScript unit tests passed; an independent rerun of 209 focused ownership/cache tests passed. Malformed script endings, comment reconstruction, inert DOM content, and uppercase markup have regression coverage.
- Seven new Worker cache-migration integration tests passed; deterministic revalidation-fixture regression failed before the mock repair and passed afterward.
- Go tests/vet, TypeScript build, formatting, lint, and generation-consistency checks passed.
- Structured autoreview completed with no reported blocking findings.
- Full hosted CI is required before merge. Local aggregate verification was limited by integration setup timeouts under host load and stalled SQLc dependency extraction; no test timeouts or production guards were weakened.

Docs and the Unreleased changelog are updated. Worker deployment and a CLI release are required for rollout; no Peekaboo product code is changed.
