### PR TITLE
fix: relay PR metadata with native-compatible JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixes
 
 - Return native uppercase `OPEN`/`CLOSED` states in issue-view/list JSON before `--jq`, preserving lowercase raw `gh api` REST states.
+- Relay PR fork metadata, assignees, and native check-rollup JSON through shared transports to reduce local GitHub quota usage; hydrate repeated fields once and reject inconsistent check/status pagination before output while retaining guarded native fallback.
+- Match native PR-view author and label JSON shapes and file change-type enums, sharing author profile hydration and removing REST-only file fields.
 - Allow typed attachments on protected `gh issue create` and `gh pr edit` through strict snapshots and inline-reference rewriting, requiring an explicit body for PR attachment edits.
 - Allow exact repository branch-protection, ruleset, and applicable branch-rules GETs through freshly policy-checked native gh fallback, preserving caller permissions and encoded branch names without pooled credentials or shared caching.
 

--- a/cmd/octopool/cli_e2e_test.go
+++ b/cmd/octopool/cli_e2e_test.go
@@ -171,7 +171,7 @@ func TestCLIEndToEndRelayAndFallback(t *testing.T) {
 					}
 					writeCLIEnvelope(t, w, map[string]any{"head": map[string]any{"sha": "abc1234"}})
 				case strings.HasSuffix(path, "/check-runs"):
-					writeCLIEnvelope(t, w, map[string]any{"total_count": 1, "check_runs": []map[string]any{{"name": "CI", "status": "completed", "conclusion": "success"}}})
+					writeCLIEnvelope(t, w, map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "name": "CI", "status": "completed", "conclusion": "success"}}})
 				case strings.HasSuffix(path, "/status"):
 					writeCLIEnvelope(t, w, map[string]any{"total_count": 0, "statuses": []any{}})
 				default:

--- a/cmd/octopool/cli_protocol_e2e_test.go
+++ b/cmd/octopool/cli_protocol_e2e_test.go
@@ -133,11 +133,11 @@ func TestCLIEndToEndCheckExitCodes(t *testing.T) {
 				case "/repos/openclaw/octopool/pulls/7":
 					writeCLIEnvelope(t, w, map[string]any{"head": map[string]any{"sha": "abc123"}})
 				case "/repos/openclaw/octopool/commits/abc123/check-runs":
-					writeCLIEnvelope(t, w, map[string]any{"check_runs": []map[string]any{{
-						"name": "CI", "status": test.status, "conclusion": test.conclusion,
+					writeCLIEnvelope(t, w, map[string]any{"total_count": 1, "check_runs": []map[string]any{{
+						"id": 1, "name": "CI", "status": test.status, "conclusion": test.conclusion,
 					}}})
 				case "/repos/openclaw/octopool/commits/abc123/status":
-					writeCLIEnvelope(t, w, map[string]any{"statuses": []any{}})
+					writeCLIEnvelope(t, w, map[string]any{"total_count": 0, "statuses": []any{}})
 				default:
 					http.Error(w, "unexpected checks path", http.StatusBadRequest)
 				}

--- a/cmd/octopool/gh_top_checks.go
+++ b/cmd/octopool/gh_top_checks.go
@@ -106,73 +106,32 @@ func prCheckItemsForSHAWithHeaders(
 	sha string,
 	headers map[string]string,
 ) ([]any, error) {
-	checkRuns := []any{}
-	totalCheckRuns := 0
-	for page := 1; page <= maxRelayPages; page++ {
-		request := ghAPIRequest{
-			method:  "GET",
-			path:    repoPath(repo, "commits", sha, "check-runs"),
-			query:   map[string]any{"per_page": strconv.Itoa(relayPageSize), "page": strconv.Itoa(page)},
-			headers: headers,
-		}
-		checkRunsEnvelope, err := client.do(ctx, request)
-		if err != nil {
-			return nil, err
-		}
-		items, total, err := checkRunItems(checkRunsEnvelope)
-		if err != nil {
-			return nil, err
-		}
-		if page == 1 {
-			totalCheckRuns = total
-		}
-		checkRuns = append(checkRuns, items...)
-		if len(checkRuns) >= totalCheckRuns || len(items) < relayPageSize {
-			break
-		}
-	}
-	if len(checkRuns) < totalCheckRuns {
-		return nil, localFallbackError{Reason: "pagination_exhausted"}
-	}
-	statuses := []any{}
-	totalStatuses := 0
-	for page := 1; page <= maxRelayPages; page++ {
-		statusEnvelope, err := client.do(ctx, ghAPIRequest{
-			method:  "GET",
-			path:    repoPath(repo, "commits", sha, "status"),
-			query:   map[string]any{"per_page": strconv.Itoa(relayPageSize), "page": strconv.Itoa(page)},
-			headers: headers,
-		})
-		if err != nil {
-			return nil, err
-		}
-		items, total, err := statusItems(statusEnvelope)
-		if err != nil {
-			return nil, err
-		}
-		if page == 1 {
-			totalStatuses = total
-		}
-		statuses = append(statuses, items...)
-		if len(statuses) >= totalStatuses || len(items) < relayPageSize {
-			break
-		}
-	}
-	if len(statuses) < totalStatuses {
-		return nil, localFallbackError{Reason: "pagination_exhausted"}
-	}
-	return ghCheckItems(append(checkRuns, statuses...)), nil
-}
-
-func checkRunItems(envelope relayEnvelope) ([]any, int, error) {
-	return envelopeCollectionPage(envelope, "check_runs")
-}
-
-func statusItems(envelope relayEnvelope) ([]any, int, error) {
-	rawItems, total, err := envelopeCollectionPage(envelope, "statuses")
+	items, err := prCheckContextsForSHA(ctx, client, repo, sha, headers)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
+	return ghCheckItems(items), nil
+}
+
+// Preserve the context discriminator and source fields until each gh export
+// projects them; pr checks and pr view expose different public JSON contracts.
+func prCheckContextsForSHA(ctx context.Context, client ghRelayClient, repo, sha string, headers map[string]string) ([]any, error) {
+	checkRuns, err := relayCompleteCollection(ctx, client, ghAPIRequest{
+		method: "GET", path: repoPath(repo, "commits", sha, "check-runs"), headers: headers,
+	}, "check_runs")
+	if err != nil {
+		return nil, err
+	}
+	statuses, err := relayCompleteCollection(ctx, client, ghAPIRequest{
+		method: "GET", path: repoPath(repo, "commits", sha, "status"), headers: headers,
+	}, "statuses")
+	if err != nil {
+		return nil, err
+	}
+	return append(checkRuns, statusItems(statuses)...), nil
+}
+
+func statusItems(rawItems []any) []any {
 	items := make([]any, 0, len(rawItems))
 	for _, raw := range rawItems {
 		status, ok := raw.(map[string]any)
@@ -195,7 +154,7 @@ func statusItems(envelope relayEnvelope) ([]any, int, error) {
 		}
 		items = append(items, item)
 	}
-	return items, total, nil
+	return items
 }
 
 func ghCheckItems(items []any) []any {

--- a/cmd/octopool/gh_top_collection.go
+++ b/cmd/octopool/gh_top_collection.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strconv"
+)
+
+// These REST collections advertise total_count and numeric item IDs. Validate
+// raw identities before projection; a stable SHA does not freeze page contents.
+func relayCompleteCollection(ctx context.Context, client ghRelayClient, request ghAPIRequest, key string) ([]any, error) {
+	items := []any{}
+	seen := map[int64]bool{}
+	total := int64(-1)
+	request.query = cloneQuery(request.query)
+	request.query["per_page"] = strconv.Itoa(relayPageSize)
+	for page := 1; page <= maxRelayPages; page++ {
+		request.query["page"] = strconv.Itoa(page)
+		envelope, err := client.do(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+		body, err := envelopeBodyBytes(envelope)
+		if err != nil {
+			return nil, err
+		}
+		var response map[string]any
+		decoder := json.NewDecoder(bytes.NewReader(body))
+		decoder.UseNumber()
+		if err := decoder.Decode(&response); err != nil {
+			return nil, err
+		}
+		count, countOK := response["total_count"].(json.Number)
+		pageTotal, err := count.Int64()
+		pageItems, itemsOK := response[key].([]any)
+		if !countOK || err != nil || pageTotal < 0 || !itemsOK {
+			return nil, localFallbackError{Reason: "pagination_shape_unsupported"}
+		}
+		if total == -1 {
+			total = pageTotal
+		}
+		if pageTotal != total {
+			return nil, localFallbackError{Reason: "pagination_changed"}
+		}
+		if total > maxRelayPages*relayPageSize {
+			return nil, localFallbackError{Reason: "pagination_exhausted"}
+		}
+		expected := min(int(total)-len(items), relayPageSize)
+		if len(pageItems) != expected {
+			return nil, localFallbackError{Reason: "pagination_incomplete"}
+		}
+		for _, raw := range pageItems {
+			item, _ := raw.(map[string]any)
+			number, ok := item["id"].(json.Number)
+			id, err := number.Int64()
+			if !ok || err != nil || id <= 0 || seen[id] {
+				return nil, localFallbackError{Reason: "pagination_identity_invalid"}
+			}
+			seen[id] = true
+		}
+		items = append(items, pageItems...)
+		if int64(len(items)) == total {
+			return items, nil
+		}
+	}
+	return nil, localFallbackError{Reason: "pagination_exhausted"}
+}

--- a/cmd/octopool/gh_top_collection_test.go
+++ b/cmd/octopool/gh_top_collection_test.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestRelayCompleteCollection(t *testing.T) {
+	for _, collection := range []struct{ path, key string }{
+		{"commits/" + metadataHead + "/check-runs", "check_runs"},
+		{"commits/" + metadataHead + "/status", "statuses"},
+		{"actions/runs", "workflow_runs"},
+	} {
+		for _, scenario := range []string{
+			"empty", "full", "boundary", "large-identities", "growing", "shrinking",
+			"duplicate-page", "duplicate-item", "short", "oversized", "exhausted",
+			"missing-total", "fractional-total", "negative-total", "missing-array",
+			"missing-id", "string-id", "fractional-id", "non-object",
+		} {
+			t.Run(collection.key+"/"+scenario, func(t *testing.T) {
+				calls := 0
+				relayTestServer(t, func(request map[string]any) any {
+					calls++
+					query := request["query"].(map[string]any)
+					if query["page"] != strconv.Itoa(calls) || query["per_page"] != "100" {
+						t.Fatalf("unexpected query: %v", query)
+					}
+					total := 101
+					if scenario == "empty" {
+						total = 0
+					}
+					if scenario == "boundary" {
+						total = 1000
+					}
+					if scenario == "exhausted" {
+						total = 1001
+					}
+					count := min(100, total-(calls-1)*100)
+					items := make([]any, count)
+					for i := range items {
+						id := int64((calls-1)*100 + i + 1)
+						if scenario == "large-identities" {
+							id += 1 << 53
+						}
+						if scenario == "duplicate-page" && calls == 2 {
+							id = 1
+						}
+						if scenario == "duplicate-item" {
+							id = 1
+						}
+						items[i] = map[string]any{"id": id}
+					}
+					if scenario == "growing" && calls == 2 {
+						total = 201
+					}
+					if scenario == "shrinking" && calls == 2 {
+						total = 100
+					}
+					if scenario == "short" {
+						items = items[:99]
+					}
+					if scenario == "oversized" {
+						items = append(items, map[string]any{"id": 102})
+					}
+					response := map[string]any{"total_count": total, collection.key: items}
+					switch scenario {
+					case "missing-total":
+						delete(response, "total_count")
+					case "fractional-total":
+						response["total_count"] = 100.5
+					case "negative-total":
+						response["total_count"] = -1
+					case "missing-array":
+						delete(response, collection.key)
+					case "missing-id":
+						items[0] = map[string]any{}
+					case "string-id":
+						items[0] = map[string]any{"id": "1"}
+					case "fractional-id":
+						items[0] = map[string]any{"id": 1.5}
+					case "non-object":
+						items[0] = nil
+					}
+					return response
+				})
+				client, err := newGHRelayClient()
+				if err != nil {
+					t.Fatal(err)
+				}
+				items, err := relayCompleteCollection(t.Context(), client, ghAPIRequest{
+					method: "GET", path: "/repos/acme/repo/" + collection.path,
+				}, collection.key)
+				wantSize := map[string]int{"empty": 0, "full": 101, "boundary": 1000, "large-identities": 101}
+				if size, valid := wantSize[scenario]; valid {
+					if err != nil || len(items) != size {
+						t.Fatalf("items=%d err=%v", len(items), err)
+					}
+					if want := max(1, (size+99)/100); calls != want {
+						t.Fatalf("calls=%d want=%d", calls, want)
+					}
+				} else if !isLocalFallback(err) || items != nil {
+					t.Fatalf("incomplete collection escaped: items=%d err=%v", len(items), err)
+				}
+				if calls > maxRelayPages {
+					t.Fatalf("unbounded pagination: %d", calls)
+				}
+			})
+		}
+	}
+}
+
+// New checks can arrive at the same SHA between pages. The second page then
+// repeats successes while the old failure moves to page 3. Neither consumer may
+// publish those repeated successes as a complete snapshot.
+func TestPRChecksGrowingCollectionsUseGuardedFallback(t *testing.T) {
+	for _, key := range []string{"check_runs", "statuses"} {
+		for _, command := range []string{"view", "checks"} {
+			for _, noFallback := range []string{"", "1"} {
+				t.Run(key+"/"+command+"/no-fallback="+noFallback, func(t *testing.T) {
+					t.Setenv("OCTOPOOL_NO_FALLBACK", noFallback)
+					pages := []int{}
+					rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+						request := decodeCLIRequest(t, w, r)
+						path := request["path"].(string)
+						if strings.HasSuffix(path, "/pulls/1") {
+							writeCLIEnvelope(t, w, map[string]any{"head": map[string]any{"sha": metadataHead}})
+							return
+						}
+						collection := "check_runs"
+						if strings.HasSuffix(path, "/status") {
+							collection = "statuses"
+						}
+						if collection != key {
+							writeCLIEnvelope(t, w, map[string]any{"total_count": 0, collection: []any{}})
+							return
+						}
+						page, _ := strconv.Atoi(request["query"].(map[string]any)["page"].(string))
+						pages = append(pages, page)
+						total, count := 101, 100
+						if page > 1 {
+							total = 201
+						}
+						if page == 3 {
+							count = 1
+						}
+						items := make([]any, count)
+						for i := range items {
+							id, conclusion := 101-i, "success"
+							if page == 3 {
+								id, conclusion = 1, "failure"
+							}
+							items[i] = map[string]any{"id": id, "name": fmt.Sprint(id), "status": "completed", "conclusion": conclusion}
+							if collection == "statuses" {
+								items[i] = map[string]any{"id": id, "context": fmt.Sprint(id), "state": conclusion}
+							}
+						}
+						writeCLIEnvelope(t, w, map[string]any{"total_count": total, collection: items})
+					})
+					capture := captureRewriteGH(t)
+					args := []string{"pr", command, "1", "-R", "acme/repo", "--json", "name,state"}
+					if command == "view" {
+						args[6] = "statusCheckRollup"
+					}
+					var out bytes.Buffer
+					err := runGH(t.Context(), args, &out, io.Discard)
+					if !reflect.DeepEqual(pages, []int{1, 2}) {
+						t.Fatalf("pages=%v", pages)
+					}
+					if noFallback == "1" {
+						if err == nil || out.Len() != 0 {
+							t.Fatalf("partial result: err=%v out=%q", err, out.String())
+						}
+						if _, err := os.Stat(capture); !os.IsNotExist(err) {
+							t.Fatal("native fallback ran")
+						}
+					} else {
+						if err != nil || out.String() != "child stdout\n" {
+							t.Fatalf("partial result before fallback: err=%v out=%q", err, out.String())
+						}
+						got := readRewriteCapture(t, capture)
+						if got.Env["GH_HOST"] != "github.com" || !strings.Contains(strings.Join(got.Args, " "), "--repo=acme/repo") {
+							t.Fatalf("unpinned fallback: %+v", got)
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestSplitFieldsPreservesFirstOccurrence(t *testing.T) {
+	got := splitFields("assignees,assignees,files statusCheckRollup,files")
+	if !reflect.DeepEqual(got, []string{"assignees", "files", "statusCheckRollup"}) {
+		t.Fatalf("fields=%v", got)
+	}
+}
+
+func TestGHPRChecksWatchRejectsRepeatedCollectionIDs(t *testing.T) {
+	calls := 0
+	relayTestServer(t, func(request map[string]any) any {
+		path := request["path"].(string)
+		if strings.HasSuffix(path, "/pulls/1") {
+			return map[string]any{"head": map[string]any{"sha": metadataHead}}
+		}
+		if !strings.HasSuffix(path, "/check-runs") {
+			t.Fatalf("unexpected path %s", path)
+		}
+		calls++
+		count := 100
+		if calls == 2 {
+			count = 1
+		}
+		items := make([]any, count)
+		for i := range items {
+			items[i] = map[string]any{"id": i + 1, "name": fmt.Sprint(i), "status": "completed", "conclusion": "success"}
+		}
+		return map[string]any{"total_count": 101, "check_runs": items}
+	})
+	var out bytes.Buffer
+	result := handleGHPR(t.Context(), []string{"checks", "1", "-R", "acme/repo", "--watch"}, &out)
+	if result.action != ghFail || !isLocalFallback(result.err) || out.Len() != 0 || calls != 2 {
+		t.Fatalf("watch accepted incomplete snapshot: result=%+v output=%q calls=%d", result, out.String(), calls)
+	}
+}

--- a/cmd/octopool/gh_top_fields.go
+++ b/cmd/octopool/gh_top_fields.go
@@ -81,7 +81,7 @@ var supportedPRFields = supportedFields(
 	"number", "title", "body", "state", "url", "author", "createdAt", "updatedAt", "closedAt",
 	"mergedAt", "headRefName", "headRefOid", "baseRefName", "baseRefOid", "isDraft", "labels",
 	"additions", "deletions", "changedFiles", "mergeable", "merged", "files", "commits", "comments",
-	"reviews",
+	"reviews", "headRepository", "headRepositoryOwner", "assignees", "statusCheckRollup",
 )
 
 var supportedPRListFields = supportedFields(

--- a/cmd/octopool/gh_top_human_test.go
+++ b/cmd/octopool/gh_top_human_test.go
@@ -135,7 +135,7 @@ func TestHumanPRChecksExactOutputAndSanitizesName(t *testing.T) {
 			return map[string]any{"head": map[string]any{"sha": "abc123"}}
 		case "/repos/openclaw/octopool/commits/abc123/check-runs":
 			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{
-				"name": "Check\x1b[31m", "status": "completed", "conclusion": "success",
+				"id": 1, "name": "Check\x1b[31m", "status": "completed", "conclusion": "success",
 				"started_at": "2026-07-17T21:00:00Z", "completed_at": "2026-07-17T21:03:12Z",
 				"details_url": "https://github.com/openclaw/octopool/actions/runs/29614118703/job/87995297404",
 			}}}
@@ -356,7 +356,7 @@ func TestHumanPRChecksPendingExitsEight(t *testing.T) {
 			return map[string]any{"head": map[string]any{"sha": "abc123"}}
 		case "/repos/openclaw/octopool/commits/abc123/check-runs":
 			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{
-				"name": "Check", "status": "in_progress", "started_at": "2026-07-17T21:00:00Z",
+				"id": 1, "name": "Check", "status": "in_progress", "started_at": "2026-07-17T21:00:00Z",
 			}}}
 		case "/repos/openclaw/octopool/commits/abc123/status":
 			return map[string]any{"total_count": 0, "statuses": []map[string]any{}}

--- a/cmd/octopool/gh_top_options.go
+++ b/cmd/octopool/gh_top_options.go
@@ -193,8 +193,10 @@ func splitFields(raw string) []string {
 		return r == ',' || r == ' '
 	})
 	out := make([]string, 0, len(parts))
+	seen := make(map[string]bool, len(parts))
 	for _, part := range parts {
-		if part != "" {
+		if part != "" && !seen[part] {
+			seen[part] = true
 			out = append(out, part)
 		}
 	}

--- a/cmd/octopool/gh_top_pr.go
+++ b/cmd/octopool/gh_top_pr.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"math"
 	"strconv"
 	"strings"
 )
@@ -25,7 +26,7 @@ func needsLivePRRead(fields []string) bool {
 	for _, field := range fields {
 		switch field {
 		case "headRefOid", "baseRefOid", "state", "merged", "mergedAt", "mergeable",
-			"mergeStateStatus", "closedAt":
+			"mergeStateStatus", "closedAt", "statusCheckRollup":
 			return true
 		}
 	}
@@ -142,9 +143,86 @@ func relayPRView(ctx context.Context, stdout io.Writer, repo string, number stri
 	}
 	normalizePRViewState(pr)
 	normalizePRViewMergeable(pr)
-	filesHeadSHA := ""
+	hydratedHeadSHA := ""
+	users := map[string]map[string]any{}
 	for _, field := range opts.json {
 		switch field {
+		case "author":
+			author, present := pr["user"]
+			if !present {
+				return localFallbackError{Reason: "pull request response did not include author"}
+			}
+			mapped, err := relayPRViewAuthor(ctx, client, author, users)
+			if err != nil {
+				return err
+			}
+			pr["user"] = mapped
+		case "labels":
+			labels, err := mapPRViewLabels(pr["labels"])
+			if err != nil {
+				return err
+			}
+			pr[field] = labels
+		case "headRepository":
+			repository, present := valueAtPath(pr, "head", "repo")
+			if !present {
+				return errors.New("pull request response did not include head.repo")
+			}
+			pr[field] = nil
+			if repository != nil {
+				repository, ok := repository.(map[string]any)
+				if !ok || firstString(repository, "node_id") == "" || firstString(repository, "name") == "" || firstString(repository, "full_name") == "" {
+					return errors.New("pull request response did not include head repository identity")
+				}
+				pr[field] = map[string]any{
+					"id": firstString(repository, "node_id"), "name": firstString(repository, "name"),
+					"nameWithOwner": firstString(repository, "full_name"),
+				}
+			}
+		case "headRepositoryOwner":
+			owner, present := valueAtPath(pr, "head", "user")
+			if !present {
+				return errors.New("pull request response did not include head.user")
+			}
+			if owner == nil {
+				// gh's Owner zero value retains login when a deleted owner is null.
+				pr[field] = map[string]any{"login": ""}
+				continue
+			}
+			profile, err := relayPRUser(ctx, client, owner, users)
+			if err != nil {
+				return err
+			}
+			mapped := map[string]any{"id": profile["node_id"], "login": profile["login"]}
+			if profile["type"] == "User" && firstString(profile, "name") != "" {
+				mapped["name"] = profile["name"]
+			}
+			pr[field] = mapped
+		case "assignees":
+			assignees, ok := pr[field].([]any)
+			if !ok {
+				return errors.New("pull request response did not include assignees array")
+			}
+			mapped := make([]any, 0, len(assignees))
+			for _, assignee := range assignees {
+				profile, err := relayPRUser(ctx, client, assignee, users)
+				if err != nil {
+					return err
+				}
+				mapped = append(mapped, map[string]any{"id": profile["node_id"], "login": profile["login"], "name": firstString(profile, "name"), "databaseId": profile["id"]})
+			}
+			pr[field] = mapped
+		case "statusCheckRollup":
+			sha := nestedStringValue(pr, "head", "sha")
+			if sha == "" {
+				return errors.New("pull request response did not include head.sha")
+			}
+			rollup, err := relayPRStatusCheckRollup(ctx, client, repo, sha)
+			if err != nil {
+				return err
+			}
+			hydratedHeadSHA = sha
+			pr[field] = rollup
 		case "files":
 			sha := nestedStringValue(pr, "head", "sha")
 			if sha == "" {
@@ -160,8 +238,12 @@ func relayPRView(ctx context.Context, stdout io.Writer, repo string, number stri
 			if err != nil {
 				return err
 			}
-			filesHeadSHA = sha
-			pr["files"] = mapPRFiles(files)
+			mapped, err := mapPRFiles(files)
+			if err != nil {
+				return err
+			}
+			hydratedHeadSHA = sha
+			pr["files"] = mapped
 		case "commits":
 			commits, err := relayPagedArray(ctx, client, repoPath(repo, "pulls", number, "commits"), nil)
 			if err != nil {
@@ -182,13 +264,13 @@ func relayPRView(ctx context.Context, stdout io.Writer, repo string, number stri
 			pr["reviews"] = mapPRReviews(reviews)
 		}
 	}
-	if filesHeadSHA != "" {
+	if hydratedHeadSHA != "" {
 		currentSHA, err := relayPRHeadSHA(ctx, client, repo, number, 0)
 		if err != nil {
 			return err
 		}
-		if currentSHA != filesHeadSHA {
-			return localFallbackError{Reason: "pull request head changed during file pagination"}
+		if currentSHA != hydratedHeadSHA {
+			return localFallbackError{Reason: "pull request head changed during metadata hydration"}
 		}
 	}
 	raw, err := json.Marshal(pr)
@@ -238,7 +320,7 @@ func normalizePRViewMergeable(pr map[string]any) {
 func prViewHeaders(opts ghTopOptions) map[string]string {
 	for _, field := range opts.json {
 		switch field {
-		case "files", "commits", "comments", "reviews":
+		case "files", "commits", "comments", "reviews", "statusCheckRollup":
 			continue
 		}
 		if !supportedPublicPRViewFields[field] {
@@ -292,16 +374,28 @@ func relayPagedArrayWithHeaders(
 	return items, nil
 }
 
-func mapPRFiles(items []any) []any {
-	return mapObjects(items, func(item map[string]any) map[string]any {
-		return map[string]any{
-			"path":         firstString(item, "filename"),
-			"additions":    item["additions"],
-			"deletions":    item["deletions"],
-			"changeType":   item["status"],
-			"originalPath": firstString(item, "previous_filename"),
+func mapPRFiles(items []any) ([]any, error) {
+	changeTypes := map[string]string{
+		"added": "ADDED", "removed": "DELETED", "modified": "MODIFIED",
+		"renamed": "RENAMED", "copied": "COPIED", "changed": "CHANGED",
+	}
+	out := make([]any, 0, len(items))
+	for _, raw := range items {
+		item, _ := raw.(map[string]any)
+		changeType := changeTypes[firstString(item, "status")]
+		additions, addOK := item["additions"].(float64)
+		deletions, delOK := item["deletions"].(float64)
+		if changeType == "" || firstString(item, "filename") == "" || !addOK || !delOK ||
+			additions < 0 || deletions < 0 || additions != math.Trunc(additions) || deletions != math.Trunc(deletions) {
+			return nil, localFallbackError{Reason: "unsupported pull request file shape"}
 		}
-	})
+		// Native PullRequestFile has no originalPath, including for renames.
+		out = append(out, map[string]any{
+			"path": firstString(item, "filename"), "additions": additions,
+			"deletions": deletions, "changeType": changeType,
+		})
+	}
+	return out, nil
 }
 
 func mapPRCommits(items []any) []any {

--- a/cmd/octopool/gh_top_pr_export.go
+++ b/cmd/octopool/gh_top_pr_export.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"strings"
+)
+
+func relayPRViewAuthor(ctx context.Context, client ghRelayClient, raw any, users map[string]map[string]any) (map[string]any, error) {
+	// gh's author query selects id/name only for User. Its zero Author value
+	// (including a null/deleted actor) uses the same two-key export as bots.
+	if raw == nil {
+		return map[string]any{"is_bot": true, "login": "app/"}, nil
+	}
+	user, _ := raw.(map[string]any)
+	login := firstString(user, "login")
+	if login == "" {
+		return nil, localFallbackError{Reason: "unsupported pull request author identity"}
+	}
+	switch firstString(user, "type") {
+	case "Bot":
+		slug, ok := strings.CutSuffix(login, "[bot]")
+		if !ok || slug == "" {
+			return nil, localFallbackError{Reason: "unsupported pull request bot login"}
+		}
+		return map[string]any{"is_bot": true, "login": "app/" + slug}, nil
+	case "User":
+		profile, err := relayPRUser(ctx, client, raw, users)
+		if err != nil {
+			return nil, err
+		}
+		if profile["type"] != "User" {
+			return nil, localFallbackError{Reason: "pull request author profile type changed"}
+		}
+		return map[string]any{
+			"id": profile["node_id"], "is_bot": false,
+			"login": profile["login"], "name": firstString(profile, "name"),
+		}, nil
+	default:
+		return nil, localFallbackError{Reason: "unsupported pull request author type"}
+	}
+}
+
+func mapPRViewLabels(raw any) ([]any, error) {
+	labels, ok := raw.([]any)
+	if !ok {
+		return nil, localFallbackError{Reason: "pull request response did not include labels array"}
+	}
+	out := make([]any, 0, len(labels))
+	for _, raw := range labels {
+		label, _ := raw.(map[string]any)
+		name, nameOK := label["name"].(string)
+		color, colorOK := label["color"].(string)
+		description, descriptionPresent := label["description"]
+		_, descriptionOK := description.(string)
+		if firstString(label, "node_id") == "" || !nameOK || !colorOK || !descriptionPresent || (description != nil && !descriptionOK) {
+			return nil, localFallbackError{Reason: "unsupported pull request label shape"}
+		}
+		out = append(out, map[string]any{
+			"id": label["node_id"], "name": name, "color": color,
+			"description": firstString(label, "description"),
+		})
+	}
+	return out, nil
+}

--- a/cmd/octopool/gh_top_pr_export_test.go
+++ b/cmd/octopool/gh_top_pr_export_test.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestRunGHPRViewAuthorNativeShape(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		author      any
+		profileName any
+		want        map[string]any
+	}{
+		{"user", map[string]any{"id": 12, "node_id": "U_alice", "login": "alice", "type": "User", "url": "https://example.test/alice"}, "Alice", map[string]any{"id": "U_alice", "login": "alice", "name": "Alice", "is_bot": false}},
+		{"null-name", map[string]any{"id": 12, "node_id": "U_alice", "login": "alice", "type": "User"}, nil, map[string]any{"id": "U_alice", "login": "alice", "name": "", "is_bot": false}},
+		{"bot", map[string]any{"id": 13, "node_id": "B_clockwork", "login": "clockwork[bot]", "type": "Bot"}, nil, map[string]any{"login": "app/clockwork", "is_bot": true}},
+		{"deleted", nil, nil, map[string]any{"login": "app/", "is_bot": true}},
+	} {
+		for _, repeated := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/repeated=%v", test.name, repeated), func(t *testing.T) {
+				profileCalls := 0
+				rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+					req := decodeCLIRequest(t, w, r)
+					switch req["path"] {
+					case "/repos/acme/repo/pulls/1":
+						if headers, _ := req["headers"].(map[string]any); headers["x-octopool-public-shape"] != nil {
+							t.Error("author needs full REST identity")
+						}
+						writeCLIEnvelope(t, w, map[string]any{"user": test.author, "number": 1})
+					case "/users/alice":
+						profileCalls++
+						writeCLIEnvelope(t, w, map[string]any{"id": 12, "node_id": "U_alice", "login": "alice", "type": "User", "name": test.profileName})
+					default:
+						t.Errorf("unexpected request: %v", req["path"])
+						w.WriteHeader(400)
+					}
+				})
+				capture := captureRewriteGH(t)
+				fields := "author"
+				if repeated {
+					fields = "number,author,author"
+				}
+				var out bytes.Buffer
+				if err := runGH(t.Context(), []string{"pr", "view", "1", "-R", "acme/repo", "--json", fields}, &out, io.Discard); err != nil {
+					t.Fatal(err)
+				}
+				var got map[string]any
+				if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(got["author"], test.want) {
+					t.Fatalf("author=%#v want=%#v", got["author"], test.want)
+				}
+				wantCalls := 0
+				if test.want["is_bot"] == false {
+					wantCalls = 1
+				}
+				if profileCalls != wantCalls {
+					t.Fatalf("profile calls=%d want=%d", profileCalls, wantCalls)
+				}
+				if _, err := os.Stat(capture); !os.IsNotExist(err) {
+					t.Fatal("unexpected native fallback")
+				}
+			})
+		}
+	}
+}
+
+func TestRunGHPRViewLabelsNativeShape(t *testing.T) {
+	for _, empty := range []bool{false, true} {
+		t.Run(fmt.Sprint(empty), func(t *testing.T) {
+			labels := []any{}
+			want := []any{}
+			if !empty {
+				// Keep upstream order, including node IDs that would sort differently.
+				for i, description := range []any{nil, "", "Description"} {
+					id, name := fmt.Sprintf("LA_%d", 3-i), fmt.Sprintf("label-%d", i)
+					labels = append(labels, map[string]any{"id": i + 1, "node_id": id, "name": name, "description": description, "color": "abc123", "url": "https://example.test/label", "default": false})
+					text, _ := description.(string)
+					want = append(want, map[string]any{"id": id, "name": name, "description": text, "color": "abc123"})
+				}
+			}
+			relayTestServer(t, func(req map[string]any) any {
+				if req["path"] != "/repos/acme/repo/pulls/1" {
+					t.Fatalf("unexpected request: %v", req["path"])
+				}
+				return map[string]any{"labels": labels}
+			})
+			capture := captureRewriteGH(t)
+			var out bytes.Buffer
+			if err := runGH(t.Context(), []string{"pr", "view", "1", "-R", "acme/repo", "--json", "labels,labels"}, &out, io.Discard); err != nil {
+				t.Fatal(err)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got["labels"], want) {
+				t.Fatalf("labels=%#v want=%#v", got["labels"], want)
+			}
+			if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Fatal("unexpected native fallback")
+			}
+		})
+	}
+}
+
+func TestRunGHPRViewFilesNativeShape(t *testing.T) {
+	for _, test := range []struct{ rest, native string }{
+		{"added", "ADDED"}, {"removed", "DELETED"}, {"modified", "MODIFIED"},
+		{"renamed", "RENAMED"}, {"copied", "COPIED"}, {"changed", "CHANGED"},
+	} {
+		t.Run(test.rest, func(t *testing.T) {
+			calls := 0
+			relayTestServer(t, func(req map[string]any) any {
+				if strings.HasSuffix(req["path"].(string), "/files") {
+					calls++
+					return []any{map[string]any{"filename": "new.txt", "previous_filename": "old.txt", "additions": 2, "deletions": 1, "status": test.rest}}
+				}
+				return map[string]any{"head": map[string]any{"sha": metadataHead}}
+			})
+			capture := captureRewriteGH(t)
+			var out bytes.Buffer
+			if err := runGH(t.Context(), []string{"pr", "view", "1", "-R", "acme/repo", "--json", "files,files"}, &out, io.Discard); err != nil {
+				t.Fatal(err)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			want := []any{map[string]any{"path": "new.txt", "additions": float64(2), "deletions": float64(1), "changeType": test.native}}
+			if !reflect.DeepEqual(got["files"], want) {
+				t.Fatalf("files=%#v want=%#v", got["files"], want)
+			}
+			if calls != 1 {
+				t.Fatalf("file calls=%d", calls)
+			}
+			if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Fatal("unexpected native fallback")
+			}
+		})
+	}
+}
+
+func TestRunGHPRViewFilesUnsupportedStatus(t *testing.T) {
+	// REST admits unchanged, but GraphQL PatchStatus has no equivalent.
+	for _, status := range []any{nil, "", "unchanged", "future-status", "MODIFIED", 1} {
+		for _, noFallback := range []string{"", "1"} {
+			t.Run(fmt.Sprintf("%v/no-fallback=%s", status, noFallback), func(t *testing.T) {
+				t.Setenv("OCTOPOOL_NO_FALLBACK", noFallback)
+				rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+					req := decodeCLIRequest(t, w, r)
+					if strings.HasSuffix(req["path"].(string), "/files") {
+						file := map[string]any{"filename": "unknown.txt", "additions": 0, "deletions": 0}
+						if status != nil {
+							file["status"] = status
+						}
+						writeCLIEnvelope(t, w, []any{map[string]any{"filename": "valid.txt", "status": "added", "additions": 1, "deletions": 0}, file})
+						return
+					}
+					writeCLIEnvelope(t, w, map[string]any{"head": map[string]any{"sha": metadataHead}})
+				})
+				capture := captureRewriteGH(t)
+				var out bytes.Buffer
+				err := runGH(t.Context(), []string{"pr", "view", "1", "-R", "acme/repo", "--json", "files"}, &out, io.Discard)
+				if noFallback == "1" {
+					if err == nil || out.Len() != 0 {
+						t.Fatalf("partial JSON: err=%v out=%q", err, out.String())
+					}
+					if _, err := os.Stat(capture); !os.IsNotExist(err) {
+						t.Fatal("native fallback ran")
+					}
+				} else {
+					if err != nil || out.String() != "child stdout\n" {
+						t.Fatalf("partial JSON before fallback: err=%v out=%q", err, out.String())
+					}
+					got := readRewriteCapture(t, capture)
+					if got.Env["GH_HOST"] != "github.com" {
+						t.Fatalf("unpinned fallback: %+v", got)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestRunGHPRViewAuthorRechecksPolicy(t *testing.T) {
+	profileCalls := 0
+	updatePolicy := func() {}
+	policy, _ := rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+		req := decodeCLIRequest(t, w, r)
+		if req["path"] == "/repos/acme/repo/pulls/1" {
+			updatePolicy()
+			writeCLIEnvelope(t, w, map[string]any{"user": map[string]any{"login": "alice", "node_id": "U_alice", "id": 12, "type": "User"}})
+			return
+		}
+		profileCalls++
+		t.Errorf("forbidden profile request: %v", req["path"])
+		w.WriteHeader(400)
+	})
+	updatePolicy = func() { policy.Store(strings.ReplaceAll(rewriteActiveTestPolicy, "internal-model", "/users/")) }
+	capture := captureRewriteGH(t)
+	var out bytes.Buffer
+	err := runGH(t.Context(), []string{"pr", "view", "1", "-R", "acme/repo", "--json", "author"}, &out, io.Discard)
+	if err == nil || out.Len() != 0 || profileCalls != 0 {
+		t.Fatalf("err=%v output=%q profile calls=%d", err, out.String(), profileCalls)
+	}
+	if _, err := os.Stat(capture); !os.IsNotExist(err) {
+		t.Fatal("policy denial delegated")
+	}
+}
+
+func TestRunGHPRViewExportIncompleteShapes(t *testing.T) {
+	for _, test := range []struct {
+		name, field string
+		body        map[string]any
+	}{
+		{"missing-author", "author", map[string]any{}},
+		{"unknown-author", "author", map[string]any{"user": map[string]any{"login": "other", "node_id": "M_other", "type": "Mannequin"}}},
+		{"unknown-bot-login", "author", map[string]any{"user": map[string]any{"login": "unmapped-bot", "type": "Bot"}}},
+		{"missing-label-id", "labels", map[string]any{"labels": []any{map[string]any{"name": "bug", "description": "", "color": "abc123"}}}},
+		{"null-labels", "labels", map[string]any{"labels": nil}},
+		{"invalid-description", "labels", map[string]any{"labels": []any{map[string]any{"node_id": "LA_bug", "name": "bug", "description": 12, "color": "abc123"}}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OCTOPOOL_NO_FALLBACK", "1")
+			relayTestServer(t, func(req map[string]any) any {
+				if req["path"] != "/repos/acme/repo/pulls/1" {
+					t.Fatalf("unexpected request: %v", req["path"])
+				}
+				return test.body
+			})
+			capture := captureRewriteGH(t)
+			var out bytes.Buffer
+			err := runGH(t.Context(), []string{"pr", "view", "1", "-R", "acme/repo", "--json", test.field}, &out, io.Discard)
+			if err == nil || out.Len() != 0 {
+				t.Fatalf("err=%v output=%q", err, out.String())
+			}
+			if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Fatal("unexpected fallback")
+			}
+		})
+	}
+}

--- a/cmd/octopool/gh_top_pr_metadata.go
+++ b/cmd/octopool/gh_top_pr_metadata.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/url"
+	"strings"
+	"time"
+)
+
+func relayPRUser(ctx context.Context, client ghRelayClient, raw any, users map[string]map[string]any) (map[string]any, error) {
+	user, _ := raw.(map[string]any)
+	login, nodeID := firstString(user, "login"), firstString(user, "node_id")
+	if login == "" || nodeID == "" {
+		return nil, errors.New("pull request response did not include user identity")
+	}
+	key := strings.ToLower(login)
+	profile := users[key]
+	if profile == nil {
+		request := ghAPIRequest{method: "GET", path: "/users/" + url.PathEscape(login)}
+		if !safeRelayRequest(request) {
+			return nil, errors.New("unsupported pull request user lookup")
+		}
+		envelope, err := client.do(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+		body, err := envelopeBodyBytes(envelope)
+		if err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(body, &profile); err != nil {
+			return nil, err
+		}
+		users[key] = profile
+	}
+	_, hasName := profile["name"]
+	_, stringName := profile["name"].(string)
+	_, hasID := profile["id"].(float64)
+	if !strings.EqualFold(firstString(profile, "login"), login) || firstString(profile, "node_id") != nodeID || !hasName || (!stringName && profile["name"] != nil) || !hasID || firstString(profile, "type") == "" {
+		return nil, errors.New("user response did not include matching complete identity")
+	}
+	return profile, nil
+}
+
+func relayPRStatusCheckRollup(ctx context.Context, client ghRelayClient, repo, sha string) ([]any, error) {
+	headers := map[string]string{"cache-control": "max-age=0"}
+	items, err := prCheckContextsForSHA(ctx, client, repo, sha, headers)
+	if err != nil {
+		return nil, err
+	}
+	workflows := map[json.Number]string{}
+	for _, raw := range items {
+		item, _ := raw.(map[string]any)
+		if nestedStringValue(item, "app", "slug") == "github-actions" {
+			if err := hydratePRCheckWorkflows(ctx, client, repo, sha, headers, workflows); err != nil {
+				return nil, err
+			}
+			break
+		}
+	}
+	rollup := make([]any, 0, len(items))
+	for _, raw := range items {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			return nil, errors.New("invalid check context")
+		}
+		if _, status := item["context"]; status {
+			rollup = append(rollup, map[string]any{
+				"__typename": "StatusContext", "context": firstString(item, "context"),
+				"state":     strings.ToUpper(firstString(item, "conclusion")),
+				"targetUrl": firstString(item, "details_url"), "startedAt": ghCheckTimestamp(item, "started_at"),
+			})
+			continue
+		}
+		workflow := ""
+		if nestedStringValue(item, "app", "slug") == "github-actions" {
+			suite, _ := valueAtPath(item, "check_suite", "id")
+			id, _ := suite.(json.Number)
+			var found bool
+			workflow, found = workflows[id]
+			if !found {
+				return nil, errors.New("workflow run response did not include GitHub Actions check suite")
+			}
+		}
+		rollup = append(rollup, map[string]any{
+			"__typename": "CheckRun", "name": firstString(item, "name"), "workflowName": workflow,
+			"status": strings.ToUpper(firstString(item, "status")), "conclusion": strings.ToUpper(firstString(item, "conclusion")),
+			"startedAt": ghCheckTimestamp(item, "started_at"), "completedAt": ghCheckTimestamp(item, "completed_at"),
+			"detailsUrl": firstString(item, "details_url"),
+		})
+	}
+	return rollup, nil
+}
+
+// gh exports time.Time fields: absent/null timestamps serialize as the zero
+// time, not null or an empty string (api/queries_pr.go and api/export_pr.go).
+func ghCheckTimestamp(item map[string]any, field string) string {
+	if value := firstString(item, field); value != "" {
+		return value
+	}
+	return time.Time{}.Format(time.RFC3339)
+}
+
+func hydratePRCheckWorkflows(ctx context.Context, client ghRelayClient, repo, sha string, headers map[string]string, workflows map[json.Number]string) error {
+	request := ghAPIRequest{
+		method: "GET", path: repoPath(repo, "actions", "runs"), headers: headers,
+		query: map[string]any{"head_sha": sha},
+	}
+	if !safeRelayRequest(request) {
+		return errors.New("unsupported workflow run lookup")
+	}
+	// Filtered workflow queries and the shared collector are bounded to 1,000
+	// items. Never fabricate an empty name from an incomplete workflow lookup.
+	items, err := relayCompleteCollection(ctx, client, request, "workflow_runs")
+	if err != nil {
+		return err
+	}
+	for _, raw := range items {
+		run := raw.(map[string]any)
+		if firstString(run, "head_sha") != sha {
+			return errors.New("workflow run response did not match pull request head")
+		}
+		id, ok := run["check_suite_id"].(json.Number)
+		if !ok {
+			return errors.New("workflow run response did not include check_suite_id")
+		}
+		name, ok := run["name"].(string)
+		if !ok {
+			return errors.New("workflow run response did not include name")
+		}
+		workflows[id] = name
+	}
+	return nil
+}

--- a/cmd/octopool/gh_top_pr_metadata_test.go
+++ b/cmd/octopool/gh_top_pr_metadata_test.go
@@ -1,0 +1,440 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const metadataHead = "0123456789abcdef0123456789abcdef01234567"
+
+// OpenClaw scripts/pr-lib/worktree.sh:pr_meta_json reads this complete shape.
+const metadataFields = "number,title,state,isDraft,author,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner,url,body,labels,assignees,changedFiles,additions,deletions,statusCheckRollup,files"
+
+func TestRunGHPRViewMetadataUnderActivePolicy(t *testing.T) {
+	for _, test := range []struct{ fresh, fields string }{
+		{"", metadataFields}, {"1", metadataFields},
+		{"", metadataFields + "," + metadataFields},
+		{"", "assignees,assignees," + metadataFields},
+	} {
+		t.Run("fresh="+test.fresh+"/"+test.fields, func(t *testing.T) {
+			t.Setenv("OCTOPOOL_FRESH", test.fresh)
+			prCalls := 0
+			paths := []string{}
+			rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+				request := decodeCLIRequest(t, w, r)
+				path := request["path"].(string)
+				paths = append(paths, path)
+				headers, _ := request["headers"].(map[string]any)
+				immutableOrDescriptive := path == "/users/contributor" || strings.HasSuffix(path, "/files")
+				if (!immutableOrDescriptive || test.fresh == "1") && headers["cache-control"] != "max-age=0" {
+					t.Errorf("metadata request must be fresh: %#v", request)
+				}
+				switch path {
+				case "/repos/acme/repo/pulls/1":
+					prCalls++
+					writeCLIEnvelope(t, w, map[string]any{
+						"number": 1, "title": "Metadata", "state": "open", "draft": false,
+						"user": map[string]any{"id": 13, "node_id": "U_contributor", "login": "contributor", "type": "User"}, "base": map[string]any{"ref": "main"},
+						"html_url": "https://github.com/acme/repo/pull/1", "body": "Read metadata", "labels": []any{},
+						"changed_files": 1, "additions": 2, "deletions": 1,
+						"head": map[string]any{
+							"sha": metadataHead, "ref": "feature",
+							"repo": map[string]any{"node_id": "R_fork", "id": 12, "name": "repo", "full_name": "contributor/repo"},
+							"user": map[string]any{"node_id": "U_contributor", "id": 13, "login": "contributor"},
+						},
+						"assignees": []any{map[string]any{"node_id": "U_contributor", "id": 13, "login": "contributor"}},
+					})
+				case "/repos/acme/repo/pulls/1/files":
+					if request["route_hint"].(map[string]any)["pr_head_sha"] != metadataHead {
+						t.Error("files not bound to metadata head")
+					}
+					writeCLIEnvelope(t, w, []any{map[string]any{"filename": "fixed.go", "additions": 2, "deletions": 1, "status": "modified"}})
+				case "/repos/acme/repo/commits/" + metadataHead + "/check-runs":
+					writeCLIEnvelope(t, w, map[string]any{"total_count": 2, "check_runs": []any{
+						map[string]any{"id": 1, "name": "unit", "status": "completed", "conclusion": "success", "started_at": "2026-08-29T01:00:00Z", "completed_at": "2026-08-29T01:01:00Z", "details_url": "https://example.test/unit", "check_suite": map[string]any{"id": 42}, "app": map[string]any{"slug": "github-actions"}},
+						map[string]any{"id": 2, "name": "external", "status": "queued", "conclusion": nil, "started_at": nil, "completed_at": nil, "details_url": nil, "check_suite": map[string]any{"id": 43}, "app": map[string]any{"slug": "third-party"}},
+					}})
+				case "/repos/acme/repo/commits/" + metadataHead + "/status":
+					writeCLIEnvelope(t, w, map[string]any{"total_count": 1, "statuses": []any{map[string]any{"id": 1, "context": "ci/external", "state": "pending", "target_url": "https://example.test/status", "created_at": "2026-08-29T01:02:00Z"}}})
+				case "/users/contributor":
+					writeCLIEnvelope(t, w, map[string]any{"node_id": "U_contributor", "id": 13, "login": "contributor", "name": "Contributor", "type": "User"})
+				case "/repos/acme/repo/actions/runs":
+					query := request["query"].(map[string]any)
+					if query["head_sha"] != metadataHead {
+						t.Errorf("workflow query = %#v", query)
+					}
+					writeCLIEnvelope(t, w, map[string]any{"total_count": 1, "workflow_runs": []any{map[string]any{"id": 1, "head_sha": metadataHead, "check_suite_id": 42, "name": "CI"}}})
+				default:
+					t.Errorf("unexpected metadata path %q", path)
+					w.WriteHeader(400)
+				}
+			})
+			capture := captureRewriteGH(t)
+			var out bytes.Buffer
+			err := runGH(t.Context(), []string{"pr", "view", "1", "-R", "acme/repo", "--json", test.fields}, &out, io.Discard)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			want := map[string]any{
+				"number": float64(1), "headRefOid": metadataHead,
+				"title": "Metadata", "state": "OPEN", "isDraft": false,
+				"author": map[string]any{"id": "U_contributor", "is_bot": false, "login": "contributor", "name": "Contributor"}, "baseRefName": "main", "headRefName": "feature",
+				"url": "https://github.com/acme/repo/pull/1", "body": "Read metadata", "labels": []any{},
+				"changedFiles": float64(1), "additions": float64(2), "deletions": float64(1),
+				"files":               []any{map[string]any{"path": "fixed.go", "additions": float64(2), "deletions": float64(1), "changeType": "MODIFIED"}},
+				"headRepository":      map[string]any{"id": "R_fork", "name": "repo", "nameWithOwner": "contributor/repo"},
+				"headRepositoryOwner": map[string]any{"id": "U_contributor", "login": "contributor", "name": "Contributor"},
+				"assignees":           []any{map[string]any{"id": "U_contributor", "login": "contributor", "name": "Contributor", "databaseId": float64(13)}},
+				"statusCheckRollup": []any{
+					map[string]any{"__typename": "CheckRun", "name": "unit", "workflowName": "CI", "status": "COMPLETED", "conclusion": "SUCCESS", "startedAt": "2026-08-29T01:00:00Z", "completedAt": "2026-08-29T01:01:00Z", "detailsUrl": "https://example.test/unit"},
+					map[string]any{"__typename": "CheckRun", "name": "external", "workflowName": "", "status": "QUEUED", "conclusion": "", "startedAt": "0001-01-01T00:00:00Z", "completedAt": "0001-01-01T00:00:00Z", "detailsUrl": ""},
+					map[string]any{"__typename": "StatusContext", "context": "ci/external", "state": "PENDING", "targetUrl": "https://example.test/status", "startedAt": "2026-08-29T01:02:00Z"},
+				},
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("metadata = %s, want %#v", out.String(), want)
+			}
+			if prCalls != 2 || len(paths) != 7 || paths[len(paths)-1] != "/repos/acme/repo/pulls/1" {
+				t.Errorf("hydration must finish with head verification: %v", paths)
+			}
+			if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Fatal("metadata unexpectedly ran native gh")
+			}
+		})
+	}
+}
+
+func TestRunGHPRViewRollupRejectsUnstableHead(t *testing.T) {
+	t.Setenv("OCTOPOOL_NO_FALLBACK", "1")
+	for _, scenario := range []string{"missing", "moved", "missing-final"} {
+		t.Run(scenario, func(t *testing.T) {
+			prCalls := 0
+			rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+				request := decodeCLIRequest(t, w, r)
+				path := request["path"].(string)
+				switch {
+				case path == "/repos/acme/repo/pulls/1":
+					prCalls++
+					sha := metadataHead
+					if scenario == "missing" || (scenario == "missing-final" && prCalls == 2) {
+						sha = ""
+					} else if scenario == "moved" && prCalls == 2 {
+						sha = strings.Repeat("f", 40)
+					}
+					writeCLIEnvelope(t, w, map[string]any{"head": map[string]any{"sha": sha}})
+				case strings.HasSuffix(path, "/check-runs"):
+					writeCLIEnvelope(t, w, map[string]any{"total_count": 0, "check_runs": []any{}})
+				case strings.HasSuffix(path, "/status"):
+					writeCLIEnvelope(t, w, map[string]any{"total_count": 0, "statuses": []any{}})
+				default:
+					t.Errorf("unexpected request %s", path)
+					w.WriteHeader(400)
+				}
+			})
+			capture := captureRewriteGH(t)
+			var out bytes.Buffer
+			if err := runGH(t.Context(), []string{"pr", "view", "1", "-R", "acme/repo", "--json", "statusCheckRollup"}, &out, io.Discard); err == nil {
+				t.Fatal("unstable head unexpectedly succeeded")
+			}
+			if out.Len() != 0 {
+				t.Fatalf("published partial metadata: %q", out.String())
+			}
+			wantCalls := 2
+			if scenario == "missing" {
+				wantCalls = 1
+			}
+			if prCalls != wantCalls {
+				t.Fatalf("head checks = %d, want %d", prCalls, wantCalls)
+			}
+			if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Fatal("unstable head unexpectedly ran native gh")
+			}
+		})
+	}
+}
+
+func TestRunGHPRViewRollupPaginates(t *testing.T) {
+	t.Setenv("OCTOPOOL_NO_FALLBACK", "1")
+	pages := map[string]int{}
+	relayTestServer(t, func(request map[string]any) any {
+		path := request["path"].(string)
+		if strings.HasSuffix(path, "/pulls/1") {
+			return map[string]any{"head": map[string]any{"sha": metadataHead}}
+		}
+		pages[path]++
+		page := pages[path]
+		count := 100
+		if page == 2 {
+			count = 1
+		}
+		items := make([]any, count)
+		key := "check_runs"
+		for i := range items {
+			suite := (page-1)*100 + i + 1
+			switch {
+			case strings.HasSuffix(path, "/check-runs"):
+				items[i] = map[string]any{"id": suite, "name": fmt.Sprintf("job-%d", suite), "status": "completed", "conclusion": "success", "check_suite": map[string]any{"id": suite}, "app": map[string]any{"slug": "github-actions"}}
+			case strings.HasSuffix(path, "/status"):
+				key = "statuses"
+				items[i] = map[string]any{"id": suite, "context": fmt.Sprintf("status-%d", suite), "state": "success"}
+			case strings.HasSuffix(path, "/actions/runs"):
+				key = "workflow_runs"
+				items[i] = map[string]any{"id": suite, "head_sha": metadataHead, "check_suite_id": suite, "name": fmt.Sprintf("workflow-%d", suite)}
+			default:
+				t.Fatalf("unexpected path %q", path)
+			}
+		}
+		return map[string]any{"total_count": 101, key: items}
+	})
+	capture := captureRewriteGH(t)
+	var out bytes.Buffer
+	err := runGH(t.Context(), []string{"pr", "view", "1", "-R", "acme/repo", "--json", "statusCheckRollup"}, &out, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got struct{ StatusCheckRollup []map[string]any }
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.StatusCheckRollup) != 202 || got.StatusCheckRollup[100]["workflowName"] != "workflow-101" || got.StatusCheckRollup[201]["context"] != "status-101" {
+		t.Fatalf("incomplete rollup: %s", out.String())
+	}
+	for path, count := range pages {
+		if count != 2 {
+			t.Errorf("%s pages = %d", path, count)
+		}
+	}
+	if _, err := os.Stat(capture); !os.IsNotExist(err) {
+		t.Fatal("pagination unexpectedly ran native gh")
+	}
+}
+
+func TestRunGHPRViewDeletedForkOwner(t *testing.T) {
+	for _, deletedOwner := range []bool{false, true} {
+		t.Run(fmt.Sprint(deletedOwner), func(t *testing.T) {
+			var owner any
+			wantOwner := map[string]any{"login": ""}
+			if !deletedOwner {
+				owner = map[string]any{"node_id": "O_org", "login": "org"}
+				wantOwner = map[string]any{"id": "O_org", "login": "org"}
+			}
+			rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+				request := decodeCLIRequest(t, w, r)
+				switch request["path"] {
+				case "/repos/acme/repo/pulls/1":
+					writeCLIEnvelope(t, w, map[string]any{"head": map[string]any{"repo": nil, "user": owner}, "assignees": []any{}})
+				case "/users/org":
+					writeCLIEnvelope(t, w, map[string]any{"node_id": "O_org", "id": 14, "login": "org", "name": "Organization", "type": "Organization"})
+				default:
+					t.Errorf("unexpected request: %#v", request)
+					w.WriteHeader(400)
+				}
+			})
+			capture := captureRewriteGH(t)
+			var out bytes.Buffer
+			if err := runGH(t.Context(), []string{"pr", "view", "1", "-R", "acme/repo", "--json", "headRepository,headRepositoryOwner,assignees"}, &out, io.Discard); err != nil {
+				t.Fatal(err)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			want := map[string]any{"assignees": []any{}, "headRepository": nil, "headRepositoryOwner": wantOwner}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("deleted fork projection = %s, want %#v", out.String(), want)
+			}
+			if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Fatal("deleted fork unexpectedly ran native gh")
+			}
+		})
+	}
+}
+
+func TestRunGHPRViewMetadataFailsClosedDuringHydration(t *testing.T) {
+	t.Setenv("OCTOPOOL_NO_FALLBACK", "1")
+	for _, scenario := range []string{"identity", "assignees-missing", "assignees-null", "assignees-object", "workflow-bound", "workflow-head", "workflow-missing", "policy-change"} {
+		t.Run(scenario, func(t *testing.T) {
+			workflowCalls := 0
+			setPolicy := func() {}
+			policy, _ := rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+				request := decodeCLIRequest(t, w, r)
+				path := request["path"].(string)
+				switch {
+				case strings.HasSuffix(path, "/pulls/1"):
+					pr := map[string]any{"head": map[string]any{"sha": metadataHead, "user": map[string]any{"node_id": "U_user", "login": "user"}}}
+					if scenario == "assignees-null" {
+						pr["assignees"] = nil
+					}
+					if scenario == "assignees-object" {
+						pr["assignees"] = map[string]any{}
+					}
+					writeCLIEnvelope(t, w, pr)
+				case path == "/users/user":
+					writeCLIEnvelope(t, w, map[string]any{"node_id": "U_different", "id": 12, "login": "user", "name": "User", "type": "User"})
+				case strings.HasSuffix(path, "/check-runs"):
+					writeCLIEnvelope(t, w, map[string]any{"total_count": 1, "check_runs": []any{map[string]any{"id": 1, "name": "unit", "check_suite": map[string]any{"id": 42}, "app": map[string]any{"slug": "github-actions"}}}})
+				case strings.HasSuffix(path, "/status"):
+					if scenario == "policy-change" {
+						setPolicy()
+					}
+					writeCLIEnvelope(t, w, map[string]any{"total_count": 0, "statuses": []any{}})
+				case strings.HasSuffix(path, "/actions/runs"):
+					workflowCalls++
+					total := 1
+					if scenario == "workflow-bound" {
+						total = 1001
+					}
+					runs := []any{map[string]any{"id": 1, "head_sha": strings.Repeat("f", 40), "check_suite_id": 42, "name": "wrong-head"}}
+					if scenario == "workflow-missing" {
+						total = 0
+						runs = []any{}
+					}
+					writeCLIEnvelope(t, w, map[string]any{"total_count": total, "workflow_runs": runs})
+				default:
+					t.Errorf("unexpected path %s", path)
+					w.WriteHeader(400)
+				}
+			})
+			setPolicy = func() { policy.Store(strings.ReplaceAll(rewriteActiveTestPolicy, "internal-model", "head_sha")) }
+			capture := captureRewriteGH(t)
+			fields := "statusCheckRollup"
+			if scenario == "identity" {
+				fields = "headRepositoryOwner"
+			}
+			if strings.HasPrefix(scenario, "assignees-") {
+				fields = "assignees"
+			}
+			var out bytes.Buffer
+			if err := runGH(t.Context(), []string{"pr", "view", "1", "-R", "acme/repo", "--json", fields}, &out, io.Discard); err == nil {
+				t.Fatal("incomplete or forbidden hydration succeeded")
+			}
+			if out.Len() != 0 {
+				t.Fatalf("partial metadata = %q", out.String())
+			}
+			wantCalls := 1
+			if scenario == "policy-change" || scenario == "identity" || strings.HasPrefix(scenario, "assignees-") {
+				wantCalls = 0
+			}
+			if workflowCalls != wantCalls {
+				t.Errorf("workflow calls = %d, want %d", workflowCalls, wantCalls)
+			}
+			if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Fatal("rejected hydration unexpectedly ran native gh")
+			}
+		})
+	}
+}
+
+func TestRunGHPRViewMetadataTypedFallback(t *testing.T) {
+	for _, scenario := range []string{"head-moved", "workflow-limit"} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Setenv("OCTOPOOL_NO_FALLBACK", "")
+			prCalls := 0
+			rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+				req := decodeCLIRequest(t, w, r)
+				path := req["path"].(string)
+				switch {
+				case strings.HasSuffix(path, "/pulls/1"):
+					prCalls++
+					sha := metadataHead
+					if prCalls == 2 {
+						sha = strings.Repeat("f", 40)
+					}
+					writeCLIEnvelope(t, w, map[string]any{"head": map[string]any{"sha": sha}})
+				case strings.HasSuffix(path, "/check-runs"):
+					writeCLIEnvelope(t, w, map[string]any{"total_count": 1, "check_runs": []any{map[string]any{"id": 1, "status": "completed", "conclusion": "success", "app": map[string]any{"slug": "github-actions"}, "check_suite": map[string]any{"id": 42}}}})
+				case strings.HasSuffix(path, "/status"):
+					writeCLIEnvelope(t, w, map[string]any{"total_count": 0, "statuses": []any{}})
+				case strings.HasSuffix(path, "/actions/runs"):
+					total := 1
+					if scenario == "workflow-limit" {
+						total = 1001
+					}
+					writeCLIEnvelope(t, w, map[string]any{"total_count": total, "workflow_runs": []any{map[string]any{"id": 1, "head_sha": metadataHead, "check_suite_id": 42, "name": "CI"}}})
+				default:
+					t.Errorf("unexpected path %s", path)
+					w.WriteHeader(400)
+				}
+			})
+			capture := captureRewriteGH(t)
+			var out bytes.Buffer
+			if err := runGH(t.Context(), []string{"pr", "view", "1", "-R", "acme/repo", "--json", "statusCheckRollup"}, &out, io.Discard); err != nil {
+				t.Fatal(err)
+			}
+			if out.String() != "child stdout\n" {
+				t.Fatalf("partial JSON before fallback: %q", out.String())
+			}
+			got := readRewriteCapture(t, capture)
+			want := []string{"pr", "view", "1", "--repo=acme/repo", "--json=statusCheckRollup"}
+			if !reflect.DeepEqual(got.Args, want) || got.Env["GH_HOST"] != "github.com" {
+				t.Fatalf("fallback=%+v", got)
+			}
+		})
+	}
+}
+
+func TestRunGHPRViewMetadataUpstreamFailuresStayClosed(t *testing.T) {
+	for _, phase := range []string{"profile", "checks", "statuses", "workflows", "final-head"} {
+		for _, upstream := range []int{403, 404, 500} {
+			t.Run(fmt.Sprintf("%s/%d", phase, upstream), func(t *testing.T) {
+				t.Setenv("OCTOPOOL_NO_FALLBACK", "")
+				prCalls := 0
+				rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+					req := decodeCLIRequest(t, w, r)
+					path := req["path"].(string)
+					current := ""
+					var data any
+					switch {
+					case strings.HasSuffix(path, "/pulls/1"):
+						prCalls++
+						if prCalls == 2 {
+							current = "final-head"
+						}
+						data = map[string]any{"head": map[string]any{"sha": metadataHead, "user": map[string]any{"login": "alice", "node_id": "U_alice"}}}
+					case path == "/users/alice":
+						current = "profile"
+						data = map[string]any{"login": "alice", "node_id": "U_alice", "id": 12, "type": "User", "name": nil}
+					case strings.HasSuffix(path, "/check-runs"):
+						current = "checks"
+						data = map[string]any{"total_count": 1, "check_runs": []any{map[string]any{"id": 1, "name": "unit", "status": "completed", "conclusion": "success", "check_suite": map[string]any{"id": 42}, "app": map[string]any{"slug": "github-actions"}}}}
+					case strings.HasSuffix(path, "/status"):
+						current = "statuses"
+						data = map[string]any{"total_count": 0, "statuses": []any{}}
+					case strings.HasSuffix(path, "/actions/runs"):
+						current = "workflows"
+						data = map[string]any{"total_count": 1, "workflow_runs": []any{map[string]any{"id": 1, "check_suite_id": 42, "head_sha": metadataHead, "name": "CI"}}}
+					default:
+						t.Errorf("unexpected request: %s", path)
+						w.WriteHeader(400)
+						return
+					}
+					if current == phase {
+						_ = json.NewEncoder(w).Encode(map[string]any{"status": upstream, "body_encoding": "json", "body": map[string]any{"message": "upstream failure"}})
+						return
+					}
+					writeCLIEnvelope(t, w, data)
+				})
+				capture := captureRewriteGH(t)
+				var out bytes.Buffer
+				err := runGH(t.Context(), []string{"pr", "view", "1", "-R", "acme/repo", "--json", "headRepositoryOwner,statusCheckRollup"}, &out, io.Discard)
+				if err == nil || out.Len() != 0 {
+					t.Fatalf("upstream failure: err=%v out=%q", err, out.String())
+				}
+				if _, err := os.Stat(capture); !os.IsNotExist(err) {
+					t.Fatal("upstream error unexpectedly delegated")
+				}
+			})
+		}
+	}
+}

--- a/cmd/octopool/gh_top_pr_test.go
+++ b/cmd/octopool/gh_top_pr_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -31,7 +32,7 @@ func TestRunGHPRViewHydratesDetails(t *testing.T) {
 			if hint["pr_head_sha"] != "0123456789abcdef0123456789abcdef01234567" {
 				t.Fatalf("route hint = %#v", hint)
 			}
-			return []map[string]any{{"filename": "cmd/octopool/gh.go"}}
+			return []map[string]any{{"filename": "cmd/octopool/gh.go", "status": "modified", "additions": 2, "deletions": 1}}
 		case "/repos/openclaw/octopool/pulls/7/commits":
 			return []map[string]any{{"sha": "abc1234"}}
 		case "/repos/openclaw/octopool/issues/7/comments":
@@ -76,7 +77,7 @@ func TestRunGHPRViewFilesFallsBackWhenHeadMoves(t *testing.T) {
 			}
 			return map[string]any{"number": 7, "head": map[string]any{"sha": sha}}
 		case "/repos/openclaw/octopool/pulls/7/files":
-			return []map[string]any{{"filename": "moving.ts"}}
+			return []map[string]any{{"filename": "moving.ts", "status": "modified", "additions": 2, "deletions": 1}}
 		default:
 			t.Fatalf("path = %v", body["path"])
 			return nil
@@ -87,19 +88,6 @@ func TestRunGHPRViewFilesFallsBackWhenHeadMoves(t *testing.T) {
 		"view", "7", "-R", "openclaw/octopool", "--json", "number,files",
 	}, &bytes.Buffer{})
 	if result.action != ghFail || !isLocalFallback(result.err) {
-		t.Fatalf("action=%v err=%v", result.action, result.err)
-	}
-}
-
-func TestRunGHPRViewFallsBackForStatusCheckRollup(t *testing.T) {
-	var out bytes.Buffer
-	result := handleGHPR(t.Context(), []string{
-		"view",
-		"7",
-		"-R", "openclaw/octopool",
-		"--json", "number,statusCheckRollup",
-	}, &out)
-	if result.err != nil || result.action != ghDelegate {
 		t.Fatalf("action=%v err=%v", result.action, result.err)
 	}
 }
@@ -127,9 +115,9 @@ func TestRunGHPRChecksUsesCacheableRequests(t *testing.T) {
 		case "/repos/openclaw/octopool/pulls/7":
 			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
 		case "/repos/openclaw/octopool/commits/abc1234/check-runs":
-			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"name": "CI", "status": "completed", "conclusion": "success"}}}
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "name": "CI", "status": "completed", "conclusion": "success"}}}
 		case "/repos/openclaw/octopool/commits/abc1234/status":
-			return map[string]any{"statuses": []map[string]any{}}
+			return map[string]any{"total_count": 0, "statuses": []map[string]any{}}
 		default:
 			t.Fatalf("path = %v", body["path"])
 			return nil
@@ -151,17 +139,13 @@ func TestRunGHPRChecksUsesCacheableRequests(t *testing.T) {
 }
 
 func TestStatusItemsMapLegacyContexts(t *testing.T) {
-	envelope := relayEnvelope{
-		Status:       200,
-		BodyEncoding: "json",
-		Body:         []byte(`{"statuses":[{"context":"ci/external","state":"success","target_url":"https://example.test","created_at":"2026-05-27T00:00:00Z","updated_at":"2026-05-27T00:01:00Z"}]}`),
-	}
-	items, total, err := statusItems(envelope)
-	if err != nil {
+	var rawItems []any
+	if err := json.Unmarshal([]byte(`[{"id":1,"context":"ci/external","state":"success","target_url":"https://example.test","created_at":"2026-05-27T00:00:00Z","updated_at":"2026-05-27T00:01:00Z"}]`), &rawItems); err != nil {
 		t.Fatal(err)
 	}
-	if len(items) != 1 || total != 1 {
-		t.Fatalf("items = %#v total=%d", items, total)
+	items := statusItems(rawItems)
+	if len(items) != 1 {
+		t.Fatalf("items = %#v", items)
 	}
 	item := items[0].(map[string]any)
 	if item["name"] != "ci/external" || item["conclusion"] != "success" || item["details_url"] != "https://example.test" {

--- a/cmd/octopool/gh_top_watch_test.go
+++ b/cmd/octopool/gh_top_watch_test.go
@@ -150,12 +150,12 @@ func TestGHPRChecksWatchPendingToDone(t *testing.T) {
 			return map[string]any{
 				"total_count": 2,
 				"check_runs": []map[string]any{
-					{"name": "CI", "status": status, "conclusion": conclusion, "details_url": "https://example.test/ci"},
-					{"name": "Lint", "status": "completed", "conclusion": "success", "details_url": "https://example.test/lint"},
+					{"id": 1, "name": "CI", "status": status, "conclusion": conclusion, "details_url": "https://example.test/ci"},
+					{"id": 2, "name": "Lint", "status": "completed", "conclusion": "success", "details_url": "https://example.test/lint"},
 				},
 			}
 		case "/repos/openclaw/octopool/commits/abc1234/status":
-			return map[string]any{"statuses": []any{}}
+			return map[string]any{"total_count": 0, "statuses": []any{}}
 		default:
 			t.Fatalf("unexpected path = %v", body["path"])
 			return nil
@@ -190,11 +190,11 @@ func TestGHPRChecksWatchFailFast(t *testing.T) {
 		case "/repos/openclaw/octopool/commits/abc1234/check-runs":
 			checkCalls++
 			return map[string]any{"total_count": 2, "check_runs": []map[string]any{
-				{"name": "CI", "status": "completed", "conclusion": "failure"},
-				{"name": "Integration", "status": "queued"},
+				{"id": 1, "name": "CI", "status": "completed", "conclusion": "failure"},
+				{"id": 2, "name": "Integration", "status": "queued"},
 			}}
 		case "/repos/openclaw/octopool/commits/abc1234/status":
-			return map[string]any{"statuses": []any{}}
+			return map[string]any{"total_count": 0, "statuses": []any{}}
 		default:
 			t.Fatalf("unexpected path = %v", body["path"])
 			return nil
@@ -227,11 +227,11 @@ func TestGHPRChecksWatchFailFastIgnoresCancelled(t *testing.T) {
 				pendingStatus, pendingConclusion = "completed", "success"
 			}
 			return map[string]any{"total_count": 2, "check_runs": []map[string]any{
-				{"name": "CI", "status": "completed", "conclusion": "cancelled"},
-				{"name": "Integration", "status": pendingStatus, "conclusion": pendingConclusion},
+				{"id": 1, "name": "CI", "status": "completed", "conclusion": "cancelled"},
+				{"id": 2, "name": "Integration", "status": pendingStatus, "conclusion": pendingConclusion},
 			}}
 		case "/repos/openclaw/octopool/commits/abc1234/status":
-			return map[string]any{"statuses": []any{}}
+			return map[string]any{"total_count": 0, "statuses": []any{}}
 		default:
 			t.Fatalf("unexpected path = %v", body["path"])
 			return nil
@@ -284,7 +284,7 @@ func TestGHPRChecksWatchCachedEmptyRevalidatesFresh(t *testing.T) {
 				// Stale shared-cache entry from before checks registered.
 				return map[string]any{"total_count": 0, "check_runs": []any{}}
 			}
-			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"name": "CI", "status": "completed", "conclusion": "success"}}}
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "name": "CI", "status": "completed", "conclusion": "success"}}}
 		case strings.HasSuffix(path, "/status"):
 			return map[string]any{"total_count": 0, "statuses": []any{}}
 		default:
@@ -314,7 +314,7 @@ func TestGHPRChecksWatchFreshEmptyTerminalIsNotGreen(t *testing.T) {
 				// Terminal confirmation sees the checks vanish (rerun lag).
 				return map[string]any{"total_count": 0, "check_runs": []any{}}
 			}
-			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"name": "CI", "status": "completed", "conclusion": "success"}}}
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "name": "CI", "status": "completed", "conclusion": "success"}}}
 		case strings.HasSuffix(path, "/status"):
 			return map[string]any{"total_count": 0, "statuses": []any{}}
 		default:
@@ -363,9 +363,9 @@ func TestGHPRChecksWatchEqualsTrueSpelling(t *testing.T) {
 		case "/repos/openclaw/octopool/pulls/7":
 			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
 		case "/repos/openclaw/octopool/commits/abc1234/check-runs":
-			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"name": "CI", "status": "completed", "conclusion": "success"}}}
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "name": "CI", "status": "completed", "conclusion": "success"}}}
 		case "/repos/openclaw/octopool/commits/abc1234/status":
-			return map[string]any{"statuses": []any{}}
+			return map[string]any{"total_count": 0, "statuses": []any{}}
 		default:
 			t.Fatalf("unexpected path = %v", body["path"])
 			return nil
@@ -425,9 +425,9 @@ func TestGHPRChecksWatchRevalidatesHeadBeforeTerminal(t *testing.T) {
 		case strings.HasSuffix(path, "/check-runs"):
 			sha := strings.Split(path, "/")[5]
 			checkFetches = append(checkFetches, sha)
-			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"name": "CI", "status": "completed", "conclusion": "success"}}}
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "name": "CI", "status": "completed", "conclusion": "success"}}}
 		case strings.HasSuffix(path, "/status"):
-			return map[string]any{"statuses": []any{}}
+			return map[string]any{"total_count": 0, "statuses": []any{}}
 		default:
 			t.Fatalf("unexpected path = %v", path)
 			return nil
@@ -499,12 +499,12 @@ func TestGHPRChecksWatchConfirmsRerunSameHead(t *testing.T) {
 				freshCheckReads++
 				if freshCheckReads == 1 {
 					// Rerun in flight: same head SHA, cached payload obsolete.
-					return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"name": "CI", "status": "in_progress"}}}
+					return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "name": "CI", "status": "in_progress"}}}
 				}
 			}
-			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"name": "CI", "status": "completed", "conclusion": "success"}}}
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "name": "CI", "status": "completed", "conclusion": "success"}}}
 		case strings.HasSuffix(path, "/status"):
-			return map[string]any{"statuses": []any{}}
+			return map[string]any{"total_count": 0, "statuses": []any{}}
 		default:
 			t.Fatalf("unexpected path = %v", path)
 			return nil
@@ -777,7 +777,7 @@ func TestGHPRChecksWatchAuthFailureDoesNotHandoff(t *testing.T) {
 			}
 			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
 		case strings.HasSuffix(path, "/check-runs"):
-			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"name": "CI", "status": "completed", "conclusion": "success"}}}
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "name": "CI", "status": "completed", "conclusion": "success"}}}
 		case strings.HasSuffix(path, "/status"):
 			return map[string]any{"total_count": 0, "statuses": []any{}}
 		default:

--- a/cmd/octopool/string_rewrites_process_test.go
+++ b/cmd/octopool/string_rewrites_process_test.go
@@ -1881,7 +1881,7 @@ func TestStringRewriteActivePRHydrationAndPaginationFallback(t *testing.T) {
 			case "/repos/acme/repo/pulls/1":
 				writeCLIEnvelope(t, w, map[string]any{"number": 1, "head": map[string]any{"sha": "0123456789abcdef0123456789abcdef01234567"}})
 			case "/repos/acme/repo/pulls/1/files":
-				writeCLIEnvelope(t, w, []map[string]any{{"filename": "safe.go"}})
+				writeCLIEnvelope(t, w, []map[string]any{{"filename": "safe.go", "status": "added", "additions": 1, "deletions": 0}})
 			default:
 				t.Error("unexpected hydration path")
 				w.WriteHeader(400)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -210,6 +210,32 @@ draft/lifecycle status, checks, or merge policy. Raw `gh api` REST reads retain 
 boolean, null, or absent `mergeable` values. `mergeCommit` and `mergeStateStatus` remain
 unsupported and delegate to real `gh`, including when requested alongside `mergeable`;
 `gh pr list --json mergeable` also delegates.
+PR views also relay `headRepository`, `headRepositoryOwner`, `assignees`, and
+`statusCheckRollup` to reduce local GitHub quota usage through shared transports and
+eligible caching, including under active string rewrite protection. Fork metadata
+uses GitHub node IDs; a deleted head repository is `null`. Requested author, owner, and assignee
+names use a shared per-command profile lookup. The rollup preserves native `gh`
+`CheckRun` and `StatusContext` fields and resolves workflow names by check-suite ID
+from head-filtered Actions runs, without guessing from job names or URLs. Check/status
+pages and workflow lookups read live; after all hydration, a final live PR head check
+rejects a moving head before any JSON is printed. A matching SHA is not an atomic
+snapshot: checks can change on the same commit. Both `pr checks` and the rollup require
+consistent page totals, unique upstream IDs, and complete pages, bounded to 1,000 items
+per collection. The workflow lookup uses the same completeness checks. Inconsistent
+or incomplete collections emit no partial JSON and follow the existing typed native
+fallback, including fresh policy checks and host pinning under active rewrite rules.
+`OCTOPOOL_NO_FALLBACK=1` keeps these cases as failures. Repeated JSON fields are accepted
+and hydrated once.
+PR-view `author`, `labels`, and `files` use native JSON projections regardless of the
+other requested fields. User authors export `id` (node ID), `is_bot`, `login`, and
+`name`; bot authors use native `is_bot` and `app/…` login keys. Labels export node IDs,
+names, descriptions (null becomes an empty string), and colors in upstream order.
+Files export only `path`, `additions`, `deletions`, and `changeType`, including renames.
+File change types use native enums; REST `removed` becomes `DELETED`. Unsupported or
+missing statuses, including REST `unchanged` with no native enum, follow guarded
+fallback before any JSON is printed.
+Upgrade note: PR-view scripts using numeric author/label IDs, REST-only nested keys,
+lowercase file statuses, or `originalPath` must use these native projections instead.
 Upgrade note: scripts relying on earlier Octopool boolean/null output must use explicit
 enum comparisons. Replace `.mergeable == true` with `.mergeable == "MERGEABLE"` and
 `.mergeable == false` with `.mergeable == "CONFLICTING"`; handle `"UNKNOWN"` separately.
@@ -558,8 +584,8 @@ how a stale answer gets read as current fact.
 Three things keep that honest:
 
 - **Gate fields read live.** `gh pr view --json` reads that include `headRefOid`,
-  `baseRefOid`, `state`, `merged`, `mergedAt`, `mergeable`, `mergeStateStatus`, or
-  `closedAt` send `cache-control: max-age=0` automatically. These are the values callers
+  `baseRefOid`, `state`, `merged`, `mergedAt`, `mergeable`, `mergeStateStatus`,
+  `closedAt`, or `statusCheckRollup` send `cache-control: max-age=0` automatically. These are the values callers
   branch on, so they require an upstream fetch or successful conditional revalidation.
   Descriptive fields (`title`, `body`, `labels`, `author`) stay cached.
 - **Cached decision reads announce themselves.** When a PR, issue, run, or checks route is


### PR DESCRIPTION
## Purpose and design

Extend guarded relay coverage for PR fork repository/owner metadata, assignees, and status-check rollups, reducing reliance on the caller's local GitHub quota. Current released Octopool already supports the original request through guarded native fallback; this PR deliberately adds shared-transport/eligible-cache coverage rather than claiming that native fallback is still broken.

Successful supported reads use the existing policy-aware relay. Incomplete, changing, or unrepresentable results retain the established guarded native fallback, including fresh policy checks and host pinning. There is no new unconditional no-native guarantee and no policy or authentication bypass.

## Repairs made during review

- One shared collection reader now checks every page's total, exact page size, unique upstream IDs, and the existing bound before projecting checks, statuses, or workflow names. This prevents growing same-SHA collections from publishing duplicate successes while omitting a failing check. It also repairs the preexisting reader used by `pr checks`.
- Repeated JSON fields hydrate once instead of reprocessing already-exported assignees.
- The first live comparison exposed three additional native-shape mismatches. PR-view author/label objects now use native node IDs and keys; files use native change-type enums (`removed` becomes `DELETED`) without REST-only fields.
- Current main's guarded fallback, attachments, labels/assignees, protection reads, and issue-state handling are preserved. Documentation includes the JSON-shape upgrade and does not claim an atomic same-SHA snapshot.

## Inspectable live proof

Recorded on 2026-08-30, starting at 20:32:22 UTC, against [openclaw/openclaw PR129348](https://github.com/openclaw/openclaw/pull/129348). Native baselines used the ordinary installed Octopool 0.5.16 shim, whose supported fallback supplies native GitHub CLI JSON. Candidate reads used the compiled PR code with `OCTOPOOL_NO_FALLBACK=1` and a temporary `OCTOPOOL_GH_PATH` sentinel that records and rejects any native-child invocation. Saved credentials, policy, and installed binaries were unchanged.

Exact projection:

```bash
gh pr view 129348 --repo openclaw/openclaw --json number,title,state,isDraft,author,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner,url,body,labels,assignees,changedFiles,additions,deletions,statusCheckRollup,files
```

The candidate ran the same arguments through its `gh` subcommand. Results compared complete parsed field values, normalizing only the order of check/status contexts; no fields or object keys were removed to obtain parity.

| Invocation | Exit | Fields | Files | Checks | Assignees | Seconds |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Native before | 0 | 19 | 72 | 266 | 1 | 3.098 |
| Relay first | 0 | 19 | 72 | 266 | 1 | 21.271 |
| Relay second | 0 | 19 | 72 | 266 | 1 | 19.442 |
| Native after | 0 | 19 | 72 | 266 | 1 | 2.472 |
| Relay with all requested fields repeated | 0 | 19 | 72 | 266 | 1 | 12.853 |

Captured comparison output:

```json
{
  "native_bracket_stable": true,
  "differing_fields": {"relay-first": [], "relay-second": []},
  "all_fields_match": true,
  "repeated_fields_exact_parity": true,
  "native_child_invocations": 0,
  "structural_negative": {"exit_code": 1, "guard_denial": true, "stdout_empty": true}
}
```

All four ordinary outputs share canonical SHA-256 `5d707642d7578a9b98d0d3d5a6e56018f23a3dfead670b6f29565a21ee86328b`. The tested binary SHA-256 is `e5dce5de4ccecc995ffc2136209760b8c0976d51a86ee0606d81857fb46546f9`; the PR's Go source/test files are byte-matched to the reviewed, live-tested snapshot before publication. The negative control used an unresolved owner placeholder and was rejected before output or native dispatch.

This is proof of relay execution and sampled native-output parity, not a latency improvement or a fleet-wide quota benchmark. The sample was slower than native `gh`; freshness-sensitive data is revalidated rather than served arbitrarily stale. Historical workflow/rerun ordering and all possible GitHub actor types are not exhaustively live-tested; unsupported shapes use the existing fallback.

## Local and CI verification

The original two reproduction tests failed before repair. The initial live comparison also failed for author/labels/files, then passed after their corrections. Focused regressions, full `pnpm check` (516 Worker unit tests, 218 Worker E2E tests, Go tests/vet, generation, formatting, lint, and type checks), and the docs build passed on the repaired snapshot.

After integration with the newer issue-state fix, one local parallel Worker E2E run had a duplicate fixture row and two setup timeouts. The unchanged affected file passed all 74 tests on retry; the entire unchanged Worker suite then passed all 218 tests with `--maxWorkers=1 --no-file-parallelism`, without increasing any timeout or weakening assertions. The remaining build/type, full Go test/vet, module-tidiness, and docs checks also passed on the integrated source. Exact-head CI must still pass the standard configuration before merge.

No release, local CLI installation, Worker deployment, authentication change, or protection-policy change is included.
