### PR TITLE
docs: remove deployment-only changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## 0.5.17 - Unreleased
 
-### Changes
-
-- Move the `octopool.dev` proxy Worker into the OpenClaw Services Cloudflare account under its own service so one non-interactive deployment credential covers both hosted Workers.
-
 ### Fixes
 
 - Return native uppercase `OPEN`/`CLOSED` states in issue-view/list JSON before `--jq`, preserving lowercase raw `gh api` REST states.


### PR DESCRIPTION
## Summary

Remove an internal Cloudflare deployment migration from the user-facing 0.5.17 notes.

## Tests

- `pnpm format:check`
