### PR TITLE
fix: move public proxy to Services Cloudflare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@
 
 - Keep active string-rewrite protection best-effort for evolving native `gh` commands by filtering visible arguments, declared piped JSON/text, and `--input` snapshots instead of blocking workflow dispatches, job logs, uploads, or newly added flags solely because their command shape is not structurally modeled.
 
+### Changes
+
+- Move the `octopool.dev` proxy Worker into the OpenClaw Services Cloudflare account under its own service so one non-interactive deployment credential covers both hosted Workers.
+
 ## 0.5.11 - 2026-08-29
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.5.17 - Unreleased
 
+### Changes
+
+- Move the `octopool.dev` proxy Worker into the OpenClaw Services Cloudflare account under its own service so one non-interactive deployment credential covers both hosted Workers.
+
 ### Fixes
 
 - Return native uppercase `OPEN`/`CLOSED` states in issue-view/list JSON before `--jq`, preserving lowercase raw `gh api` REST states.
@@ -41,10 +45,6 @@
 ### Fixes
 
 - Keep active string-rewrite protection best-effort for evolving native `gh` commands by filtering visible arguments, declared piped JSON/text, and `--input` snapshots instead of blocking workflow dispatches, job logs, uploads, or newly added flags solely because their command shape is not structurally modeled.
-
-### Changes
-
-- Move the `octopool.dev` proxy Worker into the OpenClaw Services Cloudflare account under its own service so one non-interactive deployment credential covers both hosted Workers.
 
 ## 0.5.11 - 2026-08-29
 

--- a/README.md
+++ b/README.md
@@ -232,8 +232,9 @@ pnpm install
 pnpm check        # format + lint + vitest + types + go test + go vet
 pnpm test         # vitest only
 pnpm test:e2e:cli-worker # compiled CLI → local Workerd/D1/DO → public GitHub
-pnpm run deploy   # authoritative Worker, then octopool.dev proxy Worker
-pnpm e2e          # smoke-test the live deployment
+pnpm run deploy                 # both OpenClaw Services-account Workers
+pnpm run deploy:public-proxy    # octopool.dev proxy Worker only
+pnpm e2e                        # smoke-test the live deployment
 pnpm docs:site    # build the docs site into dist/docs-site
 pnpm sql:generate # regenerate Worker query constants
 pnpm sql:compile  # validate migrations and query types with sqlc

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -131,14 +131,21 @@ octopool stats
 
 ## Cloudflare resources
 
-- Worker `octopool` — entry `src/index.ts`, `nodejs_compat`, observability on.
-- Public-host Worker `octopool` in the personal Cloudflare account (OpenClaw deployment
-  only) — entry `src/openclaw-proxy.ts`, custom-domain proxy for `octopool.dev`.
+The hosted OpenClaw deployment keeps both Workers in the OpenClaw Services account
+(`91b59577e757131d68d55a471fe32aca`):
+
+- Authoritative Worker `octopool` — config `wrangler.jsonc`, entry `src/index.ts`,
+  `nodejs_compat`, observability on, custom domain `octopool.openclaw.ai`.
+- Public-host Worker `octopool-public-proxy` — config `wrangler.public-proxy.jsonc`, entry
+  `src/openclaw-proxy.ts`, custom-domain proxy for `octopool.dev`.
 - Durable Object `PoolCoordinator` (binding `POOL_COORDINATOR`, SQLite-backed,
   migration tag `v1`).
-- D1 database `octopool` (binding `DB`).
-- Custom domain route — `octopool.dev` for OpenClaw; whatever you set in `routes[]` for
-  your own deployment.
+- D1 database `octopool-wnam` (binding `DB`).
+
+Both hosted Worker deploys use the Molty item `OpenClaw Services Cloudflare API Token`;
+the proxy does not use a personal-account Cloudflare credential. The shared
+`OCTOPOOL_PROXY_SECRET` still has to exist on both Workers. Self-hosted deployments use
+whatever account and routes they configure.
 
 ## Configuration
 
@@ -265,8 +272,10 @@ pnpm install
 pnpm check        # format:check + lint + vitest + build + go test + go vet
 pnpm test         # vitest only
 pnpm test:e2e:cli-worker # compiled CLI → local Workerd/D1/DO → public GitHub
-pnpm run deploy   # authoritative Worker, then octopool.dev proxy Worker
-pnpm e2e          # smoke-test the live deployment
+pnpm run deploy                 # authoritative Worker, then public proxy
+pnpm run deploy:authoritative   # authoritative Worker only
+pnpm run deploy:public-proxy    # octopool.dev proxy Worker only
+pnpm e2e                        # smoke-test the live deployment
 ```
 
 `pnpm check` is the deterministic TypeScript + Go gate. The networked release gate
@@ -274,10 +283,13 @@ pnpm e2e          # smoke-test the live deployment
 D1, a real Durable Object, and public GitHub. The Go CLI also builds/tests with
 `go build ./cmd/octopool` and `go test ./...`.
 
-`pnpm run deploy` runs both `wrangler deploy` calls. Self-hosters who don't operate the
-public-host proxy can run `wrangler deploy` directly. Pushing to `main` does **not**
-auto-deploy the Worker — only the docs site has a GitHub Pages workflow. Run
-`wrangler deploy` (or `pnpm run deploy`) whenever Worker code or landing-page CSS needs to
+The hosted deployment runs both commands with `CLOUDFLARE_API_TOKEN` loaded from the
+Molty item `OpenClaw Services Cloudflare API Token`; both Worker configs are pinned to the
+same Services account. Use the config-qualified `deploy:public-proxy` command when proving
+proxy deploy access so Wrangler cannot target the authoritative Worker by accident.
+Self-hosters who don't operate the public-host proxy can run `deploy:authoritative` only.
+Pushing to `main` does **not** auto-deploy the Workers — only the docs site has a GitHub
+Pages workflow. Run `pnpm run deploy` whenever Worker code or landing-page CSS needs to
 ship to production.
 
 ## SQL catalog

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -26,9 +26,14 @@ durable release evidence; signing uses the OpenClaw Foundation Developer ID.
 5. Fleet rollout: `brew update && brew upgrade octopool` on every Mac;
    verify `octopool version` matches and the shim still relays
    (`OCTOPOOL_NO_FALLBACK=1 gh api repos/openclaw/octopool --jq .full_name`).
-6. Worker changes additionally need `pnpm run deploy` (both wrangler configs)
-   from the release commit; R2/D1 bindings must be provisioned first
-   (see docs/cache.md for the actions-logs bucket and its lifecycle rule).
+6. Worker changes additionally need `pnpm run deploy` from the release commit. Load
+   `CLOUDFLARE_API_TOKEN` through the approved 1Password workflow from the Molty item
+   `OpenClaw Services Cloudflare API Token`; both `wrangler.jsonc` (`octopool`) and
+   `wrangler.public-proxy.jsonc` (`octopool-public-proxy`) are pinned to the OpenClaw
+   Services account. Use `pnpm run deploy:public-proxy` for a proxy-only proof. Never
+   substitute a personal-account Cloudflare token. R2/D1 bindings must be provisioned
+   first (see docs/cache.md for the actions-logs bucket and its lifecycle rule), and
+   `OCTOPOOL_PROXY_SECRET` must already exist on both Workers.
 7. Record evidence in openclaw/releases: dispatch
    `openclaw-release-evidence.yml` with `release_id=octopool-X.Y.Z`,
    `package_spec=octopool@X.Y.Z`, and the release workflow run in `runs`.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "wrangler types && tsc --noEmit -p tsconfig.src.json && tsc --noEmit -p tsconfig.test.json",
     "check": "pnpm routes:check && pnpm sql:check && pnpm format:check && pnpm lint && pnpm test && pnpm test:e2e && pnpm build && go test ./... && go vet ./...",
-    "deploy": "wrangler deploy && wrangler deploy --config wrangler.public-proxy.jsonc",
+    "deploy": "pnpm run deploy:authoritative && pnpm run deploy:public-proxy",
+    "deploy:authoritative": "wrangler deploy",
+    "deploy:public-proxy": "wrangler deploy --config wrangler.public-proxy.jsonc",
     "docs:site": "node scripts/build-docs-site.mjs",
     "e2e": "sh test/e2e.sh",
     "format": "oxfmt . --write && gofmt -w $(git ls-files '*.go')",

--- a/wrangler.public-proxy.jsonc
+++ b/wrangler.public-proxy.jsonc
@@ -1,9 +1,10 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
-  "name": "octopool",
-  "account_id": "de09342a728de2c25c85cc6b34d68739",
+  "name": "octopool-public-proxy",
+  "account_id": "91b59577e757131d68d55a471fe32aca",
   "main": "src/openclaw-proxy.ts",
   "compatibility_date": "2026-05-26",
+  "workers_dev": true,
   "observability": {
     "enabled": true,
     "head_sampling_rate": 1,
@@ -11,6 +12,5 @@
   "vars": {
     "OCTOPOOL_ORIGIN": "https://octopool.openclaw.ai",
   },
-  "migrations": [{ "tag": "v2-public-proxy", "deleted_classes": ["PoolCoordinator"] }],
   "routes": [{ "pattern": "octopool.dev", "custom_domain": true }],
 }


### PR DESCRIPTION
## Summary

Move the octopool.dev proxy Worker and zone ownership to OpenClaw Services, give the proxy its own Worker name, split deploy scripts, and update the runbooks and changelog.

## Why

The prior personal-account pin could not be deployed by the non-interactive Services credential.

## Tests

- `pnpm check`
- `pnpm e2e`
