### PR TITLE
fix: prevent stale results from freshness-bounded reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.5.11 - Unreleased
 
+### Fixes
+
+- Honor requested cache-age bounds during upstream outages so live PR reads cannot silently return stale heads, preserve conditional revalidation and ordinary stale availability, and warn about stale responses even under OCTOPOOL_FRESH=1.
+
 ## 0.5.10 - 2026-08-28
 
 ### Fixes

--- a/cmd/octopool/gh_fresh_read_test.go
+++ b/cmd/octopool/gh_fresh_read_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -98,5 +101,67 @@ func TestVolatileRouteKindCoversDecisionRoutes(t *testing.T) {
 		if volatileRouteKind(kind) {
 			t.Fatalf("%s should not be treated as volatile", kind)
 		}
+	}
+}
+
+func TestCLIEndToEndCacheFreshnessNotices(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds and executes the CLI binary")
+	}
+	bin := buildCLIBinary(t)
+	for _, test := range []struct {
+		name, cache, fresh, quiet string
+		wantNotice                bool
+	}{
+		{"ordinary stale", "stale", "", "", true},
+		{"fresh stale from older relay", "stale", "1", "", true},
+		{"quiet stale", "stale", "1", "1", false},
+		{"ordinary hit", "hit", "", "", true},
+		{"fresh revalidated hit", "hit", "1", "", false},
+		{"fresh miss", "miss", "1", "", false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			const head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			server := cliRelayServer(t, func(w http.ResponseWriter, r *http.Request) {
+				request := decodeCLIRequest(t, w, r)
+				if request == nil {
+					return
+				}
+				headers, _ := request["headers"].(map[string]any)
+				if test.fresh == "1" && headers["cache-control"] != "max-age=0" {
+					t.Errorf("headers = %v, want max-age=0", headers)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if err := json.NewEncoder(w).Encode(relayEnvelope{
+					Status: 200, Body: json.RawMessage(`{"head":{"sha":"` + head + `"}}`), BodyEncoding: "json",
+					Relay: relayMeta{Cache: test.cache, RouteKind: "pr_view"},
+				}); err != nil {
+					t.Error(err)
+				}
+			})
+			result := runCLI(t, bin, server.URL, map[string]string{
+				"OCTOPOOL_FRESH": test.fresh, "OCTOPOOL_QUIET_CACHE": test.quiet,
+				"OCTOPOOL_NO_FALLBACK": "1",
+			}, "gh", "api", "repos/openclaw/freshness-fixture/pulls/73")
+			if result.err != nil {
+				t.Fatalf("err=%v stderr=%q", result.err, result.stderr)
+			}
+			var body struct {
+				Head struct {
+					SHA string `json:"sha"`
+				} `json:"head"`
+			}
+			if err := json.Unmarshal([]byte(result.stdout), &body); err != nil || body.Head.SHA != head {
+				t.Fatalf("stdout=%q err=%v", result.stdout, err)
+			}
+			if test.wantNotice != strings.Contains(result.stderr, "pr_view served from shared cache") {
+				t.Errorf("notice=%q, want notice=%v", result.stderr, test.wantNotice)
+			}
+			if test.cache == "stale" && test.wantNotice {
+				if !strings.Contains(result.stderr, "not a live read") || strings.Contains(result.stderr, "set OCTOPOOL_FRESH=1") {
+					t.Errorf("stale notice must warn against live decisions without repeating FRESH advice: %q", result.stderr)
+				}
+			}
+		})
 	}
 }

--- a/cmd/octopool/gh_relay.go
+++ b/cmd/octopool/gh_relay.go
@@ -47,7 +47,7 @@ func volatileRouteKind(kind string) bool {
 // cached answer is indistinguishable from a live one, which is how a stale head
 // SHA or a "still open" merged PR reads as truth.
 func noteCachedRead(envelope relayEnvelope) {
-	if freshReadRequested() || quietCacheNotices() {
+	if quietCacheNotices() || (freshReadRequested() && envelope.Relay.Cache != "stale") {
 		return
 	}
 	if envelope.Relay.Cache != "hit" && envelope.Relay.Cache != "stale" {
@@ -56,12 +56,17 @@ func noteCachedRead(envelope relayEnvelope) {
 	if !volatileRouteKind(envelope.Relay.RouteKind) {
 		return
 	}
+	advice := "set OCTOPOOL_FRESH=1 for a live read"
+	if envelope.Relay.Cache == "stale" {
+		advice = "not a live read; do not use for live decisions"
+	}
 	fmt.Fprintf(
 		os.Stderr,
-		"octopool: %s served from shared cache (%s)%s; set OCTOPOOL_FRESH=1 for a live read\n",
+		"octopool: %s served from shared cache (%s)%s; %s\n",
 		envelope.Relay.RouteKind,
 		envelope.Relay.Cache,
 		cacheExpirySuffix(envelope.Relay.CacheExpiresAt),
+		advice,
 	)
 }
 

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -73,11 +73,15 @@ a follower in a cold colo reacquires coordinator ownership and performs one seri
 takeover fill. This can produce one fill per cold colo, but never overlapping ownerless
 upstream requests.
 
-Cacheable requests can instead bound acceptable staleness with a
-`cache-control: max-age=N` header. A fresh entry older than `N` seconds is treated as a
-miss and refetched, and the refill writes through to the shared cache, so concurrent
-bounded-freshness readers coalesce onto one upstream request rather than each bypassing
-the cache. The CLI's `gh pr checks` resolves the PR head SHA this way with `max-age=60`.
+Cacheable requests can bound cache age with a `cache-control: max-age=N` header.
+The bound applies to both fresh hits and outage stale fallback: an older entry cannot
+be served without successful upstream revalidation. `max-age=0` always requires an
+upstream fetch or conditional revalidation, including when a cached timestamp equals
+the current time. Old entries remain eligible for conditional requests; a successful
+`304` confirms and republishes the stored body. Successful refills write through to
+the shared cache. Positive bounds let concurrent readers share an acceptable refill;
+zero-bound readers each require upstream validation. The CLI's `gh pr checks` resolves
+the PR head SHA with `max-age=60`.
 
 ### Token-free GitHub reads
 
@@ -274,8 +278,10 @@ If the eligible token-free and pooled backends are unavailable, depleted, coolin
 or rate-limited, Octopool may serve an expired public cache entry for a short route-specific
 grace window. Mutable CI
 payloads get only minutes; terminal CI payloads get up to a day; PR/issue detail routes
-get up to an hour; immutable-ish commit views can get up to a day. Stale serves still run
-the public-repo guard and active-identity check before returning.
+get up to an hour; immutable-ish commit views can get up to a day. Requests without an
+age bound retain this outage fallback; an explicit bound must also be satisfied.
+Otherwise the existing typed failure/local-fallback flow applies. Stale serves still
+run the public-repo guard and active-identity check before returning.
 
 Cache publication is awaited before returning a miss response, closing the response/write
 race for immediate repeat reads. Concurrent identical misses acquire renewable,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -469,17 +469,22 @@ Three things keep that honest:
 - **Gate fields read live.** `gh pr view --json` reads that include `headRefOid`,
   `baseRefOid`, `state`, `merged`, `mergedAt`, `mergeable`, `mergeStateStatus`, or
   `closedAt` send `cache-control: max-age=0` automatically. These are the values callers
-  branch on, so they always come from GitHub. Descriptive fields (`title`, `body`, `labels`,
-  `author`) stay cached.
+  branch on, so they require an upstream fetch or successful conditional revalidation.
+  Descriptive fields (`title`, `body`, `labels`, `author`) stay cached.
 - **Cached decision reads announce themselves.** When a PR, issue, run, or checks route is
   served from the shared cache, the CLI prints one line to stderr naming the route, whether
   it was a hit or a stale serve, and when it refreshes. stdout stays untouched, so `--json`
-  and `--jq` consumers are unaffected. Silence it with `OCTOPOOL_QUIET_CACHE=1`.
+  and `--jq` consumers are unaffected. A stale response warns that it is unsafe for live
+  decisions even under `OCTOPOOL_FRESH=1`; older relays may ignore the requested bound.
+  A normal `hit` under FRESH remains quiet because it may have been live-revalidated.
+  Silence cache notices with `OCTOPOOL_QUIET_CACHE=1`.
 - **Anything can request a live read.** `OCTOPOOL_FRESH=1` applies `max-age=0` at shared
   relay request construction, including top-level `run view` and every jobs hydration
   request. An explicit `cache-control` header retains precedence, including headers
-  passed through `gh api -H`. Ordinary reads retain caching. The relay's existing bounded
-  stale fallback still applies when upstream backends are unavailable.
+  passed through `gh api -H`. Every explicit age bound also applies during outages:
+  `max-age=0` cannot return an unvalidated cached success. If upstream cannot satisfy the
+  bound, the existing typed failure/local-fallback flow applies. Reads without an age
+  bound retain the relay's route-limited stale outage fallback.
 
 Note that `git push` never passes through Octopool, so the relay cannot invalidate a PR
 entry when a branch moves. That is why the gate fields read live rather than relying on
@@ -508,7 +513,8 @@ These are dev/CI escape hatches, not the everyday UX:
 - `OCTOPOOL_FRESH=1` — default every relayed read to `cache-control: max-age=0`, including
   run metadata and jobs; explicit cache-control headers take precedence. Use it right after
   a `git push` or a merge, when a cached answer could describe the previous state. It can
-  cost API quota; leave it off for ordinary reads. Bounded stale outage fallback is unchanged.
+  cost API quota; leave it off for ordinary reads. Outage fallback cannot exceed the
+  requested age bound.
 - `OCTOPOOL_QUIET_CACHE=1` — suppress the one-line stderr note printed when a
   decision-shaped route (PR/issue/run/checks) is served from the shared cache.
 - `OCTOPOOL_NO_FALLBACK=1` — fail instead of running real `gh` after Octopool returns

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -154,6 +154,10 @@ function withinRequestedMaxAge(cached: CachedGitHubResponse, maxAgeSeconds?: num
   if (maxAgeSeconds === undefined) {
     return true;
   }
+  // A live read must revalidate even a same-time or future-dated cache entry.
+  if (maxAgeSeconds === 0) {
+    return false;
+  }
   const createdAt = parseSQLiteTimestamp(cached.created_at);
   return Number.isFinite(createdAt) && Date.now() - createdAt <= maxAgeSeconds * 1000;
 }
@@ -162,15 +166,14 @@ export async function readStaleGitHubCache(
   env: Env,
   cacheKey: string,
   route: RouteInfo,
+  maxAgeSeconds?: number,
 ): Promise<CachedGitHubResponse | undefined> {
   const row = await env.DB.prepare(queries.readGitHubCacheAny).bind(cacheKey).first<CacheRow>();
-  if (row === null) {
+  if (row === null || !staleCacheAllowed(row, route)) {
     return undefined;
   }
-  if (!staleCacheAllowed(row, route)) {
-    return undefined;
-  }
-  return cacheRowResponse(row);
+  const cached = cacheRowResponse(row);
+  return cached !== undefined && withinRequestedMaxAge(cached, maxAgeSeconds) ? cached : undefined;
 }
 
 export function staleCacheSeconds(route: RouteInfo, freshTtlSeconds?: number): number {

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -490,6 +490,7 @@ async function attemptStaleRelayCacheRevalidation(
 async function staleRevalidationCandidates(state: ActiveRelay): Promise<RevalidationCandidate[]> {
   const candidates: RevalidationCandidate[] = [];
   for (const candidate of staleCacheCandidates(state)) {
+    // Age bounds restrict serving; old validators can still confirm the body live.
     const cached = await readStaleGitHubCache(state.env, candidate.cacheKey, state.route);
     if (cached === undefined) {
       continue;
@@ -997,7 +998,12 @@ async function serveStaleRelayCache(
     return undefined;
   }
   for (const candidate of staleCacheCandidates(state)) {
-    const cached = await readStaleGitHubCache(state.env, candidate.cacheKey, state.route);
+    const cached = await readStaleGitHubCache(
+      state.env,
+      candidate.cacheKey,
+      state.route,
+      state.maxAgeSeconds,
+    );
     if (
       cached === undefined ||
       !(await cachedResponseAvailable(

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -19,6 +19,7 @@ describe("github cache policy", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it("keys equivalent query and header order identically", async () => {
@@ -267,6 +268,34 @@ describe("github cache policy", () => {
     });
     await expect(readGitHubCache(env, "cache-key", undefined, 15)).resolves.toBeUndefined();
   });
+
+  it.each([
+    { source: "edge", offsetMs: 0 },
+    { source: "shared", offsetMs: 0 },
+    { source: "edge", offsetMs: 1_000 },
+    { source: "shared", offsetMs: 1_000 },
+  ])(
+    "requires revalidation for max-age=0 at $source timestamp offset $offsetMs",
+    async ({ source, offsetMs }) => {
+      const now = Date.parse("2026-08-29T12:00:00Z");
+      vi.spyOn(Date, "now").mockReturnValue(now);
+      const created_at = sqliteUTC(now + offsetMs);
+      const expires_at = sqliteUTC(now + 60_000);
+      const body = { head: { sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" } };
+      vi.stubGlobal("caches", {
+        default: {
+          match: async () =>
+            source === "edge"
+              ? Response.json({ status: 200, headers: {}, body, created_at, expires_at })
+              : undefined,
+        },
+      });
+      const env = cacheRowEnv({ created_at, expires_at, body_json: JSON.stringify(body) });
+
+      await expect(readGitHubCache(env, "cache-key", undefined, 0)).resolves.toBeUndefined();
+      await expect(readGitHubCache(env, "cache-key")).resolves.toMatchObject({ body });
+    },
+  );
 
   it("falls through a too-old edge entry to a newer D1 fill without evicting it", async () => {
     const edgeEntry = {

--- a/test/e2e/cache-revalidation.test.ts
+++ b/test/e2e/cache-revalidation.test.ts
@@ -12,88 +12,110 @@ type RelayEnvelope = {
 };
 
 describe("Worker end-to-end cache revalidation", () => {
-  it("refreshes an anonymous API entry on 304 with stored body and state-derived TTL", async () => {
-    await seedPool();
-    let apiCalls = 0;
-    const upstream = vi.fn<typeof fetch>(async (input, init) => {
-      const request = new Request(input, init);
-      expect(bearer(request)).toBeUndefined();
-      expect(request.url).toBe(`https://api.github.com${RUN_PATH}`);
-      apiCalls++;
-      if (request.headers.get("if-none-match") === '"run-v1"') {
-        return new Response(null, { status: 304, headers: apiHeaders('"run-v1"') });
-      }
-      return jsonResponse(
-        { id: 123, status: "in_progress", conclusion: null },
-        200,
-        apiHeaders('"run-v1"'),
-      );
-    });
-    vi.stubGlobal("fetch", upstream);
-
-    await relay(RUN_PATH);
-    await expireCacheEntry("run_view");
-    const response = await relay(RUN_PATH);
-
-    expect(await response.json<RelayEnvelope>()).toMatchObject({
-      body: { id: 123, status: "in_progress" },
-      relay: { cache: "hit", route_kind: "run_view" },
-    });
-    expect(apiCalls).toBe(2);
-    expect(
-      await env.DB.prepare(
-        `SELECT unixepoch(expires_at) - unixepoch(created_at) AS ttl
-         FROM github_cache_entries WHERE route_kind = 'run_view'`,
-      ).first(),
-    ).toEqual({ ttl: 60 });
-    expect(
-      await env.DB.prepare(
-        "SELECT cache_status, fallback_reason FROM audit_events ORDER BY rowid DESC LIMIT 1",
-      ).first(),
-    ).toEqual({ cache_status: "hit", fallback_reason: "cache_revalidated" });
-  });
-
-  it("stores a replacement response when conditional revalidation returns 200", async () => {
-    await seedPool();
-    let apiCalls = 0;
-    vi.stubGlobal(
-      "fetch",
-      vi.fn<typeof fetch>(async (input, init) => {
+  it.each([undefined, 0, 20])(
+    "refreshes an anonymous API entry on 304 with max-age=%s",
+    async (maxAge) => {
+      await seedPool();
+      let apiCalls = 0;
+      const upstream = vi.fn<typeof fetch>(async (input, init) => {
         const request = new Request(input, init);
+        expect(bearer(request)).toBeUndefined();
         expect(request.url).toBe(`https://api.github.com${RUN_PATH}`);
         apiCalls++;
         if (request.headers.get("if-none-match") === '"run-v1"') {
-          return jsonResponse(
-            { id: 123, status: "completed", conclusion: "success" },
-            200,
-            apiHeaders('"run-v2"'),
-          );
+          return new Response(null, { status: 304, headers: apiHeaders('"run-v1"') });
         }
         return jsonResponse(
           { id: 123, status: "in_progress", conclusion: null },
           200,
           apiHeaders('"run-v1"'),
         );
-      }),
-    );
+      });
+      vi.stubGlobal("fetch", upstream);
 
-    await relay(RUN_PATH);
-    await expireCacheEntry("run_view");
-    const response = await relay(RUN_PATH);
+      await relay(RUN_PATH);
+      await expireCacheEntry("run_view");
+      const response = await relay(RUN_PATH, undefined, {
+        headers: maxAge === undefined ? {} : { "cache-control": `max-age=${maxAge}` },
+      });
 
-    expect(await response.json<RelayEnvelope>()).toMatchObject({
-      body: { id: 123, status: "completed" },
-      relay: { cache: "miss", route_kind: "run_view" },
-    });
-    expect(apiCalls).toBe(2);
-    expect(
-      await env.DB.prepare(
-        `SELECT json_extract(body_json, '$.status') AS status,
+      expect(await response.json<RelayEnvelope>()).toMatchObject({
+        body: { id: 123, status: "in_progress" },
+        relay: { cache: "hit", route_kind: "run_view" },
+      });
+      expect(apiCalls).toBe(2);
+      expect(
+        await env.DB.prepare(
+          `SELECT unixepoch(expires_at) - unixepoch(created_at) AS ttl
+         FROM github_cache_entries WHERE route_kind = 'run_view'`,
+        ).first(),
+      ).toEqual({ ttl: 60 });
+      expect(
+        await env.DB.prepare(
+          "SELECT cache_status, fallback_reason FROM audit_events ORDER BY rowid DESC LIMIT 1",
+        ).first(),
+      ).toEqual({ cache_status: "hit", fallback_reason: "cache_revalidated" });
+      const shared = await relay(RUN_PATH);
+      expect(await shared.json<RelayEnvelope>()).toMatchObject({
+        body: { id: 123, status: "in_progress" },
+        relay: { cache: "hit" },
+      });
+      expect(apiCalls).toBe(2);
+    },
+  );
+
+  it.each([undefined, 0, 20])(
+    "stores a conditional 200 replacement with max-age=%s",
+    async (maxAge) => {
+      await seedPool();
+      let apiCalls = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>(async (input, init) => {
+          const request = new Request(input, init);
+          expect(request.url).toBe(`https://api.github.com${RUN_PATH}`);
+          apiCalls++;
+          if (request.headers.get("if-none-match") === '"run-v1"') {
+            return jsonResponse(
+              { id: 123, status: "completed", conclusion: "success" },
+              200,
+              apiHeaders('"run-v2"'),
+            );
+          }
+          return jsonResponse(
+            { id: 123, status: "in_progress", conclusion: null },
+            200,
+            apiHeaders('"run-v1"'),
+          );
+        }),
+      );
+
+      await relay(RUN_PATH);
+      await expireCacheEntry("run_view");
+      const response = await relay(RUN_PATH, undefined, {
+        headers: maxAge === undefined ? {} : { "cache-control": `max-age=${maxAge}` },
+      });
+
+      expect(await response.json<RelayEnvelope>()).toMatchObject({
+        body: { id: 123, status: "completed" },
+        relay: { cache: "miss", route_kind: "run_view" },
+      });
+      expect(apiCalls).toBe(2);
+      expect(
+        await env.DB.prepare(
+          `SELECT json_extract(body_json, '$.status') AS status,
                 unixepoch(expires_at) - unixepoch(created_at) AS ttl
          FROM github_cache_entries WHERE route_kind = 'run_view'`,
-      ).first(),
-    ).toEqual({ status: "completed", ttl: 60 });
-  });
+        ).first(),
+      ).toEqual({ status: "completed", ttl: 60 });
+      const shared = await relay(RUN_PATH);
+      expect(await shared.json<RelayEnvelope>()).toMatchObject({
+        body: { id: 123, status: "completed" },
+        relay: { cache: "hit" },
+      });
+      expect(apiCalls).toBe(2);
+    },
+  );
 
   it.each([202, 204])(
     "publishes a %i replacement response without a second fill",
@@ -433,7 +455,8 @@ async function expireCacheEntry(routeKind: string): Promise<void> {
   expect(row).not.toBeNull();
   await env.DB.prepare(
     `UPDATE github_cache_entries
-     SET expires_at = datetime('now', '-1 second'),
+     SET created_at = datetime('now', '-180 seconds'),
+         expires_at = datetime('now', '-1 second'),
          stale_expires_at = datetime('now', '+1 hour')
      WHERE cache_key = ?`,
   )

--- a/test/e2e/max-age-cache.test.ts
+++ b/test/e2e/max-age-cache.test.ts
@@ -1,9 +1,10 @@
 import { env } from "cloudflare:workers";
 import { describe, expect, it, vi } from "vitest";
 import { deleteEdgeJSON } from "../../src/edge-cache";
-import { jsonResponse, relay, seedPool } from "./harness";
+import { bearer, jsonResponse, rateHeaders, relay, seedPool } from "./harness";
 
-const PR_PATH = "/repos/openclaw/octopool/pulls/42";
+const REPO_PATH = "/repos/openclaw/freshness-fixture";
+const PR_PATH = `${REPO_PATH}/pulls/73`;
 const FIRST_HEAD = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const SECOND_HEAD = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 
@@ -29,7 +30,7 @@ describe("Worker end-to-end bounded-freshness cache", () => {
             head: { sha: prFetches === 1 ? FIRST_HEAD : SECOND_HEAD },
           });
         }
-        if (url.pathname === "/repos/openclaw/octopool") {
+        if (url.pathname === REPO_PATH) {
           return jsonResponse({ private: false });
         }
         return jsonResponse({ message: "unexpected upstream request" }, 500);
@@ -95,5 +96,113 @@ describe("Worker end-to-end bounded-freshness cache", () => {
       "miss",
       "hit",
     ]);
+  });
+
+  describe.each(["anonymous", "identity"])("%s cache source", (source) => {
+    describe.each(["raw", "public-shaped"])("%s request", (shape) => {
+      it.each([
+        { maxAge: 0, age: 30, expired: false },
+        { maxAge: 20, age: 30, expired: false },
+        { maxAge: 0, age: 180, expired: true },
+        { maxAge: 20, age: 180, expired: true },
+      ])(
+        "rejects out-of-bound outage success: max-age=$maxAge, expired=$expired",
+        async ({ maxAge, age, expired }) => {
+          await seedPool();
+          const headers: Record<string, string> =
+            shape === "raw" ? {} : { "x-octopool-public-shape": "pr-summary-v1" };
+          let head = FIRST_HEAD;
+          let unavailable = false;
+          let limitedCalls = 0;
+          vi.stubGlobal(
+            "fetch",
+            vi.fn<typeof fetch>(async (input, init) => {
+              const request = new Request(input, init);
+              const url = new URL(request.url);
+              if (url.pathname === REPO_PATH) {
+                return jsonResponse({ private: false });
+              }
+              if (url.hostname === "api.github.com" && url.pathname === PR_PATH) {
+                if (unavailable && bearer(request) === "test-primary-token") {
+                  limitedCalls++;
+                  return jsonResponse(
+                    { message: "fixture rate limit" },
+                    429,
+                    rateHeaders({ remaining: 0, retryAfter: 60 }),
+                  );
+                }
+                if (
+                  !unavailable &&
+                  (source === "anonymous" ||
+                    head === SECOND_HEAD ||
+                    bearer(request) === "test-primary-token")
+                ) {
+                  return jsonResponse({ state: "open", merged_at: null, head: { sha: head } });
+                }
+              }
+              return jsonResponse({ message: "fixture upstream unavailable" }, 503);
+            }),
+          );
+
+          const primed = await relay(PR_PATH, undefined, { headers });
+          expect(await primed.json<RelayEnvelope>()).toMatchObject({
+            body: { head: { sha: FIRST_HEAD } },
+            relay: { cache: "miss" },
+          });
+          const row = await env.DB.prepare(
+            "SELECT cache_key, identity_id FROM github_cache_entries WHERE route_kind = 'pr_view'",
+          ).first<{ cache_key: string; identity_id: string | null }>();
+          expect(row).toMatchObject({ identity_id: source === "anonymous" ? null : "primary" });
+          await env.DB.prepare(
+            `UPDATE github_cache_entries
+             SET created_at = datetime('now', ?), expires_at = datetime('now', ?),
+                 stale_expires_at = datetime('now', '+1 hour') WHERE cache_key = ?`,
+          )
+            .bind(`-${age} seconds`, expired ? "-60 seconds" : "+90 seconds", row!.cache_key)
+            .run();
+          await deleteEdgeJSON("github-v1", row!.cache_key);
+
+          head = SECOND_HEAD;
+          unavailable = true;
+          const bounded = { headers: { ...headers, "Cache-Control": `max-age=${maxAge}` } };
+          const rejected = await relay(PR_PATH, undefined, bounded);
+          expect(rejected.status).toBe(424);
+          expect(await rejected.json()).toMatchObject({
+            error: { code: "fallback_local", details: { reason: "github_rate_limited" } },
+          });
+          expect(limitedCalls).toBe(1);
+
+          // The coordinator now skips the cooling identity; error fallback must also honor the bound.
+          const cooling = await relay(PR_PATH, undefined, bounded);
+          expect(cooling.status).toBe(424);
+          expect(await cooling.json()).toMatchObject({
+            error: { code: "fallback_local", details: { reason: "identities_cooling_down" } },
+          });
+          expect(limitedCalls).toBe(1);
+
+          // Neither a rejected bound nor a failed refresh destroys ordinary outage availability.
+          for (const allowedHeaders of [headers, { ...headers, "cache-control": "max-age=600" }]) {
+            const allowed = await relay(PR_PATH, undefined, { headers: allowedHeaders });
+            expect(allowed.status).toBe(200);
+            expect(await allowed.json<RelayEnvelope>()).toMatchObject({
+              body: { head: { sha: FIRST_HEAD } },
+              relay: { cache: expired ? "stale" : "hit", stale_ok: expired },
+            });
+          }
+
+          unavailable = false;
+          const recovered = await relay(PR_PATH, undefined, bounded);
+          expect(await recovered.json<RelayEnvelope>()).toMatchObject({
+            body: { head: { sha: SECOND_HEAD } },
+            relay: { cache: "miss" },
+          });
+          const shared = await relay(PR_PATH, undefined, { headers });
+          expect(await shared.json<RelayEnvelope>()).toMatchObject({
+            body: { head: { sha: SECOND_HEAD } },
+            relay: { cache: "hit" },
+          });
+        },
+      );
+    });
   });
 });


### PR DESCRIPTION
Related incident: [OpenClaw PR #132578 — env SecretRef alias repair](https://github.com/openclaw/openclaw/pull/132578). This is a separate Octopool repair; it does not modify OpenClaw or its exact-head landing guards.

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled; this branch is in the upstream repository.

</details>

## What Problem This Solves

Fixes an issue where users requesting a live PR head or other freshness-bounded GitHub state could still receive an old cached success when eligible upstream backends were unavailable or rate-limited. `OCTOPOOL_FRESH=1` also hid the stale-response warning, making that old result look current.

The reported incident left an exact-head CI watcher seeing the previous PR head after a successful push. A credential-free loopback fixture against the installed 0.5.10 binary confirmed that automatic gate-field reads, `OCTOPOOL_FRESH=1`, and explicit `Cache-Control: max-age=0` send identical normalized relay requests. The later success with an explicit header does not establish a casing-specific behavior; recovery after a later PR edit likewise does not prove a relay invalidation hook.

## Why This Change Was Made

The normal edge/D1 cache path enforced the request age, but outage stale serving dropped it. Pass the bound into the canonical stale-cache reader and reuse its existing age check; zero-age reads always require upstream validation, even at a matching or future cache timestamp. Leave old entries available for genuine upstream conditional revalidation rather than disabling the shared cache or adding a consumer workaround.

Actual stale responses now warn against treating the result as live even under FRESH. A FRESH `hit` stays quiet because a successful upstream `304` can legitimately produce that result. No new configuration, dependencies, cache keys, schema changes, or protocol fields are introduced.

Production LOC: +22/-8 (net +14). Tests: +298/-72 (net +226). The production growth carries the existing freshness bound across the missing owner boundary, makes zero-age semantics explicit, and corrects the stale notice; duplicate stale-row rejection branches are consolidated. A broader cache refactor is unnecessary for this invariant.

## User Impact

Freshness-bounded metadata reads receive an upstream-validated response or the existing typed failure/local-fallback outcome, rather than an out-of-bound stale success. Ordinary unbounded reads retain route-limited stale availability during outages; positive age bounds still permit shared cache hits and refills. Upstream validation or local fallback can cost quota when callers demand current state.

The server-side change is required to enforce the bound; the CLI warning also makes stale responses from older relays visible. This PR does not release a new CLI version, replace an installed shim, or deploy a running relay.

## Evidence

- **Before:** 15 Worker fixture cases failed with `expected 200 to be 424`, demonstrating forbidden old-head successes. A sixteenth case hit the existing timeout. Four edge/D1 zero-age boundary cases and two compiled-CLI notice cases also failed for their intended reasons.
- **After:** all 31 regression/revalidation Worker tests passed together, plus 28 Worker sibling tests covering cache-fill ownership, identity fallback, public-repository security, and PR-state hints. The outage matrix covers anonymous/identity cache entries, raw/public-shaped requests, fresh/expired route TTLs, zero/nonzero age bounds, cooldown fallback, recovery, and write-through. Existing `200`/`304` coverage is extended rather than replaced.
- 128 TypeScript cache/coalescing/policy/public-proof tests, targeted Go tests, source/test typechecks, formatting/lint, and whitespace checks passed. The parent independently reran the 128 tests and compiled-CLI warning regression and built/probed the candidate CLI across seven isolated command variants.
- Initial missing checkout dependencies were restored with the existing frozen lockfile; manifests and lockfile stayed unchanged. Earlier test/hook timeouts passed on unchanged bounded reruns, without raised timeouts or modified operator services. A fixture's cooldown expectation was corrected to the existing wire `424 fallback_local` response, not by changing production error handling.
- Fresh independent pre-commit review and exact-head CI are recorded in the landing verification below when complete.

Focused commands:

```bash
node_modules/.bin/vitest run --config vitest.e2e.config.ts --maxWorkers=1 --no-file-parallelism test/e2e/max-age-cache.test.ts test/e2e/cache-revalidation.test.ts
```

```bash
node_modules/.bin/vitest run --config vitest.e2e.config.ts --maxWorkers=1 --no-file-parallelism test/e2e/worker.test.ts test/e2e/relay-security.test.ts test/e2e/pr-state-cache.test.ts test/e2e/public-repos.test.ts test/e2e/cache-fill-behavior.test.ts
```

```bash
node_modules/.bin/vitest run --exclude '.claude/**' --maxWorkers=1 test/cache.test.ts test/cache-coalesce.test.ts test/policy.test.ts test/public-repos.test.ts test/pr-state.test.ts
```

```bash
go test ./cmd/octopool -run 'Test(PRView|GHAPI|VolatileRouteKind|CLIEndToEndCacheFreshnessNotices|GHRelayClient|RelayFresh|RunOwnership|RunGHPRView|NormalizePRViewState|ParseLocalFallback|RelayRetry)' -count=1
```

```bash
node_modules/.bin/tsc --noEmit -p tsconfig.src.json
```

```bash
node_modules/.bin/tsc --noEmit -p tsconfig.test.json
```

Proof limits: these are real local Worker/Workerd/D1/Durable Object and compiled-CLI fixtures, not a deployed production-relay test. No credentials/configuration dumps or live operator state were used. The historical incident's backend conditions cannot be reconstructed from this fixture alone.

## Landing Verification

Candidate head: `9ee66e2b3bcd0b9b9b9300f4d4ce9ae6718e88c8`, based on `840fe168ea2dbc94c0b7e78d93f0b5dcb39f3d26`. The reviewed implementation rebased without conflicts or patch changes; the 0.5.11 Unreleased changelog entry is a separate documentation commit. The implementation and changelog pre-commit reviews each reported no actionable findings in their selected P0 scope.

Post-rebase verification passed on this candidate without retries: 31 Worker regression/revalidation tests, 28 Worker sibling tests, 128 TypeScript owner/sibling tests, targeted Go regressions, both TypeScript programs, touched formatting/lint/gofmt, source type generation, the candidate CLI build, and the 13-page docs site build. Local unit discovery excluded the unrelated nested checkout; CI ran the full check in a clean checkout.

- [CI run 33262928989](https://github.com/openclaw/octopool/actions/runs/33262928989), attempt 1: **success** on the exact candidate head. All steps passed, including full `pnpm check`, docs site build, and GoReleaser snapshot with publishing disabled.
- [CodeQL run 33262927462](https://github.com/openclaw/octopool/actions/runs/33262927462), attempt 1: **success** on the same head; no new alerts in changed code.

The PR is ready for maintainer review. No merge, release, deployment, or installed-shim replacement has been performed.
