### PR TITLE
fix: support protected assignee workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.5.15 - Unreleased
 
+### Fixes
+
+- Allow structurally validated assignee metadata on strict protected PR/issue creation and metadata-only edits, including native `@me` and `@copilot` values.
+
 ## 0.5.14 - 2026-08-30
 
 ### Fixes

--- a/cmd/octopool/string_rewrites_args.go
+++ b/cmd/octopool/string_rewrites_args.go
@@ -180,14 +180,14 @@ func prepareRewriteContent(policy stringRewritePolicy, args []string, stdin io.R
 	booleanSpec := ""
 	switch command {
 	case "pr create":
-		valueSpec += " --title,-t --body,-b --body-file,-F --head,-H --base,-B --label,-l"
+		valueSpec += " --title,-t --body,-b --body-file,-F --head,-H --base,-B --label,-l --assignee,-a"
 		booleanSpec = "--draft,-d --no-maintainer-edit"
 	case "pr edit":
 		valueSpec += " --title,-t --body,-b --body-file,-F --add-assignee --remove-assignee --add-label --remove-label"
 	case "issue edit":
-		valueSpec += " --title,-t --body,-b --body-file,-F --add-label --remove-label"
+		valueSpec += " --title,-t --body,-b --body-file,-F --add-label --remove-label --add-assignee --remove-assignee"
 	case "issue create":
-		valueSpec += " --title,-t --body,-b --body-file,-F --label,-l"
+		valueSpec += " --title,-t --body,-b --body-file,-F --label,-l --assignee,-a"
 	case "pr comment", "issue comment":
 		valueSpec += " --body,-b --body-file,-F"
 		booleanSpec = "--edit-last --create-if-none"
@@ -253,11 +253,11 @@ func prepareRewriteContent(policy stringRewritePolicy, args []string, stdin io.R
 	if create && (!flags.has("--title") || !hasBody) {
 		return errRewriteBlocked
 	}
-	metadataEdit := (command == "pr edit" && (flags.has("--add-assignee") || flags.has("--remove-assignee"))) || flags.has("--add-label") || flags.has("--remove-label")
+	metadataEdit := flags.has("--add-assignee") || flags.has("--remove-assignee") || flags.has("--add-label") || flags.has("--remove-label")
 	if args[1] == "edit" && !flags.has("--title") && !hasBody && !metadataEdit {
 		return errRewriteBlocked
 	}
-	for _, name := range []string{"--add-assignee", "--remove-assignee"} {
+	for _, name := range []string{"--assignee", "--add-assignee", "--remove-assignee"} {
 		if flags.has(name) && !validRewriteAssignees(flags.values[name]) {
 			return errRewriteBlocked
 		}

--- a/cmd/octopool/string_rewrites_pr.go
+++ b/cmd/octopool/string_rewrites_pr.go
@@ -104,7 +104,7 @@ func validRewriteAssignees(value string) bool {
 		return false
 	}
 	for _, login := range values {
-		if !rewriteGitHubLogin.MatchString(login) {
+		if login != "@me" && login != "@copilot" && !rewriteGitHubLogin.MatchString(login) {
 			return false
 		}
 	}

--- a/cmd/octopool/string_rewrites_process_test.go
+++ b/cmd/octopool/string_rewrites_process_test.go
@@ -198,7 +198,7 @@ func TestStringRewriteProcessSnapshots(t *testing.T) {
 		want  string
 	}{
 		{"issue inline", []string{"issue", "create", "-tinternal-model", "-binternal-model", "-Racme/repo"}, "unused", false, "public"},
-		{"issue create label", []string{"issue", "create", "--title=safe", "--body-file=FILE", "--label=bug", "--repo=acme/repo"}, "unused", true, "public 🦞"},
+		{"issue create metadata", []string{"issue", "create", "--title=safe", "--body-file=FILE", "--label=bug", "--assignee=steipete", "--repo=acme/repo"}, "unused", true, "public 🦞"},
 		{"issue body file", []string{"issue", "edit", "1", "--body-file=FILE", "--repo=acme/repo"}, "unused", true, "public 🦞"},
 		{"pr body stdin", []string{"pr", "comment", "1", "-F-", "-Racme/repo"}, "internal-model 🦞", false, "public 🦞"},
 		{"review", []string{"pr", "review", "1", "--approve", "--body=internal-model", "-Racme/repo"}, "", false, "public"},
@@ -232,8 +232,8 @@ func TestStringRewriteProcessSnapshots(t *testing.T) {
 				t.Fatalf("streams: %q %q", out.String(), stderr.String())
 			}
 			capture := readRewriteCapture(t, capturePath)
-			if test.name == "issue create label" && !slices.Contains(capture.Args, "--label=bug") {
-				t.Fatalf("label metadata was not preserved: %v", capture.Args)
+			if test.name == "issue create metadata" && (!slices.Contains(capture.Args, "--label=bug") || !slices.Contains(capture.Args, "--assignee=steipete")) {
+				t.Fatalf("issue metadata was not preserved: %v", capture.Args)
 			}
 			if capture.Stdin != "" {
 				t.Fatal("child retained live stdin")
@@ -546,6 +546,7 @@ func TestStringRewriteMaintainerCompatibility(t *testing.T) {
 		{"convert draft", []string{"pr", "ready", "123", "--repo", "acme/repo", "--undo"}, false},
 		{"pinned squash", []string{"pr", "merge", "123", "--repo", "https://github.com/acme/repo", "--squash", "--match-head-commit", sha}, true},
 		{"claim assignee", []string{"pr", "edit", "123", "--repo", "acme/repo", "--add-assignee", "steipete"}, false},
+		{"self-assign issue", []string{"issue", "edit", "123", "--repo", "acme/repo", "--add-assignee", "@me"}, false},
 		{"add issue labels", []string{"issue", "edit", "123", "--repo", "acme/repo", "--add-label", "bug,help wanted"}, false},
 		{"remove pr label", []string{"pr", "edit", "123", "--repo", "acme/repo", "--remove-label", "blocked"}, false},
 	} {
@@ -1293,6 +1294,9 @@ func TestStringRewriteProcessBlocks(t *testing.T) {
 		{"issue", "create", "-Racme/repo", "--title", "safe", "--body", "safe", "--label", ",bug"},
 		{"issue", "create", "-Racme/repo", "--title", "safe", "--body", "safe", "--label", "bug", "-l", "enhancement"},
 		{"issue", "edit", "1", "-Racme/repo", "--add-label", "internal-model"},
+		{"issue", "create", "-Racme/repo", "--title", "safe", "--body", "safe", "--assignee", "internal-model"},
+		{"issue", "create", "-Racme/repo", "--title", "safe", "--body", "safe", "--assignee", "@other"},
+		{"issue", "create", "-Racme/repo", "--title", "safe", "--body", "safe", "--assignee", "steipete", "-a", "@me"},
 		{"api", "repos/acme/repo/issues/1/assignees", "--method", "POST", "-f", "assignees[]=internal-model"},
 		{"api", "repos/acme/repo/issues/1/assignees", "--method", "POST", "-f", "assignees=alice", "-f", "assignees[]=bob"},
 		{"api", "repos/acme/repo/issues/1/assignees", "--method", "POST", "-f", "labels[]=safe"},

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -391,8 +391,9 @@ With active rules, the initial local publication vocabulary is deliberately cons
   files, or stdin; numeric PR/issue selectors for existing items. PR creation requires
   explicit `--head` and `--base`; the head must already be pushed. `--head` prevents gh
   from implicitly pushing or forking. Reviews require one explicit review action. PR/issue creation
-  accepts one `--label`/`-l` value (use a comma-separated list), while PR/issue edits accept
-  metadata-only `--add-label`/`--remove-label`. PR create/comment also accept repeated `--attach`
+  accepts one `--label`/`-l` and one `--assignee`/`-a` value (use comma-separated lists),
+  while PR/issue edits accept metadata-only add/remove label and assignee flags. Assignees may
+  include native `@me` or `@copilot`. PR create/comment also accept repeated `--attach`
   image/video files as described below.
 - Release `create`/`edit`: explicit title/notes or notes files; one tag and no asset uploads.
   Creation requires `--verify-tag`, so gh cannot create a missing tag. Generated notes,
@@ -478,8 +479,8 @@ Allowlisted top-level reads may fall back to native gh after Octopool pins and c
 repository, numeric/ref selector, JSON field projection, filters, and composed request. This
 covers readiness/CI projections, issue comment projections, and PR head filters whose fixed
 GraphQL shapes are not representable by the relay. Numeric `pr ready` (or a checked
-current/explicit nonnumeric Git branch) and metadata-only
-`pr edit --add-assignee|--remove-assignee` are also allowed without free-form text. Exact-head
+current/explicit nonnumeric Git branch) and metadata-only PR/issue edits with add/remove label
+or assignee flags are also allowed without free-form text. Exact-head
 `pr merge --squash --match-head-commit` is converted to the immediate pull-request merge REST
 endpoint with only the checked SHA and squash method; it never enables auto-merge, so a branch
 that requires a merge queue fails closed. Subject/body merge flags, admin/auto merge variants,


### PR DESCRIPTION
## Summary

- support strict protected `--assignee`/`-a` metadata on PR and issue creation
- support metadata-only add/remove assignee edits for PRs and issues
- preserve strict title/body snapshots while validating comma-separated logins and native `@me`/`@copilot`

## Verification

- `pnpm check`
- `go test -race ./cmd/octopool -count=1`
- exact reported labeled and assigned issue-create shape reaches a fake native child unchanged
- invalid, repeated, and protected assignee values remain blocked
- independent P0–P2 review and structured autoreview clean
