### PR TITLE
fix: preserve protected inline media references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.5.16 - Unreleased
 
+### Fixes
+
+- Preserve native inline Markdown attachment references under strict protection by rewriting matched local destinations to private snapshots before upload while keeping code spans untouched and unsupported reference-style definitions blocked.
+- Keep protected `gh repo view owner/repo` targets positional and GitHub.com-validated instead of translating them into an unsupported native `--repo` flag.
+
 ## 0.5.15 - 2026-08-30
 
 ### Fixes

--- a/cmd/octopool/string_rewrites_args.go
+++ b/cmd/octopool/string_rewrites_args.go
@@ -293,49 +293,8 @@ func prepareRewriteContent(policy stringRewritePolicy, args []string, stdin io.R
 	}
 	prepared.args = append([]string{args[0], args[1]}, flags.positionals...)
 	prepared.args = append(prepared.args, "--repo="+flags.values["--repo"])
-	for _, flag := range flags.ordered {
-		if flag.name == "--repo" {
-			continue
-		}
-		switch flag.name {
-		case "--title", body, file:
-			text := flag.value
-			if flag.name == file {
-				data, err := readRewriteFile(flag.value, stdin, rewriteMaxContent-prepared.inputBytes)
-				if err != nil {
-					return err
-				}
-				text = string(data)
-			}
-			text, err = prepared.text(policy, text)
-			if err != nil {
-				return err
-			}
-			// Native gh matches body references against the supplied file paths.
-			// Private snapshots change those paths, so require append-only uploads.
-			if flag.name != "--title" && rewriteBodyReferencesAttachment(text, attachments) {
-				return errRewriteBlocked
-			}
-			// Empty create fields can re-enable gh's prompts/default generation.
-			if create && strings.TrimSpace(text) == "" {
-				return errRewriteBlocked
-			}
-			if flag.name == "--title" {
-				prepared.args = append(prepared.args, "--title="+text)
-			} else {
-				path, err := prepared.snapshot([]byte(text))
-				if err != nil {
-					return err
-				}
-				prepared.args = append(prepared.args, file+"="+path)
-			}
-		default:
-			if err := policy.checkStructural(flag.value); err != nil {
-				return err
-			}
-			prepared.args = append(prepared.args, flag.name+"="+flag.value)
-		}
-	}
+	attachmentArgs := make([]string, 0, len(attachments))
+	attachmentSnapshots := make([]rewriteAttachmentSnapshot, 0, len(attachments))
 	remainingAttachmentBytes := rewriteMaxAttachmentBytes
 	for _, attachment := range attachments {
 		if err := checkRewriteAttachmentPath(policy, attachment.source); err != nil {
@@ -364,12 +323,60 @@ func prepareRewriteContent(policy stringRewritePolicy, args []string, stdin io.R
 			}
 		}
 		path, size, err := prepared.snapshotAttachment(attachment, remainingAttachmentBytes)
-		if err != nil {
-			return err
+		if err != nil || policy.check(path) != nil {
+			return errRewriteBlocked
 		}
 		remainingAttachmentBytes -= size
-		prepared.args = append(prepared.args, "--attach="+rewriteAttachmentArgument(attachment, path, alt))
+		attachmentArgs = append(attachmentArgs, "--attach="+rewriteAttachmentArgument(attachment, path, alt))
+		attachmentSnapshots = append(attachmentSnapshots, rewriteAttachmentSnapshot{source: attachment.source, snapshot: path})
 	}
+	for _, flag := range flags.ordered {
+		if flag.name == "--repo" {
+			continue
+		}
+		switch flag.name {
+		case "--title", body, file:
+			text := flag.value
+			if flag.name == file {
+				data, err := readRewriteFile(flag.value, stdin, rewriteMaxContent-prepared.inputBytes)
+				if err != nil {
+					return err
+				}
+				text = string(data)
+			}
+			text, err = prepared.text(policy, text)
+			if err != nil {
+				return err
+			}
+			if flag.name != "--title" {
+				previousLength := len(text)
+				text, err = rewriteBodyAttachmentReferences(text, attachmentSnapshots)
+				prepared.outputBytes += len(text) - previousLength
+				if err != nil || prepared.outputBytes < 0 || prepared.outputBytes > rewriteMaxContent || policy.check(text) != nil || policy.containsRuleMaterial(text) {
+					return errRewriteBlocked
+				}
+			}
+			// Empty create fields can re-enable gh's prompts/default generation.
+			if create && strings.TrimSpace(text) == "" {
+				return errRewriteBlocked
+			}
+			if flag.name == "--title" {
+				prepared.args = append(prepared.args, "--title="+text)
+			} else {
+				path, err := prepared.snapshot([]byte(text))
+				if err != nil {
+					return err
+				}
+				prepared.args = append(prepared.args, file+"="+path)
+			}
+		default:
+			if err := policy.checkStructural(flag.value); err != nil {
+				return err
+			}
+			prepared.args = append(prepared.args, flag.name+"="+flag.value)
+		}
+	}
+	prepared.args = append(prepared.args, attachmentArgs...)
 	prepared.stdin = strings.NewReader("")
 	return nil
 }

--- a/cmd/octopool/string_rewrites_attachments.go
+++ b/cmd/octopool/string_rewrites_attachments.go
@@ -14,12 +14,14 @@ import (
 )
 
 const (
-	rewriteMaxAttachments      = 16
-	rewriteMaxAttachmentBytes  = int64(100 << 20)
-	rewriteMaxImageAttachment  = int64(10 << 20)
-	rewriteMaxVideoAttachment  = int64(100 << 20)
-	rewriteAttachmentKindImage = "image"
-	rewriteAttachmentKindVideo = "video"
+	rewriteMaxAttachments          = 16
+	rewriteMaxAttachmentBytes      = int64(100 << 20)
+	rewriteMaxImageAttachment      = int64(10 << 20)
+	rewriteMaxVideoAttachment      = int64(100 << 20)
+	rewriteMaxAttachmentReferences = 64
+	rewriteMaxAttachmentCandidates = 256
+	rewriteAttachmentKindImage     = "image"
+	rewriteAttachmentKindVideo     = "video"
 )
 
 var rewriteAttachmentExtensions = map[string]string{
@@ -163,52 +165,243 @@ func rewriteAttachmentArgument(attachment rewriteAttachment, snapshot, alt strin
 	return snapshot
 }
 
-func rewriteBodyReferencesAttachment(body string, attachments []rewriteAttachment) bool {
-	if len(attachments) == 0 {
-		return false
+type rewriteAttachmentSnapshot struct {
+	source   string
+	snapshot string
+}
+
+type rewriteAttachmentEdit struct {
+	start       int
+	stop        int
+	replacement string
+}
+
+type rewriteAttachmentRange struct {
+	start int
+	stop  int
+}
+
+type rewriteAttachmentLinkState struct {
+	image       bool
+	destination string
+	title       string
+	reference   bool
+	depth       int
+}
+
+func rewriteBodyAttachmentReferences(body string, snapshots []rewriteAttachmentSnapshot) (string, error) {
+	if len(snapshots) == 0 {
+		return body, nil
 	}
-	byPath := make(map[string]bool, len(attachments))
-	for _, attachment := range attachments {
-		path, err := filepath.Abs(attachment.source)
-		if err == nil {
-			byPath[path] = true
+	byPath := make(map[string]string, len(snapshots))
+	for _, snapshot := range snapshots {
+		path, err := filepath.Abs(snapshot.source)
+		if err != nil {
+			return "", errRewriteBlocked
 		}
+		byPath[path] = snapshot.snapshot
 	}
-	document := goldmark.New().Parser().Parse(text.NewReader([]byte(body)))
-	found := false
+	candidateAttempts := 0
+	for rewritten := 0; rewritten <= rewriteMaxAttachmentReferences; rewritten++ {
+		source := []byte(body)
+		nodes, states := rewriteAttachmentLinkStates(source)
+		target, snapshot := -1, ""
+		for index, state := range states {
+			if value, matched := rewriteAttachmentDestinationSnapshot(state.destination, byPath); matched {
+				target, snapshot = index, value
+				break
+			}
+		}
+		if target < 0 {
+			return body, nil
+		}
+		if states[target].reference || rewritten == rewriteMaxAttachmentReferences {
+			return "", errRewriteBlocked
+		}
+		edit, ok := rewriteValidatedAttachmentEdit(source, nodes[target], states, target, snapshot, &candidateAttempts)
+		if !ok {
+			return "", errRewriteBlocked
+		}
+		body = body[:edit.start] + edit.replacement + body[edit.stop:]
+	}
+	return "", errRewriteBlocked
+}
+
+func rewriteAttachmentLinkStates(source []byte) ([]ast.Node, []rewriteAttachmentLinkState) {
+	document := goldmark.New().Parser().Parse(text.NewReader(source))
+	nodes := []ast.Node{}
+	states := []rewriteAttachmentLinkState{}
 	_ = ast.Walk(document, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
 			return ast.WalkContinue, nil
 		}
-		var destination string
+		state := rewriteAttachmentLinkState{}
 		switch value := node.(type) {
 		case *ast.Image:
-			destination = string(value.Destination)
+			state.image, state.destination, state.title, state.reference = true, string(value.Destination), string(value.Title), value.Reference != nil
 		case *ast.Link:
-			destination = string(value.Destination)
+			state.destination, state.title, state.reference = string(value.Destination), string(value.Title), value.Reference != nil
 		default:
 			return ast.WalkContinue, nil
 		}
-		if rewriteAttachmentDestinationMatches(destination, byPath) {
-			found = true
-			return ast.WalkStop, nil
+		for parent := node.Parent(); parent != nil; parent = parent.Parent() {
+			state.depth++
 		}
+		nodes = append(nodes, node)
+		states = append(states, state)
 		return ast.WalkContinue, nil
 	})
-	return found
+	return nodes, states
 }
 
-func rewriteAttachmentDestinationMatches(destination string, byPath map[string]bool) bool {
-	if destination == "" || strings.HasPrefix(destination, "#") || rewriteAttachmentDestinationRemote(destination) {
+func rewriteValidatedAttachmentEdit(source []byte, node ast.Node, states []rewriteAttachmentLinkState, target int, snapshot string, candidateAttempts *int) (rewriteAttachmentEdit, bool) {
+	_, high, ok := rewriteAttachmentBlockRange(node, len(source))
+	if !ok {
+		return rewriteAttachmentEdit{}, false
+	}
+	for index := node.Pos(); index+1 < high; index++ {
+		if source[index] != ']' || source[index+1] != '(' || rewriteAttachmentEscaped(source, index) {
+			continue
+		}
+		range_ := rewriteAttachmentDestinationRange(source, index+2, high)
+		if range_.start >= range_.stop || rewriteAttachmentComparableSource(string(source[range_.start:range_.stop])) != rewriteUnescapeMarkdownPath(states[target].destination) {
+			continue
+		}
+		*candidateAttempts++
+		if *candidateAttempts > rewriteMaxAttachmentCandidates {
+			return rewriteAttachmentEdit{}, false
+		}
+		replacement := rewriteAttachmentMarkdownPath(snapshot, source[range_.start:range_.stop])
+		expectedDestination := rewriteAttachmentMarkdownDestination(snapshot)
+		candidate := string(source[:range_.start]) + replacement + string(source[range_.stop:])
+		_, candidateStates := rewriteAttachmentLinkStates([]byte(candidate))
+		if rewriteAttachmentStateTransition(states, candidateStates, target, expectedDestination) {
+			return rewriteAttachmentEdit{range_.start, range_.stop, replacement}, true
+		}
+	}
+	return rewriteAttachmentEdit{}, false
+}
+
+func rewriteAttachmentStateTransition(before, after []rewriteAttachmentLinkState, target int, expectedDestination string) bool {
+	if len(before) != len(after) || target < 0 || target >= len(before) {
 		return false
+	}
+	for index := range before {
+		if before[index].image != after[index].image || before[index].title != after[index].title || before[index].reference != after[index].reference || before[index].depth != after[index].depth {
+			return false
+		}
+		if index == target {
+			if after[index].destination != expectedDestination {
+				return false
+			}
+		} else if before[index].destination != after[index].destination {
+			return false
+		}
+	}
+	return true
+}
+
+func rewriteAttachmentDestinationSnapshot(destination string, byPath map[string]string) (string, bool) {
+	if destination == "" || strings.HasPrefix(destination, "#") || rewriteAttachmentDestinationRemote(destination) {
+		return "", false
 	}
 	for _, candidate := range rewriteAttachmentCandidatePaths(destination) {
 		path, err := filepath.Abs(candidate)
-		if err == nil && byPath[path] {
-			return true
+		if err == nil {
+			if snapshot, ok := byPath[path]; ok {
+				return snapshot, true
+			}
 		}
 	}
-	return false
+	return "", false
+}
+
+func rewriteAttachmentMarkdownDestination(path string) string {
+	return (&url.URL{Path: filepath.ToSlash(path)}).EscapedPath()
+}
+
+func rewriteAttachmentMarkdownPath(path string, raw []byte) string {
+	encoded := rewriteAttachmentMarkdownDestination(path)
+	if len(raw) >= 2 && raw[0] == '<' && raw[len(raw)-1] == '>' {
+		return "<" + encoded + ">"
+	}
+	return encoded
+}
+
+func rewriteAttachmentBlockRange(node ast.Node, size int) (int, int, bool) {
+	for current := node.Parent(); current != nil; current = current.Parent() {
+		if current.Type() != ast.TypeBlock {
+			continue
+		}
+		lines := current.Lines()
+		if lines == nil || lines.Len() == 0 {
+			return 0, 0, false
+		}
+		low, high := lines.At(0).Start, lines.At(lines.Len()-1).Stop
+		return low, high, low >= 0 && low <= high && high <= size
+	}
+	return 0, 0, false
+}
+
+func rewriteAttachmentDestinationRange(source []byte, index, high int) rewriteAttachmentRange {
+	index = rewriteAttachmentSkipSpace(source, index, high)
+	if index < high && source[index] == '<' {
+		for stop := index + 1; stop < high && source[stop] != '\n'; stop++ {
+			if source[stop] == '\\' && stop+1 < high {
+				stop++
+				continue
+			}
+			if source[stop] == '>' {
+				return rewriteAttachmentRange{index, stop + 1}
+			}
+		}
+		return rewriteAttachmentRange{}
+	}
+	start, depth := index, 0
+	for index < high {
+		switch source[index] {
+		case '\\':
+			if index+1 < high {
+				index++
+			}
+		case ' ', '\t', '\n', '\r':
+			if depth == 0 {
+				return rewriteAttachmentRange{start, index}
+			}
+		case '(':
+			depth++
+		case ')':
+			if depth == 0 {
+				return rewriteAttachmentRange{start, index}
+			}
+			depth--
+		}
+		index++
+	}
+	return rewriteAttachmentRange{start, index}
+}
+
+func rewriteAttachmentComparableSource(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) >= 2 && value[0] == '<' && value[len(value)-1] == '>' {
+		value = value[1 : len(value)-1]
+	}
+	return rewriteUnescapeMarkdownPath(value)
+}
+
+func rewriteAttachmentEscaped(source []byte, index int) bool {
+	count := 0
+	for previous := index - 1; previous >= 0 && source[previous] == '\\'; previous-- {
+		count++
+	}
+	return count%2 == 1
+}
+
+func rewriteAttachmentSkipSpace(source []byte, index, high int) int {
+	for index < high && (source[index] == ' ' || source[index] == '\t' || source[index] == '\n' || source[index] == '\r') {
+		index++
+	}
+	return index
 }
 
 func rewriteAttachmentDestinationRemote(destination string) bool {

--- a/cmd/octopool/string_rewrites_guard.go
+++ b/cmd/octopool/string_rewrites_guard.go
@@ -225,8 +225,15 @@ func prepareRewriteRead(policy stringRewritePolicy, args []string, prepared *rew
 	if err := policy.guardRequest(request); err != nil {
 		return err
 	}
-	prepared.args = append([]string{args[0], args[1]}, flags.positionals...)
-	prepared.args = append(prepared.args, "--repo="+flags.values["--repo"])
+	if command == "repo view" {
+		if err := policy.checkStructural("github.com/" + flags.values["--repo"]); err != nil {
+			return err
+		}
+		prepared.args = []string{"repo", "view", flags.values["--repo"]}
+	} else {
+		prepared.args = append([]string{args[0], args[1]}, flags.positionals...)
+		prepared.args = append(prepared.args, "--repo="+flags.values["--repo"])
+	}
 	for _, flag := range flags.ordered {
 		if flag.name != "--repo" {
 			if flag.boolean && flag.value == "true" {

--- a/cmd/octopool/string_rewrites_process_test.go
+++ b/cmd/octopool/string_rewrites_process_test.go
@@ -96,6 +96,23 @@ func captureRewriteAttachmentPath(value string) string {
 	return value
 }
 
+func capturedAttachmentSnapshot(args []string, extension string) string {
+	for _, arg := range args {
+		spec, ok := strings.CutPrefix(arg, "--attach=")
+		if !ok {
+			continue
+		}
+		marker := strings.ToLower(extension) + "#"
+		if index := strings.Index(strings.ToLower(spec), marker); index >= 0 {
+			return spec[:index+len(extension)]
+		}
+		if strings.HasSuffix(strings.ToLower(spec), strings.ToLower(extension)) {
+			return spec
+		}
+	}
+	return ""
+}
+
 func captureRewriteGH(t *testing.T) string {
 	t.Helper()
 	if runtime.GOOS == "windows" {
@@ -390,6 +407,63 @@ func TestStringRewriteAttachments(t *testing.T) {
 		t.Fatalf("code attachment reference was not preserved: %+v", codeCapture)
 	}
 
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	relativeImage, err := filepath.Rel(workingDirectory, image)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, reference := range []string{image, strings.ReplaceAll(image, "#", "%23"), relativeImage} {
+		capturePath := captureRewriteGH(t)
+		referenceBody := "![safe](" + reference + ")"
+		args := []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", referenceBody, "--attach", image}
+		if err := execRealGH(t.Context(), args, io.Discard, io.Discard); err != nil {
+			t.Fatal(err)
+		}
+		capture := readRewriteCapture(t, capturePath)
+		snapshot := capturedAttachmentSnapshot(capture.Args, ".png")
+		if snapshot == "" {
+			t.Fatalf("attachment snapshot missing: %v", capture.Args)
+		}
+		rewritten := false
+		for path, content := range capture.Files {
+			if path != snapshot && strings.Contains(content, "![safe]") {
+				rewritten = strings.Contains(content, snapshot) && !strings.Contains(content, reference)
+			}
+		}
+		if !rewritten {
+			t.Fatalf("inline attachment reference was not rewritten: %+v", capture)
+		}
+	}
+
+	for _, complexBody := range []string{
+		"![<span title=\"](" + image + ")\">x</span>](" + image + ")",
+		"[![thumb](https://example.com/thumb.png \" ](" + image + ")\")](" + image + ")",
+	} {
+		capturePath := captureRewriteGH(t)
+		args := []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", complexBody, "--attach", image}
+		if err := execRealGH(t.Context(), args, io.Discard, io.Discard); err != nil {
+			t.Fatal(err)
+		}
+		capture := readRewriteCapture(t, capturePath)
+		snapshot := capturedAttachmentSnapshot(capture.Args, ".png")
+		found := false
+		for path, content := range capture.Files {
+			if path == snapshot {
+				continue
+			}
+			_, states := rewriteAttachmentLinkStates([]byte(content))
+			for _, state := range states {
+				found = found || state.destination == snapshot
+			}
+		}
+		if !found {
+			t.Fatalf("complex inline destination was not structurally rewritten: %+v", capture)
+		}
+	}
+
 	literalBodyCapturePath := captureRewriteGH(t)
 	literalBody := "--attach=" + image
 	literalBodyArgs := []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", literalBody}
@@ -401,6 +475,36 @@ func TestStringRewriteAttachments(t *testing.T) {
 		return strings.HasPrefix(arg, "--attach=")
 	}) {
 		t.Fatalf("flag value was reinterpreted as an attachment: %+v", literalBodyCapture)
+	}
+}
+
+func TestStringRewritePolicyCreatedAttachmentReference(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	directory := t.TempDir()
+	source := filepath.Join(directory, "public.png")
+	if err := os.WriteFile(source, []byte("safe"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	protectedReference := filepath.Join(directory, "internal-model.png")
+	capturePath := captureRewriteGH(t)
+	args := []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", "![safe](" + protectedReference + ")", "--attach", source}
+	if err := execRealGH(t.Context(), args, io.Discard, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	capture := readRewriteCapture(t, capturePath)
+	snapshot := capturedAttachmentSnapshot(capture.Args, ".png")
+	found := false
+	for path, content := range capture.Files {
+		if path == snapshot {
+			continue
+		}
+		_, states := rewriteAttachmentLinkStates([]byte(content))
+		for _, state := range states {
+			found = found || state.destination == snapshot
+		}
+	}
+	if !found {
+		t.Fatalf("policy-created attachment reference was not rewritten: %+v", capture)
 	}
 }
 
@@ -448,9 +552,8 @@ func TestStringRewriteAttachmentBlocks(t *testing.T) {
 		}
 	}
 	safe := filepath.Join(directory, "safe.png")
-	hash := filepath.Join(directory, "hash#safe.png")
 	video := filepath.Join(directory, "safe.mp4")
-	for _, path := range []string{safe, hash, video} {
+	for _, path := range []string{safe, video} {
 		if err := os.WriteFile(path, []byte("safe"), 0600); err != nil {
 			t.Fatal(err)
 		}
@@ -463,11 +566,10 @@ func TestStringRewriteAttachmentBlocks(t *testing.T) {
 		{"edit last without body", []string{"pr", "comment", "1", "--repo", "acme/repo", "--edit-last", "--attach", safe}},
 		{"delete last with attachment", []string{"pr", "comment", "1", "--repo", "acme/repo", "--delete-last", "--attach", safe}},
 		{"duplicate file", []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", "safe", "--attach", safe, "--attach", safe}},
-		{"inline reference", []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", "![safe](" + safe + ")", "--attach", safe}},
-		{"hash reference", []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", "![safe](" + hash + ")", "--attach", hash}},
-		{"encoded hash reference", []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", "![safe](" + strings.ReplaceAll(hash, "#", "%23") + ")", "--attach", hash}},
+		{"malformed inline then shortcut reference", []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", "![shot](" + safe + " garbage)\n\n[shot]: " + safe, "--attach", safe}},
 		{"reference definition", []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", "![safe][shot]\n\n[shot]: <" + safe + ">", "--attach", safe}},
 		{"multiline reference definition", []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", "![safe][shot]\n\n[shot]:\n  " + safe, "--attach", safe}},
+		{"too many inline references", []string{"pr", "comment", "1", "--repo", "acme/repo", "--body", strings.Repeat("![safe]("+safe+")\n", rewriteMaxAttachmentReferences+1), "--attach", safe}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			capturePath := captureRewriteGH(t)
@@ -583,6 +685,15 @@ func TestStringRewriteMaintainerCompatibility(t *testing.T) {
 				}
 			}
 		})
+	}
+
+	repoViewCapturePath := captureRewriteGH(t)
+	if err := execRealGH(t.Context(), []string{"repo", "view", "https://github.com/acme/repo", "--json", "nameWithOwner"}, io.Discard, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	repoViewCapture := readRewriteCapture(t, repoViewCapturePath)
+	if !slices.Contains(repoViewCapture.Args, "acme/repo") || slices.ContainsFunc(repoViewCapture.Args, func(arg string) bool { return strings.HasPrefix(arg, "--repo") }) {
+		t.Fatalf("repo view target was not kept positional: %v", repoViewCapture.Args)
 	}
 
 	repo := t.TempDir()
@@ -1277,6 +1388,7 @@ func TestStringRewriteProcessBlocks(t *testing.T) {
 		{"api", "repos/acme/%69nternal-model"},
 		{"api", "repos/acme/repo/issues?q=%2569nternal-model"},
 		{"pr", "view", "1", "--repo", "https://example.com/acme/repo", "--json", "number"},
+		{"repo", "view", "https://ghe.example/acme/repo", "--json", "nameWithOwner"},
 		{"pr", "view", "1", "--json", "number,internal-model", "-Racme/repo"},
 		{"pr", "list", "--head", "internal-model", "-Racme/repo"},
 		{"pr", "ready", "internal-model", "-Racme/repo"},

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -422,10 +422,13 @@ Protected PR create/comment commands accept up to 16 repeated `--attach FILE` or
 extensions are MOV, MP4, and WebM. Images are limited to 10 MiB each, videos to 100 MiB each,
 and all attachments together to 100 MiB. The source path is structurally checked, optional
 `#alt text` is rewritten, default image alt text remains based on the original filename, and
-native `gh` receives suffix-preserving private byte-for-byte snapshots. Empty files, directories,
-other extensions, video alt text, and body references to an attached local file are blocked;
-omit local references and let native `gh` append uploaded media. A new PR comment may consist
-only of attachments. An `--edit-last` attachment update still requires an explicit body because
+native `gh` receives suffix-preserving private byte-for-byte snapshots. Recognized inline
+Markdown links/images that point at an attached local file are rewritten to the matching snapshot,
+so native `gh` can preserve labels, alt text, titles, and normal upload-URL replacement. Up to 64
+matched inline references are rewritten with bounded parser verification. Code spans remain literal;
+matching reference-style definitions are blocked rather than published with broken paths. Empty
+files, directories, other extensions, and video alt text are blocked. A new PR comment
+may consist only of attachments. An `--edit-last` attachment update still requires an explicit body because
 native `gh` would otherwise fetch and republish the existing text after the guard runs. Other
 modeled body requirements stay unchanged. Attachment bytes are not text- or vision-inspected, so
 callers remain responsible for reviewing the media itself before publication.


### PR DESCRIPTION
## Summary

- preserve strict protected inline Markdown attachment references by rewriting parser-confirmed local destinations to private snapshots before native upload
- sanitize body text before attachment matching and structurally verify each destination edit, including nested/raw-HTML ambiguity checks
- keep code spans literal, reference-style definitions fail-closed, and bounded reference/candidate limits explicit
- keep protected `gh repo view owner/repo` targets positional across repeated preparation

## Verification

- `pnpm check`
- `go test -race ./cmd/octopool -count=1`
- exact PR 133067 four-image body/attachment shape reaches a fake native child without publication
- exact protected `gh repo view openclaw/octopool` returns the expected repository
- ambiguity, policy-ordering, bounds, reference-style, percent/escaped path, cleanup, and double-preparation regressions
- independent P0–P2 review and structured autoreview clean
