### PR TITLE
fix: support protected PR media attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.5.13 - Unreleased
 
+### Fixes
+
+- Allow protected `gh pr create` and `gh pr comment` media attachments by validating paths, rewriting image alt text, and passing immutable private snapshots to native `gh` without weakening strict body filtering.
+
 ## 0.5.12 - 2026-08-29
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ octopool gh api repos/openclaw/openclaw/pulls/85341 --jq .number
 octopool stats
 ```
 
-Install it as a `gh` shim — safe reads try Octopool first, while supported writes and explicit server fallback signals use your local `gh` after outbound-policy checks. Active rewrite rules block commands whose final content cannot be inspected:
+Install it as a `gh` shim — safe reads try Octopool first, while supported writes and explicit server fallback signals use your local `gh` after outbound-policy checks. Active rewrite rules strictly snapshot modeled publication bodies and media attachments; evolving native command shapes receive bounded best-effort filtering:
 
 ```sh
 octopool install-shim

--- a/cmd/octopool/string_rewrites_args.go
+++ b/cmd/octopool/string_rewrites_args.go
@@ -203,7 +203,17 @@ func prepareRewriteContent(policy stringRewritePolicy, args []string, stdin io.R
 	default:
 		return errRewriteBlocked
 	}
-	flags, err := parseRewriteFlags(args[2:], rewriteFlagNames(valueSpec), rewriteFlagNames(booleanSpec))
+	commandArgs := args[2:]
+	valueFlags := rewriteFlagNames(valueSpec)
+	var attachments []rewriteAttachment
+	var err error
+	if command == "pr create" || command == "pr comment" {
+		commandArgs, attachments, err = extractRewriteAttachments(commandArgs, valueFlags)
+		if err != nil {
+			return err
+		}
+	}
+	flags, err := parseRewriteFlags(commandArgs, valueFlags, rewriteFlagNames(booleanSpec))
 	if err != nil {
 		return err
 	}
@@ -254,7 +264,8 @@ func prepareRewriteContent(policy stringRewritePolicy, args []string, stdin io.R
 			}
 		}
 	}
-	if (args[1] == "comment" || args[1] == "review") && !hasBody {
+	attachmentOnlyComment := command == "pr comment" && len(attachments) > 0 && flags.values["--edit-last"] != "true"
+	if (args[1] == "comment" || args[1] == "review") && !hasBody && !attachmentOnlyComment {
 		return errRewriteBlocked
 	}
 	if command == "pr create" {
@@ -297,6 +308,11 @@ func prepareRewriteContent(policy stringRewritePolicy, args []string, stdin io.R
 			if err != nil {
 				return err
 			}
+			// Native gh matches body references against the supplied file paths.
+			// Private snapshots change those paths, so require append-only uploads.
+			if flag.name != "--title" && rewriteBodyReferencesAttachment(text, attachments) {
+				return errRewriteBlocked
+			}
 			// Empty create fields can re-enable gh's prompts/default generation.
 			if create && strings.TrimSpace(text) == "" {
 				return errRewriteBlocked
@@ -316,6 +332,40 @@ func prepareRewriteContent(policy stringRewritePolicy, args []string, stdin io.R
 			}
 			prepared.args = append(prepared.args, flag.name+"="+flag.value)
 		}
+	}
+	remainingAttachmentBytes := rewriteMaxAttachmentBytes
+	for _, attachment := range attachments {
+		if err := checkRewriteAttachmentPath(policy, attachment.source); err != nil {
+			return err
+		}
+		alt := attachment.alt
+		if attachment.kind == rewriteAttachmentKindImage {
+			if !attachment.hasAlt {
+				alt = rewriteAttachmentDefaultAlt(attachment)
+			}
+			alt, err = prepared.text(policy, alt)
+			if err != nil {
+				return err
+			}
+			if alt == "" && attachment.hasAlt {
+				alt, err = prepared.text(policy, rewriteAttachmentDefaultAlt(attachment))
+				if err != nil {
+					return err
+				}
+			}
+			if alt == "" {
+				alt, err = prepared.text(policy, "attachment")
+				if err != nil || alt == "" {
+					return errRewriteBlocked
+				}
+			}
+		}
+		path, size, err := prepared.snapshotAttachment(attachment, remainingAttachmentBytes)
+		if err != nil {
+			return err
+		}
+		remainingAttachmentBytes -= size
+		prepared.args = append(prepared.args, "--attach="+rewriteAttachmentArgument(attachment, path, alt))
 	}
 	prepared.stdin = strings.NewReader("")
 	return nil

--- a/cmd/octopool/string_rewrites_attachments.go
+++ b/cmd/octopool/string_rewrites_attachments.go
@@ -1,0 +1,298 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
+)
+
+const (
+	rewriteMaxAttachments      = 16
+	rewriteMaxAttachmentBytes  = int64(100 << 20)
+	rewriteMaxImageAttachment  = int64(10 << 20)
+	rewriteMaxVideoAttachment  = int64(100 << 20)
+	rewriteAttachmentKindImage = "image"
+	rewriteAttachmentKindVideo = "video"
+)
+
+var rewriteAttachmentExtensions = map[string]string{
+	".gif":  rewriteAttachmentKindImage,
+	".jpeg": rewriteAttachmentKindImage,
+	".jpg":  rewriteAttachmentKindImage,
+	".mov":  rewriteAttachmentKindVideo,
+	".mp4":  rewriteAttachmentKindVideo,
+	".png":  rewriteAttachmentKindImage,
+	".webm": rewriteAttachmentKindVideo,
+	".webp": rewriteAttachmentKindImage,
+}
+
+type rewriteAttachment struct {
+	source string
+	alt    string
+	hasAlt bool
+	kind   string
+	info   os.FileInfo
+}
+
+func extractRewriteAttachments(args []string, valueFlags map[string]string) ([]string, []rewriteAttachment, error) {
+	remaining := make([]string, 0, len(args))
+	attachments := make([]rewriteAttachment, 0, 4)
+	var totalBytes int64
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		value := ""
+		switch {
+		case arg == "--attach":
+			index++
+			if index >= len(args) {
+				return nil, nil, errRewriteBlocked
+			}
+			value = args[index]
+		case strings.HasPrefix(arg, "--attach="):
+			value = strings.TrimPrefix(arg, "--attach=")
+		default:
+			remaining = append(remaining, arg)
+			if rewriteFlagConsumesNext(arg, valueFlags) && index+1 < len(args) {
+				index++
+				remaining = append(remaining, args[index])
+			}
+			continue
+		}
+		if value == "" || len(attachments) >= rewriteMaxAttachments {
+			return nil, nil, errRewriteBlocked
+		}
+		attachment, err := newRewriteAttachment(value)
+		if err != nil || attachment.info.Size() > rewriteMaxAttachmentBytes-totalBytes {
+			return nil, nil, errRewriteBlocked
+		}
+		for _, seen := range attachments {
+			if os.SameFile(seen.info, attachment.info) {
+				return nil, nil, errRewriteBlocked
+			}
+		}
+		totalBytes += attachment.info.Size()
+		attachments = append(attachments, attachment)
+	}
+	return remaining, attachments, nil
+}
+
+func rewriteFlagConsumesNext(arg string, valueFlags map[string]string) bool {
+	name, _, equals := strings.Cut(arg, "=")
+	if !strings.HasPrefix(arg, "--") && len(name) > 2 {
+		name = arg[:2]
+		equals = true
+	}
+	_, ok := valueFlags[name]
+	return ok && !equals
+}
+
+func newRewriteAttachment(value string) (rewriteAttachment, error) {
+	source, alt, hasAlt := splitRewriteAttachment(value)
+	extension := strings.ToLower(filepath.Ext(source))
+	kind := rewriteAttachmentExtensions[extension]
+	if source == "" || kind == "" || (kind == rewriteAttachmentKindVideo && hasAlt && alt != "") {
+		return rewriteAttachment{}, errRewriteBlocked
+	}
+	// Follow symlinks like native gh. Only the checked alias and a private byte
+	// snapshot reach the child; the target path is never exposed.
+	info, err := os.Stat(source)
+	if err != nil || !info.Mode().IsRegular() || info.Size() == 0 {
+		return rewriteAttachment{}, errRewriteBlocked
+	}
+	limit := rewriteMaxVideoAttachment
+	if kind == rewriteAttachmentKindImage {
+		limit = rewriteMaxImageAttachment
+	}
+	if info.Size() > limit {
+		return rewriteAttachment{}, errRewriteBlocked
+	}
+	return rewriteAttachment{source: source, alt: alt, hasAlt: hasAlt, kind: kind, info: info}, nil
+}
+
+// GitHub CLI treats the complete value as a path when it exists. Otherwise it
+// scans hashes from right to left so filenames containing hashes remain usable.
+func splitRewriteAttachment(value string) (string, string, bool) {
+	if rewriteAttachmentPathExists(value) {
+		return value, "", false
+	}
+	for end := len(value); end > 0; {
+		index := strings.LastIndex(value[:end], "#")
+		if index <= 0 {
+			break
+		}
+		if rewriteAttachmentPathExists(value[:index]) {
+			return value[:index], value[index+1:], true
+		}
+		end = index
+	}
+	if index := strings.LastIndex(value, "#"); index > 0 {
+		return value[:index], value[index+1:], true
+	}
+	return value, "", false
+}
+
+func rewriteAttachmentPathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func checkRewriteAttachmentPath(policy stringRewritePolicy, path string) error {
+	if strings.ContainsAny(path, "\x00\r\n") {
+		return errRewriteBlocked
+	}
+	return policy.check(path)
+}
+
+func rewriteAttachmentDefaultAlt(attachment rewriteAttachment) string {
+	name := filepath.Base(attachment.source)
+	name = strings.TrimSuffix(name, filepath.Ext(name))
+	return strings.ReplaceAll(name, ".", " ")
+}
+
+func rewriteAttachmentArgument(attachment rewriteAttachment, snapshot, alt string) string {
+	if attachment.kind == rewriteAttachmentKindImage {
+		return snapshot + "#" + alt
+	}
+	return snapshot
+}
+
+func rewriteBodyReferencesAttachment(body string, attachments []rewriteAttachment) bool {
+	if len(attachments) == 0 {
+		return false
+	}
+	byPath := make(map[string]bool, len(attachments))
+	for _, attachment := range attachments {
+		path, err := filepath.Abs(attachment.source)
+		if err == nil {
+			byPath[path] = true
+		}
+	}
+	document := goldmark.New().Parser().Parse(text.NewReader([]byte(body)))
+	found := false
+	_ = ast.Walk(document, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		var destination string
+		switch value := node.(type) {
+		case *ast.Image:
+			destination = string(value.Destination)
+		case *ast.Link:
+			destination = string(value.Destination)
+		default:
+			return ast.WalkContinue, nil
+		}
+		if rewriteAttachmentDestinationMatches(destination, byPath) {
+			found = true
+			return ast.WalkStop, nil
+		}
+		return ast.WalkContinue, nil
+	})
+	return found
+}
+
+func rewriteAttachmentDestinationMatches(destination string, byPath map[string]bool) bool {
+	if destination == "" || strings.HasPrefix(destination, "#") || rewriteAttachmentDestinationRemote(destination) {
+		return false
+	}
+	for _, candidate := range rewriteAttachmentCandidatePaths(destination) {
+		path, err := filepath.Abs(candidate)
+		if err == nil && byPath[path] {
+			return true
+		}
+	}
+	return false
+}
+
+func rewriteAttachmentDestinationRemote(destination string) bool {
+	parsed, err := url.Parse(destination)
+	if err != nil {
+		return false
+	}
+	return len(parsed.Scheme) > 1 || parsed.Host != ""
+}
+
+func rewriteAttachmentCandidatePaths(destination string) []string {
+	paths := []string{destination}
+	if unescaped := rewriteUnescapeMarkdownPath(destination); unescaped != destination {
+		paths = append(paths, unescaped)
+	}
+	for _, path := range append([]string(nil), paths...) {
+		if decoded, err := url.PathUnescape(path); err == nil && decoded != path {
+			paths = append(paths, decoded)
+		}
+	}
+	return paths
+}
+
+func rewriteUnescapeMarkdownPath(path string) string {
+	if !strings.Contains(path, `\`) {
+		return path
+	}
+	const punctuation = `!"#$%&'()*+,-./:;<=>?@[\]^_` + "`" + `{|}~`
+	var out strings.Builder
+	out.Grow(len(path))
+	for index := 0; index < len(path); index++ {
+		if path[index] == '\\' && index+1 < len(path) && strings.IndexByte(punctuation, path[index+1]) >= 0 {
+			index++
+		}
+		out.WriteByte(path[index])
+	}
+	return out.String()
+}
+
+func (prepared *rewritePreparation) snapshotAttachment(attachment rewriteAttachment, remaining int64) (string, int64, error) {
+	if remaining < 0 {
+		return "", 0, errRewriteBlocked
+	}
+	input, err := openRewriteAttachment(attachment.source)
+	if err != nil {
+		return "", 0, errRewriteBlocked
+	}
+	defer input.Close()
+	info, err := input.Stat()
+	limit := rewriteMaxVideoAttachment
+	if attachment.kind == rewriteAttachmentKindImage {
+		limit = rewriteMaxImageAttachment
+	}
+	if remaining < limit {
+		limit = remaining
+	}
+	if err != nil || !info.Mode().IsRegular() || info.Size() == 0 || info.Size() > limit || !os.SameFile(attachment.info, info) {
+		return "", 0, errRewriteBlocked
+	}
+	if prepared.directory == "" {
+		directory, err := os.MkdirTemp("", "octopool-content-")
+		if err != nil {
+			return "", 0, errRewriteBlocked
+		}
+		prepared.directory = directory
+	}
+	extension := strings.ToLower(filepath.Ext(attachment.source))
+	output, err := os.CreateTemp(prepared.directory, "attachment-*"+extension)
+	if err != nil {
+		return "", 0, errRewriteBlocked
+	}
+	path := output.Name()
+	copied, copyErr := io.CopyN(output, input, limit+1)
+	if errors.Is(copyErr, io.EOF) {
+		copyErr = nil
+	}
+	closeErr := output.Close()
+	if copyErr != nil || closeErr != nil || copied != info.Size() || copied > limit {
+		return "", 0, errRewriteBlocked
+	}
+	path = filepath.Clean(path)
+	if prepared.snapshots == nil {
+		prepared.snapshots = map[string]bool{}
+	}
+	prepared.snapshots[path] = true
+	return path, copied, nil
+}

--- a/cmd/octopool/string_rewrites_attachments_open_other.go
+++ b/cmd/octopool/string_rewrites_attachments_open_other.go
@@ -1,0 +1,9 @@
+//go:build !aix && !android && !darwin && !dragonfly && !freebsd && !illumos && !ios && !linux && !netbsd && !openbsd && !solaris && !windows
+
+package main
+
+import "os"
+
+func openRewriteAttachment(path string) (*os.File, error) {
+	return os.Open(path)
+}

--- a/cmd/octopool/string_rewrites_attachments_open_unix.go
+++ b/cmd/octopool/string_rewrites_attachments_open_unix.go
@@ -1,0 +1,12 @@
+//go:build aix || android || darwin || dragonfly || freebsd || illumos || ios || linux || netbsd || openbsd || solaris
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func openRewriteAttachment(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+}

--- a/cmd/octopool/string_rewrites_attachments_open_windows.go
+++ b/cmd/octopool/string_rewrites_attachments_open_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package main
+
+import "os"
+
+func openRewriteAttachment(path string) (*os.File, error) {
+	return os.Open(path)
+}

--- a/cmd/octopool/string_rewrites_attachments_unix_test.go
+++ b/cmd/octopool/string_rewrites_attachments_unix_test.go
@@ -1,0 +1,33 @@
+//go:build darwin || linux
+
+package main
+
+import (
+	"io"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestStringRewriteAttachmentFIFOIsNonblocking(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	fifo := filepath.Join(t.TempDir(), "pipe.png")
+	if err := syscall.Mkfifo(fifo, 0600); err != nil {
+		t.Fatal(err)
+	}
+	captureRewriteGH(t)
+	done := make(chan error, 1)
+	go func() {
+		args := []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", "safe", "--attach", fifo}
+		done <- execRealGH(t.Context(), args, io.Discard, io.Discard)
+	}()
+	select {
+	case err := <-done:
+		if err != errRewriteBlocked {
+			t.Fatalf("FIFO error=%v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("FIFO attachment blocked during open")
+	}
+}

--- a/cmd/octopool/string_rewrites_process_test.go
+++ b/cmd/octopool/string_rewrites_process_test.go
@@ -24,6 +24,7 @@ type rewriteCapture struct {
 	Args           []string
 	Stdin          string
 	Files          map[string]string
+	FileData       map[string][]byte
 	Modes          map[string]uint32
 	DirectoryModes map[string]uint32
 	Env            map[string]string
@@ -41,13 +42,16 @@ func TestRewriteCaptureProcess(t *testing.T) {
 			break
 		}
 	}
-	capture := rewriteCapture{Args: args, Files: map[string]string{}, Modes: map[string]uint32{}, DirectoryModes: map[string]uint32{}, Env: map[string]string{"GH_HOST": os.Getenv("GH_HOST"), "GH_REPO": os.Getenv("GH_REPO")}}
+	capture := rewriteCapture{Args: args, Files: map[string]string{}, FileData: map[string][]byte{}, Modes: map[string]uint32{}, DirectoryModes: map[string]uint32{}, Env: map[string]string{"GH_HOST": os.Getenv("GH_HOST"), "GH_REPO": os.Getenv("GH_REPO")}}
 	input, _ := io.ReadAll(os.Stdin)
 	capture.Stdin = string(input)
 	for _, arg := range args {
 		paths := []string{}
-		for _, prefix := range []string{"--body-file=", "--notes-file=", "--input="} {
+		for _, prefix := range []string{"--body-file=", "--notes-file=", "--input=", "--attach="} {
 			if path, ok := strings.CutPrefix(arg, prefix); ok {
+				if prefix == "--attach=" {
+					path = captureRewriteAttachmentPath(path)
+				}
 				paths = append(paths, path)
 			}
 		}
@@ -63,6 +67,7 @@ func TestRewriteCaptureProcess(t *testing.T) {
 				os.Exit(80)
 			}
 			capture.Files[path] = string(data)
+			capture.FileData[path] = data
 			info, _ := os.Stat(path)
 			capture.Modes[path] = uint32(info.Mode().Perm())
 			dir, _ := os.Stat(filepath.Dir(path))
@@ -78,6 +83,19 @@ func TestRewriteCaptureProcess(t *testing.T) {
 	exit, _ := strconv.Atoi(os.Getenv("OCTOPOOL_TEST_REWRITE_EXIT"))
 	os.Exit(exit)
 }
+
+func captureRewriteAttachmentPath(value string) string {
+	if _, err := os.Stat(value); err == nil {
+		return value
+	}
+	for index := strings.LastIndex(value, "#"); index > 0; index = strings.LastIndex(value[:index], "#") {
+		if _, err := os.Stat(value[:index]); err == nil {
+			return value[:index]
+		}
+	}
+	return value
+}
+
 func captureRewriteGH(t *testing.T) string {
 	t.Helper()
 	if runtime.GOOS == "windows" {
@@ -109,6 +127,25 @@ func readRewriteCapture(t *testing.T, path string) rewriteCapture {
 	}
 	return capture
 }
+
+func rewriteCaptureHasContent(capture rewriteCapture, want string) bool {
+	for _, content := range capture.Files {
+		if content == want {
+			return true
+		}
+	}
+	return false
+}
+
+func rewriteCaptureHasData(capture rewriteCapture, want []byte) bool {
+	for _, data := range capture.FileData {
+		if bytes.Equal(data, want) {
+			return true
+		}
+	}
+	return false
+}
+
 func rewriteTestServer(t *testing.T, policyBody string, relay http.HandlerFunc) (*atomic.Value, *atomic.Int64) {
 	t.Helper()
 	body := &atomic.Value{}
@@ -228,6 +265,267 @@ func TestStringRewriteProcessSnapshots(t *testing.T) {
 		})
 	}
 }
+
+func TestStringRewriteAttachments(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	directory := t.TempDir()
+	body := filepath.Join(directory, "body.md")
+	image := filepath.Join(directory, "image#one.png")
+	video := filepath.Join(directory, "clip.mp4")
+	imageData := []byte{0x89, 'P', 'N', 'G', 0x00, 0xff}
+	videoData := []byte{0x00, 0x00, 0x00, 0x18, 'f', 't', 'y', 'p', 0xff}
+	for path, data := range map[string][]byte{body: []byte("internal-model"), image: imageData, video: videoData} {
+		if err := os.WriteFile(path, data, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	capturePath := captureRewriteGH(t)
+	args := []string{"pr", "comment", "1", "--repo", "acme/repo", "--body-file", body, "--attach", image + "#internal-model screenshot", "--attach=" + video}
+	if err := execRealGH(t.Context(), args, io.Discard, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	capture := readRewriteCapture(t, capturePath)
+	if capture.Stdin != "" || len(capture.FileData) != 3 {
+		t.Fatalf("attachment capture=%+v", capture)
+	}
+	seenBody, seenImage, seenVideo := false, false, false
+	for path, data := range capture.FileData {
+		switch {
+		case string(data) == "public":
+			seenBody = true
+		case bytes.Equal(data, imageData):
+			seenImage = strings.HasSuffix(path, ".png")
+		case bytes.Equal(data, videoData):
+			seenVideo = strings.HasSuffix(path, ".mp4")
+		default:
+			t.Fatalf("unexpected snapshot bytes %x", data)
+		}
+		if runtime.GOOS != "windows" && (capture.Modes[path] != 0600 || capture.DirectoryModes[path] != 0700) {
+			t.Fatal("attachment snapshot permissions are not private")
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatal("attachment snapshot leaked")
+		}
+	}
+	if !seenBody || !seenImage || !seenVideo {
+		t.Fatalf("missing snapshots body=%v image=%v video=%v", seenBody, seenImage, seenVideo)
+	}
+	if slices.ContainsFunc(capture.Args, func(arg string) bool {
+		return arg == body || strings.Contains(arg, image) || strings.Contains(arg, video) || strings.Contains(arg, "internal-model")
+	}) {
+		t.Fatalf("original path/text reached child: %v", capture.Args)
+	}
+	if !slices.ContainsFunc(capture.Args, func(arg string) bool {
+		return strings.HasPrefix(arg, "--attach=") && strings.HasSuffix(arg, ".png#public screenshot")
+	}) {
+		t.Fatalf("rewritten attachment alt missing: %v", capture.Args)
+	}
+	for path, expected := range map[string][]byte{body: []byte("internal-model"), image: imageData, video: videoData} {
+		data, err := os.ReadFile(path)
+		if err != nil || !bytes.Equal(data, expected) {
+			t.Fatalf("original attachment changed: %s", path)
+		}
+	}
+
+	alias := filepath.Join(directory, "alias.png")
+	if err := os.Symlink(image, alias); err != nil {
+		t.Fatal(err)
+	}
+	aliasCapturePath := captureRewriteGH(t)
+	aliasArgs := []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", "safe", "--attach", alias}
+	if err := execRealGH(t.Context(), aliasArgs, io.Discard, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	aliasCapture := readRewriteCapture(t, aliasCapturePath)
+	if !rewriteCaptureHasData(aliasCapture, imageData) || slices.ContainsFunc(aliasCapture.Args, func(arg string) bool { return strings.Contains(arg, alias) }) {
+		t.Fatalf("symlink attachment was not privately snapshotted: %+v", aliasCapture)
+	}
+
+	createCapturePath := captureRewriteGH(t)
+	createArgs := []string{"pr", "create", "--repo", "acme/repo", "--title", "safe", "--body", "safe", "--head", "feature", "--base", "main", "--attach", image}
+	if err := execRealGH(t.Context(), createArgs, io.Discard, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	createCapture := readRewriteCapture(t, createCapturePath)
+	if !slices.ContainsFunc(createCapture.Args, func(arg string) bool {
+		return strings.HasPrefix(arg, "--attach=") && strings.HasSuffix(arg, ".png#image#one")
+	}) {
+		t.Fatalf("default attachment alt missing: %v", createCapture.Args)
+	}
+
+	attachmentOnlyCapturePath := captureRewriteGH(t)
+	attachmentOnlyArgs := []string{"pr", "comment", "1", "--repo", "acme/repo", "--attach", image}
+	if err := execRealGH(t.Context(), attachmentOnlyArgs, io.Discard, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	attachmentOnlyCapture := readRewriteCapture(t, attachmentOnlyCapturePath)
+	if len(attachmentOnlyCapture.FileData) != 1 || !slices.ContainsFunc(attachmentOnlyCapture.Args, func(arg string) bool {
+		return strings.HasPrefix(arg, "--attach=")
+	}) {
+		t.Fatalf("attachment-only comment changed shape: %+v", attachmentOnlyCapture)
+	}
+
+	editCapturePath := captureRewriteGH(t)
+	editArgs := []string{"pr", "comment", "1", "--repo", "acme/repo", "--edit-last", "--body", "safe", "--attach", image}
+	if err := execRealGH(t.Context(), editArgs, io.Discard, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	editCapture := readRewriteCapture(t, editCapturePath)
+	if len(editCapture.FileData) != 2 || !rewriteCaptureHasContent(editCapture, "safe") {
+		t.Fatalf("explicit edit-last body changed shape: %+v", editCapture)
+	}
+
+	codeCapturePath := captureRewriteGH(t)
+	codeBody := "`![example](" + image + ")`"
+	codeArgs := []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", codeBody, "--attach", image}
+	if err := execRealGH(t.Context(), codeArgs, io.Discard, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	codeCapture := readRewriteCapture(t, codeCapturePath)
+	if len(codeCapture.FileData) != 2 || !rewriteCaptureHasContent(codeCapture, codeBody) {
+		t.Fatalf("code attachment reference was not preserved: %+v", codeCapture)
+	}
+
+	literalBodyCapturePath := captureRewriteGH(t)
+	literalBody := "--attach=" + image
+	literalBodyArgs := []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", literalBody}
+	if err := execRealGH(t.Context(), literalBodyArgs, io.Discard, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	literalBodyCapture := readRewriteCapture(t, literalBodyCapturePath)
+	if len(literalBodyCapture.FileData) != 1 || !rewriteCaptureHasContent(literalBodyCapture, literalBody) || slices.ContainsFunc(literalBodyCapture.Args, func(arg string) bool {
+		return strings.HasPrefix(arg, "--attach=")
+	}) {
+		t.Fatalf("flag value was reinterpreted as an attachment: %+v", literalBodyCapture)
+	}
+}
+
+func TestStringRewriteAttachmentBlocks(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	directory := t.TempDir()
+	unsupported := filepath.Join(directory, "artifact.txt")
+	protected := filepath.Join(directory, "internal-model.png")
+	empty := filepath.Join(directory, "empty.png")
+	oversizedImage := filepath.Join(directory, "large.png")
+	oversizedVideo := filepath.Join(directory, "large.mp4")
+	for _, path := range []string{unsupported, protected} {
+		if err := os.WriteFile(path, []byte("safe"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for path, size := range map[string]int64{empty: 0, oversizedImage: rewriteMaxImageAttachment + 1, oversizedVideo: rewriteMaxAttachmentBytes + 1} {
+		if err := os.WriteFile(path, nil, 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Truncate(path, size); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, test := range []struct {
+		attachment string
+		body       string
+	}{
+		{unsupported, "safe"},
+		{protected, "safe"},
+		{directory, "safe"},
+		{empty, "safe"},
+		{oversizedImage, "safe"},
+		{oversizedVideo, "safe"},
+		{protected + "#safe", "safe"},
+		{filepath.Join(directory, "missing.png"), "safe"},
+	} {
+		capturePath := captureRewriteGH(t)
+		args := []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", test.body, "--attach", test.attachment}
+		if err := execRealGH(t.Context(), args, io.Discard, io.Discard); err != errRewriteBlocked {
+			t.Fatalf("attachment %q error=%v", test.attachment, err)
+		}
+		if _, err := os.Stat(capturePath); !os.IsNotExist(err) {
+			t.Fatal("blocked attachment reached child")
+		}
+	}
+	safe := filepath.Join(directory, "safe.png")
+	hash := filepath.Join(directory, "hash#safe.png")
+	video := filepath.Join(directory, "safe.mp4")
+	for _, path := range []string{safe, hash, video} {
+		if err := os.WriteFile(path, []byte("safe"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, test := range []struct {
+		name string
+		args []string
+	}{
+		{"video alt", []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", "safe", "--attach", video + "#caption"}},
+		{"edit last without body", []string{"pr", "comment", "1", "--repo", "acme/repo", "--edit-last", "--attach", safe}},
+		{"delete last with attachment", []string{"pr", "comment", "1", "--repo", "acme/repo", "--delete-last", "--attach", safe}},
+		{"duplicate file", []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", "safe", "--attach", safe, "--attach", safe}},
+		{"inline reference", []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", "![safe](" + safe + ")", "--attach", safe}},
+		{"hash reference", []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", "![safe](" + hash + ")", "--attach", hash}},
+		{"encoded hash reference", []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", "![safe](" + strings.ReplaceAll(hash, "#", "%23") + ")", "--attach", hash}},
+		{"reference definition", []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", "![safe][shot]\n\n[shot]: <" + safe + ">", "--attach", safe}},
+		{"multiline reference definition", []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", "![safe][shot]\n\n[shot]:\n  " + safe, "--attach", safe}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			capturePath := captureRewriteGH(t)
+			if err := execRealGH(t.Context(), test.args, io.Discard, io.Discard); err != errRewriteBlocked {
+				t.Fatalf("error=%v", err)
+			}
+			if _, err := os.Stat(capturePath); !os.IsNotExist(err) {
+				t.Fatal("blocked attachment reached child")
+			}
+		})
+	}
+	args := []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", "safe"}
+	for range rewriteMaxAttachments + 1 {
+		args = append(args, "--attach", safe)
+	}
+	capturePath := captureRewriteGH(t)
+	if err := execRealGH(t.Context(), args, io.Discard, io.Discard); err != errRewriteBlocked {
+		t.Fatalf("attachment count error=%v", err)
+	}
+	if _, err := os.Stat(capturePath); !os.IsNotExist(err) {
+		t.Fatal("excess attachments reached child")
+	}
+}
+
+func TestStringRewriteAttachmentAltFallback(t *testing.T) {
+	policy := `{"schema_version":1,"revision":1,"updated_at":"2026-08-29T00:00:00Z","rules":[{"pattern":"secret-alt","replacement":""}]}`
+	rewriteTestServer(t, policy, nil)
+	image := filepath.Join(t.TempDir(), "friendly.png")
+	if err := os.WriteFile(image, []byte("safe"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	for _, suffix := range []string{"#secret-alt", "#"} {
+		capturePath := captureRewriteGH(t)
+		args := []string{"pr", "comment", "1", "--repo", "acme/repo", "--attach", image + suffix}
+		if err := execRealGH(t.Context(), args, io.Discard, io.Discard); err != nil {
+			t.Fatal(err)
+		}
+		capture := readRewriteCapture(t, capturePath)
+		if !slices.ContainsFunc(capture.Args, func(arg string) bool {
+			return strings.HasPrefix(arg, "--attach=") && strings.HasSuffix(arg, ".png#friendly")
+		}) {
+			t.Fatalf("original filename alt fallback missing: %v", capture.Args)
+		}
+	}
+}
+
+func TestRewriteAttachmentPathSemantics(t *testing.T) {
+	policy, err := compileStringRewriteRules([]stringRewriteRule{{Pattern: "internal-model", Replacement: "public"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := checkRewriteAttachmentPath(policy, `.\\shot.png`); err != nil {
+		t.Fatal("Windows path separators were rejected")
+	}
+	if rewriteAttachmentDestinationRemote(`C:/work/shot.png`) {
+		t.Fatal("Windows volume path was classified as remote")
+	}
+	if !rewriteAttachmentDestinationRemote(`https://example.com/shot.png`) {
+		t.Fatal("HTTPS destination was classified as local")
+	}
+}
+
 func TestStringRewriteMaintainerCompatibility(t *testing.T) {
 	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
 	sha := strings.Repeat("a", 40)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -390,7 +390,8 @@ With active rules, the initial local publication vocabulary is deliberately cons
 - PR/issue `create`, `edit`, `comment`, and PR `review`: explicit title/body flags, body
   files, or stdin; numeric PR/issue selectors for existing items. PR creation requires
   explicit `--head` and `--base`; the head must already be pushed. `--head` prevents gh
-  from implicitly pushing or forking. Reviews require one explicit review action.
+  from implicitly pushing or forking. Reviews require one explicit review action. PR create/comment
+  also accept repeated `--attach` image/video files as described below.
 - Release `create`/`edit`: explicit title/notes or notes files; one tag and no asset uploads.
   Creation requires `--verify-tag`, so gh cannot create a missing tag. Generated notes,
   notes from tags, and other implicit content sources are blocked.
@@ -413,13 +414,26 @@ are blocked. Input files are read into bounded snapshots, never modified, and ne
 by the child. Sanitized snapshots use a private 0700 directory and 0600 files, removed
 after execution, including nonzero exits. These modeled commands do not retain live stdin.
 
+Protected PR create/comment commands accept up to 16 repeated `--attach FILE` or
+`--attach=FILE` values. Raster image extensions are GIF, JPEG/JPG, PNG, and WebP; video
+extensions are MOV, MP4, and WebM. Images are limited to 10 MiB each, videos to 100 MiB each,
+and all attachments together to 100 MiB. The source path is structurally checked, optional
+`#alt text` is rewritten, default image alt text remains based on the original filename, and
+native `gh` receives suffix-preserving private byte-for-byte snapshots. Empty files, directories,
+other extensions, video alt text, and body references to an attached local file are blocked;
+omit local references and let native `gh` append uploaded media. A new PR comment may consist
+only of attachments. An `--edit-last` attachment update still requires an explicit body because
+native `gh` would otherwise fetch and republish the existing text after the guard runs. Other
+modeled body requirements stay unchanged. Attachment bytes are not text- or vision-inspected, so
+callers remain responsible for reviewing the media itself before publication.
+
 Commands and flags outside the modeled vocabulary use a bounded best-effort pass-through
 instead of being denied solely for being new or unfamiliar. Octopool rewrites every visible
 argument, snapshots and filters `--input` files or `--input=-`, snapshots typed
 `-F`/`--field key=@source` text without changing its formatting, and filters stdin when the
 command explicitly declares it (currently `workflow run --json`). Valid JSON request stdin/files are decoded recursively so string keys and values are rewritten
 without corrupting JSON; other valid UTF-8 is rewritten as text. This keeps workflow
-dispatches (`gh workflow run` field or `--json` forms), job-log reads, uploads, and newly
+dispatches (`gh workflow run` field or `--json` forms), job-log reads, unmodeled uploads, and newly
 introduced native flags working while active rules still remove visible matches. Native
 children force `GH_HOST=github.com` and remove inherited `GH_REPO`; best-effort
 `--repo`/`-R` values are structurally checked before rewriting and normalized to
@@ -466,7 +480,7 @@ current/explicit nonnumeric Git branch) and metadata-only
 endpoint with only the checked SHA and squash method; it never enables auto-merge, so a branch
 that requires a merge queue fails closed. Subject/body merge flags, admin/auto merge variants,
 URL selectors, numeric inferred branches, and unpinned merges remain blocked on that strict
-lifecycle path. Other editor/web/template/fill modes, uploads, aliases/extensions, raw
+lifecycle path. Other editor/web/template/fill modes, unmodeled uploads, aliases/extensions, raw
 GraphQL, and newly introduced native commands/flags use best-effort filtering and retain
 native behavior. A denial reports only the generic unsafe-input boundary and never echoes the
 rejected text.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -209,9 +209,10 @@ failures occur before audit context exists. Bodies, credentials, and raw tokens 
 - `octopool gh ...` and a binary named `gh` translate supported safe reads.
 - Mutations, bodies, unsafe headers/queries, unsupported flags, and unknown commands delegate
   locally without contacting Octopool.
-- With active rewrite rules, modeled local commands use strict structural snapshots; unmodeled
-  delegated commands receive bounded best-effort filtering of visible argv, explicitly declared stdin, and
-  `--input` snapshots rather than failing solely because their shape is unknown.
+- With active rewrite rules, modeled local commands use strict structural snapshots, including
+  validated PR media attachments; unmodeled delegated commands receive bounded best-effort filtering
+  of visible argv, explicitly declared stdin, and `--input` snapshots rather than failing solely because
+  their shape is unknown.
 - Safe requests contact Octopool first and delegate only on explicit `fallback_local` or
   stale/invalid Octopool auth. `OCTOPOOL_NO_FALLBACK` disables delegation.
 - The canonical relay client loop retries selected transient pool fallbacks and

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/openclaw/octopool
 
 go 1.26
+
+require github.com/yuin/goldmark v1.8.5

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/yuin/goldmark v1.8.5 h1:r6N5afV5qj/5S4UTch8agZHJ8UxNCMwX7WjkkJam2NA=
+github.com/yuin/goldmark v1.8.5/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=


### PR DESCRIPTION
## Summary

- add typed `--attach` handling to protected `gh pr create` and `gh pr comment` commands
- keep title/body filtering strict while rewriting image alt text and handing native `gh` private immutable media snapshots
- validate media types, per-file and aggregate sizes, duplicate file identities, Markdown references, platform path semantics, and nonblocking special-file rejection

## Verification

- `pnpm check`
- `go test -race ./cmd/octopool -count=1`
- Windows, Linux, and additional Go OS cross-compilation
- independent P0–P2 review and structured autoreview clean
