### PR TITLE
fix: normalize issue JSON state casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Return native uppercase `OPEN`/`CLOSED` states in issue-view/list JSON before `--jq`, preserving lowercase raw `gh api` REST states.
 - Allow typed attachments on protected `gh issue create` and `gh pr edit` through strict snapshots and inline-reference rewriting, requiring an explicit body for PR attachment edits.
 - Allow exact repository branch-protection, ruleset, and applicable branch-rules GETs through freshly policy-checked native gh fallback, preserving caller permissions and encoded branch names without pooled credentials or shared caching.
 

--- a/cmd/octopool/gh_top_issue.go
+++ b/cmd/octopool/gh_top_issue.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"strconv"
 	"strings"
@@ -40,11 +41,7 @@ func handleGHIssue(ctx context.Context, args []string, stdout io.Writer) ghResul
 		if !machineReadable(opts) || !supportedJSONFields(opts, supportedIssueFields) {
 			return ghDelegated()
 		}
-		return ghCompleted(relayTop(ctx, stdout, ghAPIRequest{
-			method:  "GET",
-			path:    repoPath(repo, "issues", number),
-			headers: publicShapeHeaders(opts, supportedPublicIssueViewFields, publicShapeIssueSummary),
-		}, opts, fieldMapIssue))
+		return ghCompleted(relayIssueView(ctx, stdout, repo, number, opts))
 	case "list":
 		repo, ok := repoOnly(opts)
 		if !ok || limitOverOnePage(opts) || hasCurrentUserFilter(opts) {
@@ -74,6 +71,50 @@ func handleGHIssue(ctx context.Context, args []string, stdout io.Writer) ghResul
 		}, opts))
 	default:
 		return ghDelegated()
+	}
+}
+
+func relayIssueView(ctx context.Context, stdout io.Writer, repo string, number string, opts ghTopOptions) error {
+	request := ghAPIRequest{
+		method:  "GET",
+		path:    repoPath(repo, "issues", number),
+		headers: publicShapeHeaders(opts, supportedPublicIssueViewFields, publicShapeIssueSummary),
+	}
+	if !safeRelayRequest(request) {
+		return errors.New("internal error: top-level gh command built an unsupported relay request")
+	}
+	client, err := newGHRelayClient()
+	if err != nil {
+		return err
+	}
+	envelope, err := client.do(ctx, request)
+	if err != nil {
+		return err
+	}
+	body, err := envelopeBodyBytes(envelope)
+	if err != nil {
+		return err
+	}
+	var issue map[string]any
+	if err := json.Unmarshal(body, &issue); err != nil {
+		return err
+	}
+	normalizeIssueJSONState(issue)
+	raw, err := json.Marshal(issue)
+	if err != nil {
+		return err
+	}
+	filtered, err := filterJSONFields(raw, opts.json, fieldMapIssue)
+	if err != nil {
+		return err
+	}
+	return writeBytes(ctx, stdout, filtered, opts.jq)
+}
+
+func normalizeIssueJSONState(issue map[string]any) {
+	// Normalize only the decoded CLI copy; REST and public-page cache values stay intact.
+	if state, ok := issue["state"].(string); ok {
+		issue["state"] = strings.ToUpper(state)
 	}
 }
 
@@ -120,6 +161,9 @@ func relayIssueList(ctx context.Context, stdout io.Writer, request ghAPIRequest,
 	}
 	if len(opts.json) == 0 {
 		return renderHumanIssueList(stdout, filtered)
+	}
+	for _, issue := range filtered {
+		normalizeIssueJSONState(issue)
 	}
 	raw, err := json.Marshal(filtered)
 	if err != nil {

--- a/cmd/octopool/gh_top_issue_state_test.go
+++ b/cmd/octopool/gh_top_issue_state_test.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const issueStateTestTime = "2026-08-30T18:20:25Z"
+
+func issueStateFixture(state string) map[string]any {
+	var closedAt any
+	if strings.EqualFold(state, "closed") {
+		closedAt = issueStateTestTime
+	}
+	return map[string]any{
+		"number": float64(5), "title": "Issue fixture", "state": state,
+		"closed_at": closedAt, "html_url": "https://github.com/openclaw/octopool/issues/5",
+		"user": map[string]any{"login": "octocat"},
+	}
+}
+
+func TestRunGHIssueViewStateProjection(t *testing.T) {
+	t.Setenv("OCTOPOOL_FRESH", "")
+	for _, state := range []string{"open", "closed"} {
+		for _, source := range []string{"rest", "public", "cached-lowercase-public"} {
+			t.Run(state+"/"+source, func(t *testing.T) {
+				for _, fields := range []string{
+					"state", "state,closedAt", "number,title,state,url,author",
+					"number,title,state,closedAt,url,author", "title,closedAt",
+				} {
+					t.Run(fields, func(t *testing.T) {
+						wantShape := "issue-summary-v1"
+						if strings.Contains(fields, "closedAt") {
+							wantShape = ""
+						}
+						fixture := issueStateFixture(state)
+						if source != "rest" && wantShape != "" {
+							delete(fixture, "closed_at")
+							if source == "public" {
+								fixture["state"] = strings.ToUpper(state)
+							}
+						}
+						before, _ := json.Marshal(fixture)
+						calls := 0
+						relayTestServer(t, func(request map[string]any) any {
+							calls++
+							if request["method"] != "GET" || request["path"] != "/repos/openclaw/octopool/issues/5" {
+								t.Errorf("unexpected request: %#v", request)
+							}
+							headers, _ := request["headers"].(map[string]any)
+							if shape, _ := headers["x-octopool-public-shape"].(string); shape != wantShape {
+								t.Errorf("shape = %q, want %q", shape, wantShape)
+							}
+							if headers["cache-control"] != "max-age=0" {
+								t.Errorf("freshness headers = %#v", headers)
+							}
+							return fixture
+						})
+						var out bytes.Buffer
+						result := handleGHIssue(t.Context(), []string{"view", "5", "-R", "openclaw/octopool", "--json", fields}, &out)
+						if result.action != ghComplete || result.err != nil {
+							t.Fatalf("action=%v err=%v", result.action, result.err)
+						}
+						all := map[string]any{
+							"number": float64(5), "title": "Issue fixture", "state": strings.ToUpper(state),
+							"closedAt": fixture["closed_at"], "url": fixture["html_url"], "author": fixture["user"],
+						}
+						want := map[string]any{}
+						for _, field := range strings.Split(fields, ",") {
+							want[field] = all[field]
+						}
+						var got map[string]any
+						if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+							t.Fatal(err)
+						}
+						if !reflect.DeepEqual(got, want) {
+							t.Errorf("projection = %#v, want %#v", got, want)
+						}
+						after, _ := json.Marshal(fixture)
+						if !bytes.Equal(before, after) || calls != 1 {
+							t.Errorf("source changed or unexpected request count: before=%s after=%s calls=%d", before, after, calls)
+						}
+					})
+				}
+			})
+		}
+	}
+}
+
+func TestRunGHIssueStateProjectionBeforeJQ(t *testing.T) {
+	if !jqAvailable() {
+		t.Skip("jq not installed")
+	}
+	for _, state := range []string{"open", "closed"} {
+		for _, command := range []string{"view", "list"} {
+			t.Run(state+"/"+command, func(t *testing.T) {
+				relayTestServer(t, func(request map[string]any) any {
+					if command == "list" {
+						return []any{issueStateFixture(state)}
+					}
+					return issueStateFixture(state)
+				})
+				for _, fields := range []string{"state", "state,closedAt", "title"} {
+					args := []string{command}
+					prefix := ""
+					if command == "view" {
+						args = append(args, "5")
+					} else {
+						prefix = ".[0] | "
+					}
+					expr := `.state == "` + strings.ToUpper(state) + `" and (has("closedAt") == ` + strconv.FormatBool(strings.Contains(fields, "closedAt")) + `) and (has("closed_at") | not)`
+					if fields == "title" {
+						expr = `keys == ["title"]`
+					}
+					args = append(args, "-R", "openclaw/octopool", "--json", fields, "--jq", prefix+expr)
+					var out bytes.Buffer
+					result := handleGHIssue(t.Context(), args, &out)
+					if result.action != ghComplete || result.err != nil || out.String() != "true\n" {
+						t.Errorf("fields=%s action=%v err=%v jq=%q", fields, result.action, result.err, out.String())
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestRunGHIssueListStateProjection(t *testing.T) {
+	for _, fields := range []string{"state", "number,state,closedAt", "number,state,closedAt,milestone"} {
+		t.Run(fields, func(t *testing.T) {
+			pr := map[string]any{"number": float64(9), "state": "closed", "pull_request": map[string]any{}}
+			items := []any{issueStateFixture("open"), pr, issueStateFixture("closed")}
+			relayTestServer(t, func(request map[string]any) any {
+				query, _ := request["query"].(map[string]any)
+				if request["path"] != "/repos/openclaw/octopool/issues" || query["state"] != "all" || query["per_page"] != "100" || query["page"] != "1" {
+					t.Errorf("unexpected list request: %#v", request)
+				}
+				return items
+			})
+			var out bytes.Buffer
+			result := handleGHIssue(t.Context(), []string{"list", "-R", "openclaw/octopool", "--state", "all", "--limit", "2", "--json", fields}, &out)
+			if result.action != ghComplete || result.err != nil {
+				t.Fatalf("action=%v err=%v", result.action, result.err)
+			}
+			var got []map[string]any
+			if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			if len(got) != 2 || got[0]["state"] != "OPEN" || got[1]["state"] != "CLOSED" {
+				t.Errorf("list projection = %#v", got)
+			}
+			if strings.Contains(fields, "closedAt") && (got[0]["closedAt"] != nil || got[1]["closedAt"] != issueStateTestTime) {
+				t.Errorf("list closedAt = %#v", got)
+			}
+			if items[0].(map[string]any)["state"] != "open" || items[2].(map[string]any)["state"] != "closed" || pr["state"] != "closed" {
+				t.Errorf("source items changed: %#v", items)
+			}
+		})
+	}
+}
+
+func TestRunGHIssueStateUnsupportedFieldsDelegate(t *testing.T) {
+	emptyRewriteTestServer(t)
+	for _, command := range []string{"view", "list"} {
+		for _, fields := range []string{"number,title,state,closedAt,url,author,comments", "state,closed", "state,stateReason"} {
+			args := []string{command}
+			if command == "view" {
+				args = append(args, "5")
+			}
+			args = append(args, "-R", "openclaw/octopool", "--json", fields, "--jq", "{number,state,closedAt}")
+			var out bytes.Buffer
+			result := handleGHIssue(t.Context(), args, &out)
+			if result.action != ghDelegate || result.err != nil || out.Len() != 0 {
+				t.Errorf("args=%v action=%v err=%v out=%q", args, result.action, result.err, out.String())
+			}
+		}
+	}
+}
+
+func TestRunGHIssueStatePreservesRESTAndSearch(t *testing.T) {
+	for _, state := range []string{"open", "closed"} {
+		t.Run(state, func(t *testing.T) {
+			fixture := issueStateFixture(state)
+			relayTestServer(t, func(request map[string]any) any {
+				if request["path"] == "/search/issues" {
+					return map[string]any{"items": []any{fixture}}
+				}
+				return fixture
+			})
+			var out bytes.Buffer
+			if err := runGH(t.Context(), []string{"api", "repos/openclaw/octopool/issues/5"}, &out, &bytes.Buffer{}); err != nil {
+				t.Fatal(err)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, fixture) {
+				t.Errorf("REST = %#v, want %#v", got, fixture)
+			}
+			out.Reset()
+			result := handleGHSearch(t.Context(), []string{"issues", "cache", "-R", "openclaw/octopool", "--json", "state"}, &out)
+			if result.action != ghComplete || result.err != nil || out.String() != "[{\"state\":\""+state+"\"}]\n" {
+				t.Errorf("search action=%v err=%v output=%q", result.action, result.err, out.String())
+			}
+		})
+	}
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -197,6 +197,12 @@ regardless of the other requested fields or whether the relay uses a public page
 Draft status is separate: an open draft has `state: "OPEN"` and `isDraft: true` when
 requested. This conversion happens before field filtering and `--jq`; raw `gh api` REST
 states, PR search states, and human-format `DRAFT` display remain unchanged.
+`gh issue view --json state` and `gh issue list --json state` return native `OPEN` or
+`CLOSED` values across supported field subsets, including REST and public-page/cache
+payloads. This conversion happens before field filtering and `--jq`, without changing
+the cached representation. Raw `gh api` REST issue states remain lowercase; issue search
+states and human-format output remain unchanged. Unsupported issue fields such as
+`comments`, `closed`, and `stateReason` still delegate the entire request to real `gh`.
 `gh pr view --json mergeable` likewise returns a JSON enum string before filtering and
 `--jq`: REST `true` becomes `"MERGEABLE"`, `false` becomes `"CONFLICTING"`, and null or
 absent values become `"UNKNOWN"`. This uses only REST `mergeable`, not `mergeable_state`,


### PR DESCRIPTION
## Summary

Issue JSON state casing depended on the requested fields: relay-backed `gh issue view --json state` preserved lowercase REST/cache values, while richer requests containing unsupported `comments` delegated to native gh and returned its uppercase enum. The issue projection was unchanged between installed v0.5.16 and current main, so this was not merely deployed-version drift.

Normalize decoded issue-view/list CLI state to `OPEN`/`CLOSED` before field selection and `--jq`, following the existing PR projection boundary. Do not change raw `gh api` REST data, cached representations, field allowlists, native delegation, policy checks, freshness behavior, search output, or human rendering.

## Verification

- Focused projection tests failed before the fix and passed afterward: field subsets, public and REST-shaped payloads, lowercase cached payloads, jq ordering, list PR exclusion, delegation, and raw REST/search preservation.
- Full `pnpm check` passed: 516 unit tests, 218 Worker E2E tests, TypeScript build, Go tests, and vet. Docs build and Go race suite passed.
- Codex autoreview scoped-clean at the configured P0 threshold; parent diff review complete.
- Read-only live candidate test with freshness requested on issue 131553: narrow view and state/closedAt both returned `CLOSED`, matching the native-delegated rich shape; the jq enum guard returned true; raw REST still returned lowercase `closed` with the same close timestamp. An open issue returned `OPEN` through list and view.

No issue mutations, installed binary changes, releases, auth/policy/config/PATH changes, or OpenClaw checkout changes were needed for this proof.
