### PR TITLE
fix: match native PR list and search JSON states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.18 - Unreleased
+
+### Fixes
+
+- Return native uppercase PR-list lifecycle states and lowercase merged PR-search states from nested merge metadata before `--jq`, preserving raw API and cache payloads.
+
 ## 0.5.17 - 2026-08-30
 
 ### Fixes

--- a/cmd/octopool/gh_top_pr.go
+++ b/cmd/octopool/gh_top_pr.go
@@ -76,12 +76,12 @@ func handleGHPR(ctx context.Context, args []string, stdout io.Writer) ghResult {
 		if !machineReadable(opts) || !supportedJSONFields(opts, supportedPRListFields) {
 			return ghDelegated()
 		}
-		return ghCompleted(relayTop(ctx, stdout, ghAPIRequest{
+		return ghCompleted(relayPRList(ctx, stdout, ghAPIRequest{
 			method:  "GET",
 			path:    repoPath(repo, "pulls"),
 			query:   query,
 			headers: publicShapeHeaders(opts, supportedPublicPRListFields, publicShapePullRequestList),
-		}, opts, fieldMapPR))
+		}, opts))
 	case "diff":
 		repo, number, ok := repoNumber(opts)
 		if !ok || hasTopModifiersExceptPatch(opts) || machineReadable(opts) || opts.jq != "" {
@@ -109,6 +109,40 @@ func handleGHPR(ctx context.Context, args []string, stdout io.Writer) ghResult {
 	default:
 		return ghDelegated()
 	}
+}
+
+func relayPRList(ctx context.Context, stdout io.Writer, request ghAPIRequest, opts ghTopOptions) error {
+	if !safeRelayRequest(request) {
+		return errors.New("internal error: top-level gh command built an unsupported relay request")
+	}
+	client, err := newGHRelayClient()
+	if err != nil {
+		return err
+	}
+	envelope, err := client.do(ctx, request)
+	if err != nil {
+		return err
+	}
+	body, err := envelopeBodyBytes(envelope)
+	if err != nil {
+		return err
+	}
+	var items []map[string]any
+	if err := json.Unmarshal(body, &items); err != nil {
+		return err
+	}
+	for _, pr := range items {
+		normalizePRViewState(pr)
+	}
+	raw, err := json.Marshal(items)
+	if err != nil {
+		return err
+	}
+	filtered, err := filterJSONFields(raw, opts.json, fieldMapPR)
+	if err != nil {
+		return err
+	}
+	return writeBytes(ctx, stdout, filtered, opts.jq)
 }
 
 func relayPRView(ctx context.Context, stdout io.Writer, repo string, number string, opts ghTopOptions) error {

--- a/cmd/octopool/gh_top_pr_list_state_test.go
+++ b/cmd/octopool/gh_top_pr_list_state_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func prListStateFixtures(public bool) ([]map[string]any, []string) {
+	if public {
+		return []map[string]any{
+			{"state": "OPEN", "draft": false},
+			{"state": "CLOSED", "draft": false},
+			{"state": "DRAFT", "draft": true},
+			{"state": "MERGED", "draft": false},
+		}, []string{"OPEN", "CLOSED", "OPEN", "MERGED"}
+	}
+	return []map[string]any{
+		{"state": "open", "draft": false, "merged_at": nil},
+		{"state": "closed", "draft": false, "merged_at": nil},
+		{"state": "closed", "draft": false, "merged_at": prStateTestTime},
+		{"state": "open", "draft": true},
+		{"state": "closed", "draft": true},
+		{"state": "closed", "draft": false, "merged": true},
+		{"state": "DRAFT", "draft": true, "closed_at": prStateTestTime},
+	}, []string{"OPEN", "CLOSED", "MERGED", "OPEN", "CLOSED", "MERGED", "CLOSED"}
+}
+
+func TestRunGHPRListStateProjection(t *testing.T) {
+	for _, test := range []struct {
+		name, fields, shape  string
+		public, empty, fresh bool
+	}{
+		{"public state", "state", "pr-list-v1", true, false, false},
+		{"public expanded", "number,state,isDraft", "pr-list-v1", true, false, false},
+		{"REST public fallback", "state", "pr-list-v1", false, false, false},
+		{"REST forced", "state,headRefOid", "", false, false, false},
+		{"REST expanded", "number,state,headRefOid,isDraft", "", false, false, false},
+		{"state omitted", "number,isDraft", "pr-list-v1", false, false, false},
+		{"fresh state omitted", "number,isDraft", "pr-list-v1", false, false, true},
+		{"empty", "state,headRefOid", "", false, true, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OCTOPOOL_FRESH", "")
+			if test.fresh {
+				t.Setenv("OCTOPOOL_FRESH", "1")
+			}
+			t.Setenv("OCTOPOOL_NO_FALLBACK", "1")
+			items, states := prListStateFixtures(test.public)
+			if test.empty {
+				items, states = []map[string]any{}, []string{}
+			}
+			want := make([]map[string]any, 0, len(items))
+			for i, item := range items {
+				item["number"] = float64(i + 1)
+				if !test.public {
+					item["head"] = map[string]any{"sha": prStateTestHead}
+				}
+				all := map[string]any{"number": float64(i + 1), "state": states[i], "headRefOid": prStateTestHead, "isDraft": item["draft"]}
+				row := map[string]any{}
+				for _, field := range strings.Split(test.fields, ",") {
+					row[field] = all[field]
+				}
+				want = append(want, row)
+			}
+			before, _ := json.Marshal(items)
+			calls := 0
+			relayTestServer(t, func(request map[string]any) any {
+				calls++
+				headers := map[string]any{}
+				if test.shape != "" {
+					headers["x-octopool-public-shape"] = test.shape
+				}
+				if strings.Contains(test.fields, "state") || test.fresh {
+					headers["cache-control"] = "max-age=0"
+				}
+				wantRequest := map[string]any{
+					"pool": "maintainers", "method": "GET", "path": "/repos/openclaw/octopool/pulls",
+					"query": map[string]any{"state": "all", "per_page": "20"}, "headers": headers,
+				}
+				if !reflect.DeepEqual(request, wantRequest) {
+					t.Errorf("request = %#v, want %#v", request, wantRequest)
+				}
+				return items
+			})
+			capture := captureRewriteGH(t)
+			var out, stderr bytes.Buffer
+			if err := runGH(t.Context(), []string{"pr", "list", "-R", "openclaw/octopool", "--state", "all", "--limit", "20", "--json", test.fields}, &out, &stderr); err != nil {
+				t.Fatalf("runGH: %v, stderr=%q", err, stderr.String())
+			}
+			var got []map[string]any
+			if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("projection = %#v, want %#v", got, want)
+			}
+			after, _ := json.Marshal(items)
+			if !bytes.Equal(before, after) || calls != 1 {
+				t.Errorf("source changed or extra requests: before=%s after=%s calls=%d", before, after, calls)
+			}
+			if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Error("unexpected native fallback")
+			}
+		})
+	}
+}
+
+func TestRunGHPRListStateDelegation(t *testing.T) {
+	for _, test := range []struct{ state, fields string }{
+		{"closed", "state,headRefOid"}, {"merged", "state,headRefOid"},
+		{"all", "state,mergeable"}, {"all", "state,comments"}, {"all", "state,merged"},
+		{"all", "state,mergeStateStatus"},
+	} {
+		t.Run(test.state+"/"+test.fields, func(t *testing.T) {
+			emptyRewriteTestServer(t)
+			t.Setenv("OCTOPOOL_NO_FALLBACK", "")
+			capture := captureRewriteGH(t)
+			args := []string{"pr", "list", "-R", "openclaw/octopool", "--state", test.state, "--json", test.fields}
+			var out, stderr bytes.Buffer
+			if err := runGH(t.Context(), args, &out, &stderr); err != nil {
+				t.Fatal(err)
+			}
+			if got := readRewriteCapture(t, capture); !reflect.DeepEqual(got.Args, args) || out.String() != "child stdout\n" {
+				t.Errorf("delegation: args=%v output=%q", got.Args, out.String())
+			}
+		})
+	}
+}

--- a/cmd/octopool/gh_top_search.go
+++ b/cmd/octopool/gh_top_search.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 var allowedSearchTerm = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
@@ -167,6 +168,17 @@ func relayGitHubSearch(
 		return err
 	}
 	items, _ := response["items"].([]any)
+	for _, item := range items {
+		issue, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		// Native search derives lowercase merged only from nested PR metadata.
+		mergedAt, err := time.Parse(time.RFC3339, nestedStringValue(issue, "pull_request", "merged_at"))
+		if err == nil && !mergedAt.IsZero() {
+			issue["state"] = "merged"
+		}
+	}
 	raw, err := json.Marshal(items)
 	if err != nil {
 		return err

--- a/cmd/octopool/gh_top_search_state_test.go
+++ b/cmd/octopool/gh_top_search_state_test.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestRunGHSearchStateProjection(t *testing.T) {
+	for _, test := range []struct {
+		name, kind, want string
+		item             map[string]any
+	}{
+		{"open PR", "prs", "open", map[string]any{"state": "open", "pull_request": map[string]any{}}},
+		{"closed PR", "prs", "closed", map[string]any{"state": "closed", "pull_request": map[string]any{}}},
+		{"merged PR", "prs", "merged", map[string]any{"state": "closed", "pull_request": map[string]any{"merged_at": prStateTestTime}}},
+		{"null merge", "prs", "closed", map[string]any{"state": "closed", "pull_request": map[string]any{"merged_at": nil}}},
+		{"empty merge", "prs", "closed", map[string]any{"state": "closed", "pull_request": map[string]any{"merged_at": ""}}},
+		{"zero merge", "prs", "closed", map[string]any{"state": "closed", "pull_request": map[string]any{"merged_at": "0001-01-01T00:00:00Z"}}},
+		{"closed draft", "prs", "closed", map[string]any{"state": "closed", "draft": true, "isDraft": true}},
+		{"top-level merge only", "prs", "closed", map[string]any{"state": "closed", "merged_at": prStateTestTime}},
+		{"passed-through state", "prs", "MERGED", map[string]any{"state": "MERGED"}},
+		{"open issue", "issues", "open", map[string]any{"state": "open"}},
+		{"closed issue", "issues", "closed", map[string]any{"state": "closed"}},
+		{"shared search export", "issues", "merged", map[string]any{"state": "closed", "pull_request": map[string]any{"merged_at": prStateTestTime}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OCTOPOOL_FRESH", "")
+			t.Setenv("OCTOPOOL_NO_FALLBACK", "1")
+			before, _ := json.Marshal(test.item)
+			calls := 0
+			relayTestServer(t, func(request map[string]any) any {
+				calls++
+				kind := "pr"
+				if test.kind == "issues" {
+					kind = "issue"
+				}
+				want := map[string]any{
+					"pool": "maintainers", "method": "GET", "path": "/search/issues",
+					"query":   map[string]any{"q": "repo:openclaw/octopool type:" + kind + " cache", "per_page": "20"},
+					"headers": map[string]any{"x-octopool-public-shape": "issue-search-v1"},
+				}
+				if !reflect.DeepEqual(request, want) {
+					t.Errorf("request = %#v, want %#v", request, want)
+				}
+				return map[string]any{"items": []any{test.item}}
+			})
+			capture := captureRewriteGH(t)
+			var out, stderr bytes.Buffer
+			if err := runGH(t.Context(), []string{"search", test.kind, "cache", "-R", "openclaw/octopool", "--limit", "20", "--json", "state"}, &out, &stderr); err != nil {
+				t.Fatalf("runGH: %v, stderr=%q", err, stderr.String())
+			}
+			if want := "[{\"state\":\"" + test.want + "\"}]\n"; out.String() != want {
+				t.Errorf("projection = %q, want %q", out.String(), want)
+			}
+			after, _ := json.Marshal(test.item)
+			if !bytes.Equal(before, after) || calls != 1 {
+				t.Errorf("source changed or extra requests: before=%s after=%s calls=%d", before, after, calls)
+			}
+			if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Error("unexpected native fallback")
+			}
+		})
+	}
+}
+
+func TestRunGHListAndSearchStateBeforeJQ(t *testing.T) {
+	if !jqAvailable() {
+		t.Skip("jq is not installed")
+	}
+	for _, test := range []struct {
+		name, fields, expression string
+		args                     []string
+		body                     any
+	}{
+		{"list REST", "state,headRefOid", `.[0] | .state == "MERGED" and keys == ["headRefOid", "state"]`, []string{"pr", "list", "--state", "all"}, []any{map[string]any{"state": "closed", "head": map[string]any{"sha": prStateTestHead}, "merged_at": prStateTestTime}}},
+		{"list page", "state,isDraft", `.[0] | .state == "OPEN" and .isDraft == true and keys == ["isDraft", "state"]`, []string{"pr", "list", "--state", "all"}, []any{map[string]any{"state": "DRAFT", "draft": true}}},
+		{"list state omitted", "number", `.[0] | keys == ["number"]`, []string{"pr", "list", "--state", "all"}, []any{map[string]any{"number": 1, "state": "closed", "merged_at": prStateTestTime}}},
+		{"search merged", "state", `.[0] | .state == "merged" and keys == ["state"]`, []string{"search", "prs", "cache"}, map[string]any{"items": []any{map[string]any{"state": "closed", "pull_request": map[string]any{"merged_at": prStateTestTime}}}}},
+		{"search state omitted", "number", `.[0] | keys == ["number"]`, []string{"search", "prs", "cache"}, map[string]any{"items": []any{map[string]any{"number": 1, "state": "closed", "pull_request": map[string]any{"merged_at": prStateTestTime}}}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OCTOPOOL_NO_FALLBACK", "1")
+			calls := 0
+			relayTestServer(t, func(request map[string]any) any { calls++; return test.body })
+			capture := captureRewriteGH(t)
+			args := append(test.args, "-R", "openclaw/octopool", "--json", test.fields, "--jq", test.expression)
+			var out, stderr bytes.Buffer
+			if err := runGH(t.Context(), args, &out, &stderr); err != nil || out.String() != "true\n" || calls != 1 {
+				t.Errorf("err=%v output=%q stderr=%q calls=%d", err, out.String(), stderr.String(), calls)
+			}
+			if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Error("unexpected native fallback")
+			}
+		})
+	}
+}
+
+func TestRunGHListAndSearchStatePreservesRawAPI(t *testing.T) {
+	t.Setenv("OCTOPOOL_NO_FALLBACK", "1")
+	t.Setenv("OCTOPOOL_FRESH", "")
+	pr := map[string]any{"number": float64(1), "state": "closed", "merged_at": prStateTestTime, "draft": false}
+	search := map[string]any{"items": []any{map[string]any{"number": float64(1), "state": "closed", "pull_request": map[string]any{"merged_at": prStateTestTime}}}}
+	pulls := []any{pr}
+	fixtures := map[string]any{"/repos/openclaw/octopool/pulls": pulls, "/repos/openclaw/octopool/pulls/1": pr, "/search/issues": search}
+	before, _ := json.Marshal(fixtures)
+	calls := 0
+	relayTestServer(t, func(request map[string]any) any {
+		calls++
+		fixture, ok := fixtures[request["path"].(string)]
+		if !ok {
+			t.Errorf("unexpected request: %#v", request)
+		}
+		return fixture
+	})
+	capture := captureRewriteGH(t)
+	for _, args := range [][]string{
+		{"pr", "list", "-R", "openclaw/octopool", "--state", "all", "--json", "state"},
+		{"search", "prs", "cache", "-R", "openclaw/octopool", "--json", "state"},
+		{"search", "prs", "cache", "-R", "openclaw/octopool", "--json", "number"},
+	} {
+		var out, stderr bytes.Buffer
+		if err := runGH(t.Context(), args, &out, &stderr); err != nil {
+			t.Fatal(err)
+		}
+		want := "[{\"state\":\"MERGED\"}]\n"
+		if args[0] == "search" {
+			want = "[{\"state\":\"merged\"}]\n"
+			if args[len(args)-1] == "number" {
+				want = "[{\"number\":1}]\n"
+			}
+		}
+		if out.String() != want {
+			t.Errorf("args=%v output=%q, want %q", args, out.String(), want)
+		}
+	}
+	for path, want := range fixtures {
+		args := []string{"api", strings.TrimPrefix(path, "/")}
+		if path == "/search/issues" {
+			args[1] += "?q=repo:openclaw/octopool+type:pr+cache"
+		}
+		var out, stderr bytes.Buffer
+		if err := runGH(t.Context(), args, &out, &stderr); err != nil {
+			t.Fatal(err)
+		}
+		var got any
+		if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("raw %s = %#v, want %#v", path, got, want)
+		}
+	}
+	after, _ := json.Marshal(fixtures)
+	if !bytes.Equal(before, after) || calls != 6 {
+		t.Errorf("source changed or extra requests: before=%s after=%s calls=%d", before, after, calls)
+	}
+	if _, err := os.Stat(capture); !os.IsNotExist(err) {
+		t.Error("unexpected native fallback")
+	}
+}
+
+func TestRunGHListAndSearchStateProtection(t *testing.T) {
+	for _, command := range []struct {
+		name, output string
+		args         []string
+		body         any
+	}{
+		{"list", "[{\"state\":\"MERGED\"}]\n", []string{"pr", "list", "--state", "all"}, []any{map[string]any{"state": "closed", "merged_at": prStateTestTime}}},
+		{"search", "[{\"state\":\"merged\"}]\n", []string{"search", "prs", "cache"}, map[string]any{"items": []any{map[string]any{"state": "closed", "pull_request": map[string]any{"merged_at": prStateTestTime}}}}},
+	} {
+		for _, mode := range []string{"allowed", "auth failure", "policy denial"} {
+			t.Run(command.name+"/"+mode, func(t *testing.T) {
+				t.Setenv("OCTOPOOL_NO_FALLBACK", "")
+				policy := rewriteActiveTestPolicy
+				if mode == "policy denial" {
+					policy = strings.ReplaceAll(policy, "internal-model", "octopool")
+				}
+				calls := 0
+				_, policyCalls := rewriteTestServer(t, policy, func(w http.ResponseWriter, r *http.Request) {
+					calls++
+					if mode == "auth failure" {
+						w.WriteHeader(http.StatusUnauthorized)
+						_, _ = w.Write([]byte(`{"error":{"code":"invalid_auth","message":"expired"}}`))
+						return
+					}
+					writeCLIEnvelope(t, w, command.body)
+				})
+				capture := captureRewriteGH(t)
+				args := append(command.args, "-R", "openclaw/octopool", "--json", "state")
+				var out, stderr bytes.Buffer
+				err := runGH(t.Context(), args, &out, &stderr)
+				wantCalls := 1
+				if mode == "policy denial" {
+					wantCalls = 0
+				}
+				if (err == nil) != (mode == "allowed") || calls != wantCalls || policyCalls.Load() == 0 {
+					t.Errorf("err=%v relays=%d policies=%d", err, calls, policyCalls.Load())
+				}
+				if mode == "allowed" && out.String() != command.output || mode != "allowed" && out.Len() != 0 {
+					t.Errorf("output=%q", out.String())
+				}
+				if _, err := os.Stat(capture); !os.IsNotExist(err) {
+					t.Error("unexpected native fallback")
+				}
+			})
+		}
+	}
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -192,11 +192,17 @@ human-format reads. Supported `--json` fields are intentionally conservative. Co
 `gh` field names are mapped where the REST API uses different
 names, such as `url`, `author`, `headRefName`, `headRefOid`, `baseRefName`,
 `baseRefOid`, `isDraft`, `databaseId`, `workflowName`, and `nameWithOwner`.
-`gh pr view --json state` returns the GraphQL lifecycle `OPEN`, `CLOSED`, or `MERGED`
-regardless of the other requested fields or whether the relay uses a public page or REST.
+`gh pr view --json state` and `gh pr list --json state` return the GraphQL lifecycle
+`OPEN`, `CLOSED`, or `MERGED` regardless of the other requested fields or whether the relay
+uses a public page or REST.
 Draft status is separate: an open draft has `state: "OPEN"` and `isDraft: true` when
-requested. This conversion happens before field filtering and `--jq`; raw `gh api` REST
-states, PR search states, and human-format `DRAFT` display remain unchanged.
+requested. This conversion happens before field filtering and `--jq`, without changing
+cached payloads, raw `gh api` REST states, or human-format `DRAFT` display.
+`gh search prs --json state` and `gh search issues --json state` retain native lowercase
+`open`/`closed` states and return `merged` when the result has a nonzero nested
+`pull_request.merged_at` timestamp. Top-level `merged_at` and draft status do not change
+search state. Search conversion also precedes field filtering and `--jq` and leaves raw
+`gh api /search/issues` responses and cached payloads unchanged.
 `gh issue view --json state` and `gh issue list --json state` return native `OPEN` or
 `CLOSED` values across supported field subsets, including REST and public-page/cache
 payloads. This conversion happens before field filtering and `--jq`, without changing


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where scripts consuming `gh pr list --json state` received lowercase REST states, including `closed` for merged pull requests, when the selected fields required REST. PR search also returned `closed` instead of native `gh`'s lowercase `merged` despite nested merge metadata.

## Why This Change Was Made

PR-list JSON now reuses the existing PR lifecycle normalizer before field filtering and `--jq`. Search separately follows native `gh`'s search export contract: a nonzero nested `pull_request.merged_at` produces lowercase `merged`; other states pass through.

Both conversions operate only on decoded CLI output copies. Protected routing, policy/auth checks, fallback decisions, source/cache payloads, raw `gh api`, and the existing issue-view/list repair are unchanged. Existing PR-list `closed`/`merged` filter delegation is preserved.

## User Impact

PR view/list lifecycle JSON consistently uses `OPEN`, `CLOSED`, or `MERGED`, with draft status kept separate. Search retains lowercase `open`/`closed` and correctly identifies merged PRs. Documentation and the unreleased changelog describe the command-specific contracts.

## Evidence

All three original synthetic reproductions failed before the fix and passed afterward through `runGH` and loopback policy/relay fixtures. New regressions cover REST/public-page payloads, draft and merged states, field subsets, `--jq`, raw API preservation, unsupported-field/filter delegation, and active-policy/auth failure boundaries.

- New regression tests verified red before production changes and green afterward.
- Existing PR/issue state, mergeable, search, and human-output tests passed.
- Protected routing/policy/auth/fallback regression selections passed before and after.
- `go test ./...`, `go vet ./...`, Go formatting, and `git diff --check` passed.

No live-service changes, installs, deployments, or releases are part of this PR.
