### PR TITLE
feat: add server-managed regex rewriting and purging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.5.9 - Unreleased
 
+### Changes
+
+- Add file-configured regex replacement and purging with deployment-wide server rules, additive local rules, and fail-closed protection for supported GitHub submissions and relay inputs.
+
 ## 0.5.8 - 2026-08-28
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Octopool moves that traffic off individual machines and onto Cloudflare:
 - **Public-page transports preserve token quota.** Public PR diffs, commit/compare diff and patch media, explicit-ref content files, workflow-filtered run lists, and shaped run job/step metadata use [token-free GitHub endpoints](https://docs.octopool.dev/token-free.html); supported top-level `gh run list/view` and `gh release view` reads prefer public pages before anonymous API and pooled PAT/App fallbacks.
 - **Tokens stay server-side.** Each named client authenticates to octopool with its own short caller token (issued in exchange for `gh auth token`), so one user's Macs remain independently active and measurable. Each caller retains at most 16 active client sessions, retiring the least recently updated stale session as new names appear. The underlying PATs and App private keys never leave the Worker — not into responses, not into audit rows, not into the cache.
 - **Org-gated, public-repo only.** Only verified members of one GitHub org can mint a caller token, and every repo route is checked against GitHub's public-visibility endpoint before a pooled identity or cache entry is used. Private-repo callers fall back to their own `gh`.
-- **Fails open to real `gh`.** The CLI is a drop-in `gh` shim. Safe read-shaped calls try Octopool first, so the server owns cache, app/PAT routing, and pool policy. Mutations and secret-bearing requests stay local; safe reads run your real `gh` only when Octopool explicitly returns `fallback_local`.
+- **Local writes, controlled fallback.** The CLI is a drop-in `gh` shim. Safe read-shaped calls try Octopool first, so the server owns cache, app/PAT routing, and pool policy. Writes retain your local GitHub identity; relay fallback never bypasses outbound protection.
+- **Server and local regex protection.** Import a JSON rules file to replace private terms with approved text or purge matches before supported submissions. Deployment-wide rules and optional additional local rules protect the shim; the Worker independently blocks matching read inputs. Policy failures and uninspectable commands fail closed rather than sending unchecked content. See [CLI protection](docs/cli.md) and [administration](docs/admin.md).
 
 If you're not running a maintainer team and you don't care about GitHub rate limits, you don't need this.
 
@@ -88,7 +89,7 @@ octopool gh api repos/openclaw/openclaw/pulls/85341 --jq .number
 octopool stats
 ```
 
-Install it as a transparent `gh` shim — safe reads try Octopool first, while mutations, unusual flags, and explicit server fallback signals pass through to your local `gh`:
+Install it as a `gh` shim — safe reads try Octopool first, while supported writes and explicit server fallback signals use your local `gh` after outbound-policy checks. Active rewrite rules block commands whose final content cannot be inspected:
 
 ```sh
 octopool install-shim

--- a/cmd/octopool/cli_e2e_test.go
+++ b/cmd/octopool/cli_e2e_test.go
@@ -63,7 +63,8 @@ func TestCLIEndToEndRelayAndFallback(t *testing.T) {
 
 	t.Run("unsupported command delegates to real gh", func(t *testing.T) {
 		fake := fakeGH(t)
-		result := runCLI(t, bin, "http://127.0.0.1:1", map[string]string{"OCTOPOOL_GH_PATH": fake}, "gh", "alias", "list")
+		server := cliRelayServer(t, func(w http.ResponseWriter, r *http.Request) { t.Errorf("unexpected relay dispatch") })
+		result := runCLI(t, bin, server.URL, map[string]string{"OCTOPOOL_GH_PATH": fake}, "gh", "alias", "list")
 		if result.err != nil || strings.TrimSpace(result.stdout) != "real-gh:alias list" {
 			t.Fatalf("err=%v stdout=%q stderr=%q", result.err, result.stdout, result.stderr)
 		}
@@ -258,6 +259,8 @@ func runCLI(t *testing.T, bin string, serverURL string, extra map[string]string,
 	home := t.TempDir()
 	env := append(os.Environ(),
 		"HOME="+home,
+		"XDG_CONFIG_HOME="+filepath.Join(home, ".config"),
+		"OCTOPOOL_STRING_REWRITE_FILE=",
 		"OCTOPOOL_TOKEN=test-token",
 		"OCTOPOOL_POOL=maintainers",
 		"OCTOPOOL_URL="+serverURL,
@@ -276,7 +279,10 @@ func runCLI(t *testing.T, bin string, serverURL string, extra map[string]string,
 func cliRelayServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/github/request" || r.Header.Get("Authorization") != "Bearer test-token" {
+		if serveEmptyRewritePolicy(t, w, r, "test-token", "maintainers") {
+			return
+		}
+		if r.URL.Path != "/v1/github/request" || r.Method != "POST" || r.Header.Get("Authorization") != "Bearer test-token" {
 			http.Error(w, "unexpected relay request", http.StatusBadRequest)
 			return
 		}

--- a/cmd/octopool/cli_protocol_e2e_test.go
+++ b/cmd/octopool/cli_protocol_e2e_test.go
@@ -82,7 +82,7 @@ func TestCLIEndToEndRelayProtocol(t *testing.T) {
 		}
 	})
 
-	t.Run("auth failure delegates to real gh", func(t *testing.T) {
+	t.Run("auth failure does not delegate to real gh", func(t *testing.T) {
 		server := cliRelayServer(t, func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusUnauthorized)
 			_, _ = w.Write([]byte(`{"error":{"code":"invalid_auth","message":"expired"}}`))
@@ -90,14 +90,15 @@ func TestCLIEndToEndRelayProtocol(t *testing.T) {
 		result := runCLI(t, bin, server.URL, map[string]string{"OCTOPOOL_GH_PATH": fakeGH(t)},
 			"gh", "api", "repos/openclaw/octopool",
 		)
-		if result.err != nil || strings.TrimSpace(result.stdout) != "real-gh:api repos/openclaw/octopool" {
+		if result.err == nil || result.stdout != "" || !strings.Contains(result.stderr, "invalid_auth") {
 			t.Fatalf("err=%v stdout=%q stderr=%q", result.err, result.stdout, result.stderr)
 		}
 	})
 
 	t.Run("real gh exit code passes through", func(t *testing.T) {
 		fake := fakeGHWithExit(t, 7)
-		result := runCLI(t, bin, "http://127.0.0.1:1", map[string]string{"OCTOPOOL_GH_PATH": fake},
+		server := cliRelayServer(t, func(w http.ResponseWriter, r *http.Request) { t.Error("unexpected relay dispatch") })
+		result := runCLI(t, bin, server.URL, map[string]string{"OCTOPOOL_GH_PATH": fake},
 			"gh", "alias", "list",
 		)
 		var exitErr *exec.ExitError

--- a/cmd/octopool/command_admin.go
+++ b/cmd/octopool/command_admin.go
@@ -14,12 +14,14 @@ func runAdmin(ctx context.Context, args []string, stdout io.Writer) error {
 		return errors.New("missing admin subcommand")
 	}
 	switch args[0] {
+	case "string-rewrites":
+		return runAdminStringRewrites(ctx, args[1:], stdout)
 	case "caller":
 		return runAdminCaller(ctx, args[1:], stdout)
 	case "identity":
 		return runAdminIdentity(ctx, args[1:], stdout)
 	case "help", "-h", "--help":
-		fmt.Fprintln(stdout, "usage: octopool admin <caller|identity> [flags]")
+		fmt.Fprintln(stdout, "usage: octopool admin <caller|identity|string-rewrites> [flags]")
 		return nil
 	default:
 		return fmt.Errorf("unknown admin subcommand %q", args[0])

--- a/cmd/octopool/command_admin_string_rewrites.go
+++ b/cmd/octopool/command_admin_string_rewrites.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+var errRewriteConflict = errors.New("string rewrite policy revision conflict; fetch the current revision and retry")
+
+func runAdminStringRewrites(ctx context.Context, args []string, stdout io.Writer) error {
+	usage := "usage: octopool admin string-rewrites <status|set --file PATH|-> [--if-revision N] [--url URL]"
+	if len(args) == 0 || args[0] == "help" || args[0] == "--help" || args[0] == "-h" {
+		fmt.Fprintln(stdout, usage)
+		return nil
+	}
+	if args[0] != "status" && args[0] != "set" {
+		return errRewriteBlocked
+	}
+	fs := flag.NewFlagSet("admin string-rewrites", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	baseURL := fs.String("url", envDefault("OCTOPOOL_URL", defaultURL), "Octopool base URL")
+	tokenEnv := fs.String("admin-token-env", "OCTOPOOL_ADMIN_TOKEN", "admin token environment variable")
+	file := fs.String("file", "", "policy JSON file or - for stdin")
+	expected := fs.Int64("if-revision", 0, "require this current revision")
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			fmt.Fprintln(stdout, usage)
+			return nil
+		}
+		return errRewriteBlocked
+	}
+	if fs.NArg() != 0 || *expected < 0 {
+		return errRewriteBlocked
+	}
+	revisionSet := false
+	fs.Visit(func(item *flag.Flag) {
+		if item.Name == "if-revision" {
+			revisionSet = true
+		}
+	})
+	if revisionSet && (*expected < 1 || *expected > 9007199254740991) {
+		return errRewriteBlocked
+	}
+	var imported stringRewritePolicy
+	if args[0] == "set" {
+		if *file == "" {
+			return errRewriteBlocked
+		}
+		data, err := readRewriteFile(*file, os.Stdin, rewriteMaxDocument)
+		if err != nil {
+			return errRewritePolicy
+		}
+		imported, err = parseStringRewritePolicy(data, false)
+		if err != nil {
+			return err
+		}
+	} else if *file != "" || *expected != 0 {
+		return errRewriteBlocked
+	}
+	token, err := requiredEnv(*tokenEnv)
+	if err != nil {
+		return errRewritePolicy
+	}
+	data, err := rewritePolicyHTTP(ctx, *baseURL, "/v1/admin/string-rewrites", token, http.MethodGet, nil)
+	if err != nil {
+		return err
+	}
+	current, err := parseStringRewritePolicy(data, true)
+	if err != nil {
+		return err
+	}
+	if args[0] == "status" {
+		fmt.Fprintf(stdout, "revision: %d\nrule_count: %d\n", current.Revision, len(current.Rules))
+		return nil
+	}
+	if *expected != 0 && *expected != current.Revision {
+		return errRewriteConflict
+	}
+	rules := make([]stringRewriteRule, 0, len(imported.Rules))
+	for _, rule := range imported.Rules {
+		rules = append(rules, rule.stringRewriteRule)
+	}
+	body, _ := json.Marshal(map[string]any{"schema_version": 1, "expected_revision": current.Revision, "rules": rules})
+	data, err = rewritePolicyHTTP(ctx, *baseURL, "/v1/admin/string-rewrites", token, http.MethodPut, body)
+	if err != nil {
+		return err
+	}
+	value, err := strictRewriteJSON(data, rewriteMaxDocument)
+	if err != nil {
+		return err
+	}
+	object, ok := exactRewriteKeys(value, "schema_version", "revision", "updated_at", "rule_count")
+	if !ok {
+		return errRewritePolicy
+	}
+	version, vok := rewriteInteger(object["schema_version"])
+	revision, rok := rewriteInteger(object["revision"])
+	updated, uok := object["updated_at"].(string)
+	count, cok := object["rule_count"].(json.Number)
+	parsedCount, cerr := count.Int64()
+	if !vok || version != 1 || !rok || revision != current.Revision+1 || !uok || !validRewriteTimestamp(updated) || !cok || cerr != nil || parsedCount != int64(len(rules)) {
+		return errRewritePolicy
+	}
+	fmt.Fprintf(stdout, "revision: %d\nrule_count: %d\n", revision, parsedCount)
+	return nil
+}

--- a/cmd/octopool/command_admin_string_rewrites_test.go
+++ b/cmd/octopool/command_admin_string_rewrites_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestAdminStringRewriteRevisionUpdate(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		conflict bool
+		revision string
+		stdin    bool
+	}{
+		{name: "file"}, {name: "stdin", stdin: true}, {name: "explicit revision", revision: "7"}, {name: "operator conflict", revision: "6"}, {name: "concurrent conflict", conflict: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			methods := []string{}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/v1/admin/string-rewrites" || r.Header.Get("Authorization") != "Bearer admin-test" {
+					t.Error("incorrect admin request")
+					w.WriteHeader(400)
+					return
+				}
+				methods = append(methods, r.Method)
+				switch r.Method {
+				case "GET":
+					_, _ = io.WriteString(w, `{"schema_version":1,"revision":7,"updated_at":"2026-08-28T00:00:00Z","rules":[]}`)
+				case "PUT":
+					var payload map[string]any
+					if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+						t.Error(err)
+					}
+					if payload["schema_version"] != float64(1) || payload["expected_revision"] != float64(7) || len(payload) != 3 {
+						t.Error("PUT is not conditional")
+					}
+					rules, ok := payload["rules"].([]any)
+					if !ok || len(rules) != 1 {
+						t.Error("missing imported rules")
+					}
+					if test.conflict {
+						w.WriteHeader(409)
+						_, _ = io.WriteString(w, `internal-model`)
+						return
+					}
+					_, _ = io.WriteString(w, `{"schema_version":1,"revision":8,"updated_at":"2026-08-28T00:00:00Z","rule_count":1}`)
+				default:
+					t.Error("unexpected method")
+					w.WriteHeader(400)
+				}
+			}))
+			defer server.Close()
+			file := filepath.Join(t.TempDir(), "policy.json")
+			if err := os.WriteFile(file, []byte(`{"schema_version":1,"rules":[{"pattern":"internal-model","replacement":"public"}]}`), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if test.stdin {
+				input, err := os.Open(file)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer input.Close()
+				original := os.Stdin
+				os.Stdin = input
+				defer func() { os.Stdin = original }()
+				file = "-"
+			}
+			t.Setenv("OCTOPOOL_ADMIN_TOKEN", "admin-test")
+			args := []string{"string-rewrites", "set", "--url", server.URL, "--file", file}
+			if test.revision != "" {
+				args = append(args, "--if-revision", test.revision)
+			}
+			var out bytes.Buffer
+			err := runAdmin(t.Context(), args, &out)
+			if test.conflict || test.revision == "6" {
+				if err != errRewriteConflict || out.Len() != 0 {
+					t.Fatalf("conflict err=%v output=%q", err, out.String())
+				}
+			} else {
+				if err != nil || out.String() != "revision: 8\nrule_count: 1\n" {
+					t.Fatalf("update err=%v output=%q", err, out.String())
+				}
+			}
+			want := []string{"GET", "PUT"}
+			if test.revision == "6" {
+				want = []string{"GET"}
+			}
+			if !reflect.DeepEqual(methods, want) {
+				t.Fatalf("methods=%v", methods)
+			}
+		})
+	}
+}
+func TestAdminStringRewriteStatusDoesNotExposeRules(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" || r.URL.Path != "/v1/admin/string-rewrites" || r.Header.Get("Authorization") != "Bearer admin-test" {
+			t.Error("invalid admin request")
+		}
+		_, _ = io.WriteString(w, rewriteActiveTestPolicy)
+	}))
+	defer server.Close()
+	t.Setenv("OCTOPOOL_ADMIN_TOKEN", "admin-test")
+	var out bytes.Buffer
+	if err := runAdmin(t.Context(), []string{"string-rewrites", "status", "--url", server.URL}, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.String() != "revision: 1\nrule_count: 1\n" {
+		t.Fatalf("output=%q", out.String())
+	}
+}

--- a/cmd/octopool/command_e2e_test.go
+++ b/cmd/octopool/command_e2e_test.go
@@ -67,6 +67,9 @@ func TestCLIEndToEndServiceCommands(t *testing.T) {
 
 	t.Run("request forwards options", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if serveEmptyRewritePolicy(t, w, r, "test-token", "maintainers") {
+				return
+			}
 			if r.Method != http.MethodPost || r.URL.Path != "/v1/github/request" {
 				http.Error(w, "unexpected relay request", http.StatusBadRequest)
 				t.Errorf("request = %s %s", r.Method, r.URL.Path)

--- a/cmd/octopool/command_request.go
+++ b/cmd/octopool/command_request.go
@@ -50,6 +50,21 @@ func runRequest(ctx context.Context, args []string, stdout io.Writer) error {
 	if len(routeHintValues) > 0 {
 		body["route_hint"] = valuesMap(routeHintValues)
 	}
+	client := ghRelayClient{baseURL: *requestFlags.baseURL, pool: *requestFlags.pool, token: token}
+	policy, err := client.stringRewritePolicy(ctx)
+	if err != nil {
+		return err
+	}
+	if len(policy.Rules) != 0 && strings.ToUpper(*method) != "GET" {
+		return errRewriteBlocked
+	}
+	query := map[string]any{}
+	for key, value := range valuesMap(queryValues) {
+		query[key] = value
+	}
+	if err := policy.guardRequest(ghAPIRequest{method: strings.ToUpper(*method), path: *path, query: query, headers: valuesMap(headerValues), routeHint: valuesMap(routeHintValues)}); err != nil {
+		return err
+	}
 	return postJSON(ctx, stdout, apiURL(*requestFlags.baseURL, "/v1/github/request"), token, body)
 }
 

--- a/cmd/octopool/gh.go
+++ b/cmd/octopool/gh.go
@@ -14,6 +14,44 @@ func runGH(ctx context.Context, args []string, stdout io.Writer, stderr io.Write
 		fmt.Fprintln(stdout, "       octopool gh pr|issue|run|repo|release|workflow|label|gist|search ...")
 		return nil
 	}
+	if !rewriteBootstrapInvocation(args) {
+		policy, err := currentStringRewritePolicy(ctx)
+		if err != nil {
+			return err
+		}
+		if len(policy.Rules) != 0 {
+			if rewriteContentCommand(args) || args[0] == "api" {
+				// Content snapshots are prepared exactly once, at the final child
+				// boundary. Read API dispatch still uses the relay after validation.
+				if args[0] != "api" {
+					return execRealGH(ctx, args, stdout, stderr)
+				}
+				opts, err := parseRewriteAPI(args[1:])
+				if err != nil {
+					return err
+				}
+				if opts.method != "GET" {
+					return execRealGH(ctx, args, stdout, stderr)
+				}
+				request, err := rewriteAPIRequest(opts)
+				if err != nil {
+					return err
+				}
+				if err := policy.guardRequest(request); err != nil {
+					return err
+				}
+				if opts.inputSet || len(opts.fields) != 0 || !rewriteReadPath(request.path) {
+					return errRewriteBlocked
+				}
+			} else {
+				prepared := &rewritePreparation{}
+				if err := prepareRewriteRead(policy, args, prepared); err != nil {
+					return err
+				}
+				args = prepared.args
+			}
+		}
+	}
 	if isGHAuthStatus(args) {
 		return runGHAuthStatus(ctx, args, stdout, stderr)
 	}

--- a/cmd/octopool/gh_fallback.go
+++ b/cmd/octopool/gh_fallback.go
@@ -38,15 +38,13 @@ func explicitRelayFallback(err error) (localFallbackError, bool) {
 }
 
 func shouldRunRealGH(err error) bool {
-	return isLocalFallback(err) || errors.Is(err, errOctopoolNotLoggedIn)
+	return isLocalFallback(err)
 }
 
 func localFallbackFromRelayError(relay *relayResponseError) (localFallbackError, bool) {
 	switch relay.Code {
 	case "fallback_local":
 		return localFallbackError{Reason: relayFallbackReason(relay), Relay: relay}, true
-	case "missing_auth", "invalid_auth":
-		return localFallbackError{Reason: "octopool auth unavailable", Relay: relay}, true
 	default:
 		return localFallbackError{}, false
 	}
@@ -112,12 +110,22 @@ func execRealGHWithStdinAndEnv(
 	stderr io.Writer,
 	env []string,
 ) error {
+	prepared, err := prepareProtectedGH(ctx, args, stdin)
+	if err != nil {
+		return err
+	}
+	defer prepared.cleanup()
+	if len(prepared.preflight) != 0 {
+		if err := execRealGHWithStdinAndEnv(ctx, prepared.preflight, strings.NewReader(""), io.Discard, io.Discard, env); err != nil {
+			return errRewriteBlocked
+		}
+	}
 	path, err := resolveGHPath(envDefault("OCTOPOOL_GH_PATH", "gh"))
 	if err != nil {
 		return err
 	}
-	cmd := exec.CommandContext(ctx, path, args...)
-	cmd.Stdin = stdin
+	cmd := exec.CommandContext(ctx, path, prepared.args...)
+	cmd.Stdin = prepared.stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	cmd.Env = env

--- a/cmd/octopool/gh_relay.go
+++ b/cmd/octopool/gh_relay.go
@@ -192,6 +192,10 @@ func transientRelayFailure(err error) bool {
 }
 
 func (client ghRelayClient) doOnce(ctx context.Context, request ghAPIRequest) (relayEnvelope, error) {
+	policy, err := client.stringRewritePolicy(ctx)
+	if err != nil {
+		return relayEnvelope{}, err
+	}
 	headers := request.headers
 	if _, explicit := headers["cache-control"]; freshReadRequested() && !explicit {
 		headers = maps.Clone(headers)
@@ -199,6 +203,11 @@ func (client ghRelayClient) doOnce(ctx context.Context, request ghAPIRequest) (r
 			headers = make(map[string]string)
 		}
 		headers["cache-control"] = "max-age=0"
+	}
+	guardedRequest := request
+	guardedRequest.headers = headers
+	if err := policy.guardRequest(guardedRequest); err != nil {
+		return relayEnvelope{}, err
 	}
 	body := map[string]any{
 		"pool":   client.pool,

--- a/cmd/octopool/gh_relay_client_test.go
+++ b/cmd/octopool/gh_relay_client_test.go
@@ -61,20 +61,20 @@ func TestRelayRetryAttempts(t *testing.T) {
 	}
 }
 
-func TestGHRelayClientInvalidAuthUsesLocalFallback(t *testing.T) {
+func TestGHRelayClientInvalidAuthFailsClosed(t *testing.T) {
 	client, calls := newRelayTestClient(t, func(int64) (int, string) {
 		return http.StatusUnauthorized, `{"error":{"code":"invalid_auth","message":"Invalid caller token"}}`
 	})
 	_, err := client.do(t.Context(), ghAPIRequest{method: "GET", path: "/repos/openclaw/openclaw"})
-	if !isLocalFallback(err) {
-		t.Fatalf("expected local fallback, got %v", err)
+	if err == nil || shouldRunRealGH(err) {
+		t.Fatalf("expected terminal auth error, got %v", err)
 	}
 	if _, explicit := explicitRelayFallback(err); explicit {
 		t.Fatal("auth reinterpretation must not gain explicit relay fallback provenance")
 	}
-	var fallback localFallbackError
-	if !errors.As(err, &fallback) || fallback.Relay == nil || fallback.Relay.Code != "invalid_auth" {
-		t.Fatalf("auth fallback provenance = %#v", fallback.Relay)
+	var relay *relayResponseError
+	if !errors.As(err, &relay) || relay.Code != "invalid_auth" {
+		t.Fatalf("auth error = %v", err)
 	}
 	if got := calls.Load(); got != 1 {
 		t.Fatalf("calls = %d", got)
@@ -240,8 +240,8 @@ func TestShouldRunRealGH(t *testing.T) {
 	if !shouldRunRealGH(localFallbackError{Reason: "route_denied"}) {
 		t.Fatal("fallback_local should run real gh")
 	}
-	if !shouldRunRealGH(errOctopoolNotLoggedIn) {
-		t.Fatal("missing octopool login should run real gh")
+	if shouldRunRealGH(errOctopoolNotLoggedIn) {
+		t.Fatal("missing octopool login must fail closed")
 	}
 	if shouldRunRealGH(assertAnError{}) {
 		t.Fatal("ordinary errors should not run real gh")
@@ -295,8 +295,19 @@ func newRelayTestClient(
 	respond func(call int64) (status int, body string),
 ) (ghRelayClient, *atomic.Int64) {
 	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("OCTOPOOL_STRING_REWRITE_FILE", "")
 	calls := &atomic.Int64{}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if serveEmptyRewritePolicy(t, w, r, "token", "maintainers") {
+			return
+		}
+		if r.URL.Path != "/v1/github/request" || r.Method != "POST" || r.Header.Get("Authorization") != "Bearer token" {
+			t.Errorf("unexpected relay request")
+			w.WriteHeader(400)
+			return
+		}
 		status, body := respond(calls.Add(1))
 		w.WriteHeader(status)
 		_, _ = w.Write([]byte(body))

--- a/cmd/octopool/gh_test_helpers_test.go
+++ b/cmd/octopool/gh_test_helpers_test.go
@@ -16,10 +16,15 @@ type relayTestResponse struct {
 func relayTestServer(t *testing.T, responseBody func(map[string]any) any) {
 	t.Helper()
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("OCTOPOOL_STRING_REWRITE_FILE", "")
 	t.Setenv("OCTOPOOL_TOKEN", "test-token")
 	t.Setenv("OCTOPOOL_POOL", "maintainers")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/github/request" {
+		if serveEmptyRewritePolicy(t, w, r, "test-token", "maintainers") {
+			return
+		}
+		if r.URL.Path != "/v1/github/request" || r.Method != "POST" {
 			http.Error(w, "unexpected relay path", http.StatusBadRequest)
 			return
 		}
@@ -65,4 +70,27 @@ func relayTestServer(t *testing.T, responseBody func(map[string]any) any) {
 	}))
 	t.Cleanup(server.Close)
 	t.Setenv("OCTOPOOL_URL", server.URL)
+}
+
+// Explicitly emulate the authoritative empty deployment policy for legacy
+// dispatch fixtures. This is an HTTP route, never a production/test bypass.
+func serveEmptyRewritePolicy(t *testing.T, w http.ResponseWriter, r *http.Request, token, pool string) bool {
+	t.Helper()
+	if r.URL.Path != "/v1/pools/"+pool+"/string-rewrites" {
+		return false
+	}
+	if r.Method != "GET" || r.Header.Get("Authorization") != "Bearer "+token || r.Header.Get("Cache-Control") != "no-cache, no-store" {
+		t.Errorf("unexpected policy request method/auth/cache directive")
+		w.WriteHeader(http.StatusBadRequest)
+		return true
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	_, _ = w.Write([]byte(`{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[]}`))
+	return true
+}
+
+func emptyRewriteTestServer(t *testing.T) {
+	t.Helper()
+	relayTestServer(t, func(map[string]any) any { t.Error("unexpected relay request"); return nil })
 }

--- a/cmd/octopool/gh_top_watch.go
+++ b/cmd/octopool/gh_top_watch.go
@@ -90,6 +90,9 @@ func retryWatchTick(ctx context.Context, backoff *watchBackoff, poll func() erro
 		if shouldRunRealGH(err) {
 			return err
 		}
+		if errors.Is(err, errRewritePolicy) || errors.Is(err, errRewriteBlocked) || errors.Is(err, errOctopoolNotLoggedIn) {
+			return err
+		}
 		// The relay client already exhausted its typed response retry policy.
 		// Watch retries remain for transport, parse, and operation-level failures.
 		var relay *relayResponseError

--- a/cmd/octopool/gh_top_watch_test.go
+++ b/cmd/octopool/gh_top_watch_test.go
@@ -573,6 +573,7 @@ func TestGHRunWatchPaginatesCompletedRunJobs(t *testing.T) {
 }
 
 func TestGHWatchDelegatesWithFlooredInterval(t *testing.T) {
+	emptyRewriteTestServer(t)
 	tests := []struct {
 		name string
 		args []string

--- a/cmd/octopool/string_rewrites.go
+++ b/cmd/octopool/string_rewrites.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"regexp"
+	"regexp/syntax"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	rewriteMaxRules       = 128
+	rewriteMaxPattern     = 256
+	rewriteMaxReplacement = 1024
+	rewriteMaxDocument    = 65536
+	rewriteMaxContent     = 1048576
+)
+
+var (
+	errRewritePolicy  = errors.New("string rewrite policy unavailable or invalid")
+	errRewriteBlocked = errors.New("string rewrite protection blocked unsupported or unsafe input")
+)
+
+type stringRewriteRule struct {
+	Pattern     string `json:"pattern"`
+	Replacement string `json:"replacement"`
+}
+type compiledRewriteRule struct {
+	stringRewriteRule
+	re    *regexp.Regexp
+	empty *syntax.Regexp
+}
+type stringRewritePolicy struct {
+	Rules     []compiledRewriteRule
+	Revision  int64
+	UpdatedAt string
+}
+
+// V1 intentionally excludes engine-specific escapes and group extensions.
+func portableRewritePattern(pattern string) bool {
+	inClass := false
+	classFirst := false
+	for i := 0; i < len(pattern); i++ {
+		c := pattern[i]
+		if c == '\\' {
+			i++
+			if i == len(pattern) || !strings.ContainsRune(`\.*+?()|[]{}^$-/bBwWdDsSnrtfav`, rune(pattern[i])) {
+				return false
+			}
+			classFirst = false
+			continue
+		}
+		if inClass {
+			if c == '[' && i+1 < len(pattern) && pattern[i+1] == ':' {
+				return false
+			}
+			if c == ']' && !classFirst {
+				inClass = false
+			}
+			classFirst = false
+			continue
+		}
+		if c == '[' {
+			inClass, classFirst = true, true
+			if i+1 < len(pattern) && pattern[i+1] == '^' {
+				i++
+			}
+		} else if c == '(' && i+1 < len(pattern) && pattern[i+1] == '?' && (i+2 >= len(pattern) || pattern[i+2] != ':') {
+			return false
+		}
+	}
+	return true
+}
+
+func compileStringRewriteRules(rules []stringRewriteRule) (stringRewritePolicy, error) {
+	if len(rules) > rewriteMaxRules {
+		return stringRewritePolicy{}, errRewritePolicy
+	}
+	var document bytes.Buffer
+	encoder := json.NewEncoder(&document)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(map[string]any{"schema_version": 1, "rules": rules}); err != nil || document.Len()-1 > rewriteMaxDocument {
+		return stringRewritePolicy{}, errRewritePolicy
+	}
+	policy := stringRewritePolicy{}
+	seen := map[string]bool{}
+	for _, rule := range rules {
+		if !utf8.ValidString(rule.Pattern) || !utf8.ValidString(rule.Replacement) || len(rule.Pattern) > rewriteMaxPattern || len(rule.Replacement) > rewriteMaxReplacement || seen[rule.Pattern] || !portableRewritePattern(rule.Pattern) {
+			return stringRewritePolicy{}, errRewritePolicy
+		}
+		re, err := regexp.Compile(rule.Pattern)
+		if err != nil || re.MatchString("") {
+			return stringRewritePolicy{}, errRewritePolicy
+		}
+		seen[rule.Pattern] = true
+		parsed, err := syntax.Parse(rule.Pattern, syntax.Perl)
+		if err != nil {
+			return stringRewritePolicy{}, errRewritePolicy
+		}
+		var empty *syntax.Regexp
+		if rewriteCanMatchEmpty(parsed, ^syntax.EmptyOp(0)) {
+			empty = parsed
+		}
+		policy.Rules = append(policy.Rules, compiledRewriteRule{rule, re, empty})
+	}
+	return policy, nil
+}
+
+func mergeStringRewritePolicies(server, local stringRewritePolicy) (stringRewritePolicy, error) {
+	rules := make([]stringRewriteRule, 0, len(server.Rules)+len(local.Rules))
+	seen := map[string]string{}
+	for _, set := range [][]compiledRewriteRule{server.Rules, local.Rules} {
+		for _, rule := range set {
+			if replacement, ok := seen[rule.Pattern]; ok {
+				if replacement != rule.Replacement {
+					return stringRewritePolicy{}, errRewritePolicy
+				}
+				continue
+			}
+			seen[rule.Pattern] = rule.Replacement
+			rules = append(rules, rule.stringRewriteRule)
+		}
+	}
+	merged, err := compileStringRewriteRules(rules)
+	merged.Revision, merged.UpdatedAt = server.Revision, server.UpdatedAt
+	return merged, err
+}
+
+func (policy stringRewritePolicy) check(text string) error {
+	if len(text) > rewriteMaxContent || !utf8.ValidString(text) {
+		return errRewriteBlocked
+	}
+	for _, rule := range policy.Rules {
+		if rule.re.MatchString(text) {
+			return errRewriteBlocked
+		}
+	}
+	return nil
+}
+
+func (policy stringRewritePolicy) rewrite(text string) (string, error) {
+	if len(text) > rewriteMaxContent || !utf8.ValidString(text) {
+		return "", errRewriteBlocked
+	}
+	matches := 0
+	for _, rule := range policy.Rules {
+		// At most one match per input byte plus the terminal empty match. This keeps
+		// match storage finite without re-running anchors against sliced strings.
+		spans := rule.re.FindAllStringIndex(text, rewriteMaxContent+1)
+		matches += len(spans)
+		if matches > rewriteMaxContent {
+			return "", errRewriteBlocked
+		}
+		size := len(text)
+		for index, span := range spans {
+			if span[0] == span[1] {
+				return "", errRewriteBlocked
+			}
+			// Go's FindAll suppresses an empty match directly after a consuming
+			// match. Check that skipped boundary in the original input context.
+			if rule.empty != nil && (index+1 == len(spans) || spans[index+1][0] > span[1]) {
+				before, after := rune(-1), rune(-1)
+				if span[1] > 0 {
+					before, _ = utf8.DecodeLastRuneInString(text[:span[1]])
+				}
+				if span[1] < len(text) {
+					after, _ = utf8.DecodeRuneInString(text[span[1]:])
+				}
+				if rewriteCanMatchEmpty(rule.empty, syntax.EmptyOpContext(before, after)) {
+					return "", errRewriteBlocked
+				}
+			}
+			size += len(rule.Replacement) - (span[1] - span[0])
+		}
+		if size > rewriteMaxContent {
+			return "", errRewriteBlocked
+		}
+		if len(spans) == 0 {
+			continue
+		}
+		var out strings.Builder
+		out.Grow(size)
+		previous := 0
+		for _, span := range spans {
+			out.WriteString(text[previous:span[0]])
+			out.WriteString(rule.Replacement)
+			previous = span[1]
+		}
+		out.WriteString(text[previous:])
+		text = out.String()
+	}
+	if err := policy.check(text); err != nil {
+		return "", err
+	}
+	return text, nil
+}
+
+func rewriteCanMatchEmpty(re *syntax.Regexp, context syntax.EmptyOp) bool {
+	switch re.Op {
+	case syntax.OpEmptyMatch, syntax.OpStar, syntax.OpQuest:
+		return true
+	case syntax.OpBeginLine:
+		return context&syntax.EmptyBeginLine != 0
+	case syntax.OpEndLine:
+		return context&syntax.EmptyEndLine != 0
+	case syntax.OpBeginText:
+		return context&syntax.EmptyBeginText != 0
+	case syntax.OpEndText:
+		return context&syntax.EmptyEndText != 0
+	case syntax.OpWordBoundary:
+		return context&syntax.EmptyWordBoundary != 0
+	case syntax.OpNoWordBoundary:
+		return context&syntax.EmptyNoWordBoundary != 0
+	case syntax.OpCapture, syntax.OpPlus:
+		return rewriteCanMatchEmpty(re.Sub[0], context)
+	case syntax.OpRepeat:
+		return re.Min == 0 || rewriteCanMatchEmpty(re.Sub[0], context)
+	case syntax.OpAlternate:
+		for _, sub := range re.Sub {
+			if rewriteCanMatchEmpty(sub, context) {
+				return true
+			}
+		}
+		return false
+	case syntax.OpConcat:
+		for _, sub := range re.Sub {
+			if !rewriteCanMatchEmpty(sub, context) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}

--- a/cmd/octopool/string_rewrites_api.go
+++ b/cmd/octopool/string_rewrites_api.go
@@ -1,0 +1,434 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type rewriteAPIOptions struct {
+	endpoint string
+	method   string
+	input    string
+	inputSet bool
+	fields   []rewriteFlag
+	output   []string
+	headers  map[string]string
+}
+
+func parseRewriteAPI(args []string) (rewriteAPIOptions, error) {
+	result := rewriteAPIOptions{headers: map[string]string{}}
+	seen := map[string]bool{}
+	values := rewriteFlagNames("--method,-X --input --field,-F --raw-field,-f --header,-H --jq,-q")
+	booleans := rewriteFlagNames("--include,-i --silent --paginate --slurp")
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if !strings.HasPrefix(arg, "-") {
+			if result.endpoint != "" {
+				return result, errRewriteBlocked
+			}
+			result.endpoint = arg
+			continue
+		}
+		// Parse one flag while retaining repeated field and header occurrences.
+		name, _, equal := strings.Cut(arg, "=")
+		if !strings.HasPrefix(name, "--") && len(name) > 2 {
+			name = name[:2]
+			equal = true
+		}
+		count := 1
+		if _, ok := values[name]; ok && !equal {
+			count = 2
+		}
+		if i+count > len(args) {
+			return result, errRewriteBlocked
+		}
+		parsed, err := parseRewriteFlags(args[i:i+count], values, booleans)
+		if err != nil || len(parsed.ordered) != 1 {
+			return result, errRewriteBlocked
+		}
+		flag := parsed.ordered[0]
+		i += count - 1
+		if flag.name != "--field" && flag.name != "--raw-field" && flag.name != "--header" {
+			if seen[flag.name] {
+				return result, errRewriteBlocked
+			}
+			seen[flag.name] = true
+		}
+		switch flag.name {
+		case "--method":
+			if flag.value == "" {
+				return result, errRewriteBlocked
+			}
+			result.method = strings.ToUpper(flag.value)
+		case "--input":
+			if flag.value == "" {
+				return result, errRewriteBlocked
+			}
+			result.input = flag.value
+			result.inputSet = true
+		case "--field", "--raw-field":
+			result.fields = append(result.fields, flag)
+		case "--header":
+			key, value, ok := strings.Cut(flag.value, ":")
+			key = strings.ToLower(strings.TrimSpace(key))
+			value = strings.TrimSpace(value)
+			if !ok || !safeRelayHeader(key) {
+				return result, errRewriteBlocked
+			}
+			if _, exists := result.headers[key]; exists {
+				return result, errRewriteBlocked
+			}
+			result.headers[key] = value
+			result.output = append(result.output, "--header="+key+": "+value)
+		default:
+			result.output = append(result.output, flag.name+"="+flag.value)
+		}
+	}
+	if result.endpoint == "" {
+		return result, errRewriteBlocked
+	}
+	if result.method == "" {
+		result.method = "GET"
+		if len(result.fields) > 0 || result.inputSet {
+			result.method = "POST"
+		}
+	}
+	if result.inputSet && len(result.fields) > 0 {
+		return result, errRewriteBlocked
+	}
+	return result, nil
+}
+
+func prepareRewriteAPI(policy stringRewritePolicy, args []string, stdin io.Reader, prepared *rewritePreparation) error {
+	opts, err := parseRewriteAPI(args[1:])
+	if err != nil {
+		return err
+	}
+	request, err := rewriteAPIRequest(opts)
+	if err != nil {
+		return err
+	}
+	if err := policy.guardRequest(request); err != nil {
+		return err
+	}
+	if opts.method == "GET" {
+		if opts.inputSet || len(opts.fields) > 0 || !rewriteReadPath(request.path) {
+			return errRewriteBlocked
+		}
+		prepared.args = append([]string{"api", opts.endpoint, "--method=GET"}, opts.output...)
+		prepared.stdin = strings.NewReader("")
+		return nil
+	}
+	if opts.method != "POST" && opts.method != "PATCH" && opts.method != "PUT" {
+		return errRewriteBlocked
+	}
+	if len(request.query) > 0 {
+		return errRewriteBlocked
+	}
+	for _, flag := range opts.output {
+		if strings.HasPrefix(flag, "--paginate") || strings.HasPrefix(flag, "--slurp") {
+			return errRewriteBlocked
+		}
+	}
+	payload := map[string]any{}
+	if len(opts.fields) > rewriteMaxRules {
+		return errRewriteBlocked
+	}
+	snapshotBytes := 0
+	if opts.inputSet {
+		data, err := readRewriteFile(opts.input, stdin, rewriteMaxContent)
+		if err != nil {
+			return err
+		}
+		value, err := strictRewriteJSON(data, rewriteMaxContent)
+		if err != nil {
+			return errRewriteBlocked
+		}
+		var ok bool
+		payload, ok = value.(map[string]any)
+		if !ok {
+			return errRewriteBlocked
+		}
+	} else {
+		for _, field := range opts.fields {
+			key, text, ok := strings.Cut(field.value, "=")
+			if !ok || key == "" {
+				return errRewriteBlocked
+			}
+			// Structured fields use --input JSON; gh's bracket accumulation grammar
+			// has ambiguous duplicate/array merging, so do not reconstruct it here.
+			if strings.ContainsAny(key, "[]") {
+				return errRewriteBlocked
+			}
+			if _, exists := payload[key]; exists {
+				return errRewriteBlocked
+			}
+			var value any = text
+			if field.name == "--field" {
+				if strings.HasPrefix(text, "@") {
+					data, err := readRewriteFile(text[1:], stdin, rewriteMaxContent)
+					if err != nil {
+						return err
+					}
+					value = string(data)
+				} else {
+					if strings.ContainsAny(text, "{}") {
+						return errRewriteBlocked
+					}
+					switch text {
+					case "true":
+						value = true
+					case "false":
+						value = false
+					case "null":
+						value = nil
+					default:
+						if number, err := strconv.ParseInt(text, 10, 64); err == nil {
+							value = json.Number(strconv.FormatInt(number, 10))
+						}
+					}
+				}
+			}
+			payload[key] = value
+			if text, ok := value.(string); ok {
+				snapshotBytes += len(key) + len(text)
+				if snapshotBytes > rewriteMaxContent {
+					return errRewriteBlocked
+				}
+			}
+		}
+	}
+	schema, err := rewriteMutationSchema(request.path, opts.method)
+	if err != nil {
+		return err
+	}
+	if err := rewriteAPIPayload(policy, prepared, payload, schema); err != nil {
+		return err
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil || len(encoded) > rewriteMaxContent {
+		return errRewriteBlocked
+	}
+	// Marshal and decode again for the final structural/content scan, including
+	// every nested string. Child gh only receives this immutable JSON snapshot.
+	if err := checkRewriteJSONStrings(policy, payload); err != nil {
+		return err
+	}
+	path, err := prepared.snapshot(encoded)
+	if err != nil {
+		return err
+	}
+	prepared.args = append([]string{"api", opts.endpoint, "--method=" + opts.method, "--input=" + path}, opts.output...)
+	prepared.stdin = strings.NewReader("")
+	if schema == "release-create" {
+		tag := payload["tag_name"].(string)
+		prepared.preflight = []string{"api", strings.TrimSuffix(request.path, "/releases") + "/git/ref/tags/" + url.PathEscape(tag), "--method=GET"}
+	}
+	return nil
+}
+
+func rewriteAPIRequest(opts rewriteAPIOptions) (ghAPIRequest, error) {
+	endpoint := opts.endpoint
+	if !strings.HasPrefix(endpoint, "/") {
+		endpoint = "/" + endpoint
+	}
+	path, rawQuery, _ := strings.Cut(endpoint, "?")
+	request := ghAPIRequest{method: opts.method, path: path, headers: opts.headers, query: map[string]any{}}
+	if !safeRelayPath(path) || strings.ContainsAny(path, "{}") || strings.Contains(path, "//") {
+		return request, errRewriteBlocked
+	}
+	query, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return request, errRewriteBlocked
+	}
+	for key, values := range query {
+		if len(values) != 1 {
+			return request, errRewriteBlocked
+		}
+		request.query[key] = values[0]
+	}
+	return request, nil
+}
+
+var rewriteMutationPath = regexp.MustCompile(`^/repos/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/(.+)$`)
+var rewriteIssueNumber = regexp.MustCompile(`^issues/[0-9]+$`)
+var rewriteCommentCreate = regexp.MustCompile(`^issues/[0-9]+/comments$`)
+var rewriteCommentEdit = regexp.MustCompile(`^(issues|pulls)/comments/[0-9]+$`)
+var rewritePullNumber = regexp.MustCompile(`^pulls/[0-9]+$`)
+var rewriteReviewCreate = regexp.MustCompile(`^pulls/[0-9]+/reviews$`)
+var rewriteReviewEdit = regexp.MustCompile(`^pulls/[0-9]+/reviews/[0-9]+$`)
+var rewriteReleaseNumber = regexp.MustCompile(`^releases/[0-9]+$`)
+
+func rewriteMutationSchema(path, method string) (string, error) {
+	match := rewriteMutationPath.FindStringSubmatch(path)
+	if match == nil {
+		return "", errRewriteBlocked
+	}
+	tail := match[1]
+	switch {
+	case method == "POST" && tail == "issues":
+		return "issue-create", nil
+	case method == "POST" && tail == "pulls":
+		return "pull-create", nil
+	case method == "POST" && tail == "releases":
+		return "release-create", nil
+	case method == "PATCH" && rewriteIssueNumber.MatchString(tail):
+		return "issue-edit", nil
+	case method == "PATCH" && rewritePullNumber.MatchString(tail):
+		return "pull-edit", nil
+	case method == "POST" && rewriteCommentCreate.MatchString(tail):
+		return "comment", nil
+	case method == "PATCH" && rewriteCommentEdit.MatchString(tail):
+		return "comment", nil
+	case method == "POST" && rewriteReviewCreate.MatchString(tail):
+		return "review", nil
+	case method == "PUT" && rewriteReviewEdit.MatchString(tail):
+		return "comment", nil
+	case method == "PATCH" && rewriteReleaseNumber.MatchString(tail):
+		return "release-edit", nil
+	}
+	return "", errRewriteBlocked
+}
+
+func rewriteAPIPayload(policy stringRewritePolicy, prepared *rewritePreparation, payload map[string]any, schema string) error {
+	spec := "body:text"
+	required := "body"
+	switch schema {
+	case "issue-create":
+		spec = "title:text body:text labels:strings assignees:strings milestone:integer"
+		required = "title body"
+	case "issue-edit":
+		spec = "title:text body:text"
+		required = ""
+	case "pull-create":
+		spec = "title:text body:text head:string base:string draft:bool maintainer_can_modify:bool"
+		required = "title body head base"
+	case "pull-edit":
+		spec = "title:text body:text"
+		required = ""
+	case "release-create":
+		spec = "name:text body:text tag_name:string draft:bool prerelease:bool make_latest:string"
+		required = "name body tag_name"
+	case "release-edit":
+		spec = "name:text body:text draft:bool prerelease:bool make_latest:string"
+		required = ""
+	case "review":
+		spec = "body:text event:string commit_id:string comments:comments"
+		required = "body event"
+	case "review-comment":
+		spec = "body:text path:string line:integer side:string start_line:integer start_side:string position:integer"
+		required = "body path"
+	}
+	allowed := map[string]string{}
+	for _, entry := range strings.Fields(spec) {
+		key, kind, _ := strings.Cut(entry, ":")
+		allowed[key] = kind
+	}
+	if len(payload) == 0 {
+		return errRewriteBlocked
+	}
+	for _, key := range strings.Fields(required) {
+		if _, ok := payload[key]; !ok {
+			return errRewriteBlocked
+		}
+	}
+	if schema == "review" {
+		event, ok := payload["event"].(string)
+		if !ok || (event != "APPROVE" && event != "COMMENT" && event != "REQUEST_CHANGES") {
+			return errRewriteBlocked
+		}
+	}
+	for key, value := range payload {
+		if err := policy.checkStructural(key); err != nil {
+			return err
+		}
+		switch allowed[key] {
+		case "text":
+			text, ok := value.(string)
+			if !ok {
+				return errRewriteBlocked
+			}
+			rewritten, err := prepared.text(policy, text)
+			if err != nil {
+				return err
+			}
+			if strings.HasSuffix(schema, "-create") && strings.TrimSpace(rewritten) == "" {
+				return errRewriteBlocked
+			}
+			payload[key] = rewritten
+		case "string":
+			text, ok := value.(string)
+			if !ok || text == "" {
+				return errRewriteBlocked
+			}
+			if err := policy.checkStructural(text); err != nil {
+				return err
+			}
+		case "strings":
+			values, ok := value.([]any)
+			if !ok {
+				return errRewriteBlocked
+			}
+			for _, value := range values {
+				text, ok := value.(string)
+				if !ok {
+					return errRewriteBlocked
+				}
+				if err := policy.checkStructural(text); err != nil {
+					return err
+				}
+			}
+		case "integer":
+			if _, ok := rewriteInteger(value); !ok {
+				return errRewriteBlocked
+			}
+		case "bool":
+			if _, ok := value.(bool); !ok {
+				return errRewriteBlocked
+			}
+		case "comments":
+			values, ok := value.([]any)
+			if !ok {
+				return errRewriteBlocked
+			}
+			for _, value := range values {
+				comment, ok := value.(map[string]any)
+				if !ok {
+					return errRewriteBlocked
+				}
+				if err := rewriteAPIPayload(policy, prepared, comment, "review-comment"); err != nil {
+					return err
+				}
+			}
+		default:
+			return errRewriteBlocked
+		}
+	}
+	return nil
+}
+func checkRewriteJSONStrings(policy stringRewritePolicy, value any) error {
+	switch value := value.(type) {
+	case string:
+		return policy.check(value)
+	case map[string]any:
+		for key, item := range value {
+			if err := policy.check(key); err != nil {
+				return err
+			}
+			if err := checkRewriteJSONStrings(policy, item); err != nil {
+				return err
+			}
+		}
+	case []any:
+		for _, item := range value {
+			if err := checkRewriteJSONStrings(policy, item); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/octopool/string_rewrites_args.go
+++ b/cmd/octopool/string_rewrites_args.go
@@ -1,0 +1,302 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+type rewriteFlag struct {
+	name    string
+	value   string
+	boolean bool
+}
+type rewriteFlags struct {
+	values      map[string]string
+	positionals []string
+	ordered     []rewriteFlag
+}
+
+// Parse only a command-specific vocabulary. Short value flags support -tVALUE
+// and -t=VALUE; boolean clusters and repeated/conflicting aliases are refused.
+func parseRewriteFlags(args []string, values, booleans map[string]string) (rewriteFlags, error) {
+	out := rewriteFlags{values: map[string]string{}}
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if !strings.HasPrefix(arg, "-") {
+			out.positionals = append(out.positionals, arg)
+			continue
+		}
+		name, value, equals := strings.Cut(arg, "=")
+		if !strings.HasPrefix(arg, "--") && len(name) > 2 {
+			name = arg[:2]
+			value = strings.TrimPrefix(arg[2:], "=")
+			equals = true
+		}
+		canonical, boolean := booleans[name]
+		if boolean {
+			if equals && value != "true" && value != "false" {
+				return out, errRewriteBlocked
+			}
+			if !equals {
+				value = "true"
+			}
+		} else {
+			var ok bool
+			canonical, ok = values[name]
+			if !ok {
+				return out, errRewriteBlocked
+			}
+			if !equals {
+				i++
+				if i >= len(args) {
+					return out, errRewriteBlocked
+				}
+				value = args[i]
+			}
+		}
+		if _, exists := out.values[canonical]; exists {
+			return out, errRewriteBlocked
+		}
+		out.values[canonical] = value
+		out.ordered = append(out.ordered, rewriteFlag{canonical, value, boolean})
+	}
+	return out, nil
+}
+func rewriteFlagNames(spec string) map[string]string {
+	out := map[string]string{}
+	for _, entry := range strings.Fields(spec) {
+		aliases := strings.Split(entry, ",")
+		for _, alias := range aliases {
+			out[alias] = aliases[0]
+		}
+	}
+	return out
+}
+func (flags rewriteFlags) has(name string) bool { _, ok := flags.values[name]; return ok }
+
+type rewritePreparation struct {
+	preflight   []string
+	args        []string
+	stdin       io.Reader
+	directory   string
+	inputBytes  int
+	outputBytes int
+}
+
+func (prepared *rewritePreparation) cleanup() {
+	if prepared.directory != "" {
+		_ = os.RemoveAll(prepared.directory)
+	}
+}
+func (prepared *rewritePreparation) text(policy stringRewritePolicy, text string) (string, error) {
+	prepared.inputBytes += len(text)
+	if prepared.inputBytes > rewriteMaxContent {
+		return "", errRewriteBlocked
+	}
+	result, err := policy.rewrite(text)
+	if err != nil {
+		return "", err
+	}
+	prepared.outputBytes += len(result)
+	if prepared.outputBytes > rewriteMaxContent {
+		return "", errRewriteBlocked
+	}
+	return result, nil
+}
+func (prepared *rewritePreparation) snapshot(data []byte) (string, error) {
+	if len(data) > rewriteMaxContent {
+		return "", errRewriteBlocked
+	}
+	if prepared.directory == "" {
+		directory, err := os.MkdirTemp("", "octopool-content-")
+		if err != nil {
+			return "", errRewriteBlocked
+		}
+		prepared.directory = directory
+	}
+	file, err := os.CreateTemp(prepared.directory, "snapshot-")
+	if err != nil {
+		return "", errRewriteBlocked
+	}
+	path := file.Name()
+	_, writeErr := file.Write(data)
+	closeErr := file.Close()
+	if writeErr != nil || closeErr != nil {
+		return "", errRewriteBlocked
+	}
+	return filepath.Clean(path), nil
+}
+
+var rewriteRepoPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
+var rewriteRefPattern = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_./:-]*$`)
+
+func rewriteRepo(flags *rewriteFlags, policy stringRewritePolicy) error {
+	repo := flags.values["--repo"]
+	// Pin inferred repository context too: the child must not resolve another
+	// repository from its environment after the structural check.
+	if repo == "" {
+		var ok bool
+		repo, ok = repoFromOptionOrCurrent("")
+		if !ok {
+			return errRewriteBlocked
+		}
+	}
+	if !rewriteRepoPattern.MatchString(repo) || strings.Contains(repo, "..") {
+		return errRewriteBlocked
+	}
+	if err := policy.checkStructural(repo); err != nil {
+		return err
+	}
+	flags.values["--repo"] = repo
+	return nil
+}
+func rewriteContentCommand(args []string) bool {
+	if len(args) < 2 {
+		return false
+	}
+	switch args[0] + " " + args[1] {
+	case "pr create", "pr edit", "pr comment", "pr review", "issue create", "issue edit", "issue comment", "release create", "release edit":
+		return true
+	}
+	return false
+}
+
+func prepareRewriteContent(policy stringRewritePolicy, args []string, stdin io.Reader, prepared *rewritePreparation) error {
+	command := args[0] + " " + args[1]
+	valueSpec := "--repo,-R"
+	booleanSpec := ""
+	switch command {
+	case "pr create":
+		valueSpec += " --title,-t --body,-b --body-file,-F --head,-H --base,-B"
+		booleanSpec = "--draft,-d --no-maintainer-edit"
+	case "pr edit", "issue edit":
+		valueSpec += " --title,-t --body,-b --body-file,-F"
+	case "issue create":
+		valueSpec += " --title,-t --body,-b --body-file,-F"
+	case "pr comment", "issue comment":
+		valueSpec += " --body,-b --body-file,-F"
+		booleanSpec = "--edit-last --create-if-none"
+	case "pr review":
+		valueSpec += " --body,-b --body-file,-F"
+		booleanSpec = "--approve,-a --request-changes,-r --comment,-c"
+	case "release create", "release edit":
+		valueSpec += " --title,-t --notes,-n --notes-file,-F"
+		booleanSpec = "--draft,-d --prerelease,-p --latest"
+		if args[1] == "create" {
+			booleanSpec += " --verify-tag"
+		}
+	default:
+		return errRewriteBlocked
+	}
+	flags, err := parseRewriteFlags(args[2:], rewriteFlagNames(valueSpec), rewriteFlagNames(booleanSpec))
+	if err != nil {
+		return err
+	}
+	if err := rewriteRepo(&flags, policy); err != nil {
+		return err
+	}
+	create := args[1] == "create"
+	release := args[0] == "release"
+	if create && !release {
+		if len(flags.positionals) != 0 {
+			return errRewriteBlocked
+		}
+	} else {
+		if len(flags.positionals) != 1 {
+			return errRewriteBlocked
+		}
+		selector := flags.positionals[0]
+		if release {
+			if !rewriteRefPattern.MatchString(selector) {
+				return errRewriteBlocked
+			}
+		} else if !isDigits(selector) {
+			return errRewriteBlocked
+		}
+		if err := policy.checkStructural(selector); err != nil {
+			return err
+		}
+	}
+	body, file := "--body", "--body-file"
+	if release {
+		body, file = "--notes", "--notes-file"
+	}
+	if flags.has(body) && flags.has(file) {
+		return errRewriteBlocked
+	}
+	hasBody := flags.has(body) || flags.has(file)
+	if create && (!flags.has("--title") || !hasBody) {
+		return errRewriteBlocked
+	}
+	if args[1] == "edit" && !flags.has("--title") && !hasBody {
+		return errRewriteBlocked
+	}
+	if (args[1] == "comment" || args[1] == "review") && !hasBody {
+		return errRewriteBlocked
+	}
+	if command == "pr create" {
+		// gh explicitly skips all pushing/forking when --head is present.
+		if !flags.has("--head") || !rewriteRefPattern.MatchString(flags.values["--head"]) || !flags.has("--base") || !rewriteRefPattern.MatchString(flags.values["--base"]) {
+			return errRewriteBlocked
+		}
+	}
+	if command == "release create" && flags.values["--verify-tag"] != "true" {
+		return errRewriteBlocked
+	}
+	if command == "pr review" {
+		count := 0
+		for _, key := range []string{"--approve", "--request-changes", "--comment"} {
+			if flags.values[key] == "true" {
+				count++
+			}
+		}
+		if count != 1 {
+			return errRewriteBlocked
+		}
+	}
+	prepared.args = append([]string{args[0], args[1]}, flags.positionals...)
+	prepared.args = append(prepared.args, "--repo="+flags.values["--repo"])
+	for _, flag := range flags.ordered {
+		if flag.name == "--repo" {
+			continue
+		}
+		switch flag.name {
+		case "--title", body, file:
+			text := flag.value
+			if flag.name == file {
+				data, err := readRewriteFile(flag.value, stdin, rewriteMaxContent-prepared.inputBytes)
+				if err != nil {
+					return err
+				}
+				text = string(data)
+			}
+			text, err = prepared.text(policy, text)
+			if err != nil {
+				return err
+			}
+			// Empty create fields can re-enable gh's prompts/default generation.
+			if create && strings.TrimSpace(text) == "" {
+				return errRewriteBlocked
+			}
+			if flag.name == "--title" {
+				prepared.args = append(prepared.args, "--title="+text)
+			} else {
+				path, err := prepared.snapshot([]byte(text))
+				if err != nil {
+					return err
+				}
+				prepared.args = append(prepared.args, file+"="+path)
+			}
+		default:
+			if err := policy.checkStructural(flag.value); err != nil {
+				return err
+			}
+			prepared.args = append(prepared.args, flag.name+"="+flag.value)
+		}
+	}
+	prepared.stdin = strings.NewReader("")
+	return nil
+}

--- a/cmd/octopool/string_rewrites_file_unix.go
+++ b/cmd/octopool/string_rewrites_file_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func openRewriteSnapshot(path string) (*os.File, error) {
+	// A concurrently replaced FIFO must not stall before File.Stat rejects it.
+	return os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+}

--- a/cmd/octopool/string_rewrites_file_windows.go
+++ b/cmd/octopool/string_rewrites_file_windows.go
@@ -1,0 +1,5 @@
+package main
+
+import "os"
+
+func openRewriteSnapshot(path string) (*os.File, error) { return os.Open(path) }

--- a/cmd/octopool/string_rewrites_guard.go
+++ b/cmd/octopool/string_rewrites_guard.go
@@ -1,0 +1,337 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net/url"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+func (policy stringRewritePolicy) checkStructural(text string) error {
+	// Inspect each bounded decoding layer, then reject residual or malformed
+	// encoding. Never change a repository/ref/query to make it pass a policy.
+	for depth := 0; depth < 4; depth++ {
+		if err := policy.check(text); err != nil {
+			return err
+		}
+		if strings.ContainsAny(text, "\\\x00\r\n") {
+			return errRewriteBlocked
+		}
+		if !strings.Contains(text, "%") {
+			return nil
+		}
+		decoded, err := url.PathUnescape(text)
+		if err != nil {
+			return errRewriteBlocked
+		}
+		text = decoded
+	}
+	return errRewriteBlocked
+}
+func (policy stringRewritePolicy) guardRequest(request ghAPIRequest) error {
+	if len(policy.Rules) == 0 {
+		return nil
+	}
+	if request.method != "GET" && request.method != "POST" && request.method != "PATCH" && request.method != "PUT" {
+		return errRewriteBlocked
+	}
+	if !safeRelayPath(request.path) || strings.ContainsAny(request.path, "{}") || strings.Contains(request.path, "//") {
+		return errRewriteBlocked
+	}
+	if err := policy.checkStructural(request.path); err != nil {
+		return err
+	}
+	for _, segment := range strings.Split(request.path, "/") {
+		if err := policy.checkStructural(segment); err != nil {
+			return err
+		}
+		decoded, err := url.PathUnescape(segment)
+		if err != nil || decoded == "." || decoded == ".." || strings.ContainsAny(decoded, "/?#%") {
+			return errRewriteBlocked
+		}
+	}
+	total := len(request.path)
+	check := func(value string) error {
+		total += len(value)
+		if total > rewriteMaxContent {
+			return errRewriteBlocked
+		}
+		return policy.checkStructural(value)
+	}
+	for key, value := range request.query {
+		if sensitiveQueryKey(key) {
+			return errRewriteBlocked
+		}
+		if err := check(key); err != nil {
+			return err
+		}
+		switch value := value.(type) {
+		case string:
+			if err := check(value); err != nil {
+				return err
+			}
+		case []string:
+			for _, item := range value {
+				if err := check(item); err != nil {
+					return err
+				}
+			}
+		default:
+			return errRewriteBlocked
+		}
+	}
+	for key, value := range request.headers {
+		if !safeRelayHeader(strings.ToLower(key)) && !rewriteInternalShapeHeader(key, value) {
+			return errRewriteBlocked
+		}
+		if err := check(key); err != nil {
+			return err
+		}
+		if err := check(value); err != nil {
+			return err
+		}
+	}
+	for key, value := range request.routeHint {
+		if err := check(key); err != nil {
+			return err
+		}
+		if err := check(value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rewriteInternalShapeHeader(key, value string) bool {
+	if key != "x-octopool-public-shape" {
+		return false
+	}
+	return slices.Contains([]string{publicShapeActionsSummary, publicShapeActionsJobs, publicShapeIssueSummary, publicShapeIssueList, publicShapeIssueSearch, publicShapePullRequestList, publicShapePullRequestSummary, publicShapePullRequestFiles, publicShapeLabelList, publicShapeWorkflowList, publicShapeWorkflowView, publicShapeReleaseSummary}, value)
+}
+
+var rewriteTagReadPath = regexp.MustCompile(`^/repos/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/git/ref/tags/[A-Za-z0-9_.-]+$`)
+
+func rewriteReadPath(path string) bool {
+	return path == "/user" || relayQueryPath(path) || rewriteTagReadPath.MatchString(path)
+}
+
+func prepareRewriteRead(policy stringRewritePolicy, args []string, prepared *rewritePreparation) error {
+	if len(args) < 2 {
+		return errRewriteBlocked
+	}
+	command := args[0] + " " + args[1]
+	values := "--repo,-R --json --jq,-q"
+	booleans := ""
+	switch command {
+	case "pr view", "issue view":
+	case "pr diff":
+		booleans = "--patch"
+	case "pr list", "issue list":
+		values += " --limit,-L --state --author --assignee --label"
+	case "run view":
+		values += " --attempt"
+		booleans = "--log --log-failed --exit-status"
+	case "run list":
+		values += " --limit,-L --branch --workflow --status"
+	case "run watch":
+		values += " --interval,-i"
+		booleans = "--exit-status"
+	case "pr checks":
+		values += " --interval,-i"
+		booleans = "--watch --fail-fast --required"
+	case "repo view":
+	case "release view":
+	case "release list", "workflow list", "label list":
+		values += " --limit,-L"
+	case "workflow view":
+	case "search issues", "search prs":
+		values += " --limit,-L --state --author --assignee --label"
+	default:
+		return errRewriteBlocked
+	}
+	flags, err := parseRewriteFlags(args[2:], rewriteFlagNames(values), rewriteFlagNames(booleans))
+	if err != nil {
+		return err
+	}
+	if flags.has("--color") {
+		return errRewriteBlocked
+	}
+	if command == "repo view" && len(flags.positionals) == 1 && !flags.has("--repo") {
+		flags.values["--repo"] = flags.positionals[0]
+		flags.positionals = nil
+	}
+	if err := rewriteRepo(&flags, policy); err != nil {
+		return err
+	}
+	switch args[1] {
+	case "view", "diff", "checks", "watch":
+		if args[0] != "repo" {
+			if len(flags.positionals) != 1 {
+				return errRewriteBlocked
+			}
+			selector := flags.positionals[0]
+			if args[0] == "pr" || args[0] == "issue" || args[0] == "run" {
+				if !isDigits(selector) {
+					return errRewriteBlocked
+				}
+			} else if !rewriteRefPattern.MatchString(selector) {
+				return errRewriteBlocked
+			}
+		} else if len(flags.positionals) != 0 {
+			return errRewriteBlocked
+		}
+	case "list":
+		if len(flags.positionals) != 0 {
+			return errRewriteBlocked
+		}
+	default:
+		if args[0] != "search" {
+			return errRewriteBlocked
+		}
+	}
+	for _, value := range flags.positionals {
+		if err := policy.checkStructural(value); err != nil {
+			return err
+		}
+	}
+	for key, value := range flags.values {
+		if key == "--jq" || key == "--json" {
+			continue
+		} // Local output projections do not go to GitHub.
+		if err := policy.checkStructural(value); err != nil {
+			return err
+		}
+	}
+	// Check the composed path/query as well as individual values. Relay dispatch
+	// checks the actual normalized request again before each network operation.
+	path := "/repos/" + flags.values["--repo"]
+	resources := map[string]string{"pr": "pulls", "issue": "issues", "run": "actions/runs", "workflow": "actions/workflows", "release": "releases", "label": "labels"}
+	if resource := resources[args[0]]; resource != "" {
+		path += "/" + resource
+	}
+	if len(flags.positionals) == 1 && args[0] != "search" {
+		path += "/" + flags.positionals[0]
+	}
+	request := ghAPIRequest{method: "GET", path: path, query: map[string]any{}}
+	if args[0] == "search" {
+		request.path = "/search/issues"
+		request.query["q"] = "repo:" + flags.values["--repo"] + " " + strings.Join(flags.positionals, " ")
+	}
+	for key, value := range flags.values {
+		if key != "--repo" && key != "--jq" && key != "--json" {
+			request.query[strings.TrimPrefix(key, "--")] = value
+		}
+	}
+	if err := policy.guardRequest(request); err != nil {
+		return err
+	}
+	prepared.args = append([]string{args[0], args[1]}, flags.positionals...)
+	prepared.args = append(prepared.args, "--repo="+flags.values["--repo"])
+	for _, flag := range flags.ordered {
+		if flag.name != "--repo" {
+			if flag.boolean && flag.value == "true" {
+				prepared.args = append(prepared.args, flag.name)
+			} else {
+				prepared.args = append(prepared.args, flag.name+"="+flag.value)
+			}
+		}
+	}
+	prepared.stdin = strings.NewReader("")
+	return nil
+}
+
+// Exceptions are complete invocations, not an auth prefix or an approval bit
+// that could accidentally bless different arguments on a later fallback.
+func rewriteBootstrapInvocation(args []string) bool {
+	if len(args) == 0 {
+		return true
+	}
+	if len(args) >= 2 && (args[len(args)-1] == "--help" || args[len(args)-1] == "-h") {
+		return rewriteBootstrapInvocation(append([]string{"help"}, args[:len(args)-1]...))
+	}
+	if len(args) == 1 && (args[0] == "--version" || args[0] == "version" || args[0] == "--help" || args[0] == "-h" || args[0] == "help") {
+		return true
+	}
+	if len(args) >= 2 && args[0] == "help" {
+		for _, arg := range args[1:] {
+			if !slices.Contains([]string{"api", "pr", "issue", "release", "auth", "status", "login", "create", "edit", "comment", "review", "view", "list"}, arg) {
+				return false
+			}
+		}
+		return true
+	}
+	if len(args) == 8 && args[0] == "api" && args[1] == "graphql" && args[2] == "--hostname" && args[3] == "github.com" && args[4] == "-f" && args[5] == "query="+authStatusViewerQuery && args[6] == "--jq" && args[7] == ".data.viewer.login" {
+		return true
+	}
+	if len(args) < 2 || args[0] != "auth" {
+		return false
+	}
+	values := "--hostname,-h"
+	booleans := ""
+	switch args[1] {
+	case "status":
+		booleans = "--active,-a"
+		values += " --json --jq,-q --template,-t"
+	case "login":
+		booleans = "--with-token --web,-w --insecure-storage --skip-ssh-key"
+		values += " --git-protocol,-p --scopes,-s"
+	default:
+		return false
+	}
+	flags, err := parseRewriteFlags(args[2:], rewriteFlagNames(values), rewriteFlagNames(booleans))
+	if err != nil || len(flags.positionals) != 0 {
+		return false
+	}
+	if flags.has("--hostname") && flags.values["--hostname"] != "github.com" {
+		return false
+	}
+	if flags.has("--git-protocol") && flags.values["--git-protocol"] != "https" && flags.values["--git-protocol"] != "ssh" {
+		return false
+	}
+	if flags.has("--scopes") {
+		for _, scope := range strings.Split(flags.values["--scopes"], ",") {
+			if !slices.Contains([]string{"repo", "read:org", "gist", "workflow"}, scope) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func prepareProtectedGH(ctx context.Context, args []string, stdin io.Reader) (*rewritePreparation, error) {
+	prepared := &rewritePreparation{args: args, stdin: stdin}
+	if rewriteBootstrapInvocation(args) {
+		return prepared, nil
+	}
+	policy, err := currentStringRewritePolicy(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(policy.Rules) == 0 {
+		return prepared, nil
+	}
+	total := 0
+	for _, arg := range args {
+		total += len(arg)
+		if total > rewriteMaxContent {
+			return nil, errRewriteBlocked
+		}
+	}
+	switch {
+	case rewriteContentCommand(args):
+		err = prepareRewriteContent(policy, args, stdin, prepared)
+	case len(args) > 0 && args[0] == "api":
+		err = prepareRewriteAPI(policy, args, stdin, prepared)
+	default:
+		// Native top-level reads may construct additional search/GraphQL
+		// requests. Only decoded raw REST GETs have an approved local shape.
+		err = errRewriteBlocked
+	}
+	if err != nil {
+		prepared.cleanup()
+		return nil, errRewriteBlocked
+	}
+	return prepared, nil
+}

--- a/cmd/octopool/string_rewrites_json.go
+++ b/cmd/octopool/string_rewrites_json.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"strconv"
+	"unicode/utf8"
+)
+
+// encoding/json replaces invalid UTF-8 and unpaired surrogates. Validate the
+// lexical strings first so that decoding cannot silently repair protected text.
+func validRewriteJSONUnicode(data []byte) bool {
+	if !utf8.Valid(data) {
+		return false
+	}
+	inString := false
+	for i := 0; i < len(data); i++ {
+		if data[i] == '"' {
+			inString = !inString
+			continue
+		}
+		if !inString || data[i] != '\\' {
+			continue
+		}
+		i++
+		if i >= len(data) {
+			return false
+		}
+		if data[i] != 'u' {
+			continue
+		}
+		if i+4 >= len(data) {
+			return false
+		}
+		code, err := strconv.ParseUint(string(data[i+1:i+5]), 16, 16)
+		if err != nil {
+			return false
+		}
+		i += 4
+		if code >= 0xdc00 && code <= 0xdfff {
+			return false
+		}
+		if code >= 0xd800 && code <= 0xdbff {
+			if i+6 >= len(data) || data[i+1] != '\\' || data[i+2] != 'u' {
+				return false
+			}
+			low, err := strconv.ParseUint(string(data[i+3:i+7]), 16, 16)
+			if err != nil || low < 0xdc00 || low > 0xdfff {
+				return false
+			}
+			i += 6
+		}
+	}
+	return !inString
+}
+
+func strictRewriteJSON(data []byte, limit int) (any, error) {
+	if len(data) > limit || !validRewriteJSONUnicode(data) {
+		return nil, errRewritePolicy
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	value, err := rewriteJSONValue(dec, 0)
+	if err != nil {
+		return nil, errRewritePolicy
+	}
+	if _, err := dec.Token(); err != io.EOF {
+		return nil, errRewritePolicy
+	}
+	return value, nil
+}
+
+func rewriteJSONValue(dec *json.Decoder, depth int) (any, error) {
+	if depth > 64 {
+		return nil, errRewritePolicy
+	}
+	token, err := dec.Token()
+	if err != nil {
+		return nil, errRewritePolicy
+	}
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return token, nil
+	}
+	switch delim {
+	case '{':
+		result := map[string]any{}
+		for dec.More() {
+			token, err := dec.Token()
+			key, ok := token.(string)
+			if err != nil || !ok {
+				return nil, errRewritePolicy
+			}
+			if _, exists := result[key]; exists {
+				return nil, errRewritePolicy
+			}
+			value, err := rewriteJSONValue(dec, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			result[key] = value
+		}
+		end, err := dec.Token()
+		if err != nil || end != json.Delim('}') {
+			return nil, errRewritePolicy
+		}
+		return result, nil
+	case '[':
+		result := []any{}
+		for dec.More() {
+			value, err := rewriteJSONValue(dec, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, value)
+		}
+		end, err := dec.Token()
+		if err != nil || end != json.Delim(']') {
+			return nil, errRewritePolicy
+		}
+		return result, nil
+	}
+	return nil, errRewritePolicy
+}
+
+func exactRewriteKeys(value any, keys ...string) (map[string]any, bool) {
+	object, ok := value.(map[string]any)
+	if !ok || len(object) != len(keys) {
+		return nil, false
+	}
+	for _, key := range keys {
+		if _, ok := object[key]; !ok {
+			return nil, false
+		}
+	}
+	return object, true
+}
+func rewriteInteger(value any) (int64, bool) {
+	number, ok := value.(json.Number)
+	if !ok {
+		return 0, false
+	}
+	integer, err := number.Int64()
+	return integer, err == nil && integer > 0 && integer <= 9007199254740991
+}
+func parseStringRewritePolicy(data []byte, server bool) (stringRewritePolicy, error) {
+	value, err := strictRewriteJSON(data, rewriteMaxDocument)
+	if err != nil {
+		return stringRewritePolicy{}, errRewritePolicy
+	}
+	keys := []string{"schema_version", "rules"}
+	if server {
+		keys = append(keys, "revision", "updated_at")
+	}
+	object, ok := exactRewriteKeys(value, keys...)
+	if !ok {
+		return stringRewritePolicy{}, errRewritePolicy
+	}
+	version, ok := rewriteInteger(object["schema_version"])
+	if !ok || version != 1 {
+		return stringRewritePolicy{}, errRewritePolicy
+	}
+	rawRules, ok := object["rules"].([]any)
+	if !ok || len(rawRules) > rewriteMaxRules {
+		return stringRewritePolicy{}, errRewritePolicy
+	}
+	rules := make([]stringRewriteRule, 0, len(rawRules))
+	for _, raw := range rawRules {
+		rule, ok := exactRewriteKeys(raw, "pattern", "replacement")
+		if !ok {
+			return stringRewritePolicy{}, errRewritePolicy
+		}
+		pattern, p := rule["pattern"].(string)
+		replacement, r := rule["replacement"].(string)
+		if !p || !r {
+			return stringRewritePolicy{}, errRewritePolicy
+		}
+		rules = append(rules, stringRewriteRule{pattern, replacement})
+	}
+	policy, err := compileStringRewriteRules(rules)
+	if err != nil {
+		return policy, err
+	}
+	if server {
+		var ok bool
+		policy.Revision, ok = rewriteInteger(object["revision"])
+		if !ok {
+			return stringRewritePolicy{}, errRewritePolicy
+		}
+		policy.UpdatedAt, ok = object["updated_at"].(string)
+		if !ok || !validRewriteTimestamp(policy.UpdatedAt) {
+			return stringRewritePolicy{}, errRewritePolicy
+		}
+	}
+	return policy, nil
+}

--- a/cmd/octopool/string_rewrites_policy.go
+++ b/cmd/octopool/string_rewrites_policy.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const rewritePolicyTimeout = 5 * time.Second
+
+func validRewriteTimestamp(value string) bool {
+	_, err := time.Parse(time.RFC3339Nano, value)
+	return err == nil
+}
+
+func boundedRewriteRead(reader io.Reader, limit int) ([]byte, error) {
+	if reader == nil {
+		return nil, errRewriteBlocked
+	}
+	data, err := io.ReadAll(io.LimitReader(reader, int64(limit)+1))
+	if err != nil || len(data) > limit {
+		return nil, errRewriteBlocked
+	}
+	return data, nil
+}
+func readRewriteFile(path string, stdin io.Reader, limit int) ([]byte, error) {
+	if path == "-" {
+		return boundedRewriteRead(stdin, limit)
+	}
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Size() > int64(limit) {
+		return nil, errRewriteBlocked
+	}
+	file, err := openRewriteSnapshot(path)
+	if err != nil {
+		return nil, errRewriteBlocked
+	}
+	defer file.Close()
+	info, err = file.Stat()
+	if err != nil || !info.Mode().IsRegular() || info.Size() > int64(limit) {
+		return nil, errRewriteBlocked
+	}
+	return boundedRewriteRead(file, limit)
+}
+
+func rewritePolicyHTTP(ctx context.Context, baseURL, path, token, method string, body []byte) ([]byte, error) {
+	parsed, err := url.Parse(baseURL)
+	if err != nil || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, errRewritePolicy
+	}
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && (parsed.Hostname() == "localhost" || parsed.Hostname() == "127.0.0.1" || parsed.Hostname() == "::1")) {
+		return nil, errRewritePolicy
+	}
+	if strings.TrimSpace(token) == "" {
+		return nil, errRewritePolicy
+	}
+	child, cancel := context.WithTimeout(ctx, rewritePolicyTimeout)
+	defer cancel()
+	request, err := http.NewRequestWithContext(child, method, apiURL(baseURL, path), bytes.NewReader(body))
+	if err != nil {
+		return nil, errRewritePolicy
+	}
+	request.Header.Set("Authorization", "Bearer "+token)
+	request.Header.Set("Cache-Control", "no-cache, no-store")
+	request.Header.Set("Accept", "application/json")
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	client := &http.Client{Timeout: rewritePolicyTimeout, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, errRewritePolicy
+	}
+	defer response.Body.Close()
+	if response.StatusCode == http.StatusConflict {
+		return nil, errRewriteConflict
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, errRewritePolicy
+	}
+	data, err := boundedRewriteRead(response.Body, rewriteMaxDocument)
+	if err != nil {
+		return nil, errRewritePolicy
+	}
+	return data, nil
+}
+
+func loadLocalStringRewritePolicy() (stringRewritePolicy, error) {
+	path := os.Getenv("OCTOPOOL_STRING_REWRITE_FILE")
+	explicit := path != ""
+	if !explicit {
+		auth, err := authPath()
+		if err != nil {
+			return stringRewritePolicy{}, errRewritePolicy
+		}
+		path = filepath.Join(filepath.Dir(auth), "string-rewrites.json")
+		if _, err := os.Lstat(path); os.IsNotExist(err) {
+			return stringRewritePolicy{}, nil
+		}
+	}
+	data, err := readRewriteFile(path, nil, rewriteMaxDocument)
+	if err != nil {
+		return stringRewritePolicy{}, errRewritePolicy
+	}
+	return parseStringRewritePolicy(data, false)
+}
+
+func (client ghRelayClient) stringRewritePolicy(ctx context.Context) (stringRewritePolicy, error) {
+	data, err := rewritePolicyHTTP(ctx, client.baseURL, "/v1/pools/"+url.PathEscape(client.pool)+"/string-rewrites", client.token, http.MethodGet, nil)
+	if err != nil {
+		return stringRewritePolicy{}, errRewritePolicy
+	}
+	server, err := parseStringRewritePolicy(data, true)
+	if err != nil {
+		return stringRewritePolicy{}, err
+	}
+	local, err := loadLocalStringRewritePolicy()
+	if err != nil {
+		return stringRewritePolicy{}, err
+	}
+	return mergeStringRewritePolicies(server, local)
+}
+func currentStringRewritePolicy(ctx context.Context) (stringRewritePolicy, error) {
+	client, err := newGHRelayClient()
+	if err != nil {
+		return stringRewritePolicy{}, errRewritePolicy
+	}
+	return client.stringRewritePolicy(ctx)
+}

--- a/cmd/octopool/string_rewrites_policy_test.go
+++ b/cmd/octopool/string_rewrites_policy_test.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestStringRewritePolicyFailuresNeverRunChild(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		code int
+		body string
+	}{
+		{"unauthorized", 401, `internal-model`}, {"forbidden", 403, `internal-model`}, {"missing", 404, `internal-model`}, {"outage", 503, `internal-model`},
+		{"invalid JSON", 200, `internal-model`}, {"missing fields", 200, `{"rules":[]}`}, {"duplicate keys", 200, `{"schema_version":1,"schema_version":1,"rules":[]}`},
+		{"oversized", 200, strings.Repeat(" ", rewriteMaxDocument) + rewriteEmptyTestPolicy},
+		{"invalid UTF8", 200, strings.Replace(rewriteActiveTestPolicy, "public", string([]byte{255}), 1)},
+		{"unpaired surrogate", 200, strings.Replace(rewriteActiveTestPolicy, "public", `\ud800`, 1)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			t.Setenv("OCTOPOOL_STRING_REWRITE_FILE", "")
+			var calls atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				if r.URL.Path != "/v1/pools/selected/string-rewrites" || r.Method != "GET" || r.Header.Get("Authorization") != "Bearer configured-token" {
+					t.Error("incorrect policy request")
+				}
+				w.WriteHeader(test.code)
+				_, _ = io.WriteString(w, test.body)
+			}))
+			defer server.Close()
+			t.Setenv("OCTOPOOL_URL", server.URL)
+			t.Setenv("OCTOPOOL_POOL", "selected")
+			t.Setenv("OCTOPOOL_TOKEN", "configured-token")
+			capture := captureRewriteGH(t)
+			var out, stderr bytes.Buffer
+			err := runGH(t.Context(), []string{"issue", "edit", "1", "--body=internal-model", "-Racme/repo"}, &out, &stderr)
+			if err != errRewritePolicy || out.Len() != 0 || stderr.Len() != 0 {
+				t.Fatalf("failure output=%q %q error=%v", out.String(), stderr.String(), err)
+			}
+			if shouldRunRealGH(err) || calls.Load() != 1 {
+				t.Fatal("policy failure was retryable/fallback eligible")
+			}
+			if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Fatal("policy failure reached child")
+			}
+		})
+	}
+}
+func TestStringRewritePolicyRedirectsAndTimeout(t *testing.T) {
+	var destinationCalls atomic.Int64
+	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		destinationCalls.Add(1)
+		_, _ = io.WriteString(w, rewriteEmptyTestPolicy)
+	}))
+	defer destination.Close()
+	for _, code := range []int{301, 302, 303, 307, 308} {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { http.Redirect(w, r, destination.URL, code) }))
+		if _, err := rewritePolicyHTTP(t.Context(), server.URL, "/policy", "test-token", "GET", nil); err != errRewritePolicy {
+			t.Fatalf("redirect error=%v", err)
+		}
+		server.Close()
+	}
+	if destinationCalls.Load() != 0 {
+		t.Fatal("policy followed a redirect")
+	}
+	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { <-r.Context().Done() }))
+	defer slow.Close()
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	if _, err := rewritePolicyHTTP(ctx, slow.URL, "/policy", "test-token", "GET", nil); err != errRewritePolicy {
+		t.Fatal(err)
+	}
+	if time.Since(start) > time.Second {
+		t.Fatal("policy ignored context deadline")
+	}
+	for _, base := range []string{"http://example.com", "https://user:pass@example.com", "https://example.com?x=y", "https://example.com#fragment"} {
+		if _, err := rewritePolicyHTTP(t.Context(), base, "/policy", "synthetic", "GET", nil); err != errRewritePolicy {
+			t.Fatal("unsafe policy URL accepted")
+		}
+	}
+}
+func TestStringRewriteMissingLoginAndLocalFile(t *testing.T) {
+	_, calls := rewriteTestServer(t, rewriteEmptyTestPolicy, nil)
+	capture := captureRewriteGH(t)
+	t.Setenv("OCTOPOOL_TOKEN", "")
+	if err := runGH(t.Context(), []string{"alias", "list"}, io.Discard, io.Discard); err != errRewritePolicy {
+		t.Fatalf("no-login error=%v", err)
+	}
+	if calls.Load() != 0 {
+		t.Fatal("missing login made a policy request")
+	}
+	t.Setenv("OCTOPOOL_TOKEN", "test-token")
+	if err := execRealGH(t.Context(), []string{"alias", "list"}, io.Discard, io.Discard); err != nil {
+		t.Fatal("absent optional default must preserve empty-policy behavior", err)
+	}
+	if err := os.Remove(capture); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("OCTOPOOL_STRING_REWRITE_FILE", filepath.Join(t.TempDir(), "missing.json"))
+	if err := execRealGH(t.Context(), []string{"alias", "list"}, io.Discard, io.Discard); err != errRewritePolicy {
+		t.Fatalf("explicit missing local error=%v", err)
+	}
+	if _, err := os.Stat(capture); !os.IsNotExist(err) {
+		t.Fatal("missing local policy reached child")
+	}
+	t.Setenv("OCTOPOOL_STRING_REWRITE_FILE", "")
+	auth, err := authPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(auth), 0700); err != nil {
+		t.Fatal(err)
+	}
+	local := filepath.Join(filepath.Dir(auth), "string-rewrites.json")
+	if err := os.WriteFile(local, []byte(`{"schema_version":1,"rules":[{"pattern":"internal-model","replacement":"public"}]}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := execRealGH(t.Context(), []string{"alias", "list"}, io.Discard, io.Discard); err != errRewriteBlocked {
+		t.Fatalf("default local policy not enforced: %v", err)
+	}
+}
+func TestStringRewriteSavedURLBinding(t *testing.T) {
+	rewriteTestServer(t, rewriteEmptyTestPolicy, nil)
+	t.Setenv("OCTOPOOL_TOKEN", "")
+	if err := saveAuth(authFile{URL: "https://saved.example", Token: "saved-token", Pool: "maintainers"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := currentStringRewritePolicy(t.Context()); err != errRewritePolicy {
+		t.Fatal("saved token was not bound to saved URL")
+	}
+}
+func TestStringRewriteDirectRequestGuard(t *testing.T) {
+	var relayCalls atomic.Int64
+	rewriteTestServer(t, rewriteEmptyTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+		relayCalls.Add(1)
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Error(err)
+		}
+		if body["path"] != "/repos/acme/repo" {
+			t.Error("unexpected direct request path")
+		}
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	})
+	local := filepath.Join(t.TempDir(), "local.json")
+	if err := os.WriteFile(local, []byte(`{"schema_version":1,"rules":[{"pattern":"internal-model","replacement":"public"}]}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("OCTOPOOL_STRING_REWRITE_FILE", local)
+	for _, args := range [][]string{
+		{"--path", "/repos/acme/internal-model"},
+		{"--path", "/repos/acme/repo", "--query", "q=%69nternal-model"},
+		{"--path", "/repos/acme/repo", "--header", "accept=internal-model"},
+		{"--path", "/repos/acme/repo", "--route-hint", "pr_state=internal-model"},
+	} {
+		if err := runRequest(t.Context(), args, io.Discard); err != errRewriteBlocked {
+			t.Fatalf("direct guard error=%v", err)
+		}
+	}
+	if relayCalls.Load() != 0 {
+		t.Fatal("blocked direct request reached relay")
+	}
+	if err := runRequest(t.Context(), []string{"--path", "/repos/acme/repo"}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if relayCalls.Load() != 1 {
+		t.Fatal("safe direct request not sent")
+	}
+}
+func TestStringRewritePolicyChangeBeforeFallback(t *testing.T) {
+	var body *atomic.Value
+	body, _ = rewriteTestServer(t, rewriteEmptyTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+		body.Store(rewriteActiveTestPolicy)
+		writeCLIFallback(t, w, "route_denied")
+	})
+	capture := captureRewriteGH(t)
+	err := runGH(t.Context(), []string{"api", "repos/acme/internal-model"}, io.Discard, io.Discard)
+	if err != errRewriteBlocked {
+		t.Fatalf("changed policy fallback error=%v", err)
+	}
+	if _, err := os.Stat(capture); !os.IsNotExist(err) {
+		t.Fatal("fallback reused an earlier approval")
+	}
+}
+func TestStringRewriteBootstrapIsNarrow(t *testing.T) {
+	if rewriteBootstrapInvocation([]string{"auth", "login", "--scopes=internal-model"}) {
+		t.Fatal("arbitrary OAuth scope bypassed policy")
+	}
+	for _, args := range [][]string{{"--version"}, {"auth", "status", "--active", "--hostname", "github.com"}, {"auth", "login", "--with-token", "--hostname", "github.com"}} {
+		if !rewriteBootstrapInvocation(args) {
+			t.Fatalf("bootstrap denied: %v", args)
+		}
+	}
+	for _, args := range [][]string{{"auth", "token"}, {"auth", "refresh"}, {"auth", "login", "--unknown"}, {"auth", "status", "--hostname", "other.example"}, {"auth", "login", "--with-token", "extra"}, {"--help", "alias", "list"}, {"api", "graphql", "-fquery=mutation {unsafe}"}} {
+		if rewriteBootstrapInvocation(args) {
+			t.Fatalf("broad bootstrap: %v", args)
+		}
+	}
+}
+
+func TestStringRewriteLocalConflictAndImmediateChange(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	local := filepath.Join(t.TempDir(), "local.json")
+	t.Setenv("OCTOPOOL_STRING_REWRITE_FILE", local)
+	write := func(text string) {
+		t.Helper()
+		if err := os.WriteFile(local, []byte(text), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(`{"schema_version":1,"rules":[{"pattern":"internal-model","replacement":"other"}]}`)
+	if _, err := currentStringRewritePolicy(t.Context()); err != errRewritePolicy {
+		t.Fatal("conflict accepted")
+	}
+	write(`{"schema_version":1,"rules":[{"pattern":"internal-model","replacement":"public"}]}`)
+	p, err := currentStringRewritePolicy(t.Context())
+	if err != nil || len(p.Rules) != 1 {
+		t.Fatal("identical local rule not deduplicated", err)
+	}
+	write(`{"schema_version":1,"rules":[{"pattern":"public","replacement":"current"}]}`)
+	p, err = currentStringRewritePolicy(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out, err := p.rewrite("internal-model"); err != nil || out != "current" {
+		t.Fatalf("stale local policy: %q %v", out, err)
+	}
+	write(`{"schema_version":1,"rules":null}`)
+	if _, err := currentStringRewritePolicy(t.Context()); err != errRewritePolicy {
+		t.Fatal("corrupt local policy reused last good value")
+	}
+}
+
+func TestStringRewriteChecksFinalFreshHeader(t *testing.T) {
+	rewriteTestServer(t, strings.Replace(rewriteActiveTestPolicy, "internal-model", "max-age=0", 1), nil)
+	t.Setenv("OCTOPOOL_FRESH", "1")
+	client, err := newGHRelayClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.do(t.Context(), ghAPIRequest{method: "GET", path: "/repos/acme/repo"}); err != errRewriteBlocked {
+		t.Fatalf("fresh header bypassed guard: %v", err)
+	}
+}
+
+func TestStringRewriteWatchPolicyErrorsAreTerminal(t *testing.T) {
+	sleeps := recordWatchSleeps(t)
+	for _, failure := range []error{errRewritePolicy, errRewriteBlocked, errOctopoolNotLoggedIn} {
+		calls := 0
+		backoff := newWatchBackoff(time.Second)
+		err := retryWatchTick(t.Context(), &backoff, func() error { calls++; return failure })
+		if err != failure || calls != 1 || len(*sleeps) != 0 {
+			t.Fatalf("policy failure retried: %v calls=%d sleeps=%v", err, calls, *sleeps)
+		}
+	}
+}

--- a/cmd/octopool/string_rewrites_process_test.go
+++ b/cmd/octopool/string_rewrites_process_test.go
@@ -1,0 +1,496 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+type rewriteCapture struct {
+	Args           []string
+	Stdin          string
+	Files          map[string]string
+	Modes          map[string]uint32
+	DirectoryModes map[string]uint32
+}
+
+func TestRewriteCaptureProcess(t *testing.T) {
+	capturePath := os.Getenv("OCTOPOOL_TEST_REWRITE_CAPTURE")
+	if capturePath == "" {
+		return
+	}
+	args := os.Args
+	for i, arg := range args {
+		if arg == "--" {
+			args = args[i+1:]
+			break
+		}
+	}
+	capture := rewriteCapture{Args: args, Files: map[string]string{}, Modes: map[string]uint32{}, DirectoryModes: map[string]uint32{}}
+	input, _ := io.ReadAll(os.Stdin)
+	capture.Stdin = string(input)
+	for _, arg := range args {
+		for _, prefix := range []string{"--body-file=", "--notes-file=", "--input="} {
+			if path, ok := strings.CutPrefix(arg, prefix); ok {
+				data, err := os.ReadFile(path)
+				if err != nil {
+					os.Exit(80)
+				}
+				capture.Files[path] = string(data)
+				info, _ := os.Stat(path)
+				capture.Modes[path] = uint32(info.Mode().Perm())
+				dir, _ := os.Stat(filepath.Dir(path))
+				capture.DirectoryModes[path] = uint32(dir.Mode().Perm())
+			}
+		}
+	}
+	data, _ := json.Marshal(capture)
+	if err := os.WriteFile(capturePath, data, 0600); err != nil {
+		os.Exit(81)
+	}
+	_, _ = io.WriteString(os.Stdout, "child stdout\n")
+	_, _ = io.WriteString(os.Stderr, "child stderr\n")
+	exit, _ := strconv.Atoi(os.Getenv("OCTOPOOL_TEST_REWRITE_EXIT"))
+	os.Exit(exit)
+}
+func captureRewriteGH(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell process fixture")
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "fake-gh")
+	script := "#!/bin/sh\nexec '" + strings.ReplaceAll(executable, "'", "'\\''") + "' -test.run=^TestRewriteCaptureProcess$ -- \"$@\"\n"
+	if err := os.WriteFile(path, []byte(script), 0700); err != nil {
+		t.Fatal(err)
+	}
+	capture := filepath.Join(t.TempDir(), "capture.json")
+	t.Setenv("OCTOPOOL_GH_PATH", path)
+	t.Setenv("OCTOPOOL_TEST_REWRITE_CAPTURE", capture)
+	return capture
+}
+func readRewriteCapture(t *testing.T, path string) rewriteCapture {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var capture rewriteCapture
+	if err := json.Unmarshal(data, &capture); err != nil {
+		t.Fatal(err)
+	}
+	return capture
+}
+func rewriteTestServer(t *testing.T, policyBody string, relay http.HandlerFunc) (*atomic.Value, *atomic.Int64) {
+	t.Helper()
+	body := &atomic.Value{}
+	body.Store(policyBody)
+	calls := &atomic.Int64{}
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("OCTOPOOL_STRING_REWRITE_FILE", "")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Error("incorrect caller auth")
+			w.WriteHeader(401)
+			return
+		}
+		if r.URL.Path == "/v1/pools/maintainers/string-rewrites" {
+			calls.Add(1)
+			if r.Method != "GET" || r.Header.Get("Cache-Control") != "no-cache, no-store" {
+				t.Error("incorrect policy method/cache")
+			}
+			w.Header().Set("Cache-Control", "no-store")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, body.Load().(string))
+			return
+		}
+		if r.URL.Path != "/v1/github/request" || r.Method != "POST" || relay == nil {
+			t.Error("unexpected relay dispatch")
+			w.WriteHeader(400)
+			return
+		}
+		relay(w, r)
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("OCTOPOOL_URL", server.URL)
+	t.Setenv("OCTOPOOL_TOKEN", "test-token")
+	t.Setenv("OCTOPOOL_POOL", "maintainers")
+	t.Setenv("OCTOPOOL_RELAY_RETRIES", "0")
+	return body, calls
+}
+
+const rewriteActiveTestPolicy = `{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"internal-model","replacement":"public"}]}`
+const rewriteEmptyTestPolicy = `{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[]}`
+
+func TestStringRewriteProcessSnapshots(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	for _, test := range []struct {
+		name  string
+		args  []string
+		stdin string
+		file  bool
+		want  string
+	}{
+		{"issue inline", []string{"issue", "create", "-tinternal-model", "-binternal-model", "-Racme/repo"}, "unused", false, "public"},
+		{"issue body file", []string{"issue", "edit", "1", "--body-file=FILE", "--repo=acme/repo"}, "unused", true, "public 🦞"},
+		{"pr body stdin", []string{"pr", "comment", "1", "-F-", "-Racme/repo"}, "internal-model 🦞", false, "public 🦞"},
+		{"review", []string{"pr", "review", "1", "--approve", "--body=internal-model", "-Racme/repo"}, "", false, "public"},
+		{"release", []string{"release", "create", "v1", "--verify-tag", "--title=internal-model", "--notes-file=FILE", "-Racme/repo"}, "", true, "public 🦞"},
+		{"pr create", []string{"pr", "create", "-tinternal-model", "-binternal-model", "-Hfeature", "-Bmain", "-Racme/repo"}, "", false, "public"},
+		{"raw typed file", []string{"api", "repos/acme/repo/issues/1/comments", "-Fbody=@FILE"}, "", true, `{"body":"public 🦞"}`},
+		{"raw typed stdin", []string{"api", "repos/acme/repo/issues/1/comments", "-Fbody=@-"}, "internal-model 🦞", false, `{"body":"public 🦞"}`},
+		{"raw literal at", []string{"api", "repos/acme/repo/issues/1/comments", "-fbody=@internal-model"}, "", false, `{"body":"@public"}`},
+		{"raw literal type", []string{"api", "repos/acme/repo/issues/1/comments", "-fbody=false"}, "", false, `{"body":"false"}`},
+		{"raw JSON", []string{"api", "repos/acme/repo/pulls/1/reviews", "--input=-"}, `{"body":"\u0069nternal-model","event":"COMMENT","comments":[{"path":"safe.go","line":1,"body":"internal-model \ud83e\udd9e"}]}`, false, `{"body":"public","comments":[{"body":"public 🦞","line":1,"path":"safe.go"}],"event":"COMMENT"}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			capturePath := captureRewriteGH(t)
+			file := filepath.Join(t.TempDir(), "original.txt")
+			original := []byte("internal-model 🦞")
+			if test.file {
+				if err := os.WriteFile(file, original, 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			args := append([]string(nil), test.args...)
+			for i, arg := range args {
+				args[i] = strings.ReplaceAll(arg, "FILE", file)
+			}
+			var out, stderr bytes.Buffer
+			err := execRealGHWithStdinAndEnv(t.Context(), args, strings.NewReader(test.stdin), &out, &stderr, os.Environ())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if out.String() != "child stdout\n" || stderr.String() != "child stderr\n" {
+				t.Fatalf("streams: %q %q", out.String(), stderr.String())
+			}
+			capture := readRewriteCapture(t, capturePath)
+			if capture.Stdin != "" {
+				t.Fatal("child retained live stdin")
+			}
+			if len(capture.Files) != 1 {
+				t.Fatalf("files=%v", capture.Files)
+			}
+			for path, content := range capture.Files {
+				if content != test.want {
+					t.Fatalf("snapshot=%q want=%q", content, test.want)
+				}
+				if capture.Modes[path] != 0600 || capture.DirectoryModes[path] != 0700 {
+					t.Fatal("snapshot permissions are not private")
+				}
+				if _, err := os.Stat(path); !os.IsNotExist(err) {
+					t.Fatal("snapshot leaked")
+				}
+				if _, err := os.Stat(filepath.Dir(path)); !os.IsNotExist(err) {
+					t.Fatal("temporary directory leaked")
+				}
+			}
+			for _, arg := range capture.Args {
+				if strings.Contains(arg, "internal-model") || strings.Contains(arg, file) {
+					t.Fatalf("unsanitized argv %q", arg)
+				}
+			}
+			if test.file {
+				data, err := os.ReadFile(file)
+				if err != nil || !bytes.Equal(data, original) {
+					t.Fatal("original file changed")
+				}
+			}
+		})
+	}
+}
+func TestStringRewriteProcessBlocks(t *testing.T) {
+	policy, _ := rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	for _, args := range [][]string{
+		{"alias", "list"}, {"extension", "exec", "x"}, {"auth", "refresh"}, {"auth", "login", "--unknown"},
+		{"api", "graphql", "-fquery=mutation { unsafe }"},
+		{"api", "repos/acme/repo/releases/1/assets", "-XPOST", "--input=-"},
+		{"api", "repos/acme/repo/issues/1/comments", "-fbody=a", "-Fbody=b"},
+		{"api", "repos/acme/repo/issues/1/comments", "-Fbody=false"},
+		{"api", "repos/acme/repo/issues/1/comments", "-Fbody=null"},
+		{"api", "repos/acme/repo/issues/1/comments", "-fbody=a", "--input=-"},
+		{"api", "repos/acme/repo/issues/1/comments", "-fbody=a", "--hostname=other.example"},
+		{"api", "repos/acme/repo/issues/1/comments", "-fbody=a", "--header=Authorization: unsafe"},
+		{"api", "repos/acme/repo/issues/1/comments", "-fbody=a", "--paginate"},
+		{"api", "repos/acme/repo/issues/1/comments", "-Fbody={branch}"},
+		{"api", "repos/acme/repo/pulls/1/reviews", "-Fcomments[0][body]=safe"},
+		{"api", "repos/acme/repo/issues/1/comments?unsafe=value", "-fbody=a"},
+		{"api", "repos/acme/repo/issues/1/comments", "-fbody=a", "-funknown=value"},
+		{"api", "repos/acme/%69nternal-model"},
+		{"api", "repos/acme/repo/issues?q=%2569nternal-model"},
+		{"pr", "view", "1", "--web", "-Racme/repo"},
+		{"release", "upload", "v1", "x", "-Racme/repo"},
+	} {
+		t.Run(strings.Join(args[:2], " "), func(t *testing.T) {
+			capture := captureRewriteGH(t)
+			err := execRealGHWithStdin(t.Context(), args, strings.NewReader(`{"body":"safe"}`), io.Discard, io.Discard)
+			if err != errRewriteBlocked {
+				t.Fatalf("expected generic block, got %v for %v", err, args)
+			}
+			if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Fatal("blocked command executed")
+			}
+		})
+	}
+	for _, raw := range []string{`{"body":"safe","\u0062ody":"internal-model"}`, `{"body":"\ud800"}`, `{"body":"internal-model","unknown":"x"}`, `{"body":false}`, `{"body":"` + string([]byte{255}) + `"}`, `[]`} {
+		capture := captureRewriteGH(t)
+		err := execRealGHWithStdin(t.Context(), []string{"api", "repos/acme/repo/issues/1/comments", "--input=-"}, strings.NewReader(raw), io.Discard, io.Discard)
+		if err != errRewriteBlocked {
+			t.Fatalf("invalid JSON error=%v", err)
+		}
+		if _, err := os.Stat(capture); !os.IsNotExist(err) {
+			t.Fatal("invalid JSON reached child")
+		}
+	}
+	policy.Store(`{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"a*","replacement":"b"}]}`)
+	capture := captureRewriteGH(t)
+	if err := execRealGH(t.Context(), []string{"alias", "list"}, io.Discard, io.Discard); err != errRewritePolicy {
+		t.Fatalf("invalid policy: %v", err)
+	}
+	if _, err := os.Stat(capture); !os.IsNotExist(err) {
+		t.Fatal("invalid policy reached child")
+	}
+}
+func TestStringRewriteFreshLocalMergeAndExit(t *testing.T) {
+	policy, calls := rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	args := []string{"issue", "edit", "1", "--body=internal-model", "-Racme/repo"}
+	capture := captureRewriteGH(t)
+	if err := execRealGH(t.Context(), args, io.Discard, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	policy.Store(strings.Replace(rewriteActiveTestPolicy, `"public"`, `"fresh"`, 1))
+	if err := execRealGH(t.Context(), args, io.Discard, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	for _, content := range readRewriteCapture(t, capture).Files {
+		if content != "fresh" {
+			t.Fatal("stale policy")
+		}
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("policy calls=%d", calls.Load())
+	}
+	local := filepath.Join(t.TempDir(), "local.json")
+	if err := os.WriteFile(local, []byte(`{"schema_version":1,"rules":[{"pattern":"fresh","replacement":"approved"}]}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("OCTOPOOL_STRING_REWRITE_FILE", local)
+	t.Setenv("OCTOPOOL_TEST_REWRITE_EXIT", "7")
+	var out, stderr bytes.Buffer
+	err := execRealGH(t.Context(), args, &out, &stderr)
+	var exit exitCodeError
+	if !errors.As(err, &exit) || exit.Code != 7 {
+		t.Fatalf("exit=%v", err)
+	}
+	if out.String() != "child stdout\n" || stderr.String() != "child stderr\n" {
+		t.Fatal("child streams changed")
+	}
+	for _, content := range readRewriteCapture(t, capture).Files {
+		if content != "approved" {
+			t.Fatal("server/local order wrong")
+		}
+	}
+}
+func TestStringRewriteEveryFallbackBoundary(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+		var request map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Error(err)
+		}
+		if request["path"] != "/repos/acme/repo" {
+			t.Error("unexpected normalized read path")
+		}
+		writeCLIFallback(t, w, "route_denied")
+	})
+	for _, entry := range []struct {
+		name   string
+		invoke func(context.Context, []string) error
+	}{
+		{"exec", func(ctx context.Context, args []string) error { return execRealGH(ctx, args, io.Discard, io.Discard) }},
+		{"stdin", func(ctx context.Context, args []string) error {
+			return execRealGHWithStdin(ctx, args, strings.NewReader(""), io.Discard, io.Discard)
+		}},
+		{"environment", func(ctx context.Context, args []string) error {
+			return execRealGHWithStdinAndEnv(ctx, args, strings.NewReader(""), io.Discard, io.Discard, os.Environ())
+		}},
+		{"fallback", func(ctx context.Context, args []string) error {
+			return execRealGHAfterLocalFallback(ctx, args, io.Discard, io.Discard, localFallbackError{Reason: "test"})
+		}},
+		{"runGH", func(ctx context.Context, args []string) error { return runGH(ctx, args, io.Discard, io.Discard) }},
+	} {
+		t.Run(entry.name, func(t *testing.T) {
+			capture := captureRewriteGH(t)
+			if err := entry.invoke(t.Context(), []string{"api", "repos/acme/repo"}); err != nil {
+				t.Fatal(err)
+			}
+			readRewriteCapture(t, capture)
+			if err := os.Remove(capture); err != nil {
+				t.Fatal(err)
+			}
+			if err := entry.invoke(t.Context(), []string{"api", "repos/acme/internal-model"}); err == nil {
+				t.Fatal("unsafe fallback accepted")
+			}
+			if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Fatal("unsafe fallback executed")
+			}
+		})
+	}
+}
+
+func TestStringRewriteRawReleaseRequiresExistingTag(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	capture := captureRewriteGH(t)
+	args := []string{"api", "repos/acme/repo/releases", "-ftag_name=v1", "-fname=internal-model", "-fbody=internal-model", "-Fdraft=true"}
+	if err := execRealGH(t.Context(), args, io.Discard, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	got := readRewriteCapture(t, capture)
+	for _, body := range got.Files {
+		if body != `{"body":"public","draft":true,"name":"public","tag_name":"v1"}` {
+			t.Fatalf("release body=%q", body)
+		}
+	}
+	t.Setenv("OCTOPOOL_TEST_REWRITE_EXIT", "4")
+	if err := execRealGH(t.Context(), args, io.Discard, io.Discard); err != errRewriteBlocked {
+		t.Fatalf("missing tag error=%v", err)
+	}
+	got = readRewriteCapture(t, capture)
+	if len(got.Args) < 2 || got.Args[1] != "/repos/acme/repo/git/ref/tags/v1" || len(got.Files) != 0 {
+		t.Fatalf("mutation ran after tag probe failed: %v", got.Args)
+	}
+}
+
+func TestStringRewriteRelayReadAndAuthFailure(t *testing.T) {
+	for _, code := range []int{200, 401} {
+		t.Run(strconv.Itoa(code), func(t *testing.T) {
+			var relays atomic.Int64
+			rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+				relays.Add(1)
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Error(err)
+				}
+				if body["method"] != "GET" || body["path"] != "/repos/acme/repo" {
+					t.Error("incorrect read dispatch")
+				}
+				if code == 401 {
+					w.WriteHeader(401)
+					_, _ = io.WriteString(w, `{"error":{"code":"invalid_auth","message":"expired"}}`)
+					return
+				}
+				writeCLIEnvelope(t, w, map[string]any{"name": "repo"})
+			})
+			capture := captureRewriteGH(t)
+			var out bytes.Buffer
+			err := runGH(t.Context(), []string{"api", "repos/acme/repo"}, &out, io.Discard)
+			if (err != nil) != (code == 401) {
+				t.Fatalf("error=%v", err)
+			}
+			if code == 200 && out.String() != `{"name":"repo"}`+"\n" {
+				t.Fatalf("output=%q", out.String())
+			}
+			if relays.Load() != 1 {
+				t.Fatal("read did not use relay")
+			}
+			if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Fatal("relay auth error/success ran a child")
+			}
+		})
+	}
+}
+
+func TestStringRewriteTopLevelWatchFallbackIsRefused(t *testing.T) {
+	recordWatchSleeps(t)
+	rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+		var request map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Error(err)
+		}
+		if request["path"] != "/repos/acme/repo/actions/runs/42" {
+			t.Error("unexpected watch path")
+		}
+		writeCLIFallback(t, w, "route_denied")
+	})
+	capture := captureRewriteGH(t)
+	err := runGH(t.Context(), []string{"run", "watch", "42", "-Racme/repo", "-i5", "--exit-status"}, io.Discard, io.Discard)
+	if err != errRewriteBlocked {
+		t.Fatalf("native watch fallback was accepted: %v", err)
+	}
+	if _, err := os.Stat(capture); !os.IsNotExist(err) {
+		t.Fatal("native watch fallback ran a child")
+	}
+}
+
+func TestStringRewriteActivePRHydrationAndPaginationFallback(t *testing.T) {
+	t.Run("hydration", func(t *testing.T) {
+		paths := []string{}
+		rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+			var request map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Error(err)
+			}
+			path, _ := request["path"].(string)
+			paths = append(paths, path)
+			switch path {
+			case "/repos/acme/repo/pulls/1":
+				writeCLIEnvelope(t, w, map[string]any{"number": 1, "head": map[string]any{"sha": "0123456789abcdef0123456789abcdef01234567"}})
+			case "/repos/acme/repo/pulls/1/files":
+				writeCLIEnvelope(t, w, []map[string]any{{"filename": "safe.go"}})
+			default:
+				t.Error("unexpected hydration path")
+				w.WriteHeader(400)
+			}
+		})
+		capture := captureRewriteGH(t)
+		var out bytes.Buffer
+		if err := runGH(t.Context(), []string{"pr", "view", "1", "-Racme/repo", "--json=number,files"}, &out, io.Discard); err != nil {
+			t.Fatal(err)
+		}
+		if len(paths) != 3 || !strings.Contains(out.String(), "safe.go") {
+			t.Fatalf("hydration paths=%v output=%q", paths, out.String())
+		}
+		if _, err := os.Stat(capture); !os.IsNotExist(err) {
+			t.Fatal("hydration unexpectedly delegated")
+		}
+	})
+	t.Run("pagination", func(t *testing.T) {
+		var relays atomic.Int64
+		rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+			relays.Add(1)
+			var request map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Error(err)
+			}
+			if request["path"] != "/repos/acme/repo/issues" {
+				t.Error("unexpected page path")
+			}
+			writeCLIEnvelope(t, w, []int{1})
+		})
+		capture := captureRewriteGH(t)
+		if err := runGH(t.Context(), []string{"api", "repos/acme/repo/issues?per_page=1", "--paginate"}, io.Discard, io.Discard); err != nil {
+			t.Fatal(err)
+		}
+		if relays.Load() != maxRelayPages {
+			t.Fatalf("page requests=%d", relays.Load())
+		}
+		got := readRewriteCapture(t, capture)
+		if !strings.Contains(strings.Join(got.Args, " "), "--paginate") {
+			t.Fatal("pagination fallback lost arguments")
+		}
+	})
+}

--- a/cmd/octopool/string_rewrites_test.go
+++ b/cmd/octopool/string_rewrites_test.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func testRewritePolicy(t *testing.T, rules ...stringRewriteRule) stringRewritePolicy {
+	t.Helper()
+	policy, err := compileStringRewriteRules(rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return policy
+}
+func TestStringRewriteSharedFixtures(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "test", "fixtures", "string-rewrites.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixtures struct {
+		Cases []struct {
+			Name   string
+			Rules  json.RawMessage
+			Input  string
+			Output string
+			Error  bool
+		}
+		InvalidPolicies []struct {
+			Name  string
+			Rules json.RawMessage
+		} `json:"invalid_policies"`
+	}
+	if err := json.Unmarshal(data, &fixtures); err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range fixtures.Cases {
+		t.Run(test.Name, func(t *testing.T) {
+			policy, err := parseStringRewritePolicy(append(append([]byte(`{"schema_version":1,"rules":`), test.Rules...), '}'), false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			output, err := policy.rewrite(test.Input)
+			if test.Error {
+				if err == nil {
+					t.Fatalf("expected rejection, got %q", output)
+				}
+				return
+			}
+			if err != nil || output != test.Output {
+				t.Fatalf("output=%q err=%v want=%q", output, err, test.Output)
+			}
+		})
+	}
+	for _, test := range fixtures.InvalidPolicies {
+		t.Run(test.Name, func(t *testing.T) {
+			if _, err := parseStringRewritePolicy(append(append([]byte(`{"schema_version":1,"rules":`), test.Rules...), '}'), false); err == nil {
+				t.Fatal("invalid policy accepted")
+			}
+		})
+	}
+}
+func TestStringRewriteStrictDocuments(t *testing.T) {
+	valid := `{"schema_version":1,"rules":[{"pattern":"internal-model","replacement":"public"}]}`
+	for _, data := range []string{
+		`{}`, `null`, `{"schema_version":1,"rules":null}`, `{"schema_version":1.0,"rules":[]}`,
+		`{"schema_version":1,"rules":[],"extra":false}`, `{"schema_version":1,"rules":[],"rules":[]}`,
+		`{"schema_version":1,"rules":[{"pattern":"a","replacement":"b","\u0072eplacement":"c"}]}`,
+		valid + `{}`, strings.Replace(valid, "public", string([]byte{0xff}), 1), strings.Replace(valid, "public", `\ud800`, 1),
+		strings.Replace(valid, "public", `\udfff`, 1), strings.Replace(valid, "public", `\ud800\u0061`, 1),
+		strings.Repeat(" ", rewriteMaxDocument) + valid,
+	} {
+		if _, err := parseStringRewritePolicy([]byte(data), false); err != errRewritePolicy {
+			t.Fatalf("expected generic rejection, got %v", err)
+		}
+	}
+	for _, text := range []string{`\ud83e\udd9e`, `literal \\ud800`, `😀`} {
+		if _, err := parseStringRewritePolicy([]byte(strings.Replace(valid, "public", text, 1)), false); err != nil {
+			t.Fatalf("valid JSON Unicode rejected: %v", err)
+		}
+	}
+	for _, data := range []string{
+		`{"schema_version":1,"rules":[],"revision":0,"updated_at":"2026-08-28T00:00:00Z"}`,
+		`{"schema_version":1,"rules":[],"revision":1,"updated_at":"not-time"}`,
+		`{"schema_version":1,"rules":[],"revision":9007199254740992,"updated_at":"2026-08-28T00:00:00Z"}`,
+		valid,
+	} {
+		if _, err := parseStringRewritePolicy([]byte(data), true); err == nil {
+			t.Fatal("invalid server policy accepted")
+		}
+	}
+}
+func TestStringRewriteBoundsAndMerge(t *testing.T) {
+	policy := testRewritePolicy(t, stringRewriteRule{"internal-model", "public"})
+	for _, text := range []string{strings.Repeat("x", rewriteMaxContent+1), string([]byte{0xff})} {
+		if _, err := policy.rewrite(text); err == nil {
+			t.Fatal("invalid content accepted")
+		}
+	}
+	expand := testRewritePolicy(t, stringRewriteRule{"x", strings.Repeat("y", rewriteMaxReplacement)})
+	if _, err := expand.rewrite(strings.Repeat("x", 2048)); err == nil {
+		t.Fatal("intermediate expansion accepted")
+	}
+	for _, rule := range []stringRewriteRule{{strings.Repeat("a", 257), "b"}, {"a", strings.Repeat("b", 1025)}} {
+		if _, err := compileStringRewriteRules([]stringRewriteRule{rule}); err == nil {
+			t.Fatal("oversized rule accepted")
+		}
+	}
+	same, err := mergeStringRewritePolicies(policy, policy)
+	if err != nil || len(same.Rules) != 1 {
+		t.Fatal("identical merge failed")
+	}
+	different := testRewritePolicy(t, stringRewriteRule{"internal-model", "other"})
+	if _, err := mergeStringRewritePolicies(policy, different); err == nil {
+		t.Fatal("conflicting override accepted")
+	}
+	local := testRewritePolicy(t, stringRewriteRule{"public", "approved"})
+	merged, err := mergeStringRewritePolicies(policy, local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, err := merged.rewrite("internal-model"); err != nil || got != "approved" {
+		t.Fatalf("merge order: %q %v", got, err)
+	}
+	badLocal := testRewritePolicy(t, stringRewriteRule{"private", "internal-model"})
+	merged, err = mergeStringRewritePolicies(policy, badLocal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := merged.rewrite("private"); err == nil {
+		t.Fatal("local policy weakened server policy")
+	}
+	rules := []stringRewriteRule{}
+	for i := 0; i < rewriteMaxRules; i++ {
+		rules = append(rules, stringRewriteRule{strings.Repeat("a", i+1), "b"})
+	}
+	full := testRewritePolicy(t, rules...)
+	if _, err := mergeStringRewritePolicies(full, policy); err == nil {
+		t.Fatal("combined limit not enforced")
+	}
+}
+func TestStringRewriteStructuralDecoding(t *testing.T) {
+	policy := testRewritePolicy(t, stringRewriteRule{"internal-model", "public"})
+	for _, value := range []string{"internal-model", "%69nternal-model", "%2569nternal-model", `\u0069nternal-model`, "%ff", "%2525252561"} {
+		if err := policy.checkStructural(value); err == nil {
+			t.Fatalf("accepted %q", value)
+		}
+	}
+	for _, request := range []ghAPIRequest{
+		{method: "GET", path: "/repos/acme/internal-model"},
+		{method: "GET", path: "/repos/acme/safe", query: map[string]any{"q": "%69nternal-model"}},
+		{method: "GET", path: "/repos/acme/safe", query: map[string]any{"internal-model": "safe"}},
+		{method: "GET", path: "/repos/acme/safe", headers: map[string]string{"accept": "internal-model"}},
+		{method: "GET", path: "/repos/acme/safe", headers: map[string]string{"authorization": "safe"}},
+		{method: "GET", path: "/repos/acme/%252e%252e"},
+	} {
+		if err := policy.guardRequest(request); err == nil {
+			t.Fatal("unsafe request accepted")
+		}
+	}
+}
+func TestStringRewriteFileReadBounded(t *testing.T) {
+	if _, err := boundedRewriteRead(strings.NewReader(strings.Repeat("x", 20)), 10); err == nil {
+		t.Fatal("read exceeded bound")
+	}
+	if _, err := readRewriteFile(t.TempDir(), nil, 20); err == nil {
+		t.Fatal("directory accepted")
+	}
+	if _, err := readRewriteFile("-", nil, 20); err == nil {
+		t.Fatal("nil stdin accepted")
+	}
+}
+func TestStringRewritePreparationRejectsUnknownShapes(t *testing.T) {
+	policy := testRewritePolicy(t, stringRewriteRule{"internal-model", "public"})
+	tests := [][]string{
+		{"pr", "create", "--title", "safe", "--body", "safe", "--repo", "acme/repo"},
+		{"pr", "create", "--title", "safe", "--body", "safe", "--repo", "acme/repo", "--head", "main", "--base", "main", "--fill"},
+		{"issue", "create", "--title", "safe", "--body", "safe", "--template", "x", "--repo", "acme/repo"},
+		{"pr", "edit", "--body", "safe", "--repo", "acme/repo"},
+		{"pr", "edit", "1", "--body", "safe", "--body-file", "-", "--repo", "acme/repo"},
+		{"pr", "comment", "1", "--body", "safe", "--editor", "--repo", "acme/repo"},
+		{"pr", "review", "1", "--body", "safe", "--repo", "acme/repo"},
+		{"pr", "review", "1", "--approve", "--comment", "--body", "safe", "--repo", "acme/repo"},
+		{"release", "create", "v1", "asset.zip", "--notes", "safe", "--title", "safe", "--verify-tag", "--repo", "acme/repo"},
+		{"release", "create", "v1", "--notes", "safe", "--title", "safe", "--repo", "acme/repo"},
+		{"release", "create", "v1", "--notes", "safe", "--title", "safe", "--verify-tag=false", "--repo", "acme/repo"},
+		{"release", "create", "v1", "--notes", "safe", "--title", "safe", "--generate-notes", "--verify-tag", "--repo", "acme/repo"},
+		{"issue", "edit", "1", "-bfoo", "--body=bar", "--repo", "acme/repo"},
+		{"issue", "edit", "--body", "safe", "--repo", "acme/repo", "--", "1"},
+		{"pr", "edit", "https://github.com/acme/repo/pull/1", "--body", "safe", "--repo", "acme/repo"},
+	}
+	for _, args := range tests {
+		t.Run(strings.Join(args[:2], " "), func(t *testing.T) {
+			p := &rewritePreparation{}
+			defer p.cleanup()
+			if err := prepareRewriteContent(policy, args, strings.NewReader("safe"), p); err == nil {
+				t.Fatalf("accepted %v", args)
+			}
+		})
+	}
+}
+func TestStringRewriteLiteralReplacementAndFlags(t *testing.T) {
+	policy := testRewritePolicy(t, stringRewriteRule{"internal-model", "--web=$1"})
+	p := &rewritePreparation{}
+	defer p.cleanup()
+	err := prepareRewriteContent(policy, []string{"issue", "create", "-tinternal-model", "-b=internal-model", "-Racme/repo"}, nil, p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.args[3] != "--title=--web=$1" {
+		t.Fatalf("args=%q", p.args)
+	}
+	var content []byte
+	for _, arg := range p.args {
+		if path, ok := strings.CutPrefix(arg, "--body-file="); ok {
+			content, err = os.ReadFile(path)
+		}
+	}
+	if err != nil || !bytes.Equal(content, []byte("--web=$1")) {
+		t.Fatalf("content=%q err=%v", content, err)
+	}
+}
+
+func TestStringRewriteSkippedAdjacentZeroWidth(t *testing.T) {
+	policy := testRewritePolicy(t, stringRewriteRule{`x|\b`, ""})
+	if _, err := policy.rewrite("x"); err != errRewriteBlocked {
+		t.Fatal("Go suppressed an adjacent zero-width match", err)
+	}
+}

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -106,3 +106,125 @@ identity registration, or login). A new pool gets the default policy:
 owners = `DEFAULT_ALLOWED_OWNERS` (`openclaw`), `allow_public_repos: true`,
 `allow_search: false`, `allow_logs: true`.
 There is no pool-creation endpoint; edit `pools.policy_json` in D1 to change a policy.
+
+## Deployment-wide string protection
+
+String rewrite rules are a **single deployment-wide policy**, independent of pool policy.
+Migration `0016_string_rewrites.sql` creates an explicit empty revision 1. An empty policy
+preserves ordinary dispatch; a missing, unreadable, or corrupt policy blocks protected
+operations. Every authenticated caller with a pool grant can download the same rules, so
+do not put credentials in patterns or replacements. Rules are not published in discovery
+or the dashboard.
+
+### Import file
+
+`octopool admin string-rewrites set --file <path>` imports this exact UTF-8 JSON shape;
+`--file -` reads stdin:
+
+```json
+{
+  "schema_version": 1,
+  "rules": [
+    { "pattern": "\\binternal-model\\b", "replacement": "gpt-5.6-sol" },
+    { "pattern": "\\binternal-family-[A-Za-z0-9_-]+\\b", "replacement": "" }
+  ]
+}
+```
+
+The file has exactly `schema_version` and `rules`; each rule has exactly `pattern` and
+`replacement`. Missing replacement is invalid; an empty replacement deletes matches.
+Duplicate JSON keys, duplicate patterns, unknown fields, invalid Unicode, and unsupported
+schema versions are rejected. Patterns are regular expressions, not globs. Keep files
+private and outside source control. The CLI's success output reports revision and rule
+count without printing rules or matching content.
+
+### HTTP contract
+
+`GET /v1/admin/string-rewrites` uses the admin bearer token.
+`GET /v1/pools/:pool/string-rewrites` uses a caller bearer token with that pool grant.
+Both return the same exact response shape:
+
+```json
+{
+  "schema_version": 1,
+  "revision": 1,
+  "updated_at": "2026-08-28T12:00:00.000Z",
+  "rules": []
+}
+```
+
+To replace the policy, read its current revision, then send
+`PUT /v1/admin/string-rewrites` with admin authentication,
+`Content-Type: application/json`, and exactly these fields:
+
+```json
+{
+  "schema_version": 1,
+  "expected_revision": 1,
+  "rules": [{ "pattern": "internal-model", "replacement": "gpt-5.6-sol" }]
+}
+```
+
+The D1 update atomically compares `expected_revision` with the current revision. A
+successful response contains no rules:
+
+```json
+{
+  "schema_version": 1,
+  "revision": 2,
+  "updated_at": "2026-08-28T12:01:00.000Z",
+  "rule_count": 1
+}
+```
+
+A stale or competing writer receives `409 string_rewrite_revision_conflict`; fetch and
+review the new policy before retrying. Use `rules: []` with the current revision to
+explicitly clear rules. Revisions are positive safe integers and increase on every
+successful PUT, including an unchanged ruleset. GET always reads the D1 primary; there is
+no policy cache, stale response, or offline fallback. All responses, including auth,
+validation, conflict, and storage errors, use `Cache-Control: no-store`.
+
+Malformed imports return `400 invalid_string_rewrite_policy`. Missing/corrupt policy or
+D1 failure returns `503 string_rewrite_policy_unavailable`, never `fallback_local`.
+Policy and denial errors contain only generic categories, not patterns, replacements,
+or matched content. The GET endpoints intentionally disclose rules to authenticated
+administrators and callers.
+
+### Portable regex semantics and limits
+
+The Worker uses pinned `re2js` 2.8.6, and the CLI uses Go `regexp`. Both apply a checked
+RE2 subset: case-sensitive, leftmost-first matching; literal Unicode characters;
+captures and `(?:noncapturing)` groups; alternation; greedy/lazy quantifiers; bracket
+classes, ranges, and negation; dot; `^`/`$` anchors; ASCII `\b`, `\B`, `\w`, `\W`,
+`\d`, `\D`, `\s`, `\S`; escaped regex punctuation (including slash and hyphen);
+and `\n`, `\r`, `\t`, `\f`, `\a`, `\v`. Dot does not match newline, `$` means
+absolute end of input, and word boundaries use ASCII word characters even beside
+non-ASCII text. Repetition counts must satisfy the engines' RE2 limits.
+
+V1 rejects flags fields, inline/scoped flags, lookaround, backreferences, named captures,
+Unicode property classes, octal escapes, `\C`, and engine-specific extensions. It also
+conservatively excludes POSIX named bracket classes, hexadecimal/Unicode escapes
+(`\x`, `\u`), `\Q…\E`, and `\A`/`\z`; write literal Unicode and use `^`/`$`.
+JSON's own Unicode escaping is accepted and decoded before regex validation. No user
+pattern is executed by the native JavaScript regex engine.
+
+Rules run globally, once each, in file order. Replacements are literal strings: `$1`
+and `$&` are not capture expansions. Later rules see earlier output. A final scan of
+**every effective pattern** blocks any remaining or newly created match, including a
+match created across deletion boundaries; there is no repeat-until-clean loop. Patterns
+matching empty input are rejected at import. Any contextual zero-width match discovered
+on actual input aborts the operation. The relay checks reads and rejects matches; it
+does not rewrite paths, search terms, or headers.
+
+Limits are 128 rules, 256 UTF-8 bytes per pattern, 1,024 bytes per replacement,
+65,536 bytes per policy document/API body (including the GET envelope), and 1,048,576
+bytes per materialized input, intermediate output, or final output. Match iteration
+and aggregate read inspection are bounded as well. Invalid UTF-8 and lone surrogates
+are rejected. The shared parity vectors live in `test/fixtures/string-rewrites.json`.
+
+An updated CLI may add a private local file beside `auth.json`, named
+`string-rewrites.json`, or use `OCTOPOOL_STRING_REWRITE_FILE`. Local files are not uploaded.
+Server rules precede local rules; identical entries deduplicate, conflicting replacements
+for the same pattern fail, and merged limits may not silently discard rules. Local rules
+cannot weaken the downloaded policy. See [CLI](cli.md) for supported publication commands
+and [Operations](operations.md#activating-string-protection) for rollout and failure behavior.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,7 +2,8 @@
 
 The `octopool` Go CLI is the product entrypoint. It logs in against the relay, stores a
 caller token locally, and acts as a drop-in `gh` shim for the read-only GitHub commands
-Octopool supports — falling through to the real `gh` for everything else.
+Octopool supports. Local GitHub writes and read fallbacks pass through the string rewrite
+guard before the real `gh` runs.
 
 Source: `cmd/octopool/`.
 
@@ -227,8 +228,8 @@ All relay-controlled single-line text has terminal control characters removed. P
 issue bodies preserve newlines and tabs while removing other control characters and
 invalid UTF-8.
 
-The command falls through to the real `gh` without contacting Octopool when any of these
-hold:
+After successfully fetching an explicit empty string rewrite policy (and finding no
+local rules), the command retains its existing real-`gh` delegation when any of these hold:
 
 - method is not `GET`, or mutating field flags are present (`-f`, `-F`, `--field`,
   `--raw-field`).
@@ -249,8 +250,10 @@ Pagination is fail-closed: if bounded relay pagination cannot prove a complete P
 check set, or filtered issue list, the CLI delegates to real `gh` instead of returning a
 partial result. Non-integer `--limit`/`-L` values are rejected explicitly.
 
-Mutating and unsupported `gh` subcommands (`gh pr create`, unusual formatting flags, …)
-are passed straight through to the real GitHub CLI, with their exit codes preserved.
+With active string rewrite rules, supported explicit content commands are sanitized before
+local execution; unsupported commands and flags are blocked. With an empty effective policy,
+mutating and unsupported subcommands retain their usual delegation. Child exit codes and
+stdout/stderr are preserved.
 `gh auth status` normally delegates too. For `gh auth status --active --hostname <host>`,
 if GitHub's REST scope probe reports the active token as invalid while the same token still
 authenticates through GraphQL, the shim reports the account as authenticated and warns that
@@ -321,9 +324,108 @@ Debug/admin raw wrapper over `POST /v1/github/request`. Prints the full relay en
 `--route-hint pr_head_sha=<sha>` or `--route-hint pr_state=closed` can be used for
 state-aware PR subresource cache probes.
 
-### `octopool admin caller|identity ...`
+### `octopool admin caller|identity|string-rewrites ...`
 
 Admin provisioning. Requires an admin token. See [Admin & provisioning](admin.md).
+
+## Outbound string rewrite protection
+
+Every protected `gh` command requires an Octopool login and a fresh authoritative policy
+from `GET /v1/pools/<pool>/string-rewrites`. Each relay request and every final real-`gh`
+dispatch checks policy; a fallback cannot reuse approval for different arguments. There is
+no persistent policy cache, offline allowance, or fallback on authentication/policy errors.
+Policy HTTP requests reject redirects, use a five-second deadline, and bound the response
+to 65,536 bytes. Help/version and narrowly parsed GitHub authentication bootstrap commands
+remain available without a policy.
+
+The same strict JSON file configures server rules and optional local rules:
+
+```json
+{
+  "schema_version": 1,
+  "rules": [
+    { "pattern": "\\binternal-model\\b", "replacement": "gpt-5.6-sol" },
+    { "pattern": "\\binternal-family-[A-Za-z0-9_-]+\\b", "replacement": "" }
+  ]
+}
+```
+
+Local rules default to `string-rewrites.json` beside `auth.json`. Set
+`OCTOPOOL_STRING_REWRITE_FILE` to select another file. An absent default is optional;
+an explicitly configured missing or unreadable file fails closed. The local file is never
+uploaded. Server rules run first, then local rules; identical entries are deduplicated,
+conflicting replacements are rejected, and combined limits still apply.
+
+Rules use a portable RE2 subset: literal Unicode, captures/noncapturing groups, alternation,
+greedy/lazy repetition, bracket classes, dot, anchors, ASCII `\b`, `\w`, `\d`, `\s`
+and their uppercase complements, escaped punctuation, and `\n`, `\r`, `\t`, `\f`,
+`\a`, `\v`. Inline flags, lookaround, backreferences, named captures, Unicode properties,
+POSIX named classes, octal/hex/Unicode escapes, `\C`, and quoted-literal extensions are
+not accepted. Use literal Unicode characters instead of regex Unicode escapes. JSON
+escapes are decoded normally; invalid UTF-8, unpaired surrogates, duplicate keys, unknown
+fields, missing fields, and duplicate patterns are rejected.
+
+Each rule replaces all matches once, in order. Replacements are literal (`$1` stays `$1`);
+an empty replacement deletes text. A final scan checks every effective pattern again and
+blocks remaining or newly created matches. Empty-string patterns are rejected at load time;
+contextual zero-width matches abort before dispatch. Limits are 128 rules, 256 UTF-8 bytes
+per pattern, 1,024 per replacement, 65,536 per policy document, and 1,048,576 bytes of
+materialized/intermediate/final content. Match iteration is also bounded.
+
+With active rules, the initial local publication vocabulary is deliberately conservative:
+
+- PR/issue `create`, `edit`, `comment`, and PR `review`: explicit title/body flags, body
+  files, or stdin; numeric PR/issue selectors for existing items. PR creation requires
+  explicit `--head` and `--base`; the head must already be pushed. `--head` prevents gh
+  from implicitly pushing or forking. Reviews require one explicit review action.
+- Release `create`/`edit`: explicit title/notes or notes files; one tag and no asset uploads.
+  Creation requires `--verify-tag`, so gh cannot create a missing tag. Generated notes,
+  notes from tags, and other implicit content sources are blocked.
+- Raw REST API equivalents: allowlisted issue/PR/review/comment/release endpoints with
+  `-f`/`--raw-field`, `-F`/`--field`, or `--input` JSON. Literal and typed fields retain
+  their distinction; only typed `@file`/`@-` values read files/stdin. Nested review comments
+  use `--input` JSON. Bracket-style field accumulation, duplicate keys, mixed input/field
+  sources, unknown properties, and custom authentication headers are rejected. Raw release
+  creation first verifies the existing remote tag with a local authenticated GET.
+
+Long flags accept separate or equal values; supported short value flags also accept
+attached values. Repeated flags/aliases and boolean clusters are rejected. Metadata flags
+not listed by the guard are unsupported; use an allowlisted raw REST shape where applicable.
+Creation also rejects sanitized empty titles/bodies/notes to avoid implicit defaults.
+Repository context is pinned into an explicit `--repo` after validation. Input files are
+read into bounded snapshots, never modified, and never reopened by the child. Sanitized
+snapshots use a private 0700 directory and 0600 files, removed after execution, including
+nonzero exits. Active-policy child commands do not retain live stdin.
+
+Reads check decoded path segments, query keys/values, and safe forwarded headers, including
+bounded percent-decoding layers. Matches in structural values are blocked, never rewritten.
+This includes direct `octopool request` with local rules and approved local read fallbacks.
+While rules are active, local read fallback is limited to explicit allowlisted raw REST GETs.
+Top-level reads still use the relay, but a requested native fallback is refused because
+native gh can construct additional search/GraphQL requests. Use an explicit raw REST GET
+for local fallback; an empty effective policy preserves the previous fallback behavior.
+Opaque paths, raw GraphQL (apart from the fixed auth viewer probe), aliases/extensions,
+editor/web/template/fill modes, uploads, unknown commands/flags, and ambiguous encodings
+are blocked while rules are active. Some native gh shapes, including URL selectors and
+bracket-style REST fields, are intentionally unsupported.
+
+Admin imports always fetch the current revision before the conditional update:
+
+```sh
+octopool admin string-rewrites status
+octopool admin string-rewrites set --file rules.json
+cat rules.json | octopool admin string-rewrites set --file - --if-revision 7
+```
+
+`--if-revision` additionally compares the operator's expected revision. A conflict never
+overwrites a newer policy. Status and successful imports print only revision and rule count,
+not patterns, replacements, matched content, or local paths.
+
+Protection covers supported traffic through this updated shim and relay, using the policy
+snapshot checked before dispatch. Direct real `gh`, browsers, Git pushes, older clients'
+local writes, existing published content, and arbitrary deliberate obfuscation are outside
+this boundary. GitHub writes continue to use the user's local credentials; the Worker
+remains GET-only.
 
 ## Cache freshness
 
@@ -372,6 +474,8 @@ These are dev/CI escape hatches, not the everyday UX:
 - `OCTOPOOL_TOKEN` — caller token override (required to use a non-saved URL).
 - `OCTOPOOL_POOL` — pool id (default `maintainers`).
 - `OCTOPOOL_GH_PATH` — path to the real `gh` binary.
+- `OCTOPOOL_STRING_REWRITE_FILE` — optional local policy JSON; an explicit unreadable or
+  missing file fails closed. Defaults to `string-rewrites.json` beside `auth.json`.
 - `OCTOPOOL_FRESH=1` — default every relayed read to `cache-control: max-age=0`, including
   run metadata and jobs; explicit cache-control headers take precedence. Use it right after
   a `git push` or a merge, when a cached answer could describe the previous state. It can

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -195,8 +195,68 @@ D1 schema lives in `migrations/`:
 - `0013_audit_backends.sql` — bounded upstream-source attribution for route-level stats.
 - `0014_public_repo_negative_proofs.sql` — cached definitive private-repository proofs.
 - `0015_drop_oauth_states.sql` — remove obsolete database-backed OAuth state.
+- `0016_string_rewrites.sql` — authoritative deployment-wide singleton string policy;
+  seeds explicit empty rules at revision 1.
 
 Apply with `wrangler d1 migrations apply DB` (add `--remote` for production).
+
+## Activating string protection
+
+Apply migration 0016 before deploying the updated Worker. The seeded empty policy
+preserves existing behavior, but the new Worker requires the row to exist even when no
+rules are configured. Install an updated CLI for local publication protection, then
+import a private UTF-8 rules file with `octopool admin string-rewrites set --file <path>`.
+See [Admin](admin.md#deployment-wide-string-protection) for the exact file/API contract,
+portable regex subset, limits, and revision conflict handling. This is a deployment-wide
+setting, not a per-pool override.
+
+Each protected CLI operation downloads a fresh policy; the Worker separately reads the
+D1 primary and compiles the policy for each relay request after authentication and
+normalization, before classification, repository probes, caches, upstream calls, or
+audit metadata. A policy change therefore affects the next request even in a warm
+isolate or on a cache hit. An in-flight operation uses the snapshot checked before its
+dispatch; changing a policy does not recall an already dispatched request. During a
+rolling deployment, old Worker instances and older CLIs retain their old behavior.
+
+This costs a CLI-to-Worker round trip plus a primary D1 read for the policy download,
+another primary read for server-relayed traffic, and bounded regex compilation/matching.
+Even empty policies require the authoritative read. There is no persistent policy cache,
+stale-read window, read-replica shortcut, or offline fallback. Measure latency and CPU
+with representative rules and request sizes before broad activation, especially when
+callers are far from the D1 primary or approach the 128-rule limit.
+
+For reads the Worker inspects the normalized path and its segments, query keys and all
+values, and allowed forwarded header names/values. The JSON envelope is decoded once
+with strict UTF-8 and duplicate-key validation. The guard checks literal and once
+percent-decoded text, including decoded segment boundaries and query `+` as space.
+Residual `%HH` after decoding (such as `%2569`), malformed percent/UTF-8 encoding, and
+embedded backslash escape layers are rejected while rules are active. This conservative
+boundary may refuse legitimate literal percent/backslash searches; it prevents common
+double encoding from revealing an unchecked name downstream. Read inspection is bounded
+in aggregate, and the raw relay envelope is capped at 1 MiB. Inputs are never silently
+rewritten into different repository or search semantics.
+
+Matching reads return `403 string_rewrite_denied` with no content in the error. Policy
+load/corruption/overload returns `503 string_rewrite_policy_unavailable`, not a
+`424 fallback_local` instruction. These failures stop before request audit/cache writes
+and do not log patterns, matched text, or backend exception messages. API responses,
+including errors, are `no-store`. Protect policy GET access and D1 backups: rules can
+contain private names even though error responses and normal import output do not.
+
+If policy storage is missing or corrupt, restore the migration/schema and last reviewed
+valid singleton row through the operator's controlled D1 recovery process. PUT cannot
+repair an unreadable current policy, and a deleted row is not a supported way to clear
+rules. For a healthy policy, deliberate deactivation is an authenticated revision-checked
+PUT with `rules: []`. Do not remove the guard, suppress load failures, or treat a D1 outage
+as an empty policy. No live rollout or credentials are required for the unit and local
+Workerd integration tests; the ordinary Worker suite applies migration 0016 explicitly
+through the migration runner and exercises the same production checks.
+
+The Worker remains GET-only. Local GitHub writes use the caller's own credentials and
+need the updated CLI's supported content preparation. Direct real `gh`, browsers, Git
+pushes, old local-write clients, unsupported obfuscation, and other programs are outside
+this boundary. Previously published content and existing stored cache/audit records are
+not retroactively purged by importing a policy.
 
 ## Build, test, deploy
 
@@ -250,8 +310,8 @@ Override the host/resolver with `OCTOPOOL_E2E_HOST` / `OCTOPOOL_E2E_RESOLVER`.
 Observability is enabled at full sampling. Every validated request from an authenticated
 caller to an existing pool writes an `audit_events` row (caller, client, pool, route key/kind,
 identity, status, error/fallback classification, duration, cache hit/miss/bypass status,
-and coalesced-fill marker); parse, authentication, and pool-lookup failures occur before
-that boundary. Secrets and request bodies are never recorded.
+and coalesced-fill marker); parse, authentication, string-protection, and pool-lookup
+failures occur before that boundary. Secrets and request bodies are never recorded.
 
 The main Worker has an hourly cron trigger at minute 17. It deletes bounded batches of
 cache entries after each entry's route-specific stale deadline and audit rows older than

--- a/migrations/0016_string_rewrites.sql
+++ b/migrations/0016_string_rewrites.sql
@@ -1,0 +1,10 @@
+CREATE TABLE string_rewrite_policy (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  schema_version INTEGER NOT NULL CHECK (schema_version = 1),
+  revision INTEGER NOT NULL CHECK (revision >= 1),
+  updated_at TEXT NOT NULL,
+  rules_json TEXT NOT NULL
+);
+
+INSERT INTO string_rewrite_policy (id, schema_version, revision, updated_at, rules_json)
+VALUES (1, 1, 1, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), '[]');

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "types": "wrangler types"
   },
   "dependencies": {
-    "parse5": "8.0.1"
+    "parse5": "8.0.1",
+    "re2js": "2.8.6"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       parse5:
         specifier: 8.0.1
         version: 8.0.1
+      re2js:
+        specifier: 2.8.6
+        version: 2.8.6
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.21.0
@@ -1171,6 +1174,10 @@ packages:
     resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
+  re2js@2.8.6:
+    resolution: {integrity: sha512-xLgQil4kIUCrAzVk9fRSkxkFNwmygLFjVxXrLc65aE1F0+Zsb8rxumFBy4XKyvgMCTL6kilDq3EZ0piE2dP/Dg==}
+    engines: {node: '>=18.0.0'}
+
   rolldown@1.1.5:
     resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2129,6 +2136,8 @@ snapshots:
       nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  re2js@2.8.6: {}
 
   rolldown@1.1.5:
     dependencies:

--- a/sql/queries/d1.sql
+++ b/sql/queries/d1.sql
@@ -25,6 +25,17 @@ SELECT policy_json
 FROM pools
 WHERE id = ?1;
 
+-- name: GetStringRewritePolicy :one
+SELECT schema_version, revision, updated_at, rules_json
+FROM string_rewrite_policy
+WHERE id = 1;
+
+-- name: ReplaceStringRewritePolicy :one
+UPDATE string_rewrite_policy
+SET revision = revision + 1, updated_at = ?1, rules_json = ?2
+WHERE id = 1 AND schema_version = 1 AND revision = ?3
+RETURNING revision, updated_at;
+
 -- name: ListActiveIdentitiesForPool :many
 SELECT id, kind, login, secret_ref, installation_id, weight
 FROM identities

--- a/src/generated/sql.ts
+++ b/src/generated/sql.ts
@@ -42,6 +42,10 @@ export const queries = {
   ensurePool:
     "INSERT INTO pools (id, name, policy_json)\nVALUES (?1, ?1, ?2)\nON CONFLICT(id) DO NOTHING",
   getPoolPolicy: "SELECT policy_json\nFROM pools\nWHERE id = ?1",
+  getStringRewritePolicy:
+    "SELECT schema_version, revision, updated_at, rules_json\nFROM string_rewrite_policy\nWHERE id = 1",
+  replaceStringRewritePolicy:
+    "UPDATE string_rewrite_policy\nSET revision = revision + 1, updated_at = ?1, rules_json = ?2\nWHERE id = 1 AND schema_version = 1 AND revision = ?3\nRETURNING revision, updated_at",
   listActiveIdentitiesForPool:
     "SELECT id, kind, login, secret_ref, installation_id, weight\nFROM identities\nWHERE pool_id = ?1\n  AND status = 'active'",
   listActiveIdentitiesForRoute:

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -281,18 +281,14 @@ function normalizeQuery(value: unknown): Record<string, string | string[]> | und
   const out: Record<string, string | string[]> = {};
   for (const [key, raw] of Object.entries(value)) {
     if (!safeQueryKey(key)) {
-      throw new HttpError(400, "invalid_query", `query key ${key} is not allowed`);
+      throw new HttpError(400, "invalid_query", "query key is not allowed");
     }
     if (typeof raw === "string") {
       out[key] = raw;
     } else if (Array.isArray(raw) && raw.every((item) => typeof item === "string")) {
       out[key] = raw;
     } else {
-      throw new HttpError(
-        400,
-        "invalid_query",
-        `query value ${key} must be a string or string array`,
-      );
+      throw new HttpError(400, "invalid_query", "query value must be a string or string array");
     }
   }
   return out;

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -18,10 +18,13 @@ import { rateFromHeaders, type GitHubRate } from "./github-rate";
 import { callAnonymousGitHubAPI, callGitHubWeb } from "./github-web";
 import { sanitizeGitHubResponse } from "./github-sanitize";
 import { PUBLIC_SHAPES } from "./github-public-shapes";
-import { HttpError, jsonResponse, parseJsonObject } from "./http";
+import { HttpError, jsonResponse } from "./http";
 import { isRecord } from "./object";
 import { githubResponseLocalFallbackReason, localFallbackError } from "./local-fallback";
 import { classifyRoute, normalizeRouteKey, validateRelayRequest } from "./policy";
+import { loadStringRewritePolicy } from "./string-rewrite-policy";
+import { readStringRewriteJSON } from "./string-rewrite-json";
+import { guardStringRewriteRead, STRING_REWRITE_LIMITS } from "./string-rewrites";
 import { poolCoordinatorStub, type PoolCoordinator } from "./pool-coordinator";
 import { verifyPRStateHint, verifyPRStateHintLive } from "./pr-state";
 import {
@@ -138,19 +141,27 @@ async function relayGitHubRequest(
   requestId: string,
 ): Promise<Response> {
   const started = Date.now();
-  const body = await parseJsonObject(request);
-  const relayRequest = validateRelayRequest(body);
-  const [caller, policy] = await Promise.all([
-    authenticateCaller(request, env, relayRequest.pool),
-    loadPoolPolicy(env, relayRequest.pool),
-  ]);
-  if (policy === null) {
-    throw new HttpError(404, "pool_not_found", "Pool not found");
+  if (!request.headers.get("content-type")?.includes("application/json")) {
+    throw new HttpError(415, "unsupported_media_type", "Expected application/json");
   }
+  let body: unknown;
+  try {
+    body = await readStringRewriteJSON(request, STRING_REWRITE_LIMITS.contentBytes);
+  } catch {
+    throw new HttpError(400, "invalid_json", "Expected a valid JSON object");
+  }
+  const relayRequest = validateRelayRequest(body);
+  const caller = await authenticateCaller(request, env, relayRequest.pool);
   // `GET /user` is served as the caller's public profile so identity probes
   // (`gh api user -q .login`) stop bouncing as route_denied onto local tokens.
   if (relayRequest.path === "/user") {
     relayRequest.path = `/users/${encodeURIComponent(caller.github_login)}`;
+  }
+  const stringPolicy = await loadStringRewritePolicy(env);
+  guardStringRewriteRead(relayRequest, stringPolicy.compiled);
+  const policy = await loadPoolPolicy(env, relayRequest.pool);
+  if (policy === null) {
+    throw new HttpError(404, "pool_not_found", "Pool not found");
   }
   const base: RelayBase = {
     env,

--- a/src/router.ts
+++ b/src/router.ts
@@ -11,6 +11,7 @@ import { rootResponse } from "./landing";
 import { createCaller, loginGitHubCLI, upsertIdentity } from "./provisioning";
 import { relayGitHub } from "./relay";
 import { parseStatsWindow, poolStats } from "./stats";
+import { getStringRewritePolicy, putStringRewritePolicy } from "./string-rewrite-policy";
 import {
   finishGitHubWebLogin,
   logoutWebSession,
@@ -73,6 +74,20 @@ export async function routeRequest(
   }
   if (request.method === "POST" && url.pathname === "/v1/login/github-cli") {
     return loginGitHubCLI(request, env);
+  }
+  if (
+    url.pathname === "/v1/admin/string-rewrites" &&
+    (request.method === "GET" || request.method === "PUT")
+  ) {
+    await authenticateAdmin(request, env);
+    return request.method === "GET"
+      ? getStringRewritePolicy(env)
+      : putStringRewritePolicy(request, env);
+  }
+  if (request.method === "GET" && /^\/v1\/pools\/[^/]+\/string-rewrites$/.test(url.pathname)) {
+    const pool = routeParam(url.pathname, /^\/v1\/pools\/(?<pool>[^/]+)\/string-rewrites$/, "pool");
+    await authenticateCaller(request, env, pool);
+    return getStringRewritePolicy(env);
   }
   if (request.method === "GET" && /^\/v1\/pools\/[^/]+\/stats$/.test(url.pathname)) {
     const pool = routeParam(url.pathname, /^\/v1\/pools\/(?<pool>[^/]+)\/stats$/, "pool");

--- a/src/string-rewrite-json.ts
+++ b/src/string-rewrite-json.ts
@@ -1,0 +1,92 @@
+import { readBodyCapped } from "./response-body";
+
+export async function readStringRewriteJSON(request: Request, limit: number): Promise<unknown> {
+  const bytes = await readBodyCapped(
+    new Response(request.body),
+    limit,
+    () => new Error("JSON limit exceeded"),
+  );
+  const text = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(bytes);
+  return parseStringRewriteJSON(text);
+}
+
+// Policy JSON must not silently accept duplicate keys or invalid Unicode.
+// This bounded parser uses JSON.parse only for individual strings/numbers.
+export function parseStringRewriteJSON(text: string): unknown {
+  let position = 0;
+  const invalid = (): never => {
+    throw new Error("Invalid policy JSON");
+  };
+  const whitespace = () => {
+    while (position < text.length && " \t\r\n".includes(text[position]!)) position++;
+  };
+  const string = (): string => {
+    const start = position++;
+    while (position < text.length) {
+      const char = text[position++];
+      if (char === "\\") {
+        position++;
+      } else if (char === '"') {
+        const value: unknown = JSON.parse(text.slice(start, position));
+        if (typeof value !== "string" || !value.isWellFormed()) invalid();
+        return value as string;
+      }
+    }
+    return invalid();
+  };
+  const value = (depth: number): unknown => {
+    if (depth > 8) invalid();
+    whitespace();
+    const char = text[position];
+    if (char === '"') return string();
+    if (char === "{" || char === "[") {
+      position++;
+      const object: Record<string, unknown> = Object.create(null);
+      const array: unknown[] = [];
+      const closing = char === "{" ? "}" : "]";
+      whitespace();
+      if (text[position] !== closing) {
+        for (;;) {
+          whitespace();
+          if (char === "{") {
+            if (text[position] !== '"') invalid();
+            const key = string();
+            if (Object.hasOwn(object, key)) invalid();
+            whitespace();
+            if (text[position++] !== ":") invalid();
+            object[key] = value(depth + 1);
+          } else {
+            array.push(value(depth + 1));
+          }
+          whitespace();
+          if (text[position] !== ",") break;
+          position++;
+        }
+      }
+      if (text[position++] !== closing) invalid();
+      return char === "{" ? object : array;
+    }
+    for (const [literal, parsed] of [
+      ["true", true],
+      ["false", false],
+      ["null", null],
+    ] as const) {
+      if (text.startsWith(literal, position)) {
+        position += literal.length;
+        return parsed;
+      }
+    }
+    const number = /^-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?/.exec(
+      text.slice(position),
+    );
+    if (number === null) return invalid();
+    position += number[0].length;
+    const parsed = Number(number[0]);
+    if (!Number.isFinite(parsed)) invalid();
+    return parsed;
+  };
+  const parsed = value(0);
+  whitespace();
+  if (position !== text.length) invalid();
+  return parsed;
+}

--- a/src/string-rewrite-policy.ts
+++ b/src/string-rewrite-policy.ts
@@ -1,0 +1,133 @@
+import { queries } from "./generated/sql";
+import { HttpError, jsonResponse } from "./http";
+import { isRecord } from "./object";
+import { parseStringRewriteJSON, readStringRewriteJSON } from "./string-rewrite-json";
+import {
+  compileStringRewriteRules,
+  hasExactKeys,
+  invalidStringRewritePolicy,
+  STRING_REWRITE_LIMITS,
+  utf8Size,
+  type CompiledStringRewriteRule,
+  type StringRewriteRule,
+} from "./string-rewrites";
+
+type StringRewritePolicy = {
+  schema_version: 1;
+  revision: number;
+  updated_at: string;
+  rules: StringRewriteRule[];
+};
+
+function unavailable(): HttpError {
+  return new HttpError(
+    503,
+    "string_rewrite_policy_unavailable",
+    "String protection policy unavailable",
+  );
+}
+
+function revision(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 1;
+}
+
+export async function loadStringRewritePolicy(env: Env): Promise<{
+  policy: StringRewritePolicy;
+  compiled: CompiledStringRewriteRule[];
+}> {
+  try {
+    // Every request starts at the primary, never the isolate config cache or a
+    // potentially stale read replica. Missing migration/row is not an empty policy.
+    const row: unknown = await env.DB.withSession("first-primary")
+      .prepare(queries.getStringRewritePolicy)
+      .first();
+    if (
+      !isRecord(row) ||
+      row.schema_version !== 1 ||
+      !revision(row.revision) ||
+      typeof row.updated_at !== "string" ||
+      typeof row.rules_json !== "string" ||
+      new Date(row.updated_at).toISOString() !== row.updated_at
+    )
+      throw unavailable();
+    utf8Size(row.rules_json, STRING_REWRITE_LIMITS.policyBytes, unavailable);
+    const compiled = compileStringRewriteRules(parseStringRewriteJSON(row.rules_json));
+    const policy: StringRewritePolicy = {
+      schema_version: 1,
+      revision: row.revision,
+      updated_at: row.updated_at,
+      rules: compiled.map(({ pattern, replacement }) => ({ pattern, replacement })),
+    };
+    utf8Size(JSON.stringify(policy), STRING_REWRITE_LIMITS.policyBytes, unavailable);
+    return { policy, compiled };
+  } catch {
+    // Do not expose D1/engine errors or let relay overload mapping authorize fallback.
+    throw unavailable();
+  }
+}
+
+export async function getStringRewritePolicy(env: Env): Promise<Response> {
+  return jsonResponse((await loadStringRewritePolicy(env)).policy);
+}
+
+export async function putStringRewritePolicy(request: Request, env: Env): Promise<Response> {
+  let expectedRevision: number;
+  let rules: StringRewriteRule[];
+  try {
+    const mediaType = request.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
+    if (mediaType !== "application/json") throw invalidStringRewritePolicy();
+    const value = await readStringRewriteJSON(request, STRING_REWRITE_LIMITS.policyBytes);
+    if (
+      !hasExactKeys(value, ["schema_version", "expected_revision", "rules"]) ||
+      value.schema_version !== 1 ||
+      !revision(value.expected_revision) ||
+      value.expected_revision >= Number.MAX_SAFE_INTEGER
+    )
+      throw invalidStringRewritePolicy();
+    expectedRevision = value.expected_revision;
+    rules = compileStringRewriteRules(value.rules).map(({ pattern, replacement }) => ({
+      pattern,
+      replacement,
+    }));
+  } catch {
+    throw invalidStringRewritePolicy();
+  }
+  const current = await loadStringRewritePolicy(env);
+  if (current.policy.revision !== expectedRevision) throw conflict();
+  const updatedAt = new Date().toISOString();
+  // Any accepted policy must also fit the caller's bounded GET decoder.
+  utf8Size(
+    JSON.stringify({
+      schema_version: 1,
+      revision: expectedRevision + 1,
+      updated_at: updatedAt,
+      rules,
+    }),
+    STRING_REWRITE_LIMITS.policyBytes,
+    invalidStringRewritePolicy,
+  );
+  let result: { revision: number; updated_at: string } | null;
+  try {
+    result = await env.DB.withSession("first-primary")
+      .prepare(queries.replaceStringRewritePolicy)
+      .bind(updatedAt, JSON.stringify(rules), expectedRevision)
+      .first<{ revision: number; updated_at: string }>();
+  } catch {
+    throw unavailable();
+  }
+  if (result === null) throw conflict();
+  return jsonResponse({
+    schema_version: 1,
+    revision: result.revision,
+    updated_at: result.updated_at,
+    rule_count: rules.length,
+  });
+}
+
+function conflict(): HttpError {
+  return new HttpError(
+    409,
+    "string_rewrite_revision_conflict",
+    "String protection policy revision conflict",
+  );
+}

--- a/src/string-rewrites.ts
+++ b/src/string-rewrites.ts
@@ -1,0 +1,199 @@
+import { RE2JS } from "re2js";
+import { HttpError } from "./http";
+import { isRecord } from "./object";
+import type { RelayRequest } from "./types";
+
+export const STRING_REWRITE_LIMITS = {
+  rules: 128,
+  patternBytes: 256,
+  replacementBytes: 1_024,
+  policyBytes: 65_536,
+  contentBytes: 1_048_576,
+} as const;
+
+export type StringRewriteRule = { pattern: string; replacement: string };
+export type CompiledStringRewriteRule = StringRewriteRule & { regex: RE2JS };
+const encoder = new TextEncoder();
+
+export function invalidStringRewritePolicy(): HttpError {
+  return new HttpError(400, "invalid_string_rewrite_policy", "Invalid string rewrite policy");
+}
+
+function denied(): HttpError {
+  return new HttpError(403, "string_rewrite_denied", "Request blocked by string protection");
+}
+
+export function hasExactKeys(value: unknown, keys: string[]): value is Record<string, unknown> {
+  return (
+    isRecord(value) &&
+    Object.keys(value).length === keys.length &&
+    keys.every((key) => Object.hasOwn(value, key))
+  );
+}
+
+export function utf8Size(value: string, limit: number, error: () => Error): number {
+  if (value.length > limit || !value.isWellFormed()) throw error();
+  const size = encoder.encode(value).length;
+  if (size > limit) throw error();
+  return size;
+}
+
+// Scan syntax, never run user patterns through the native JS regexp engine.
+// RE2JS then validates the grammar; this gate removes dialect-specific constructs.
+function validatePatternSubset(pattern: string): void {
+  let inClass = false;
+  let classFirst = false;
+  for (let i = 0; i < pattern.length; i++) {
+    const char = pattern[i];
+    if (char === "\\") {
+      const escaped = pattern[++i];
+      if (escaped === undefined || !"\\.^$|?*+()[]{}-/bBdDsSwWnrtfav".includes(escaped)) {
+        throw invalidStringRewritePolicy();
+      }
+      classFirst = false;
+      continue;
+    }
+    if (inClass) {
+      if (char === "[" && pattern[i + 1] === ":") throw invalidStringRewritePolicy();
+      if (char === "]" && !classFirst) inClass = false;
+      classFirst = false;
+      continue;
+    }
+    if (char === "[") {
+      inClass = true;
+      classFirst = true;
+      if (pattern[i + 1] === "^") i++;
+    } else if (char === "(" && pattern[i + 1] === "?" && pattern[i + 2] !== ":") {
+      throw invalidStringRewritePolicy();
+    }
+  }
+}
+
+export function compileStringRewriteRules(value: unknown): CompiledStringRewriteRule[] {
+  try {
+    if (!Array.isArray(value) || value.length > STRING_REWRITE_LIMITS.rules)
+      throw invalidStringRewritePolicy();
+    utf8Size(
+      JSON.stringify({ schema_version: 1, rules: value }),
+      STRING_REWRITE_LIMITS.policyBytes,
+      invalidStringRewritePolicy,
+    );
+    const seen = new Set<string>();
+    return value.map((rule) => {
+      if (
+        !hasExactKeys(rule, ["pattern", "replacement"]) ||
+        typeof rule.pattern !== "string" ||
+        typeof rule.replacement !== "string"
+      ) {
+        throw invalidStringRewritePolicy();
+      }
+      utf8Size(rule.pattern, STRING_REWRITE_LIMITS.patternBytes, invalidStringRewritePolicy);
+      utf8Size(
+        rule.replacement,
+        STRING_REWRITE_LIMITS.replacementBytes,
+        invalidStringRewritePolicy,
+      );
+      if (seen.has(rule.pattern)) throw invalidStringRewritePolicy();
+      seen.add(rule.pattern);
+      validatePatternSubset(rule.pattern);
+      const regex = RE2JS.compile(rule.pattern, RE2JS.DISABLE_UNICODE_GROUPS);
+      if (regex.matcher("").find()) throw invalidStringRewritePolicy();
+      return { pattern: rule.pattern, replacement: rule.replacement, regex };
+    });
+  } catch {
+    // Engine errors may contain the pattern; never let them reach logs/responses.
+    throw invalidStringRewritePolicy();
+  }
+}
+
+export function assertNoStringRewriteMatch(
+  input: string,
+  rules: readonly CompiledStringRewriteRule[],
+): void {
+  utf8Size(input, STRING_REWRITE_LIMITS.contentBytes, denied);
+  try {
+    for (const rule of rules) if (rule.regex.matcher(input).find()) throw denied();
+  } catch {
+    throw denied();
+  }
+}
+
+export function rewriteString(input: string, rules: readonly CompiledStringRewriteRule[]): string {
+  utf8Size(input, STRING_REWRITE_LIMITS.contentBytes, denied);
+  let output = input;
+  let matches = 0;
+  try {
+    for (const rule of rules) {
+      const matcher = rule.regex.matcher(output);
+      let offset = 0;
+      let size = 0;
+      let next = "";
+      let chunks: string[] = [];
+      const append = (text: string) => {
+        size += utf8Size(text, STRING_REWRITE_LIMITS.contentBytes, denied);
+        if (size > STRING_REWRITE_LIMITS.contentBytes) throw denied();
+        chunks.push(text);
+        if (chunks.length >= 1_024) {
+          next += chunks.join("");
+          chunks = [];
+        }
+      };
+      while (matcher.find()) {
+        if (++matches > STRING_REWRITE_LIMITS.contentBytes) throw denied();
+        const start = matcher.start();
+        const end = matcher.end();
+        if (start === end || start < offset) throw denied();
+        // RE2JS string match spans are UTF-16 offsets, including astral characters.
+        append(output.slice(offset, start));
+        append(rule.replacement);
+        offset = end;
+      }
+      append(output.slice(offset));
+      output = next + chunks.join("");
+    }
+    assertNoStringRewriteMatch(output, rules);
+    return output;
+  } catch {
+    throw denied();
+  }
+}
+
+export function guardStringRewriteRead(
+  request: RelayRequest,
+  rules: readonly CompiledStringRewriteRule[],
+): void {
+  if (rules.length === 0) return;
+  let bytes = 0;
+  const inspect = (value: string) => {
+    bytes += utf8Size(value, STRING_REWRITE_LIMITS.contentBytes, denied);
+    if (bytes > STRING_REWRITE_LIMITS.contentBytes) throw denied();
+    // The envelope has already decoded JSON strings. An embedded escape layer is
+    // ambiguous, so reject it instead of letting a downstream decoder uncover it.
+    if (value.includes("\\")) throw denied();
+    assertNoStringRewriteMatch(value, rules);
+  };
+  const field = (value: string, query = false): string => {
+    inspect(value);
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(query ? value.replaceAll("+", " ") : value);
+    } catch {
+      throw denied();
+    }
+    // A second percent layer is not supported, including %2569 and %252569.
+    if (/%[0-9a-fA-F]{2}/.test(decoded)) throw denied();
+    if (decoded !== value) inspect(decoded);
+    return decoded;
+  };
+  const decodedPath = field(request.path);
+  for (const segment of request.path.split("/")) inspect(segment);
+  for (const segment of decodedPath.split("/")) inspect(segment);
+  for (const [key, raw] of Object.entries(request.query ?? {})) {
+    field(key, true);
+    for (const value of Array.isArray(raw) ? raw : [raw]) field(value, true);
+  }
+  for (const [key, value] of Object.entries(request.headers ?? {})) {
+    field(key);
+    field(value);
+  }
+}

--- a/test/e2e/string-rewrites.test.ts
+++ b/test/e2e/string-rewrites.test.ts
@@ -1,0 +1,361 @@
+import { env } from "cloudflare:workers";
+import { createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { describe, expect, it, vi } from "vitest";
+import worker from "../../src/index";
+import {
+  CALLER_TOKEN,
+  callWorker,
+  githubUpstream,
+  jsonResponse,
+  POOL,
+  relay,
+  seedPool,
+} from "./harness";
+
+const adminPath = "/v1/admin/string-rewrites";
+const callerPath = `/v1/pools/${POOL}/string-rewrites`;
+const synthetic = [{ pattern: "internal-model", replacement: "gpt-5.6-sol" }];
+const adminHeaders = {
+  authorization: "Bearer test-admin-token",
+  "content-type": "application/json",
+};
+
+async function put(rules: unknown, expectedRevision = 1): Promise<Response> {
+  return callWorker(adminPath, {
+    method: "PUT",
+    headers: adminHeaders,
+    body: JSON.stringify({ schema_version: 1, expected_revision: expectedRevision, rules }),
+  });
+}
+
+async function expectNoPublication(): Promise<void> {
+  for (const table of ["audit_events", "github_cache_entries", "github_public_repos"]) {
+    expect(await env.DB.prepare(`SELECT COUNT(*) AS count FROM ${table}`).first()).toEqual({
+      count: 0,
+    });
+  }
+}
+
+describe("authoritative string rewrite policy API", () => {
+  it("seeds an explicit singleton empty revision and exposes identical authenticated GETs", async () => {
+    await seedPool();
+    const admin = await callWorker(adminPath, { headers: adminHeaders });
+    const caller = await callWorker(callerPath, {
+      headers: { authorization: `Bearer ${CALLER_TOKEN}` },
+    });
+    expect(admin.status).toBe(200);
+    expect(caller.status).toBe(200);
+    expect(admin.headers.get("cache-control")).toBe("no-store");
+    expect(caller.headers.get("cache-control")).toBe("no-store");
+    const body = await admin.json();
+    expect(body).toEqual({
+      schema_version: 1,
+      revision: 1,
+      updated_at: expect.stringMatching(/^\d{4}-.*Z$/),
+      rules: [],
+    });
+    expect(await caller.json()).toEqual(body);
+    await expect(
+      env.DB.prepare(
+        "INSERT INTO string_rewrite_policy SELECT 2, schema_version, revision, updated_at, rules_json FROM string_rewrite_policy",
+      ).run(),
+    ).rejects.toThrow();
+  });
+
+  it.each([
+    [adminPath, "GET", undefined, 401],
+    [adminPath, "GET", CALLER_TOKEN, 401],
+    [adminPath, "PUT", CALLER_TOKEN, 401],
+    [callerPath, "GET", undefined, 401],
+    [callerPath, "GET", "wrong-token", 401],
+    ["/v1/pools/ungranted/string-rewrites", "GET", CALLER_TOKEN, 401],
+    [callerPath, "PUT", CALLER_TOKEN, 404],
+  ] as const)("requires the appropriate auth for %s %s %#", async (path, method, token, status) => {
+    await seedPool();
+    await put(synthetic);
+    const response = await callWorker(path, {
+      method,
+      headers: token === undefined ? {} : { authorization: `Bearer ${token}` },
+    });
+    expect(response.status).toBe(status);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.text()).not.toContain("internal-model");
+  });
+
+  it("updates by revision without echoing rules and prevents stale writes", async () => {
+    const response = await put(synthetic);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual({
+      schema_version: 1,
+      revision: 2,
+      updated_at: expect.any(String),
+      rule_count: 1,
+    });
+    const stale = await put([]);
+    expect(stale.status).toBe(409);
+    expect(stale.headers.get("cache-control")).toBe("no-store");
+    expect(await stale.text()).not.toContain("internal-model");
+    const read = await callWorker(adminPath, { headers: adminHeaders });
+    expect(await read.json()).toMatchObject({ revision: 2, rules: synthetic });
+    const cleared = await put([], 2);
+    expect(await cleared.json()).toMatchObject({ revision: 3, rule_count: 0 });
+  });
+
+  it("atomically permits only one competing writer", async () => {
+    const responses = await Promise.all([
+      put(synthetic),
+      put([{ pattern: "internal-family-[a-z]+", replacement: "" }]),
+    ]);
+    expect(responses.map((response) => response.status).sort()).toEqual([200, 409]);
+    const row = await env.DB.prepare(
+      "SELECT revision, rules_json FROM string_rewrite_policy",
+    ).first<{ revision: number; rules_json: string }>();
+    expect(row?.revision).toBe(2);
+    expect(JSON.parse(row!.rules_json)).toHaveLength(1);
+  });
+
+  it.each([
+    '{"schema_version":1,"expected_revision":1,"rules":[],"rules":[]}',
+    '{"schema_version":1,"expected_revision":1,"rul\\u0065s":[],"rules":[]}',
+    '{"schema_version":1,"expected_revision":1,"rules":[{"pattern":"a","replacement":"","replacement":"X"}]}',
+    '{"schema_version":2,"expected_revision":1,"rules":[]}',
+    '{"schema_version":1,"expected_revision":0,"rules":[]}',
+    '{"schema_version":1,"expected_revision":1.5,"rules":[]}',
+    '{"schema_version":1,"expected_revision":9007199254740992,"rules":[]}',
+    '{"schema_version":1,"rules":[]}',
+    '{"schema_version":1,"expected_revision":1,"rules":[],"extra":true}',
+    '{"schema_version":1,"expected_revision":1,"rules":[{"pattern":"internal-model(?=x)","replacement":""}]}',
+    '{"schema_version":1,"expected_revision":1,"rules":[{"pattern":"a"}]}',
+    '{"schema_version":1,"expected_revision":1,"rules":[{"pattern":"a","replacement":"\\ud800"}]}',
+    '{"schema_version":1,"expected_revision":1,"rules":null}',
+    "invalid internal-model JSON",
+    " ".repeat(65_537),
+  ])("rejects malformed policy with a content-free response %#", async (body) => {
+    const response = await callWorker(adminPath, { method: "PUT", headers: adminHeaders, body });
+    expect(response.status).toBe(400);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toMatchObject({
+      error: { code: "invalid_string_rewrite_policy", message: "Invalid string rewrite policy" },
+    });
+    expect(
+      await env.DB.prepare("SELECT revision, rules_json FROM string_rewrite_policy").first(),
+    ).toEqual({ revision: 1, rules_json: "[]" });
+  });
+
+  it("rejects invalid UTF-8 and unsupported media types", async () => {
+    const body = new Uint8Array([
+      ...new TextEncoder().encode(
+        '{"schema_version":1,"expected_revision":1,"rules":[{"pattern":"',
+      ),
+      0xff,
+      ...new TextEncoder().encode('","replacement":""}]}'),
+    ]);
+    const invalid = await callWorker(adminPath, { method: "PUT", headers: adminHeaders, body });
+    expect(invalid.status).toBe(400);
+    const media = await callWorker(adminPath, {
+      method: "PUT",
+      headers: { ...adminHeaders, "content-type": "text/plain" },
+      body: "{}",
+    });
+    expect(media.status).toBe(400);
+  });
+});
+
+describe("server read enforcement", () => {
+  it.each([
+    { path: "/repos/openclaw/internal-model" },
+    { path: "/repos/openclaw/%69nternal-model" },
+    { path: "/repos/openclaw/%2569nternal-model" },
+    { path: "/repos/openclaw/%252569nternal-model" },
+    { path: "/unsupported/internal-model" },
+    { query: { q: "internal-model" } },
+    { query: { q: ["safe", "%69nternal-model"] } },
+    { query: { "internal-model": "safe" } },
+    { query: { q: "%2569nternal-model" } },
+    { query: { q: "\\u0069nternal-model" } },
+    { query: { q: "%5Cu0069nternal-model" } },
+    { headers: { accept: "internal-model" } },
+    { headers: { "if-none-match": "internal-model" } },
+    { headers: { "x-github-api-version": "%69nternal-model" } },
+  ])("denies before classification, probes, upstream, cache, or audit %#", async (fields) => {
+    await seedPool();
+    await put(synthetic);
+    const upstream = vi.fn<typeof fetch>().mockResolvedValue(jsonResponse({}));
+    const logs = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.stubGlobal("fetch", upstream);
+    const response = await callWorker("/v1/github/request", {
+      method: "POST",
+      headers: { authorization: `Bearer ${CALLER_TOKEN}`, "content-type": "application/json" },
+      body: JSON.stringify({
+        pool: POOL,
+        method: "GET",
+        path: "/repos/openclaw/octopool",
+        ...fields,
+      }),
+    });
+    expect(response.status).toBe(403);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    const body = await response.text();
+    expect(body).toContain('"code":"string_rewrite_denied"');
+    expect(body).not.toContain("internal-model");
+    expect(body).not.toContain("fallback_local");
+    expect(upstream).not.toHaveBeenCalled();
+    expect(logs).not.toHaveBeenCalled();
+    await expectNoPublication();
+  });
+
+  it("checks JSON-escaped input and redacts validation errors before the guard", async () => {
+    await seedPool();
+    await put(synthetic);
+    const upstream = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", upstream);
+    const request = {
+      pool: POOL,
+      method: "GET",
+      path: "/repos/openclaw/octopool",
+      query: { q: "internal-model" },
+    };
+    const escaped = await callWorker("/v1/github/request", {
+      method: "POST",
+      headers: { authorization: `Bearer ${CALLER_TOKEN}`, "content-type": "application/json" },
+      body: JSON.stringify(request).replace("internal-model", "\\u0069nternal-model"),
+    });
+    expect(escaped.status).toBe(403);
+    for (const query of [{ "internal-model-token": "safe" }, { "internal-model": 42 }]) {
+      const response = await callWorker("/v1/github/request", {
+        method: "POST",
+        headers: { authorization: `Bearer ${CALLER_TOKEN}`, "content-type": "application/json" },
+        body: JSON.stringify({ ...request, query }),
+      });
+      expect(response.status).toBe(400);
+      expect(await response.text()).not.toContain("internal-model");
+    }
+    expect(upstream).not.toHaveBeenCalled();
+    await expectNoPublication();
+  });
+
+  it("rejects duplicate envelopes and invalid UTF-8 before normalization", async () => {
+    await seedPool();
+    const prefix = '{"pool":"maintainers","method":"GET","path":"/user"';
+    for (const body of [
+      prefix + ',"path":"/rate_limit"}',
+      new Uint8Array([
+        ...new TextEncoder().encode(prefix + ',"query":{"q":"'),
+        0xff,
+        ...new TextEncoder().encode('"}}'),
+      ]),
+    ]) {
+      const response = await callWorker("/v1/github/request", {
+        method: "POST",
+        headers: { authorization: `Bearer ${CALLER_TOKEN}`, "content-type": "application/json" },
+        body,
+      });
+      expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({ error: { code: "invalid_json" } });
+    }
+    await expectNoPublication();
+  });
+
+  it("sees updates immediately in a warm isolate and blocks an already cached route", async () => {
+    await seedPool();
+    const upstream = githubUpstream({ primary: jsonResponse({ number: 17 }) });
+    vi.stubGlobal("fetch", upstream);
+    const warm = async (path: string, init?: RequestInit): Promise<Response> => {
+      const ctx = createExecutionContext();
+      const response = await worker.fetch(
+        new Request(`https://octopool.dev${path}`, init),
+        env,
+        ctx,
+      );
+      await waitOnExecutionContext(ctx);
+      return response;
+    };
+    const request = {
+      method: "POST",
+      headers: { authorization: `Bearer ${CALLER_TOKEN}`, "content-type": "application/json" },
+      body: JSON.stringify({
+        pool: POOL,
+        method: "GET",
+        path: "/repos/openclaw/internal-model/pulls/17",
+      }),
+    };
+    expect((await warm("/v1/github/request", request)).status).toBe(200);
+    const before = await env.DB.prepare("SELECT COUNT(*) AS count FROM audit_events").first();
+    expect(
+      await env.DB.prepare("SELECT COUNT(*) AS count FROM github_cache_entries").first(),
+    ).toEqual({ count: 1 });
+    const update = await warm(adminPath, {
+      method: "PUT",
+      headers: adminHeaders,
+      body: JSON.stringify({ schema_version: 1, expected_revision: 1, rules: synthetic }),
+    });
+    expect(update.status).toBe(200);
+    const downloaded = await warm(callerPath, {
+      headers: { authorization: `Bearer ${CALLER_TOKEN}` },
+    });
+    expect(await downloaded.json()).toMatchObject({ revision: 2, rules: synthetic });
+    upstream.mockClear();
+    expect((await warm("/v1/github/request", request)).status).toBe(403);
+    expect(upstream).not.toHaveBeenCalled();
+    expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM audit_events").first()).toEqual(
+      before,
+    );
+    await env.DB.prepare("DELETE FROM string_rewrite_policy").run();
+    expect((await warm("/v1/github/request", request)).status).toBe(503);
+    expect(
+      (await warm(callerPath, { headers: { authorization: `Bearer ${CALLER_TOKEN}` } })).status,
+    ).toBe(503);
+  });
+
+  it.each([
+    "DELETE FROM string_rewrite_policy",
+    "DROP TABLE string_rewrite_policy",
+    "UPDATE string_rewrite_policy SET rules_json = 'broken internal-model'",
+    'UPDATE string_rewrite_policy SET rules_json = \'[{"pattern":"internal-model(?=x)","replacement":""}]\'',
+    'UPDATE string_rewrite_policy SET rules_json = \'[{"pattern":"a","replacement":"","replacement":"X"}]\'',
+    "UPDATE string_rewrite_policy SET rules_json = 'null'",
+    "UPDATE string_rewrite_policy SET updated_at = 'internal-model'",
+  ])("fails closed on missing/corrupt policy %#", async (sql) => {
+    await seedPool();
+    await env.DB.prepare(sql).run();
+    const upstream = vi.fn<typeof fetch>();
+    const logs = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.stubGlobal("fetch", upstream);
+    for (const response of [
+      await relay("/repos/openclaw/octopool"),
+      await callWorker(adminPath, { headers: adminHeaders }),
+      await callWorker(callerPath, { headers: { authorization: `Bearer ${CALLER_TOKEN}` } }),
+      await put([]),
+    ]) {
+      expect(response.status).toBe(503);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      expect(await response.json()).toMatchObject({
+        error: {
+          code: "string_rewrite_policy_unavailable",
+          message: "String protection policy unavailable",
+        },
+      });
+    }
+    expect(upstream).not.toHaveBeenCalled();
+    expect(logs).not.toHaveBeenCalled();
+    await expectNoPublication();
+  });
+
+  it("never translates a policy D1 overload into local fallback", async () => {
+    await seedPool();
+    const upstream = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", upstream);
+    vi.spyOn(env.DB, "withSession").mockImplementation(() => {
+      throw new Error("D1 DB is overloaded. Requests queued for too long. internal-model");
+    });
+    const response = await relay("/repos/openclaw/octopool");
+    expect(response.status).toBe(503);
+    const text = await response.text();
+    expect(text).toContain("string_rewrite_policy_unavailable");
+    expect(text).not.toContain("fallback_local");
+    expect(text).not.toContain("internal-model");
+    expect(upstream).not.toHaveBeenCalled();
+    await expectNoPublication();
+  });
+});

--- a/test/fixtures/string-rewrites.json
+++ b/test/fixtures/string-rewrites.json
@@ -1,0 +1,191 @@
+{
+  "cases": [
+    {
+      "name": "synthetic literal",
+      "rules": [{ "pattern": "internal-model", "replacement": "gpt-5.6-sol" }],
+      "input": "use internal-model",
+      "output": "use gpt-5.6-sol"
+    },
+    {
+      "name": "family deletion",
+      "rules": [{ "pattern": "\\binternal-family-[A-Za-z0-9_-]+\\b", "replacement": "" }],
+      "input": "A internal-family-alpha B internal-family-beta_2 C",
+      "output": "A  B  C"
+    },
+    {
+      "name": "leftmost first alternation",
+      "rules": [{ "pattern": "ab|abc", "replacement": "X" }],
+      "input": "abc ab",
+      "output": "Xc X"
+    },
+    {
+      "name": "greedy",
+      "rules": [{ "pattern": "a.+b", "replacement": "X" }],
+      "input": "a1b a2b",
+      "output": "X"
+    },
+    {
+      "name": "lazy",
+      "rules": [{ "pattern": "a.+?b", "replacement": "X" }],
+      "input": "a1b a2b",
+      "output": "X X"
+    },
+    {
+      "name": "astral spans",
+      "rules": [{ "pattern": "(?:🦞|internal-model)", "replacement": "X" }],
+      "input": "😀🦞 internal-model 🦞😀",
+      "output": "😀X X X😀"
+    },
+    {
+      "name": "astral dot",
+      "rules": [{ "pattern": "x.y", "replacement": "X" }],
+      "input": "x😀y x🦞y",
+      "output": "X X"
+    },
+    {
+      "name": "ascii word boundaries",
+      "rules": [{ "pattern": "\\binternal-model\\b", "replacement": "X" }],
+      "input": "éinternal-modelé internal-models _internal-model",
+      "output": "éXé internal-models _internal-model"
+    },
+    {
+      "name": "newline dot",
+      "rules": [{ "pattern": "a.b", "replacement": "X" }],
+      "input": "a\nb a b",
+      "output": "a\nb X"
+    },
+    {
+      "name": "newline escape",
+      "rules": [{ "pattern": "a\\nb", "replacement": "X" }],
+      "input": "a\nb",
+      "output": "X"
+    },
+    {
+      "name": "dollar absolute end",
+      "rules": [{ "pattern": "internal-model$", "replacement": "X" }],
+      "input": "internal-model\n",
+      "output": "internal-model\n"
+    },
+    {
+      "name": "literal replacement dollars",
+      "rules": [{ "pattern": "(internal)-(model)", "replacement": "$1/$&" }],
+      "input": "internal-model",
+      "output": "$1/$&"
+    },
+    {
+      "name": "ordered rules",
+      "rules": [
+        { "pattern": "internal-model", "replacement": "intermediate" },
+        { "pattern": "intermediate", "replacement": "public" }
+      ],
+      "input": "internal-model",
+      "output": "public"
+    },
+    {
+      "name": "boundary created match",
+      "rules": [
+        { "pattern": "internal-model", "replacement": "X" },
+        { "pattern": "REMOVE", "replacement": "" }
+      ],
+      "input": "internal-REMOVEmodel",
+      "error": true
+    },
+    {
+      "name": "replacement recreates earlier match",
+      "rules": [
+        { "pattern": "internal-model", "replacement": "X" },
+        { "pattern": "placeholder", "replacement": "internal-model" }
+      ],
+      "input": "placeholder",
+      "error": true
+    },
+    {
+      "name": "self recreating replacement",
+      "rules": [{ "pattern": "internal-model", "replacement": "internal-model" }],
+      "input": "internal-model",
+      "error": true
+    },
+    {
+      "name": "contextual zero width",
+      "rules": [{ "pattern": "\\b", "replacement": "X" }],
+      "input": "word",
+      "error": true
+    },
+    {
+      "name": "contextual zero width after consuming branch",
+      "rules": [{ "pattern": "x|\\b", "replacement": "X" }],
+      "input": "x word",
+      "error": true
+    },
+    {
+      "name": "contextual zero width adjacent to deleted match",
+      "rules": [{ "pattern": "x|\\b", "replacement": "" }],
+      "input": "x",
+      "error": true
+    },
+    {
+      "name": "negated class and repetition",
+      "rules": [{ "pattern": "a[^0-9]{2,3}z", "replacement": "X" }],
+      "input": "a😀🦞z a12z",
+      "output": "X a12z"
+    },
+    {
+      "name": "ascii classes",
+      "rules": [{ "pattern": "\\d+\\s\\w+", "replacement": "X" }],
+      "input": "12 word ٣ word",
+      "output": "X ٣ word"
+    },
+    {
+      "name": "anchors",
+      "rules": [{ "pattern": "^internal-model$", "replacement": "X" }],
+      "input": "internal-model",
+      "output": "X"
+    },
+    {
+      "name": "empty policy",
+      "rules": [],
+      "input": "safe synthetic text",
+      "output": "safe synthetic text"
+    }
+  ],
+  "invalid_policies": [
+    { "name": "empty pattern", "rules": [{ "pattern": "", "replacement": "X" }] },
+    { "name": "empty matching star", "rules": [{ "pattern": "a*", "replacement": "X" }] },
+    { "name": "lookahead", "rules": [{ "pattern": "a(?=b)", "replacement": "X" }] },
+    { "name": "lookbehind", "rules": [{ "pattern": "(?<=a)b", "replacement": "X" }] },
+    { "name": "backreference", "rules": [{ "pattern": "(a)\\1", "replacement": "X" }] },
+    { "name": "inline flags", "rules": [{ "pattern": "(?i)internal-model", "replacement": "X" }] },
+    {
+      "name": "scoped inline flags",
+      "rules": [{ "pattern": "(?i:internal-model)", "replacement": "X" }]
+    },
+    { "name": "unicode properties", "rules": [{ "pattern": "\\p{L}+", "replacement": "X" }] },
+    { "name": "named capture", "rules": [{ "pattern": "(?P<name>a)", "replacement": "X" }] },
+    { "name": "octal", "rules": [{ "pattern": "\\141", "replacement": "X" }] },
+    { "name": "byte escape", "rules": [{ "pattern": "\\C", "replacement": "X" }] },
+    {
+      "name": "javascript unicode escape",
+      "rules": [{ "pattern": "\\u0061", "replacement": "X" }]
+    },
+    {
+      "name": "hex escape outside v1 subset",
+      "rules": [{ "pattern": "\\x61", "replacement": "X" }]
+    },
+    { "name": "quoted literal extension", "rules": [{ "pattern": "\\Qa\\E", "replacement": "X" }] },
+    { "name": "missing replacement", "rules": [{ "pattern": "a" }] },
+    { "name": "extra key", "rules": [{ "pattern": "a", "replacement": "X", "flags": "i" }] },
+    {
+      "name": "duplicate pattern",
+      "rules": [
+        { "pattern": "a", "replacement": "X" },
+        { "pattern": "a", "replacement": "X" }
+      ]
+    },
+    { "name": "invalid syntax", "rules": [{ "pattern": "[", "replacement": "X" }] },
+    { "name": "invalid unicode pattern", "rules": [{ "pattern": "\ud800", "replacement": "X" }] },
+    {
+      "name": "invalid unicode replacement",
+      "rules": [{ "pattern": "a", "replacement": "\udfff" }]
+    }
+  ]
+}

--- a/test/string-rewrites.test.ts
+++ b/test/string-rewrites.test.ts
@@ -1,0 +1,185 @@
+import { readFileSync } from "node:fs";
+import { URL } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parseStringRewriteJSON } from "../src/string-rewrite-json";
+import {
+  compileStringRewriteRules,
+  guardStringRewriteRead,
+  rewriteString,
+  STRING_REWRITE_LIMITS,
+} from "../src/string-rewrites";
+
+const vectors = JSON.parse(
+  readFileSync(new URL("./fixtures/string-rewrites.json", import.meta.url), "utf8"),
+) as {
+  cases: ({ name: string; rules: unknown; input: string } & (
+    | { output: string }
+    | { error: true }
+  ))[];
+  invalid_policies: { name: string; rules: unknown }[];
+};
+
+describe("shared string rewrite vectors", () => {
+  for (const vector of vectors.cases) {
+    it(vector.name, () => {
+      const rules = compileStringRewriteRules(vector.rules);
+      if ("error" in vector) {
+        expect(() => rewriteString(vector.input, rules)).toThrow(
+          "Request blocked by string protection",
+        );
+      } else {
+        expect(rewriteString(vector.input, rules)).toBe(vector.output);
+      }
+    });
+  }
+  for (const vector of vectors.invalid_policies) {
+    it(`rejects ${vector.name}`, () => {
+      expect(() => compileStringRewriteRules(vector.rules)).toThrow(
+        "Invalid string rewrite policy",
+      );
+    });
+  }
+});
+
+describe("string rewrite limits and syntax", () => {
+  it.each([
+    [{ pattern: "a".repeat(257), replacement: "" }],
+    [{ pattern: "🦞".repeat(65), replacement: "" }],
+    [{ pattern: "a", replacement: "🦞".repeat(257) }],
+    Array.from({ length: 129 }, (_, i) => ({ pattern: `value${i}`, replacement: "" })),
+    Array.from({ length: 128 }, (_, i) => ({
+      pattern: `value${i}`,
+      replacement: "x".repeat(1_024),
+    })),
+  ])("rejects limits without echoing content %#", (rules) => {
+    expect(() => compileStringRewriteRules(rules)).toThrow("Invalid string rewrite policy");
+  });
+
+  it.each([
+    "[^^](?i)word",
+    "[^](?i)word",
+    "[]](?i)word",
+    "[[:alpha:]]",
+    "\\Aword",
+    "word\\z",
+    "a{1001}",
+    "a++",
+    "a(?<name>b)",
+  ])("rejects unsupported syntax %s", (pattern) => {
+    expect(() => compileStringRewriteRules([{ pattern, replacement: "" }])).toThrow(
+      "Invalid string rewrite policy",
+    );
+  });
+
+  it("allows escaped punctuation and controls", () => {
+    const rules = compileStringRewriteRules([
+      { pattern: "\\(\\[\\.\\]\\)\\a\\f\\r\\t\\v", replacement: "X" },
+    ]);
+    expect(rewriteString("([.])\x07\f\r\t\v", rules)).toBe("X");
+  });
+
+  it("bounds input, intermediate output, and invalid Unicode", () => {
+    const rules = compileStringRewriteRules([
+      { pattern: "a", replacement: "X".repeat(1_024) },
+      { pattern: "X+", replacement: "" },
+    ]);
+    for (const text of ["a".repeat(1_025), "🦞".repeat(262_145), "\ud800", "\udfff"]) {
+      expect(() => rewriteString(text, rules)).toThrow("Request blocked by string protection");
+    }
+    expect(() => rewriteString("x".repeat(STRING_REWRITE_LIMITS.contentBytes + 1), [])).toThrow();
+    expect(rewriteString("x".repeat(STRING_REWRITE_LIMITS.contentBytes), [])).toHaveLength(
+      STRING_REWRITE_LIMITS.contentBytes,
+    );
+  });
+
+  it("handles many deletion matches without materializing an unbounded match array", () => {
+    const rules = compileStringRewriteRules([{ pattern: "a", replacement: "" }]);
+    expect(rewriteString("a".repeat(40_000), rules)).toBe("");
+  });
+});
+
+describe("strict policy JSON", () => {
+  it.each([
+    '{"rules":[],"rules":[]}',
+    '{"rules":[],"rul\\u0065s":[]}',
+    '{"rules":[{"pattern":"a","pattern":"b"}]}',
+    '{"a":"\\ud800"}',
+    '{"\\udfff":1}',
+    '{"a":01}',
+    '{"a":1e999}',
+    '{"a":true,}',
+    "[1,]",
+    "[[[[[[[[[[0]]]]]]]]]]",
+    '{"a":1} {}',
+    "\ufeff{}",
+  ])("rejects ambiguous JSON %#", (text) => {
+    expect(() => parseStringRewriteJSON(text)).toThrow();
+  });
+
+  it("decodes escaped string keys and values once", () => {
+    expect(
+      parseStringRewriteJSON(
+        '{"rul\\u0065s":[{"pattern":"\\ud83e\\udd9e","replacement":"$1/$&"}]}',
+      ),
+    ).toEqual({ rules: [{ pattern: "🦞", replacement: "$1/$&" }] });
+  });
+});
+
+describe("read protection", () => {
+  const rules = compileStringRewriteRules([{ pattern: "internal-model", replacement: "public" }]);
+  const base = { pool: "test", method: "GET", path: "/repos/example/project" };
+
+  it.each([
+    { path: "/repos/example/internal-model" },
+    { path: "/repos/example/%69nternal-model" },
+    { path: "/repos/example/%2569nternal-model" },
+    { path: "/repos/example/%252569nternal-model" },
+    { query: { q: ["safe", "internal-model"] } },
+    { query: { "internal-model": "safe" } },
+    { query: { q: "%69nternal-model" } },
+    { query: { q: "%2569nternal-model" } },
+    { query: { q: "\\u0069nternal-model" } },
+    { query: { q: "%5Cu0069nternal-model" } },
+    { query: { q: "100%" } },
+    { query: { q: "%c0%af" } },
+    { query: { q: "\ud800" } },
+    { headers: { accept: "internal-model" } },
+    { headers: { accept: "%69nternal-model" } },
+  ])("blocks a match or ambiguous encoding %#", (fields) => {
+    expect(() => guardStringRewriteRead({ ...base, ...fields }, rules)).toThrow(
+      "Request blocked by string protection",
+    );
+  });
+
+  it("inspects decoded segment boundaries and form-encoded query values", () => {
+    const anchored = compileStringRewriteRules([{ pattern: "^internal-model$", replacement: "" }]);
+    expect(() =>
+      guardStringRewriteRead({ ...base, path: "/a%2Finternal-model" }, anchored),
+    ).toThrow();
+    const spaced = compileStringRewriteRules([{ pattern: "internal model", replacement: "" }]);
+    expect(() =>
+      guardStringRewriteRead({ ...base, query: { q: "internal+model" } }, spaced),
+    ).toThrow();
+  });
+
+  it("preserves benign encoded text and does not rewrite structural fields", () => {
+    const request = {
+      ...base,
+      query: { q: "public+text%20🦞" },
+      headers: { accept: "application/json" },
+    };
+    const before = structuredClone(request);
+    guardStringRewriteRead(request, rules);
+    expect(request).toEqual(before);
+  });
+
+  it("bounds total inspected fields and preserves empty policy behavior", () => {
+    expect(() =>
+      guardStringRewriteRead(
+        { ...base, query: { q: Array.from({ length: 1_025 }, () => "x".repeat(1_024)) } },
+        rules,
+      ),
+    ).toThrow();
+    expect(() => guardStringRewriteRead({ ...base, query: { q: "100%" } }, [])).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Add configurable outbound string protection so private names can be rewritten to `gpt-5.6-sol` before publication. Regex rules also support matching whole name families and purging matches with an empty replacement.

A versioned JSON rules file configures deployment-wide server policy and optional additional local restrictions. Local rules cannot override server rules. Both implementations use a shared, bounded RE2-compatible contract, with literal replacements and a final scan that blocks remaining or newly introduced matches.

## Enforcement

GitHub writes currently bypass the read relay, so protection lives at both boundaries. The CLI sanitizes supported PR, issue, comment, review, and release content before invoking local `gh`, including inline arguments, body/notes files, stdin, and allowlisted REST JSON payloads. Original files remain untouched; the child receives sanitized snapshots.

The Worker independently checks decoded relay paths, queries, and forwarded headers before routing, cache access, audit metadata, or upstream requests. GitHub write credentials remain local, and the pooled relay stays GET-only.

Policy retrieval, validation, and inspection failures fail closed. While rules are active, unsupported interactive, generated-content, GraphQL, extension, and upload paths are refused rather than delegated unchecked. Native top-level read fallback is also refused under active rules; explicit allowlisted raw REST GETs remain eligible. Direct `gh`, browser activity, Git pushes, and older clients' local writes remain outside this boundary.

## Configuration and rollout

Import server rules from a private file:

```bash
octopool admin string-rewrites set --file rules.json
```

Optional local rules load from `string-rewrites.json` beside `auth.json`, or from `OCTOPOOL_STRING_REWRITE_FILE`. On macOS, the default is `~/Library/Application Support/octopool/string-rewrites.json`. Administration uses authenticated, revision-checked updates; caller policy responses are authenticated and non-cacheable.

Apply migration 0016 and deploy the updated Worker before rolling out the updated CLI. The migration initializes an empty policy; no private-name rules are committed or enabled by default. The CLI requires a fresh server policy, so an older server or a policy/authentication outage blocks protected operations rather than silently bypassing protection.

## Validation

- Full project checks pass, including 474 unit tests and 157 Worker integration tests, formatting/lint, SQL generation, type checks, Go tests, and vet.
- Go race checks and Linux/Windows cross-builds pass.
- All 24 independent subprocess checks pass, covering rewritten arguments/files/stdin, unchanged originals, policy failures, blocked dispatch, and preserved exit codes.
- Shared fixtures cover regex parity, Unicode, literal replacements, deletion, and zero-width matches, including a regression for Go's skipped adjacent zero-width matches.
- Documentation builds successfully; independent blocking-priority review reported no findings.

## Live proof after landing

Merged as `e8bbc89e1b4d42266a445fdb14d43535eb9de08c`; [post-merge CI passed](https://github.com/openclaw/octopool/actions/runs/33221206684). Migration 0016 and the authoritative Worker are deployed. Authenticated policy reads, unauthenticated rejection, and discovery were verified through both public hosts; a native CLI read against production also succeeded.

[Real GitHub submission and live evidence](https://github.com/openclaw/octopool/pull/66#issuecomment-5459050383): 16 live checks passed using the compiled CLI from merged main, an isolated deployed Cloudflare Worker/D1, and an actual GitHub comment. File, escaped JSON/stdin, and inline-field submissions were rewritten and purged correctly; originals stayed unchanged. Additive local rules worked, and reintroducing a server-blocked term was refused. Literal and encoded server inputs returned `403 string_rewrite_denied` without adding audit rows. Fresh policy revisions took effect immediately; stale revisions and invalid regexes were rejected.

Deliberately corrupting the isolated policy returned `503 string_rewrite_policy_unavailable` and stopped an attempted GitHub edit without changing the comment. The isolated deployment had no pooled GitHub identity: its nonmatching control request reached normal `424 fallback_local` handling, while the production native-CLI read succeeded.

The isolated Worker, Durable Object namespace, D1 database, and temporary caller credentials were removed. Production policy remains revision 1 with zero rules; no private names were used or enabled, and the globally installed CLI was not replaced.

