### PR TITLE
fix: preserve protected search and label workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.5.14 - Unreleased
 
+### Fixes
+
+- Keep best-effort `gh search --repo` filters in GitHub's required `owner/repo` form while retaining GitHub.com host validation and environment pinning.
+- Allow structurally validated labels on strict protected PR/issue creation and metadata-only label edits without weakening title/body snapshots.
+
 ## 0.5.13 - 2026-08-30
 
 ### Fixes

--- a/cmd/octopool/string_rewrites_args.go
+++ b/cmd/octopool/string_rewrites_args.go
@@ -180,14 +180,14 @@ func prepareRewriteContent(policy stringRewritePolicy, args []string, stdin io.R
 	booleanSpec := ""
 	switch command {
 	case "pr create":
-		valueSpec += " --title,-t --body,-b --body-file,-F --head,-H --base,-B"
+		valueSpec += " --title,-t --body,-b --body-file,-F --head,-H --base,-B --label,-l"
 		booleanSpec = "--draft,-d --no-maintainer-edit"
 	case "pr edit":
-		valueSpec += " --title,-t --body,-b --body-file,-F --add-assignee --remove-assignee"
+		valueSpec += " --title,-t --body,-b --body-file,-F --add-assignee --remove-assignee --add-label --remove-label"
 	case "issue edit":
-		valueSpec += " --title,-t --body,-b --body-file,-F"
+		valueSpec += " --title,-t --body,-b --body-file,-F --add-label --remove-label"
 	case "issue create":
-		valueSpec += " --title,-t --body,-b --body-file,-F"
+		valueSpec += " --title,-t --body,-b --body-file,-F --label,-l"
 	case "pr comment", "issue comment":
 		valueSpec += " --body,-b --body-file,-F"
 		booleanSpec = "--edit-last --create-if-none"
@@ -253,15 +253,18 @@ func prepareRewriteContent(policy stringRewritePolicy, args []string, stdin io.R
 	if create && (!flags.has("--title") || !hasBody) {
 		return errRewriteBlocked
 	}
-	metadataEdit := command == "pr edit" && (flags.has("--add-assignee") || flags.has("--remove-assignee"))
+	metadataEdit := (command == "pr edit" && (flags.has("--add-assignee") || flags.has("--remove-assignee"))) || flags.has("--add-label") || flags.has("--remove-label")
 	if args[1] == "edit" && !flags.has("--title") && !hasBody && !metadataEdit {
 		return errRewriteBlocked
 	}
-	if metadataEdit {
-		for _, name := range []string{"--add-assignee", "--remove-assignee"} {
-			if flags.has(name) && !validRewriteAssignees(flags.values[name]) {
-				return errRewriteBlocked
-			}
+	for _, name := range []string{"--add-assignee", "--remove-assignee"} {
+		if flags.has(name) && !validRewriteAssignees(flags.values[name]) {
+			return errRewriteBlocked
+		}
+	}
+	for _, name := range []string{"--label", "--add-label", "--remove-label"} {
+		if flags.has(name) && !validRewriteLabels(flags.values[name]) {
+			return errRewriteBlocked
 		}
 	}
 	attachmentOnlyComment := command == "pr comment" && len(attachments) > 0 && flags.values["--edit-last"] != "true"

--- a/cmd/octopool/string_rewrites_fallback.go
+++ b/cmd/octopool/string_rewrites_fallback.go
@@ -387,6 +387,7 @@ func rewriteReaderIsTerminal(reader io.Reader) bool {
 func pinBestEffortRepositories(policy stringRewritePolicy, args []string) ([]string, error) {
 	out := append([]string(nil), args...)
 	hasRepo := false
+	searchFilter := len(out) >= 2 && out[0] == "search"
 	for index := 0; index < len(out); index++ {
 		arg := out[index]
 		if arg == "--repo" || arg == "-R" {
@@ -399,7 +400,7 @@ func pinBestEffortRepositories(policy stringRewritePolicy, args []string) ([]str
 			if err != nil {
 				return nil, err
 			}
-			out[index] = repo
+			out[index] = bestEffortRepoFlagValue(repo, searchFilter)
 			continue
 		}
 		if value, ok := strings.CutPrefix(arg, "--repo="); ok {
@@ -408,7 +409,7 @@ func pinBestEffortRepositories(policy stringRewritePolicy, args []string) ([]str
 			if err != nil {
 				return nil, err
 			}
-			out[index] = "--repo=" + repo
+			out[index] = "--repo=" + bestEffortRepoFlagValue(repo, searchFilter)
 			continue
 		}
 		if value, ok := strings.CutPrefix(arg, "-R"); ok && value != "" {
@@ -417,7 +418,7 @@ func pinBestEffortRepositories(policy stringRewritePolicy, args []string) ([]str
 			if err != nil {
 				return nil, err
 			}
-			out[index] = "--repo=" + repo
+			out[index] = "--repo=" + bestEffortRepoFlagValue(repo, searchFilter)
 		}
 	}
 	if !hasRepo && bestEffortNeedsRepository(out) {
@@ -428,6 +429,13 @@ func pinBestEffortRepositories(policy stringRewritePolicy, args []string) ([]str
 		out = append(out, "--repo="+repo)
 	}
 	return out, nil
+}
+
+func bestEffortRepoFlagValue(pinned string, searchFilter bool) string {
+	if searchFilter {
+		return strings.TrimPrefix(pinned, "github.com/")
+	}
+	return pinned
 }
 
 func bestEffortNeedsRepository(args []string) bool {

--- a/cmd/octopool/string_rewrites_pr.go
+++ b/cmd/octopool/string_rewrites_pr.go
@@ -110,3 +110,12 @@ func validRewriteAssignees(value string) bool {
 	}
 	return true
 }
+
+func validRewriteLabels(value string) bool {
+	for _, label := range strings.Split(value, ",") {
+		if strings.TrimSpace(label) == "" {
+			return false
+		}
+	}
+	return value != ""
+}

--- a/cmd/octopool/string_rewrites_process_test.go
+++ b/cmd/octopool/string_rewrites_process_test.go
@@ -198,6 +198,7 @@ func TestStringRewriteProcessSnapshots(t *testing.T) {
 		want  string
 	}{
 		{"issue inline", []string{"issue", "create", "-tinternal-model", "-binternal-model", "-Racme/repo"}, "unused", false, "public"},
+		{"issue create label", []string{"issue", "create", "--title=safe", "--body-file=FILE", "--label=bug", "--repo=acme/repo"}, "unused", true, "public 🦞"},
 		{"issue body file", []string{"issue", "edit", "1", "--body-file=FILE", "--repo=acme/repo"}, "unused", true, "public 🦞"},
 		{"pr body stdin", []string{"pr", "comment", "1", "-F-", "-Racme/repo"}, "internal-model 🦞", false, "public 🦞"},
 		{"review", []string{"pr", "review", "1", "--approve", "--body=internal-model", "-Racme/repo"}, "", false, "public"},
@@ -231,6 +232,9 @@ func TestStringRewriteProcessSnapshots(t *testing.T) {
 				t.Fatalf("streams: %q %q", out.String(), stderr.String())
 			}
 			capture := readRewriteCapture(t, capturePath)
+			if test.name == "issue create label" && !slices.Contains(capture.Args, "--label=bug") {
+				t.Fatalf("label metadata was not preserved: %v", capture.Args)
+			}
 			if capture.Stdin != "" {
 				t.Fatal("child retained live stdin")
 			}
@@ -542,6 +546,8 @@ func TestStringRewriteMaintainerCompatibility(t *testing.T) {
 		{"convert draft", []string{"pr", "ready", "123", "--repo", "acme/repo", "--undo"}, false},
 		{"pinned squash", []string{"pr", "merge", "123", "--repo", "https://github.com/acme/repo", "--squash", "--match-head-commit", sha}, true},
 		{"claim assignee", []string{"pr", "edit", "123", "--repo", "acme/repo", "--add-assignee", "steipete"}, false},
+		{"add issue labels", []string{"issue", "edit", "123", "--repo", "acme/repo", "--add-label", "bug,help wanted"}, false},
+		{"remove pr label", []string{"pr", "edit", "123", "--repo", "acme/repo", "--remove-label", "blocked"}, false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			capturePath := captureRewriteGH(t)
@@ -709,6 +715,50 @@ func TestStringRewriteBestEffortFallback(t *testing.T) {
 			}
 		})
 	}
+
+	for _, test := range []struct {
+		name    string
+		args    []string
+		repoArg string
+	}{
+		{
+			"search issues repository filter",
+			[]string{"search", "issues", "internal-model", "--repo", "acme/repo", "--state", "open", "--match", "title,body", "--limit", "10", "--json", "number,title,url,updatedAt"},
+			"acme/repo",
+		},
+		{
+			"search prs repository filter",
+			[]string{"search", "prs", "internal-model", "--repo=https://github.com/acme/repo", "--state", "open", "--match", "title,body", "--limit", "10", "--json", "number,title,url,updatedAt"},
+			"--repo=acme/repo",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			capturePath := captureRewriteGH(t)
+			if err := runGH(t.Context(), test.args, io.Discard, io.Discard); err != nil {
+				t.Fatal(err)
+			}
+			capture := readRewriteCapture(t, capturePath)
+			if !slices.Contains(capture.Args, test.repoArg) || capture.Env["GH_HOST"] != "github.com" {
+				t.Fatalf("search repository filter was not pinned: args=%v env=%v", capture.Args, capture.Env)
+			}
+			if slices.ContainsFunc(capture.Args, func(arg string) bool {
+				return strings.Contains(arg, "github.com/acme/repo") || strings.Contains(arg, "internal-model")
+			}) {
+				t.Fatalf("search repository or query was rewritten incorrectly: %v", capture.Args)
+			}
+		})
+	}
+
+	t.Run("search enterprise repository blocks", func(t *testing.T) {
+		capturePath := captureRewriteGH(t)
+		args := []string{"search", "issues", "safe", "--repo", "ghe.example/acme/repo", "--match", "title"}
+		if err := runGH(t.Context(), args, io.Discard, io.Discard); err != errRewriteBlocked {
+			t.Fatalf("enterprise search repository error=%v", err)
+		}
+		if _, err := os.Stat(capturePath); !os.IsNotExist(err) {
+			t.Fatal("enterprise search repository reached child")
+		}
+	})
 
 	for _, value := range []string{"https://ghe.example/acme/repo", "ghe.example/acme/repo", "ghe.example:acme/repo", "alice@ghe.example:acme/repo"} {
 		t.Run("positional enterprise repository blocks", func(t *testing.T) {
@@ -1239,6 +1289,10 @@ func TestStringRewriteProcessBlocks(t *testing.T) {
 		{"api", "repos/acme/repo/pulls/1/merge", "--method", "PUT", "-f", "sha=" + strings.Repeat("a", 40), "-f", "merge_method=squash", "-f", "commit_title=user text"},
 		{"api", "repos/acme/internal-model/pulls/1/merge", "--method", "PUT", "-f", "sha=" + strings.Repeat("a", 40), "-f", "merge_method=squash"},
 		{"pr", "edit", "1", "-Racme/repo", "--add-assignee", "internal-model"},
+		{"issue", "create", "-Racme/repo", "--title", "safe", "--body", "safe", "--label", "internal-model"},
+		{"issue", "create", "-Racme/repo", "--title", "safe", "--body", "safe", "--label", ",bug"},
+		{"issue", "create", "-Racme/repo", "--title", "safe", "--body", "safe", "--label", "bug", "-l", "enhancement"},
+		{"issue", "edit", "1", "-Racme/repo", "--add-label", "internal-model"},
 		{"api", "repos/acme/repo/issues/1/assignees", "--method", "POST", "-f", "assignees[]=internal-model"},
 		{"api", "repos/acme/repo/issues/1/assignees", "--method", "POST", "-f", "assignees=alice", "-f", "assignees[]=bob"},
 		{"api", "repos/acme/repo/issues/1/assignees", "--method", "POST", "-f", "labels[]=safe"},

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -390,8 +390,10 @@ With active rules, the initial local publication vocabulary is deliberately cons
 - PR/issue `create`, `edit`, `comment`, and PR `review`: explicit title/body flags, body
   files, or stdin; numeric PR/issue selectors for existing items. PR creation requires
   explicit `--head` and `--base`; the head must already be pushed. `--head` prevents gh
-  from implicitly pushing or forking. Reviews require one explicit review action. PR create/comment
-  also accept repeated `--attach` image/video files as described below.
+  from implicitly pushing or forking. Reviews require one explicit review action. PR/issue creation
+  accepts one `--label`/`-l` value (use a comma-separated list), while PR/issue edits accept
+  metadata-only `--add-label`/`--remove-label`. PR create/comment also accept repeated `--attach`
+  image/video files as described below.
 - Release `create`/`edit`: explicit title/notes or notes files; one tag and no asset uploads.
   Creation requires `--verify-tag`, so gh cannot create a missing tag. Generated notes,
   notes from tags, and other implicit content sources are blocked.
@@ -437,8 +439,10 @@ dispatches (`gh workflow run` field or `--json` forms), job-log reads, unmodeled
 introduced native flags working while active rules still remove visible matches. Native
 children force `GH_HOST=github.com` and remove inherited `GH_REPO`; best-effort
 `--repo`/`-R` values are structurally checked before rewriting and normalized to
-`github.com/owner/repo`. Repo-capable commands without an explicit selector pin the current
-GitHub.com remote. Alternate API/repository hosts, explicit credential headers,
+`github.com/owner/repo`. Native `gh search` repository filters retain `owner/repo`, because the
+CLI converts that value into a `repo:` search qualifier and rejects a host-qualified form.
+Repo-capable commands without an explicit selector pin the current GitHub.com remote.
+Alternate API/repository hosts, explicit credential headers,
 unresolved API placeholders, invalid UTF-8, policy
 material, residual matches, and bounded-read failures remain blocked.
 


### PR DESCRIPTION
## Summary

- preserve `owner/repo` for best-effort native `gh search --repo` filters after validating the repository against GitHub.com
- support structurally checked label metadata on strict protected PR/issue creation and metadata-only edits
- retain strict title/body snapshots, alternate-host denial, and host-qualified repository pinning for non-search commands

## Verification

- `pnpm check`
- `go test -race ./cmd/octopool -count=1`
- exact protected search command succeeds against GitHub without an invalid host-qualified `repo:` query
- exact previously blocked issue-create body and `--label bug` shape reaches a fake native child unchanged
- independent P0–P2 review and structured autoreview clean
