### PR TITLE
fix: normalize gh pr view mergeable JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Normalize `gh pr view --json mergeable` to `MERGEABLE`, `CONFLICTING`, or `UNKNOWN` before filtering and `--jq`, preserving raw `gh api` REST values and unsupported-field delegation.
+- Normalize `gh pr view --json mergeable` to `MERGEABLE`, `CONFLICTING`, or `UNKNOWN` before filtering and `--jq`, preserving raw `gh api` REST values and unsupported-field delegation; scripts relying on older boolean/null output must migrate to explicit enum comparisons.
 
 ## 0.5.9 - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.10 - Unreleased
+
+### Fixes
+
+- Normalize `gh pr view --json mergeable` to `MERGEABLE`, `CONFLICTING`, or `UNKNOWN` before filtering and `--jq`, preserving raw `gh api` REST values and unsupported-field delegation.
+
 ## 0.5.9 - 2026-08-28
 
 ### Changes

--- a/cmd/octopool/gh_top_pr.go
+++ b/cmd/octopool/gh_top_pr.go
@@ -141,6 +141,7 @@ func relayPRView(ctx context.Context, stdout io.Writer, repo string, number stri
 		return err
 	}
 	normalizePRViewState(pr)
+	normalizePRViewMergeable(pr)
 	filesHeadSHA := ""
 	for _, field := range opts.json {
 		switch field {
@@ -218,6 +219,20 @@ func normalizePRViewState(pr map[string]any) {
 		state = "OPEN"
 	}
 	pr["state"] = state
+}
+
+func normalizePRViewMergeable(pr map[string]any) {
+	if pr == nil {
+		return
+	}
+	switch pr["mergeable"] {
+	case true:
+		pr["mergeable"] = "MERGEABLE"
+	case false:
+		pr["mergeable"] = "CONFLICTING"
+	default:
+		pr["mergeable"] = "UNKNOWN"
+	}
 }
 
 func prViewHeaders(opts ghTopOptions) map[string]string {

--- a/cmd/octopool/gh_top_pr_mergeable_test.go
+++ b/cmd/octopool/gh_top_pr_mergeable_test.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const prMergeableTestFields = "headRefOid,mergeable,isDraft,state,url"
+const prMergeableTestHead = "0123456789abcdef0123456789abcdef01234567"
+const prMergeableTestURL = "https://github.com/openclaw/octopool/pull/7"
+
+var prMergeableTestCases = []struct {
+	name    string
+	value   any
+	present bool
+	want    string
+}{
+	{"true", true, true, "MERGEABLE"},
+	{"false", false, true, "CONFLICTING"},
+	{"null", nil, true, "UNKNOWN"},
+	{"absent", nil, false, "UNKNOWN"},
+}
+
+func prMergeableFixture(value any, present bool) map[string]any {
+	pr := map[string]any{
+		"state": "open", "draft": true, "merged": false, "mergeable_state": "clean",
+		"head": map[string]any{"sha": prMergeableTestHead}, "html_url": prMergeableTestURL,
+	}
+	if present {
+		pr["mergeable"] = value
+	}
+	return pr
+}
+
+func checkPRMergeableRequest(t *testing.T, request map[string]any) {
+	t.Helper()
+	if request["method"] != "GET" || request["path"] != "/repos/openclaw/octopool/pulls/7" {
+		t.Errorf("unexpected PR request: %#v", request)
+	}
+	headers, _ := request["headers"].(map[string]any)
+	if _, present := headers["x-octopool-public-shape"]; present {
+		t.Errorf("REST read has public-shape header: %#v", headers)
+	}
+	if headers["cache-control"] != "max-age=0" {
+		t.Errorf("headers = %#v, want cache-control max-age=0", headers)
+	}
+}
+
+func checkPRMergeableProjection(t *testing.T, raw, fields, mergeable string) {
+	t.Helper()
+	var got map[string]any
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatal(err)
+	}
+	all := map[string]any{
+		"headRefOid": prMergeableTestHead, "mergeable": mergeable,
+		"isDraft": true, "state": "OPEN", "url": prMergeableTestURL,
+	}
+	want := map[string]any{}
+	for _, field := range strings.Split(fields, ",") {
+		want[field] = all[field]
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("projection = %#v, want %#v", got, want)
+	}
+	if _, requested := want["mergeable"]; requested {
+		if _, ok := got["mergeable"].(string); !ok {
+			t.Errorf("mergeable = %#v (%T), want JSON string", got["mergeable"], got["mergeable"])
+		}
+	}
+}
+
+func TestRunGHPRViewMergeableProjection(t *testing.T) {
+	t.Setenv("OCTOPOOL_FRESH", "")
+	for _, test := range prMergeableTestCases {
+		for _, fields := range []string{prMergeableTestFields, "mergeable", "headRefOid,isDraft,state,url"} {
+			t.Run(test.name+"/"+fields, func(t *testing.T) {
+				calls := 0
+				relayTestServer(t, func(request map[string]any) any {
+					calls++
+					checkPRMergeableRequest(t, request)
+					return prMergeableFixture(test.value, test.present)
+				})
+				var out bytes.Buffer
+				result := handleGHPR(t.Context(), []string{
+					"view", "7", "--repo", "openclaw/octopool", "--json", fields,
+				}, &out)
+				if result.err != nil || result.action != ghComplete {
+					t.Fatalf("action=%v err=%v", result.action, result.err)
+				}
+				checkPRMergeableProjection(t, out.String(), fields, test.want)
+				if calls != 1 {
+					t.Errorf("PR requests = %d, want 1", calls)
+				}
+			})
+		}
+	}
+}
+
+func TestRunGHAPIPRMergeablePreservesREST(t *testing.T) {
+	for _, test := range prMergeableTestCases {
+		t.Run(test.name, func(t *testing.T) {
+			pr := prMergeableFixture(test.value, test.present)
+			relayTestServer(t, func(request map[string]any) any {
+				if request["path"] != "/repos/openclaw/octopool/pulls/7" {
+					t.Errorf("unexpected path: %v", request["path"])
+				}
+				return pr
+			})
+			var out bytes.Buffer
+			if err := runGH(t.Context(), []string{"api", "repos/openclaw/octopool/pulls/7"}, &out, &bytes.Buffer{}); err != nil {
+				t.Fatal(err)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, pr) {
+				t.Errorf("raw REST = %#v, want %#v", got, pr)
+			}
+		})
+	}
+}
+
+var prMergeableDelegationArgs = [][]string{
+	{"pr", "view", "7", "--repo", "openclaw/octopool", "--json", "mergeCommit"},
+	{"pr", "view", "7", "--repo", "openclaw/octopool", "--json", "mergeStateStatus"},
+	{"pr", "view", "7", "--repo", "openclaw/octopool", "--json", "mergeable,mergeCommit"},
+	{"pr", "view", "7", "--repo", "openclaw/octopool", "--json", "mergeable,mergeStateStatus"},
+	{"pr", "list", "--repo", "openclaw/octopool", "--json", "mergeable"},
+}
+
+func TestRunGHPRMergeableUnsupportedFieldsDelegate(t *testing.T) {
+	for _, args := range prMergeableDelegationArgs {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			emptyRewriteTestServer(t)
+			var out bytes.Buffer
+			result := handleGHPR(t.Context(), args[1:], &out)
+			if result.err != nil || result.action != ghDelegate || out.Len() != 0 {
+				t.Fatalf("action=%v err=%v output=%q", result.action, result.err, out.String())
+			}
+		})
+	}
+}
+
+func TestCLIEndToEndPRMergeable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds and executes the CLI binary")
+	}
+	bin := buildCLIBinary(t)
+	for _, test := range prMergeableTestCases {
+		t.Run(test.name, func(t *testing.T) {
+			server := cliRelayServer(t, func(w http.ResponseWriter, r *http.Request) {
+				request := decodeCLIRequest(t, w, r)
+				if request == nil {
+					return
+				}
+				checkPRMergeableRequest(t, request)
+				writeCLIEnvelope(t, w, prMergeableFixture(test.value, test.present))
+			})
+			for _, fields := range []string{prMergeableTestFields, "mergeable"} {
+				t.Run(fields, func(t *testing.T) {
+					result := runCLI(t, bin, server.URL, map[string]string{
+						"OCTOPOOL_NO_FALLBACK": "1", "OCTOPOOL_FRESH": "", "OCTOPOOL_GH_PATH": fakeGH(t),
+					}, "gh", "pr", "view", "7", "--repo", "openclaw/octopool", "--json", fields)
+					if result.err != nil {
+						t.Fatalf("err=%v stdout=%q stderr=%q", result.err, result.stdout, result.stderr)
+					}
+					checkPRMergeableProjection(t, result.stdout, fields, test.want)
+				})
+			}
+			t.Run("jq", func(t *testing.T) {
+				if !jqAvailable() {
+					t.Skip("jq is not installed")
+				}
+				jq := `.mergeable == "` + test.want + `" and (.mergeable | type) == "string" and keys == ["mergeable"]`
+				result := runCLI(t, bin, server.URL, map[string]string{
+					"OCTOPOOL_NO_FALLBACK": "1", "OCTOPOOL_FRESH": "", "OCTOPOOL_GH_PATH": fakeGH(t),
+				}, "gh", "pr", "view", "7", "--repo", "openclaw/octopool", "--json", "mergeable", "--jq", jq)
+				if result.err != nil || result.stdout != "true\n" {
+					t.Fatalf("err=%v stdout=%q stderr=%q, want true", result.err, result.stdout, result.stderr)
+				}
+			})
+		})
+	}
+	for _, args := range prMergeableDelegationArgs {
+		t.Run("delegate/"+strings.Join(args, " "), func(t *testing.T) {
+			server := cliRelayServer(t, func(w http.ResponseWriter, r *http.Request) {
+				t.Error("unexpected PR relay request")
+				http.Error(w, "unexpected PR relay request", http.StatusBadRequest)
+			})
+			result := runCLI(t, bin, server.URL, map[string]string{
+				"OCTOPOOL_GH_PATH": fakeGH(t), "OCTOPOOL_NO_FALLBACK": "",
+			}, append([]string{"gh"}, args...)...)
+			want := "real-gh:" + strings.Join(args, " ") + "\n"
+			if result.err != nil || result.stdout != want {
+				t.Fatalf("err=%v stdout=%q stderr=%q, want %q", result.err, result.stdout, result.stderr, want)
+			}
+		})
+	}
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -173,6 +173,13 @@ regardless of the other requested fields or whether the relay uses a public page
 Draft status is separate: an open draft has `state: "OPEN"` and `isDraft: true` when
 requested. This conversion happens before field filtering and `--jq`; raw `gh api` REST
 states, PR search states, and human-format `DRAFT` display remain unchanged.
+`gh pr view --json mergeable` likewise returns a JSON enum string before filtering and
+`--jq`: REST `true` becomes `"MERGEABLE"`, `false` becomes `"CONFLICTING"`, and null or
+absent values become `"UNKNOWN"`. This uses only REST `mergeable`, not `mergeable_state`,
+draft/lifecycle status, checks, or merge policy. Raw `gh api` REST reads retain their
+boolean, null, or absent `mergeable` values. `mergeCommit` and `mergeStateStatus` remain
+unsupported and delegate to real `gh`, including when requested alongside `mergeable`;
+`gh pr list --json mergeable` also delegates.
 Run views also support the nested `jobs` field; Octopool composes its job/step metadata from
 the cache, exact API responses, or bounded public GitHub pages.
 `gh search issues|prs` is translated to a repo-scoped, cacheable GitHub Search request

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -180,6 +180,10 @@ draft/lifecycle status, checks, or merge policy. Raw `gh api` REST reads retain 
 boolean, null, or absent `mergeable` values. `mergeCommit` and `mergeStateStatus` remain
 unsupported and delegate to real `gh`, including when requested alongside `mergeable`;
 `gh pr list --json mergeable` also delegates.
+Upgrade note: scripts relying on earlier Octopool boolean/null output must use explicit
+enum comparisons. Replace `.mergeable == true` with `.mergeable == "MERGEABLE"` and
+`.mergeable == false` with `.mergeable == "CONFLICTING"`; handle `"UNKNOWN"` separately.
+Do not rely on truthiness: all three enum strings are truthy in `jq`.
 Run views also support the nested `jobs` field; Octopool composes its job/step metadata from
 the cache, exact API responses, or bounded public GitHub pages.
 `gh search issues|prs` is translated to a repo-scoped, cacheable GitHub Search request


### PR DESCRIPTION
## Summary

Restore native `gh pr view --json mergeable` compatibility. Octopool accepted this field but passed through the REST boolean/null value, while gh's GraphQL contract returns a string enum.

Normalize the value only in PR-view JSON projection, before field filtering and `--jq`: `true` becomes `MERGEABLE`, `false` becomes `CONFLICTING`, and null or missing values become `UNKNOWN`. Raw `gh api` REST values, live-read routing, and supported-field lists remain unchanged. Unsupported requests containing `mergeCommit` or `mergeStateStatus` still delegate to native gh without partial relay output.

Add table-driven handler and compiled-CLI regressions, document the boundary, and record the fix under 0.5.10 Unreleased. This does not publish a release or update any installed binary.

## Compatibility decision and migration

Maintainer decision: adopt native gh's enum contract rather than preserve Octopool's erroneous boolean/null projection. This is the intended compatibility repair. The raw REST `gh api` contract remains available unchanged; no boolean compatibility toggle is introduced.

Scripts written against the old Octopool output must migrate `.mergeable == true` to `.mergeable == "MERGEABLE"` and `.mergeable == false` to `.mergeable == "CONFLICTING"`, with `"UNKNOWN"` handled separately. Do not rely on truthiness: all three enum strings are truthy in `jq`. The CLI documentation and unreleased changelog explicitly call out this migration.

## Validation

- Demonstrated regression failures before the production fix for boolean, null, missing-field, and `--jq` output.
- All 38 new regression cases pass, including JSON string types, selected-field filtering, freshness headers, raw REST preservation, and original-argument delegation.
- Full `go test ./...` and `go vet ./...` pass on the refreshed branch.
- Focused regression tests pass with the race detector.
- Go formatting and `git diff --check` pass.

## Real relay CLI proof

A temporary candidate was compiled from this branch and run against the configured real relay with `OCTOPOOL_NO_FALLBACK=1`, then compared on the same public PR fields with the pinned native gh. This used the real authenticated setup, not the fixture relay or fake-gh test helper. The installed Octopool binary was not replaced. Only public PR data is included below; local paths and credentials are omitted.

`CANDIDATE` below denotes the temporary source-built binary; `NATIVE_GH` denotes the pinned native GitHub CLI. The comparison below was freshly captured at final PR head `8e3622677247f6872f71c089dd7bb3a58e68dac9`. The temporary binary was built from this branch's source; production code is unchanged from implementation commit `49055a410ccb90cbf8fdcc9116585b8bea4c86af`, and the final follow-up commit adds migration documentation only.

```bash
OCTOPOOL_NO_FALLBACK=1 OCTOPOOL_FRESH=1 "$CANDIDATE" gh pr view 67 --repo openclaw/octopool --json headRefOid,mergeable,isDraft,state,url
```

```json
{"headRefOid":"8e3622677247f6872f71c089dd7bb3a58e68dac9","isDraft":false,"mergeable":"MERGEABLE","state":"OPEN","url":"https://github.com/openclaw/octopool/pull/67"}
```

```bash
"$NATIVE_GH" pr view 67 --repo openclaw/octopool --json headRefOid,mergeable,isDraft,state,url
```

```json
{"headRefOid":"8e3622677247f6872f71c089dd7bb3a58e68dac9","isDraft":false,"mergeable":"MERGEABLE","state":"OPEN","url":"https://github.com/openclaw/octopool/pull/67"}
```

The parsed JSON objects match exactly at the same head. A separate real-relay query verifies the documented enum predicate and string type:

```bash
OCTOPOOL_NO_FALLBACK=1 OCTOPOOL_FRESH=1 "$CANDIDATE" gh pr view 67 --repo openclaw/octopool --json mergeable --jq '.mergeable == "MERGEABLE" and (.mergeable | type) == "string"'
```

```text
true
```
