### PR TITLE
fix: keep Worker E2E setup isolated after storage eviction

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -292,6 +292,64 @@ Pushing to `main` does **not** auto-deploy the Workers — only the docs site ha
 Pages workflow. Run `pnpm run deploy` whenever Worker code or landing-page CSS needs to
 ship to production.
 
+### Worker integration test isolation
+
+`pnpm test:e2e` runs real Workerd storage with a test-owned lifecycle in
+`test/e2e/setup.ts`. Each isolated file applies the actual migrations once in
+`beforeAll`, verifies that D1 was pristine, and captures an immutable migrated
+baseline. The original 10-second hook deadline, 15-second test deadline and default
+file parallelism remain in effect; migration initialization still has to finish
+within its hook deadline.
+
+Before each test, D1 restoration discovers the **current** application schema and
+foreign-key dependencies, removes views/triggers and child tables before parent
+tables, then replays the baseline in one atomic batch. This covers renamed or
+dropped tables and unexpected schema objects as well as rows. The ordinary path
+uses three D1 requests: schema discovery, batched foreign-key discovery, and the
+atomic teardown/replay. SQLite/Cloudflare internals are preserved; the export
+restores application AUTOINCREMENT sequences, migration records and the original
+string-policy seed timestamp. Unsupported foreign-key cycles (including self
+references), virtual tables and SQLite statistics tables fail explicitly before
+destructive restoration.
+
+`test/e2e/d1-baseline.ts` isolates a version-specific local runtime contract:
+Miniflare `5.20260804.0-alpha` implements
+`PRAGMA miniflare_d1_export(?,?,?);`, also used by Wrangler `4.120.1`. The D1 binding
+accepts numeric flags `bind(0, 0)` for schema plus data with no table filter. Its
+single result row is an array of **complete SQL statements**, which the adapter
+validates and submits individually through `D1.batch`. It must never be joined
+and fed to newline-splitting `D1.exec`, replaced by `D1.dump`, or used as a
+production API. Dependency updates must revalidate this export/replay contract.
+
+Storage cleanup owns the configured `POOL_COORDINATOR`, `ACTIONS_LOGS` and native
+Cache API writes. It enumerates persisted coordinator IDs, including dormant
+objects, deletes their alarms and storage inside each real object, then evicts
+each instance so the constructor recreates SQL and discards memory/timers/waiters.
+R2 cleanup lists every page and deletes at most 1,000 keys per call. The Cache API
+ledger forwards default/named cache operations to the native implementations,
+waits for owned puts, and deletes their recorded keys. It only owns writes made
+through that ledger; it cannot purge arbitrary untracked cache entries. Tests
+that explicitly provide mock caches retain their own cache semantics.
+
+The harness tracks requests and scheduled calls, draining their execution
+contexts even when handlers throw. `callWorker` retains its cold-config-cache
+behavior; `callWarmWorker` explicitly preserves a warm isolate. Concurrency tests
+register gate releases with `ownedWork` and also release/drain in `finally`.
+After each test, gates are released and requests, contexts and cache writes drain
+**before** mocks/globals are restored. A failed cleanup or timed-out hook/body
+poisons the file lifecycle: subsequent test bodies fail rather than racing the
+old promise. The deadline watchdog does not cancel Workerd operations or extend
+Vitest's timeouts. Test code must register owned async work and release gates;
+arbitrary untracked timers/writes are outside this lifecycle's ownership.
+
+The lifecycle never calls the native global storage `reset()`. The regression uses
+the official global `abortAllDurableObjects()` to reproduce a dormant internal D1
+actor; natural 11-second idle independently reproduces the same retained-storage
+failure in the pinned runtime. `evictAllDurableObjects()` only reaches the current
+Worker's explicit Durable Object bindings and does **not** establish D1 dormancy
+through its service binding. Per-stub eviction remains appropriate for testing
+the coordinator's constructor and storage cleanup.
+
 ## SQL catalog
 
 Runtime SQL lives in `sql/queries/*.sql` with sqlc annotations. `sqlc.yaml` points sqlc at

--- a/test/e2e-isolation.test.ts
+++ b/test/e2e-isolation.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  captureD1Baseline,
+  childFirstTables,
+  restoreD1Baseline,
+  validateD1Export,
+} from "./e2e/d1-baseline";
+import { IsolationLifecycle } from "./e2e/lifecycle";
+import { OwnedWork } from "./e2e/owned-work";
+
+vi.mock("cloudflare:test", () => ({ applyD1Migrations: vi.fn() }));
+afterEach(() => vi.useRealTimers());
+
+describe("D1 baseline contract", () => {
+  it("rejects SQLite statistics before export or destructive restore", async () => {
+    const batch = vi.fn();
+    const db = {
+      prepare: () => ({
+        all: async () => ({
+          results: [
+            { name: "sqlite_stat1", type: "table", sql: "CREATE TABLE sqlite_stat1(tbl,idx,stat)" },
+          ],
+        }),
+      }),
+      batch,
+    } as unknown as D1Database;
+    await expect(captureD1Baseline(db)).rejects.toThrow(
+      "does not support SQLite statistics tables",
+    );
+    await expect(restoreD1Baseline(db, [])).rejects.toThrow(
+      "does not support SQLite statistics tables",
+    );
+    expect(batch).not.toHaveBeenCalled();
+  });
+  it("orders a child created before its mixed-case FK target first", () => {
+    expect(
+      childFirstTables(
+        new Map([
+          ['child"table', ["PARENT"]],
+          ["parent", []],
+        ]),
+      ),
+    ).toEqual(['child"table', "parent"]);
+  });
+
+  it.each([
+    new Map([
+      ["a", ["b"]],
+      ["b", ["A"]],
+    ]),
+    new Map([["self", ["SELF"]]]),
+  ])("rejects cycles before any destructive batch", (graph) => {
+    expect(() => childFirstTables(graph)).toThrow("foreign-key cycles");
+  });
+
+  it("keeps complete multiline statements immutable", () => {
+    const statements = [
+      "PRAGMA defer_foreign_keys=TRUE;",
+      "CREATE TABLE multiline (\n value TEXT\n);",
+      "INSERT INTO multiline VALUES ('first\nsecond');",
+    ];
+    const baseline = validateD1Export([statements]);
+    statements.pop();
+    expect(baseline).toHaveLength(3);
+    expect(baseline[2]).toContain("first\nsecond");
+    expect(Object.isFrozen(baseline)).toBe(true);
+  });
+
+  it.each(
+    [
+      null,
+      [],
+      [[]],
+      [["CREATE TABLE unexpected (id);"]],
+      [["PRAGMA defer_foreign_keys=TRUE;", null]],
+      [["PRAGMA defer_foreign_keys=TRUE;", "CREATE VIRTUAL TABLE unsupported;"]],
+      [["PRAGMA defer_foreign_keys=TRUE;", "ANALYZE sqlite_schema;"]],
+      [["PRAGMA defer_foreign_keys=TRUE;", "PRAGMA foreign_keys=OFF;"]],
+      [["PRAGMA defer_foreign_keys=TRUE;", "CREATE TABLE incomplete (id)"]],
+    ].map((rows) => ({ rows })),
+  )("rejects unsupported export shape %#", ({ rows }) => {
+    expect(() => validateD1Export(rows)).toThrow("Unsupported Miniflare D1 export");
+  });
+});
+
+describe("test-owned work and hook lifecycle", () => {
+  it("releases gates and drains nested work before allowing cleanup", async () => {
+    const work = new OwnedWork();
+    const { promise } = work.gate();
+    const events: string[] = [];
+    work.track(
+      promise.then(() => {
+        events.push("request");
+        work.track(
+          Promise.resolve().then(() => {
+            events.push("background write");
+          }),
+        );
+      }),
+    );
+    await work.finish();
+    events.push("storage cleanup");
+    expect(events).toEqual(["request", "background write", "storage cleanup"]);
+    work.start();
+  });
+
+  it("releases a gate registered by a late request during teardown", async () => {
+    const work = new OwnedWork();
+    const first = work.gate();
+    work.track(
+      first.promise.then(async () => {
+        await work.gate().promise;
+      }),
+    );
+    await work.finish();
+    work.start();
+  });
+
+  it("preserves caller rejections and reports abandoned errors during drain", async () => {
+    const work = new OwnedWork();
+    const error = new Error("background failed");
+    await expect(work.track(Promise.reject(error))).rejects.toBe(error);
+    await expect(work.finish()).rejects.toBe(error);
+  });
+
+  it("fails closed after a deadline while the original setup is still running", async () => {
+    vi.useFakeTimers();
+    const lifecycle = new IsolationLifecycle(10_000);
+    const deferred = Promise.withResolvers<void>();
+    const setup = lifecycle.run(() => deferred.promise);
+    const rejection = expect(setup).rejects.toThrow("isolation is poisoned");
+    await vi.advanceTimersByTimeAsync(10_000);
+    const nextBody = vi.fn(async () => {});
+    await expect(lifecycle.run(nextBody)).rejects.toThrow("isolation is poisoned");
+    const cleanup = vi.fn(async () => {});
+    await expect(lifecycle.run(cleanup, true)).rejects.toThrow("isolation is poisoned");
+    expect(nextBody).not.toHaveBeenCalled();
+    expect(cleanup).not.toHaveBeenCalled();
+    deferred.resolve();
+    await rejection;
+    await expect(lifecycle.run(nextBody)).rejects.toThrow("isolation is poisoned");
+  });
+
+  it("detects a missed deadline even if work settles before the timer fires", async () => {
+    vi.useFakeTimers();
+    const lifecycle = new IsolationLifecycle(10_000);
+    await expect(
+      lifecycle.run(async () => {
+        vi.setSystemTime(Date.now() + 10_001);
+      }),
+    ).rejects.toThrow("isolation is poisoned");
+  });
+
+  it("does not restore mocks after failed drain or admit another body", async () => {
+    const lifecycle = new IsolationLifecycle(10_000);
+    const work = new OwnedWork();
+    const error = new Error("late write failed");
+    await expect(work.track(Promise.reject(error))).rejects.toBe(error);
+    const restoreMocks = vi.fn();
+    await expect(
+      lifecycle.run(async () => {
+        await work.finish();
+        restoreMocks();
+      }, true),
+    ).rejects.toBe(error);
+    expect(restoreMocks).not.toHaveBeenCalled();
+    await expect(lifecycle.run(async () => {})).rejects.toThrow("isolation is poisoned");
+  });
+
+  it("allows owned teardown after a timed-out body, while keeping the file poisoned", async () => {
+    const lifecycle = new IsolationLifecycle(10_000);
+    const work = new OwnedWork();
+    const gate = work.gate();
+    const completed = vi.fn();
+    work.track(gate.promise.then(completed));
+    lifecycle.poison(new Error("body timed out"));
+    await expect(lifecycle.run(() => work.finish(), true)).rejects.toThrow("isolation is poisoned");
+    expect(completed).toHaveBeenCalledOnce();
+    await expect(lifecycle.run(async () => {})).rejects.toThrow("isolation is poisoned");
+  });
+});

--- a/test/e2e/actions-cache-terminal-log.test.ts
+++ b/test/e2e/actions-cache-terminal-log.test.ts
@@ -1,6 +1,5 @@
 import { env } from "cloudflare:workers";
 import { withGitHubEgress } from "../../src/github-egress";
-import { createExecutionContext } from "cloudflare:test";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { githubCacheKey, readGitHubCache, writeGitHubCache } from "../../src/cache";
 import { deleteEdgeJSON } from "../../src/edge-cache";
@@ -11,7 +10,7 @@ import {
   terminalLogRunCompleted,
 } from "../../src/terminal-log-cache";
 import type { RelayRequest } from "../../src/types";
-import { bearer, jsonResponse, rateHeaders, relay, seedPool } from "./harness";
+import { bearer, jsonResponse, rateHeaders, relay, seedPool, runWithContext } from "./harness";
 
 type RelayEnvelope = {
   status: number;
@@ -140,12 +139,14 @@ describe("terminal Actions log cache", () => {
     );
 
     await expect(
-      terminalLogRunCompleted(
-        withGitHubEgress(env, []),
-        createExecutionContext(),
-        request,
-        classifyRoute(request, policy),
-        policy,
+      runWithContext((ctx) =>
+        terminalLogRunCompleted(
+          withGitHubEgress(env, []),
+          ctx,
+          request,
+          classifyRoute(request, policy),
+          policy,
+        ),
       ),
     ).resolves.toBe(false);
     expect(
@@ -201,12 +202,8 @@ describe("terminal Actions log cache", () => {
         policy,
       );
 
-      const proof = await terminalLogCacheProof(
-        withGitHubEgress(env, []),
-        createExecutionContext(),
-        logRequest,
-        logRoute,
-        policy,
+      const proof = await runWithContext((ctx) =>
+        terminalLogCacheProof(withGitHubEgress(env, []), ctx, logRequest, logRoute, policy),
       );
       expect(proof).toEqual(
         cacheable ? { key: terminalLogCacheKey(logRequest, runAttempt) } : undefined,

--- a/test/e2e/actions-ownership-cache.test.ts
+++ b/test/e2e/actions-ownership-cache.test.ts
@@ -8,6 +8,7 @@ import { runListSupersetView } from "../../src/run-list-superset";
 import { legacyActionsKey } from "../fixtures/actions-legacy-cache";
 import { exactRun, historicalHead, runIDs, wrongPatchHead } from "../fixtures/actions-ownership";
 import { jsonResponse, rateHeaders, relay, seedPool } from "./harness";
+import { ownedWork } from "./owned-work";
 
 const headers = { "x-octopool-public-shape": "actions-summary-v1" };
 const path = `/repos/openclaw/Peekaboo/actions/runs/${runIDs[0]}`;
@@ -56,11 +57,8 @@ describe("Actions ownership cache migration", () => {
   it("coalesces a clean fill, revalidates only its new key, and serves only clean stale data", async () => {
     const { request, oldKey, body, route } = await seedLegacy(path);
     await expire(oldKey);
-    let release!: () => void;
     let started!: () => void;
-    const gate = new Promise<void>((resolve) => {
-      release = resolve;
-    });
+    const { promise: gate, release } = ownedWork.gate();
     const entered = new Promise<void>((resolve) => {
       started = resolve;
     });
@@ -89,17 +87,24 @@ describe("Actions ownership cache migration", () => {
       }),
     );
     const leader = relay(path, undefined, request);
-    await entered;
-    const follower = relay(path, undefined, request);
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    release();
-    const filled = await Promise.all(
-      [leader, follower].map(async (response) => (await response).json<Envelope>()),
-    );
-    expect(filled.map((item) => item.body)).toEqual([body, body]);
-    expect(filled[1]?.relay.coalesced).toBe(true);
-    expect(apiCalls).toBe(1);
-    expect(conditionals).toEqual([null]);
+    const requests = [leader];
+    try {
+      await entered;
+      const follower = relay(path, undefined, request);
+      requests.push(follower);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      release();
+      const filled = await Promise.all(
+        [leader, follower].map(async (response) => (await response).json<Envelope>()),
+      );
+      expect(filled.map((item) => item.body)).toEqual([body, body]);
+      expect(filled[1]?.relay.coalesced).toBe(true);
+      expect(apiCalls).toBe(1);
+      expect(conditionals).toEqual([null]);
+    } finally {
+      release();
+      await Promise.allSettled(requests);
+    }
 
     const newKey = await githubCacheKey(request.pool, request, route);
     expect(newKey).not.toBe(oldKey);

--- a/test/e2e/cache-fill-behavior.test.ts
+++ b/test/e2e/cache-fill-behavior.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { bearer, jsonResponse, relay, seedPool } from "./harness";
+import { ownedWork } from "./owned-work";
 
 const PATH = "/repos/openclaw/octopool/pulls/42";
 const OPTIONS = { headers: { accept: "application/vnd.github.diff" } };
@@ -39,21 +40,30 @@ describe("Worker end-to-end cache-fill outcomes", () => {
     vi.stubGlobal("fetch", upstream.fetch);
 
     const leader = relay(PATH, undefined, OPTIONS);
-    await upstream.started;
-    const follower = relay(PATH, undefined, OPTIONS);
-    await cache.waitForGitHubMatches(3);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    upstream.release();
-    const followerResponse = await Promise.race([
-      follower,
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("follower stayed blocked")), 2_000),
-      ),
-    ]);
-    await leader.catch(() => undefined);
+    const requests = [leader];
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await upstream.started;
+      const follower = relay(PATH, undefined, OPTIONS);
+      requests.push(follower);
+      await cache.waitForGitHubMatches(3);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      upstream.release();
+      const followerResponse = await Promise.race([
+        follower,
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(() => reject(new Error("follower stayed blocked")), 2_000);
+        }),
+      ]);
+      await leader.catch(() => undefined);
 
-    expect(followerResponse.status).toBe(200);
-    expect(upstream.calls()).toBe(2);
+      expect(followerResponse.status).toBe(200);
+      expect(upstream.calls()).toBe(2);
+    } finally {
+      clearTimeout(timeout);
+      upstream.release();
+      await Promise.allSettled(requests);
+    }
   });
 
   it("keeps upstream work beyond the old eight-second lease exclusively owned", async () => {
@@ -64,17 +74,24 @@ describe("Worker end-to-end cache-fill outcomes", () => {
     vi.stubGlobal("fetch", upstream.fetch);
 
     const leader = relay(PATH, undefined, OPTIONS);
-    await upstream.started;
-    const follower = relay(PATH, undefined, OPTIONS);
-    await cache.waitForGitHubMatches(3);
-    await new Promise((resolve) => setTimeout(resolve, 8_500));
+    const requests = [leader];
+    try {
+      await upstream.started;
+      const follower = relay(PATH, undefined, OPTIONS);
+      requests.push(follower);
+      await cache.waitForGitHubMatches(3);
+      await new Promise((resolve) => setTimeout(resolve, 8_500));
 
-    expect(upstream.calls()).toBe(1);
-    expect(upstream.maxConcurrent()).toBe(1);
-    upstream.release();
-    const responses = await Promise.all([leader, follower]);
-    expect(responses.map(({ status }) => status)).toEqual([200, 200]);
-    expect(upstream.calls()).toBe(1);
+      expect(upstream.calls()).toBe(1);
+      expect(upstream.maxConcurrent()).toBe(1);
+      upstream.release();
+      const responses = await Promise.all([leader, follower]);
+      expect(responses.map(({ status }) => status)).toEqual([200, 200]);
+      expect(upstream.calls()).toBe(1);
+    } finally {
+      upstream.release();
+      await Promise.allSettled(requests);
+    }
   }, 15_000);
 });
 
@@ -86,23 +103,27 @@ async function concurrentFill(body: string, githubEntriesVisible: boolean) {
   vi.stubGlobal("fetch", upstream.fetch);
 
   const leader = relay(PATH, undefined, OPTIONS);
-  await upstream.started;
-  const follower = relay(PATH, undefined, OPTIONS);
-  await cache.waitForGitHubMatches(3);
-  await new Promise((resolve) => setTimeout(resolve, 0));
-  upstream.release();
-  return { responses: await Promise.all([leader, follower]), upstream };
+  const requests = [leader];
+  try {
+    await upstream.started;
+    const follower = relay(PATH, undefined, OPTIONS);
+    requests.push(follower);
+    await cache.waitForGitHubMatches(3);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    upstream.release();
+    return { responses: await Promise.all(requests), upstream };
+  } finally {
+    upstream.release();
+    await Promise.allSettled(requests);
+  }
 }
 
 function gatedDiffUpstream(body: string, options: { failFirst?: boolean } = {}) {
   let active = 0;
   let maximum = 0;
   let count = 0;
-  let release!: () => void;
   let markStarted!: () => void;
-  const gate = new Promise<void>((resolve) => {
-    release = resolve;
-  });
+  const { promise: gate, release } = ownedWork.gate();
   const started = new Promise<void>((resolve) => {
     markStarted = resolve;
   });
@@ -163,10 +184,20 @@ function edgeCache(githubEntriesVisible: boolean) {
     default: defaultCache,
     async waitForGitHubMatches(count: number): Promise<void> {
       while (githubMatches < count) {
-        await new Promise<void>((resolve) => {
-          matchWaiters.add(resolve);
-        });
-        matchWaiters.clear();
+        let wake!: () => void;
+        let unregister!: () => void;
+        try {
+          await new Promise<void>((resolve, reject) => {
+            wake = resolve;
+            matchWaiters.add(wake);
+            unregister = ownedWork.registerRelease(() =>
+              reject(new Error("Cache match wait interrupted by teardown")),
+            );
+          });
+        } finally {
+          unregister();
+          matchWaiters.delete(wake);
+        }
       }
     },
   };

--- a/test/e2e/cache-fill-protocol.test.ts
+++ b/test/e2e/cache-fill-protocol.test.ts
@@ -1,6 +1,7 @@
 import { env } from "cloudflare:workers";
 import { describe, expect, it } from "vitest";
 import { poolCoordinatorStub } from "../../src/pool-coordinator";
+import { ownedWork } from "./owned-work";
 
 describe("PoolCoordinator cache-fill protocol", () => {
   it("allows completion RPC to wake a waiting acquisition", async () => {
@@ -11,13 +12,25 @@ describe("PoolCoordinator cache-fill protocol", () => {
       return;
     }
 
-    const followers = [coordinator.acquireCacheFill("key"), coordinator.acquireCacheFill("key")];
-    expect(await coordinator.completeCacheFill("key", leader.token, "shared")).toBe(true);
+    const unregister = ownedWork.registerRelease(() =>
+      coordinator.completeCacheFill("key", leader.token, "failed"),
+    );
+    const followers = [
+      ownedWork.track(coordinator.acquireCacheFill("key")),
+      ownedWork.track(coordinator.acquireCacheFill("key")),
+    ];
+    try {
+      expect(await coordinator.completeCacheFill("key", leader.token, "shared")).toBe(true);
 
-    await expect(Promise.all(followers)).resolves.toEqual([
-      { kind: "completed", outcome: "shared" },
-      { kind: "completed", outcome: "shared" },
-    ]);
+      await expect(Promise.all(followers)).resolves.toEqual([
+        { kind: "completed", outcome: "shared" },
+        { kind: "completed", outcome: "shared" },
+      ]);
+    } finally {
+      await coordinator.completeCacheFill("key", leader.token, "failed");
+      unregister();
+      await Promise.allSettled(followers);
+    }
   });
 
   it("rejects stale tokens after expiry without releasing a newer owner", async () => {
@@ -27,23 +40,38 @@ describe("PoolCoordinator cache-fill protocol", () => {
     if (stale.kind !== "owner") {
       return;
     }
-    const staleFollower = coordinator.acquireCacheFill("key");
+    const releaseStale = () => coordinator.completeCacheFill("key", stale.token, "failed");
+    const unregisterStale = ownedWork.registerRelease(releaseStale);
+    const staleFollower = ownedWork.track(coordinator.acquireCacheFill("key"));
+    const followers = [staleFollower];
+    let releaseCurrent: (() => Promise<boolean>) | undefined;
+    let unregisterCurrent: (() => void) | undefined;
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 8_100));
+      const current = await coordinator.acquireCacheFill("key");
+      expect(current.kind).toBe("owner");
+      if (current.kind !== "owner") {
+        return;
+      }
+      releaseCurrent = () => coordinator.completeCacheFill("key", current.token, "failed");
+      unregisterCurrent = ownedWork.registerRelease(releaseCurrent);
 
-    await new Promise((resolve) => setTimeout(resolve, 8_100));
-    const current = await coordinator.acquireCacheFill("key");
-    expect(current.kind).toBe("owner");
-    if (current.kind !== "owner") {
-      return;
+      await expect(staleFollower).resolves.toEqual({ kind: "retry" });
+      expect(await coordinator.renewCacheFill("key", stale.token)).toBe(false);
+      expect(await coordinator.completeCacheFill("key", stale.token, "shared")).toBe(false);
+      expect(await coordinator.completeCacheFill("key", "wrong-token", "failed")).toBe(false);
+      expect(await coordinator.renewCacheFill("key", current.token)).toBe(true);
+
+      const currentFollower = ownedWork.track(coordinator.acquireCacheFill("key"));
+      followers.push(currentFollower);
+      expect(await coordinator.completeCacheFill("key", current.token, "failed")).toBe(true);
+      await expect(currentFollower).resolves.toEqual({ kind: "completed", outcome: "failed" });
+    } finally {
+      await releaseCurrent?.();
+      unregisterCurrent?.();
+      await releaseStale();
+      unregisterStale();
+      await Promise.allSettled(followers);
     }
-
-    await expect(staleFollower).resolves.toEqual({ kind: "retry" });
-    expect(await coordinator.renewCacheFill("key", stale.token)).toBe(false);
-    expect(await coordinator.completeCacheFill("key", stale.token, "shared")).toBe(false);
-    expect(await coordinator.completeCacheFill("key", "wrong-token", "failed")).toBe(false);
-    expect(await coordinator.renewCacheFill("key", current.token)).toBe(true);
-
-    const currentFollower = coordinator.acquireCacheFill("key");
-    expect(await coordinator.completeCacheFill("key", current.token, "failed")).toBe(true);
-    await expect(currentFollower).resolves.toEqual({ kind: "completed", outcome: "failed" });
   }, 15_000);
 });

--- a/test/e2e/cache-revalidation.test.ts
+++ b/test/e2e/cache-revalidation.test.ts
@@ -2,6 +2,7 @@ import { env } from "cloudflare:workers";
 import { describe, expect, it, vi } from "vitest";
 import { deleteEdgeJSON } from "../../src/edge-cache";
 import { bearer, jsonResponse, rateHeaders, relay, seedPool } from "./harness";
+import { ownedWork } from "./owned-work";
 
 const RUN_PATH = "/repos/openclaw/octopool/actions/runs/123";
 
@@ -370,11 +371,8 @@ describe("Worker end-to-end cache revalidation", () => {
 
   it("publishes a 304 refresh to coalesced waiters", async () => {
     await seedPool();
-    let releaseRevalidation!: () => void;
     let revalidationStarted!: () => void;
-    const gate = new Promise<void>((resolve) => {
-      releaseRevalidation = resolve;
-    });
+    const { promise: gate, release: releaseRevalidation } = ownedWork.gate();
     const started = new Promise<void>((resolve) => {
       revalidationStarted = resolve;
     });
@@ -412,37 +410,44 @@ describe("Worker end-to-end cache revalidation", () => {
     ).run();
     await deleteEdgeJSON("public-repo-v1", "openclaw/octopool");
     const leader = relay(RUN_PATH);
-    await started;
-    const follower = relay(RUN_PATH);
-    // Outlast the first 4s coalescing wait while the leader still owns its 8s fill lease.
-    // A follower must wait/claim again instead of starting another conditional request.
-    await new Promise((resolve) => setTimeout(resolve, 4_250));
-    const conditionalCallsBeforePublish = conditionalCalls;
-    releaseRevalidation();
-    const envelopes = await Promise.all(
-      [leader, follower].map(async (responsePromise) =>
-        (await responsePromise).json<RelayEnvelope>(),
-      ),
-    );
+    const requests = [leader];
+    try {
+      await started;
+      const follower = relay(RUN_PATH);
+      requests.push(follower);
+      // Outlast the first 4s coalescing wait while the leader still owns its 8s fill lease.
+      // A follower must wait/claim again instead of starting another conditional request.
+      await new Promise((resolve) => setTimeout(resolve, 4_250));
+      const conditionalCallsBeforePublish = conditionalCalls;
+      releaseRevalidation();
+      const envelopes = await Promise.all(
+        [leader, follower].map(async (responsePromise) =>
+          (await responsePromise).json<RelayEnvelope>(),
+        ),
+      );
 
-    expect(envelopes).toEqual([
-      expect.objectContaining({
-        body: expect.objectContaining({ id: 123, status: "in_progress" }),
-        relay: expect.objectContaining({ cache: "hit" }),
-      }),
-      expect.objectContaining({
-        body: expect.objectContaining({ id: 123, status: "in_progress" }),
-        relay: expect.objectContaining({ cache: "hit", coalesced: true }),
-      }),
-    ]);
-    expect(conditionalCallsBeforePublish).toBe(1);
-    expect(conditionalCalls).toBe(1);
-    expect(publicRepoChecks).toBe(1);
-    expect(
-      await env.DB.prepare(
-        "SELECT COUNT(*) AS count FROM audit_events WHERE fallback_reason = 'cache_revalidated'",
-      ).first(),
-    ).toEqual({ count: 1 });
+      expect(envelopes).toEqual([
+        expect.objectContaining({
+          body: expect.objectContaining({ id: 123, status: "in_progress" }),
+          relay: expect.objectContaining({ cache: "hit" }),
+        }),
+        expect.objectContaining({
+          body: expect.objectContaining({ id: 123, status: "in_progress" }),
+          relay: expect.objectContaining({ cache: "hit", coalesced: true }),
+        }),
+      ]);
+      expect(conditionalCallsBeforePublish).toBe(1);
+      expect(conditionalCalls).toBe(1);
+      expect(publicRepoChecks).toBe(1);
+      expect(
+        await env.DB.prepare(
+          "SELECT COUNT(*) AS count FROM audit_events WHERE fallback_reason = 'cache_revalidated'",
+        ).first(),
+      ).toEqual({ count: 1 });
+    } finally {
+      releaseRevalidation();
+      await Promise.allSettled(requests);
+    }
   });
 });
 

--- a/test/e2e/d1-baseline.ts
+++ b/test/e2e/d1-baseline.ts
@@ -1,0 +1,115 @@
+import type { D1Migration } from "@cloudflare/vitest-pool-workers";
+import { applyD1Migrations } from "cloudflare:test";
+
+export type D1Baseline = readonly string[];
+
+type SchemaObject = { name: string; type: string; sql: string | null };
+const internal = (name: string) => name.startsWith("_cf_") || name.startsWith("sqlite_");
+const identifier = (name: string) => `"${name.replaceAll('"', '""')}"`;
+
+async function applicationSchema(db: D1Database): Promise<SchemaObject[]> {
+  const { results } = await db
+    .prepare("SELECT name, type, sql FROM sqlite_schema ORDER BY rowid")
+    .all<SchemaObject>();
+  if (results.some(({ name }) => name.startsWith("sqlite_stat"))) {
+    throw new Error("D1 baseline does not support SQLite statistics tables");
+  }
+  const schema = results.filter(({ name }) => !internal(name));
+  if (schema.some(({ sql }) => /^CREATE\s+VIRTUAL\s+TABLE\b/i.test(sql ?? ""))) {
+    throw new Error("D1 baseline does not support virtual tables");
+  }
+  return schema;
+}
+
+export async function initializeD1Baseline(
+  db: D1Database,
+  migrations: D1Migration[],
+): Promise<D1Baseline> {
+  if ((await applicationSchema(db)).length !== 0) {
+    throw new Error("D1 baseline initialization requires a pristine database");
+  }
+  await applyD1Migrations(db, migrations);
+  return captureD1Baseline(db);
+}
+
+// Miniflare 5.20260804.0-alpha dumpSql(), also used by Wrangler 4.120.1.
+// The exact pragma accepts two numeric flags and no table filter. Its single
+// result row contains COMPLETE statements, including multiline CREATE/INSERTs.
+// This is a test-runtime contract, not a production D1 API or D1.exec() dump.
+export async function captureD1Baseline(db: D1Database): Promise<D1Baseline> {
+  await applicationSchema(db);
+  const rows: unknown = await db.prepare("PRAGMA miniflare_d1_export(?,?,?);").bind(0, 0).raw();
+  return validateD1Export(rows);
+}
+
+export function validateD1Export(rows: unknown): D1Baseline {
+  if (!Array.isArray(rows) || rows.length !== 1 || !Array.isArray(rows[0])) {
+    throw new Error("Unsupported Miniflare D1 export: expected one statement array");
+  }
+  const statements: unknown[] = Array.from(rows[0]);
+  if (
+    statements[0] !== "PRAGMA defer_foreign_keys=TRUE;" ||
+    statements.some(
+      (sql, index) =>
+        typeof sql !== "string" ||
+        !sql.endsWith(";") ||
+        (index > 0 &&
+          !/^(?:CREATE (?:TABLE|INDEX|UNIQUE INDEX|TRIGGER|VIEW)\b|INSERT INTO\b|DELETE FROM sqlite_sequence;)/i.test(
+            sql,
+          )),
+    )
+  ) {
+    throw new Error("Unsupported Miniflare D1 export statement contract");
+  }
+  return Object.freeze(statements.slice() as string[]);
+}
+
+export function childFirstTables(tables: ReadonlyMap<string, readonly string[]>): string[] {
+  // SQLite folds ASCII identifiers, including quoted FK target names.
+  const fold = (name: string) => name.replace(/[A-Z]/g, (letter) => letter.toLowerCase());
+  const names = new Map([...tables.keys()].map((name) => [fold(name), name]));
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const parentsFirst: string[] = [];
+  function visit(table: string): void {
+    if (visiting.has(table)) {
+      throw new Error(`D1 baseline does not support foreign-key cycles: ${table}`);
+    }
+    if (visited.has(table)) return;
+    visiting.add(table);
+    for (const parent of tables.get(table) ?? []) {
+      const actual = names.get(fold(parent));
+      if (actual !== undefined) visit(actual);
+    }
+    visiting.delete(table);
+    visited.add(table);
+    parentsFirst.push(table);
+  }
+  for (const table of tables.keys()) visit(table);
+  return parentsFirst.reverse();
+}
+
+export async function restoreD1Baseline(db: D1Database, baseline: D1Baseline): Promise<void> {
+  const schema = await applicationSchema(db);
+  const tables = schema.filter(({ type }) => type === "table");
+  const dependencies = tables.length
+    ? await db.batch<{ table: string }>(
+        tables.map(({ name }) => db.prepare(`PRAGMA foreign_key_list(${identifier(name)})`)),
+      )
+    : [];
+  const ordered = childFirstTables(
+    new Map(
+      tables.map(({ name }, index) => [name, dependencies[index]!.results.map((row) => row.table)]),
+    ),
+  );
+  const teardown = [
+    ...schema
+      .filter(({ type }) => type === "trigger" || type === "view")
+      .map(({ type, name }) => `DROP ${type.toUpperCase()} ${identifier(name)}`),
+    ...ordered.map((name) => `DROP TABLE ${identifier(name)}`),
+  ];
+  // DROP TABLE also removes its indexes. The export restores sqlite_sequence
+  // after recreating AUTOINCREMENT tables. All destruction/replay rolls back
+  // together on failure; foreign_keys stays enabled throughout.
+  await db.batch([...teardown, ...baseline].map((sql) => db.prepare(sql)));
+}

--- a/test/e2e/harness.ts
+++ b/test/e2e/harness.ts
@@ -5,6 +5,7 @@ import worker from "../../src/index";
 import { hashToken } from "../../src/auth";
 import { clearConfigCache } from "../../src/config-cache";
 import type { RelayRequest } from "../../src/types";
+import { ownedWork } from "./owned-work";
 
 export const CALLER_TOKEN = "caller-token";
 export const POOL = "maintainers";
@@ -24,22 +25,53 @@ export async function relay(
   });
 }
 
-export async function callWorker(path: string, init?: RequestInit): Promise<Response> {
+export function callWorker(path: string, init?: RequestInit): Promise<Response> {
   // Every simulated request starts cold: e2e tests mutate callers/identities
   // between requests via direct SQL and assert immediate effect, which the
   // isolate-local config cache would otherwise mask for its TTL.
   clearConfigCache();
-  const ctx = createExecutionContext();
-  const url = path.startsWith("https://") ? path : `https://octopool.dev${path}`;
-  const response = await worker.fetch(new Request(url, init), env, ctx);
-  await waitOnExecutionContext(ctx);
-  return response;
+  return callWarmWorker(path, init);
 }
 
-export async function runScheduled(): Promise<void> {
+// Explicitly preserve isolate-local config caches for warm-isolate assertions.
+export function callWarmWorker(path: string, init?: RequestInit): Promise<Response> {
+  const url = path.startsWith("https://") ? path : `https://octopool.dev${path}`;
+  return runWithContext((ctx) => worker.fetch(new Request(url, init), env, ctx));
+}
+
+export function runScheduled(): Promise<void> {
+  return runWithContext((ctx) => worker.scheduled({} as ScheduledController, env, ctx));
+}
+
+export function runWithContext<T>(handler: (ctx: ExecutionContext) => T | Promise<T>): Promise<T> {
   const ctx = createExecutionContext();
-  await worker.scheduled({} as ScheduledController, env, ctx);
-  await waitOnExecutionContext(ctx);
+  const waitUntil = ctx.waitUntil.bind(ctx);
+  ctx.waitUntil = (promise) => {
+    // The SDK drain has its own abandonment watchdog. Ownership must outlive
+    // that watchdog so unfinished work never permits mock restoration.
+    ownedWork.track(promise);
+    waitUntil(promise);
+  };
+  return ownedWork.track(
+    (async () => {
+      let result!: T;
+      const errors: unknown[] = [];
+      try {
+        result = await handler(ctx);
+      } catch (error) {
+        errors.push(error);
+      } finally {
+        try {
+          await waitOnExecutionContext(ctx);
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+      if (errors.length === 1) throw errors[0];
+      if (errors.length) throw new AggregateError(errors, "Handler and execution context failed");
+      return result;
+    })(),
+  );
 }
 
 export async function seedPool(options: { secondary?: boolean } = {}): Promise<void> {

--- a/test/e2e/lifecycle.ts
+++ b/test/e2e/lifecycle.ts
@@ -1,0 +1,48 @@
+// Vitest's deadline rejects the hook without cancelling its underlying promise.
+// Keep the operation owned until it settles, and never let another test race it.
+export class IsolationLifecycle {
+  private active = false;
+  private failure: Error | undefined;
+
+  constructor(private readonly hookTimeout: number) {}
+
+  poison(reason: unknown): void {
+    this.failure ??= new Error(
+      "Worker test isolation is poisoned; refusing subsequent test bodies",
+      {
+        cause: reason,
+      },
+    );
+  }
+
+  assertHealthy(): void {
+    if (this.failure) throw this.failure;
+  }
+
+  async run(operation: () => Promise<void>, cleanup = false): Promise<void> {
+    if (!cleanup) this.assertHealthy();
+    if (this.active) {
+      this.poison(new Error("Previous isolation hook has not settled"));
+      this.assertHealthy();
+    }
+    this.active = true;
+    const started = Date.now();
+    const timeout = setTimeout(() => {
+      this.poison(new Error("Isolation hook exceeded the Vitest hook deadline"));
+    }, this.hookTimeout);
+    try {
+      await operation();
+      // A busy event loop can finish work before dispatching the deadline timer.
+      if (Date.now() - started >= this.hookTimeout) {
+        this.poison(new Error("Isolation hook exceeded the Vitest hook deadline"));
+      }
+      this.assertHealthy();
+    } catch (error) {
+      this.poison(error);
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+      this.active = false;
+    }
+  }
+}

--- a/test/e2e/owned-work.ts
+++ b/test/e2e/owned-work.ts
@@ -1,0 +1,76 @@
+// Test-owned requests, background work and gate releases. Rejections remain on
+// the caller's promise and are also reported by teardown if the caller left.
+export class OwnedWork {
+  private readonly pending = new Set<Promise<unknown>>();
+  private readonly releases = new Set<() => void | Promise<unknown>>();
+  private errors: unknown[] = [];
+  private closing = false;
+
+  start(): void {
+    if (this.pending.size || this.releases.size || this.errors.length) {
+      throw new Error("Previous test still owns unfinished work");
+    }
+    this.closing = false;
+  }
+
+  track<P extends Promise<unknown>>(promise: P): P {
+    this.pending.add(promise);
+    void promise.then(
+      () => this.pending.delete(promise),
+      (error: unknown) => {
+        this.pending.delete(promise);
+        this.errors.push(error);
+      },
+    );
+    return promise;
+  }
+
+  registerRelease(release: () => void | Promise<unknown>): () => void {
+    if (this.closing) {
+      this.track(Promise.resolve().then(release));
+    } else {
+      this.releases.add(release);
+    }
+    return () => this.releases.delete(release);
+  }
+
+  gate(): { promise: Promise<void>; release(): void } {
+    let resolve!: () => void;
+    const promise = new Promise<void>((done) => {
+      resolve = done;
+    });
+    const unregister = this.registerRelease(resolve);
+    return {
+      promise,
+      release() {
+        unregister();
+        resolve();
+      },
+    };
+  }
+
+  releaseGates(): void {
+    this.closing = true;
+    for (const release of this.releases) {
+      this.releases.delete(release);
+      this.track(Promise.resolve().then(release));
+    }
+  }
+
+  async drain(): Promise<void> {
+    while (this.pending.size) {
+      await Promise.allSettled(this.pending);
+    }
+    const errors = this.errors.splice(0);
+    if (errors.length === 1) throw errors[0];
+    if (errors.length) throw new AggregateError(errors, "Test-owned work failed");
+  }
+
+  async finish(): Promise<void> {
+    this.releaseGates();
+    await this.drain();
+  }
+}
+
+// One instance per isolated Worker test file, shared by setup and the harness.
+export const ownedWork = new OwnedWork();

--- a/test/e2e/setup.ts
+++ b/test/e2e/setup.ts
@@ -1,19 +1,50 @@
 import type { D1Migration } from "@cloudflare/vitest-pool-workers";
 import { env } from "cloudflare:workers";
-import { applyD1Migrations, reset } from "cloudflare:test";
-import { afterEach, beforeEach, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, vi } from "vitest";
+import { initializeD1Baseline, type D1Baseline } from "./d1-baseline";
+import { IsolationLifecycle } from "./lifecycle";
+import { ownedWork } from "./owned-work";
+import { CacheWriteLedger, restoreStorage } from "./storage-isolation";
 
-type TestEnv = Env & {
-  TEST_MIGRATIONS: D1Migration[];
-};
+type TestEnv = Env & { TEST_MIGRATIONS: D1Migration[] };
+// Match Vitest's unchanged default hook deadline; the watchdog only poisons
+// ownership and never extends or replaces the runner's timeout.
+const lifecycle = new IsolationLifecycle(10_000);
+const cacheLedger = new CacheWriteLedger(caches);
+let baseline: D1Baseline;
 
-beforeEach(async () => {
-  await reset();
-  const testEnv = env as TestEnv;
-  await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+beforeAll(() =>
+  lifecycle.run(async () => {
+    const testEnv = env as TestEnv;
+    baseline = await initializeD1Baseline(testEnv.DB, testEnv.TEST_MIGRATIONS);
+  }),
+);
+
+beforeEach(async ({ signal }) => {
+  // Keep listening through the runner's completion-time deadline check, even
+  // if our promise has just settled. A timed-out body can also keep running.
+  signal.addEventListener(
+    "abort",
+    () => {
+      lifecycle.poison(signal.reason);
+      ownedWork.releaseGates();
+    },
+    { once: true },
+  );
+  await lifecycle.run(async () => {
+    await restoreStorage(env, baseline, cacheLedger);
+    ownedWork.start();
+    vi.stubGlobal("caches", cacheLedger.caches);
+  });
 });
 
-afterEach(() => {
-  vi.unstubAllGlobals();
-  vi.restoreAllMocks();
+afterEach(async () => {
+  ownedWork.releaseGates();
+  await lifecycle.run(async () => {
+    // Requests and waitUntil work still need the test's mocks while draining.
+    await ownedWork.drain();
+    await cacheLedger.drain();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  }, true);
 });

--- a/test/e2e/storage-isolation.test.ts
+++ b/test/e2e/storage-isolation.test.ts
@@ -1,0 +1,405 @@
+import type { D1Migration } from "@cloudflare/vitest-pool-workers";
+import { env } from "cloudflare:workers";
+import {
+  abortAllDurableObjects,
+  evictDurableObject,
+  listDurableObjectIds,
+  runInDurableObject,
+} from "cloudflare:test";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import worker from "../../src/index";
+import {
+  captureD1Baseline,
+  initializeD1Baseline,
+  restoreD1Baseline,
+  type D1Baseline,
+} from "./d1-baseline";
+import { callWarmWorker, runScheduled, runWithContext, seedPool } from "./harness";
+import { ownedWork } from "./owned-work";
+import { CacheWriteLedger, clearActionLogs, clearCoordinators } from "./storage-isolation";
+
+const migrationNames = (env as Env & { TEST_MIGRATIONS: D1Migration[] }).TEST_MIGRATIONS.map(
+  ({ name }) => name,
+);
+let baseline: D1Baseline;
+beforeAll(async () => {
+  baseline = await captureD1Baseline(env.DB);
+});
+
+describe("per-test setup boundary", () => {
+  const key = "https://octopool.dev/isolation/previous-test";
+  const coordinator = () =>
+    env.POOL_COORDINATOR.get(env.POOL_COORDINATOR.idFromName("previous-test"));
+
+  it("writes real stores through the normal test bindings", async () => {
+    await seedPool();
+    await env.ACTIONS_LOGS.put("previous-test", "old");
+    await caches.default.put(
+      key,
+      new Response("old", { headers: { "cache-control": "public, max-age=3600" } }),
+    );
+    await (
+      await caches.open("previous-test")
+    ).put(key, new Response("old", { headers: { "cache-control": "public, max-age=3600" } }));
+    expect(await caches.default.match(key)).toBeDefined();
+    expect((await coordinator().acquireCacheFill(key)).kind).toBe("owner");
+    await runInDurableObject(coordinator(), async (_instance, state) => {
+      await state.storage.setAlarm(Date.now() + 86_400_000);
+    });
+  });
+
+  it("starts the next body with the exact D1 baseline and cleared configured stores", async () => {
+    expect(await captureD1Baseline(env.DB)).toEqual(baseline);
+    expect(await env.ACTIONS_LOGS.get("previous-test")).toBeNull();
+    expect(await caches.default.match(key)).toBeUndefined();
+    expect(await (await caches.open("previous-test")).match(key)).toBeUndefined();
+    await runInDurableObject(coordinator(), async (_instance, state) => {
+      expect(await state.storage.getAlarm()).toBeNull();
+      expect(state.storage.sql.exec("SELECT * FROM cache_fills").toArray()).toEqual([]);
+    });
+    await seedPool();
+  });
+});
+
+describe("real D1 baseline restoration", () => {
+  it("restores orphaned schema/data and permits the unchanged fixed seed", async () => {
+    const policy = await env.DB.prepare("SELECT * FROM string_rewrite_policy").all();
+    const migrations = await env.DB.prepare("SELECT * FROM d1_migrations ORDER BY id").all<{
+      name: string;
+    }>();
+    expect(migrations.results.map(({ name }) => name)).toEqual(migrationNames);
+    await seedPool();
+    await env.DB.batch([
+      env.DB.prepare("ALTER TABLE identities RENAME TO identities_old"),
+      env.DB.prepare("DROP TABLE string_rewrite_policy"),
+      env.DB.prepare(
+        "CREATE TABLE isolation_sentinel (id INTEGER PRIMARY KEY AUTOINCREMENT, pool_id TEXT REFERENCES pools(id), value TEXT)",
+      ),
+      env.DB.prepare(
+        "INSERT INTO isolation_sentinel (pool_id, value) VALUES ('maintainers', 'old')",
+      ),
+      env.DB.prepare("CREATE INDEX isolation_index ON isolation_sentinel(value)"),
+      env.DB.prepare("CREATE VIEW isolation_view AS SELECT * FROM isolation_sentinel"),
+      env.DB.prepare(
+        "CREATE TRIGGER isolation_trigger AFTER INSERT ON isolation_sentinel BEGIN UPDATE isolation_sentinel SET value = 'changed' WHERE id = NEW.id; END",
+      ),
+    ]);
+    // Global abort reaches D1's internal actor behind its service binding.
+    // evictAllDurableObjects only evicts this Worker's explicit DO bindings.
+    // Natural 11-second idle reproduces the same retained-storage condition.
+    await abortAllDurableObjects();
+    await restoreD1Baseline(env.DB, baseline);
+    expect(
+      (
+        await env.DB.prepare(
+          "SELECT name FROM sqlite_schema WHERE name LIKE 'isolation_%' OR name = 'identities_old'",
+        ).all()
+      ).results,
+    ).toEqual([]);
+    expect((await env.DB.prepare("SELECT * FROM string_rewrite_policy").all()).results).toEqual(
+      policy.results,
+    );
+    expect((await env.DB.prepare("SELECT * FROM d1_migrations").all()).results).toEqual(
+      migrations.results,
+    );
+    expect(await captureD1Baseline(env.DB)).toEqual(baseline);
+    await seedPool();
+    expect(await env.DB.prepare("SELECT count(*) AS n FROM pools").first("n")).toBe(1);
+    await expect(seedPool()).rejects.toThrow("UNIQUE constraint failed: pools.id");
+    await expect(
+      env.DB.prepare(
+        "INSERT INTO identity_scopes (identity_id, owner) VALUES ('missing', 'openclaw')",
+      ).run(),
+    ).rejects.toThrow("FOREIGN KEY constraint failed");
+  });
+
+  it("orders a quoted child created before its mixed-case FK parent", async () => {
+    await env.DB.batch([
+      env.DB.prepare(
+        'CREATE TABLE "child""table" (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES "PARENT"(id))',
+      ),
+      env.DB.prepare("CREATE TABLE parent (id INTEGER PRIMARY KEY)"),
+      env.DB.prepare("INSERT INTO parent VALUES (1)"),
+      env.DB.prepare('INSERT INTO "child""table" VALUES (1, 1)'),
+    ]);
+    await restoreD1Baseline(env.DB, baseline);
+    expect(await captureD1Baseline(env.DB)).toEqual(baseline);
+  });
+
+  it("rolls back all teardown and replay if a statement fails", async () => {
+    await seedPool();
+    await env.DB.prepare("CREATE TABLE rollback_sentinel (id INTEGER)").run();
+    const before = await captureD1Baseline(env.DB);
+    await expect(
+      restoreD1Baseline(env.DB, [...baseline, "INSERT INTO nonexistent_table VALUES (1);"]),
+    ).rejects.toThrow("no such table");
+    expect(await captureD1Baseline(env.DB)).toEqual(before);
+  });
+
+  it("round trips sequences, multiline text, blobs, schema, indexes and triggers", async () => {
+    await env.DB.batch([
+      env.DB.prepare(
+        "CREATE TABLE export_values (\n id INTEGER PRIMARY KEY AUTOINCREMENT,\n value TEXT UNIQUE, data BLOB\n)",
+      ),
+      env.DB.prepare("INSERT INTO export_values (id, value, data) VALUES (?, ?, ?)").bind(
+        41,
+        "first\nsecond\r\n'quote'",
+        new Uint8Array([0, 10, 255]).buffer,
+      ),
+      env.DB.prepare("INSERT INTO export_values (id, value) VALUES (75, 'removed high sequence')"),
+      env.DB.prepare("DELETE FROM export_values WHERE id = 75"),
+      env.DB.prepare("CREATE INDEX export_index ON export_values(data)"),
+      env.DB.prepare("CREATE VIEW export_view AS SELECT id, value FROM export_values"),
+      env.DB.prepare(
+        "CREATE TRIGGER export_trigger AFTER INSERT ON export_values BEGIN UPDATE export_values SET value = upper(NEW.value) WHERE id = NEW.id; END",
+      ),
+    ]);
+    const extraBaseline = await captureD1Baseline(env.DB);
+    expect(extraBaseline.some((sql) => sql.startsWith("CREATE TABLE") && sql.includes("\n"))).toBe(
+      true,
+    );
+    expect(extraBaseline.some((sql) => sql === "DELETE FROM sqlite_sequence;")).toBe(true);
+    await restoreD1Baseline(env.DB, extraBaseline);
+    expect(
+      await env.DB.prepare("SELECT id, value, hex(data) AS data FROM export_values").first(),
+    ).toEqual({ id: 41, value: "first\nsecond\r\n'quote'", data: "000AFF" });
+    await env.DB.prepare("INSERT INTO export_values (value) VALUES ('next')").run();
+    expect(await env.DB.prepare("SELECT id, value FROM export_view WHERE id = 76").first()).toEqual(
+      { id: 76, value: "NEXT" },
+    );
+    await expect(
+      env.DB.prepare("INSERT INTO export_values (value) VALUES ('NEXT')").run(),
+    ).rejects.toThrow("UNIQUE constraint failed");
+    await restoreD1Baseline(env.DB, baseline);
+    expect(await captureD1Baseline(env.DB)).toEqual(baseline);
+  });
+
+  it("rejects initialization against an already migrated database", async () => {
+    await expect(initializeD1Baseline(env.DB, [])).rejects.toThrow("requires a pristine database");
+    expect(await captureD1Baseline(env.DB)).toEqual(baseline);
+  });
+
+  it("rejects virtual tables before destructive restore", async () => {
+    await env.DB.prepare("CREATE VIRTUAL TABLE unsupported_search USING fts5(value)").run();
+    try {
+      await expect(captureD1Baseline(env.DB)).rejects.toThrow("does not support virtual tables");
+      await expect(restoreD1Baseline(env.DB, baseline)).rejects.toThrow(
+        "does not support virtual tables",
+      );
+      expect(await env.DB.prepare("SELECT count(*) AS n FROM d1_migrations").first("n")).toBe(
+        migrationNames.length,
+      );
+    } finally {
+      await env.DB.prepare("DROP TABLE unsupported_search").run();
+    }
+  });
+
+  it("rejects cyclic dependencies before destructive restore", async () => {
+    await env.DB.batch([
+      env.DB.prepare(
+        "CREATE TABLE cycle_a (id INTEGER PRIMARY KEY, b INTEGER REFERENCES cycle_b(id))",
+      ),
+      env.DB.prepare(
+        "CREATE TABLE cycle_b (id INTEGER PRIMARY KEY, a INTEGER REFERENCES cycle_a(id))",
+      ),
+    ]);
+    try {
+      await expect(restoreD1Baseline(env.DB, baseline)).rejects.toThrow("foreign-key cycles");
+      expect(await env.DB.prepare("SELECT count(*) AS n FROM d1_migrations").first("n")).toBe(
+        migrationNames.length,
+      );
+    } finally {
+      await env.DB.batch([
+        env.DB.prepare("DROP TABLE cycle_a"),
+        env.DB.prepare("DROP TABLE cycle_b"),
+      ]);
+    }
+  });
+});
+
+describe("real configured storage ownership", () => {
+  it("clears multiple persisted dormant coordinator IDs, alarms, SQL and instances", async () => {
+    const ids = ["storage-isolation-a", "storage-isolation-b"].map((name) =>
+      env.POOL_COORDINATOR.idFromName(name),
+    );
+    const oldTokens: string[] = [];
+    for (const id of ids) {
+      const stub = env.POOL_COORDINATOR.get(id);
+      const lease = await stub.acquireCacheFill("old-key");
+      expect(lease.kind).toBe("owner");
+      if (lease.kind !== "owner") throw new Error("Expected fresh owner");
+      oldTokens.push(lease.token);
+      await runInDurableObject(stub, async (_instance, state) => {
+        await state.storage.put("sentinel", "old");
+        state.storage.sql.exec("CREATE TABLE isolation_sentinel (value TEXT)");
+        state.storage.sql.exec("INSERT INTO isolation_sentinel VALUES ('old')");
+        await state.storage.setAlarm(Date.now() + 86_400_000);
+      });
+      await evictDurableObject(stub);
+    }
+    expect((await listDurableObjectIds(env.POOL_COORDINATOR)).map(String)).toEqual(
+      expect.arrayContaining(ids.map(String)),
+    );
+    await clearCoordinators(env.POOL_COORDINATOR);
+    for (const [index, id] of ids.entries()) {
+      const stub = env.POOL_COORDINATOR.get(id);
+      await runInDurableObject(stub, async (_instance, state) => {
+        expect(await state.storage.get("sentinel")).toBeUndefined();
+        expect(await state.storage.getAlarm()).toBeNull();
+        expect(
+          state.storage.sql
+            .exec("SELECT name FROM sqlite_schema WHERE name = 'isolation_sentinel'")
+            .toArray(),
+        ).toEqual([]);
+        // Constructor recreation is required: deleteAll removed cache_fills too.
+        expect(state.storage.sql.exec("SELECT * FROM cache_fills").toArray()).toEqual([]);
+      });
+      const fresh = await stub.acquireCacheFill("old-key");
+      expect(fresh.kind).toBe("owner");
+      if (fresh.kind !== "owner") throw new Error("Expected recreated owner");
+      expect(fresh.token).not.toBe(oldTokens[index]);
+      expect(await stub.completeCacheFill("old-key", oldTokens[index]!, "shared")).toBe(false);
+      expect(await stub.completeCacheFill("old-key", fresh.token, "shared")).toBe(true);
+    }
+  });
+
+  it("deletes real R2 objects across bounded pages", async () => {
+    await Promise.all(
+      Array.from({ length: 5 }, (_, index) =>
+        env.ACTIONS_LOGS.put(`isolation/${index}`, `body-${index}`),
+      ),
+    );
+    const list = vi.spyOn(env.ACTIONS_LOGS, "list");
+    await clearActionLogs(env.ACTIONS_LOGS, 2);
+    expect(list).toHaveBeenCalledTimes(3);
+    expect(list.mock.calls[1]?.[0]?.cursor).toBeTruthy();
+    list.mockRestore();
+    expect((await env.ACTIONS_LOGS.list()).objects).toEqual([]);
+    expect(await env.ACTIONS_LOGS.get("isolation/4")).toBeNull();
+  });
+
+  it("forwards default/named cache hits and removes their owned keys", async () => {
+    const ledger = new CacheWriteLedger(caches);
+    const request = new Request("https://octopool.dev/isolation/cache", {
+      headers: { "x-test": "fixture" },
+    });
+    const named = await ledger.caches.open("isolation-named");
+    expect(named.put).toBe(named.put);
+    expect(named.constructor).toBe(caches.default.constructor);
+    for (const [cache, body] of [
+      [ledger.caches.default, "default"],
+      [named, "named"],
+    ] as const) {
+      const response = new Response(body, {
+        headers: { "cache-control": "public, max-age=3600", "x-test": "preserved" },
+      });
+      await cache.put(request, response);
+      const hit = await cache.match.call(cache, request);
+      expect(hit?.headers.get("x-test")).toBe("preserved");
+      expect(await hit?.text()).toBe(body);
+      expect(await (await cache.match(request))?.text()).toBe(body);
+      await expect(async () => cache.match.call({} as Cache, request)).rejects.toBeInstanceOf(
+        TypeError,
+      );
+    }
+    const borrowedKey = "https://octopool.dev/isolation/borrowed-method";
+    await ledger.caches.default.put.call(
+      named,
+      borrowedKey,
+      new Response("borrowed", {
+        headers: { "cache-control": "public, max-age=3600" },
+      }),
+    );
+    expect(await (await named.match(borrowedKey))?.text()).toBe("borrowed");
+    expect(await ledger.caches.default.match(borrowedKey)).toBeUndefined();
+    await ledger.clear();
+    expect(await ledger.caches.default.match(request)).toBeUndefined();
+    expect(await (await ledger.caches.open("isolation-named")).match(request)).toBeUndefined();
+    expect(await named.match(borrowedKey)).toBeUndefined();
+  });
+
+  it("settles a real streaming put before deleting its recorded key", async () => {
+    const ledger = new CacheWriteLedger(caches);
+    const gate = ownedWork.gate();
+    const request = new Request("https://octopool.dev/isolation/stream");
+    const body = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        await gate.promise;
+        controller.enqueue(new TextEncoder().encode("late body"));
+        controller.close();
+      },
+    });
+    const write = ledger.caches.default.put(
+      request,
+      new Response(body, { headers: { "cache-control": "public, max-age=3600" } }),
+    );
+    let cleared = false;
+    const cleanup = ledger.clear().then(() => {
+      cleared = true;
+    });
+    try {
+      await Promise.resolve();
+      expect(cleared).toBe(false);
+    } finally {
+      gate.release();
+      await Promise.all([write, cleanup]);
+    }
+    expect(cleared).toBe(true);
+    expect(await ledger.caches.default.match(request)).toBeUndefined();
+  });
+
+  it("releases owned request gates and drains background writes before storage cleanup", async () => {
+    const ledger = new CacheWriteLedger(caches);
+    const gate = ownedWork.gate();
+    const request = new Request("https://octopool.dev/isolation/background");
+    const events: string[] = [];
+    const response = runWithContext((ctx) => {
+      ctx.waitUntil(
+        gate.promise.then(async () => {
+          await ledger.caches.default.put(
+            request,
+            new Response("late", { headers: { "cache-control": "public, max-age=3600" } }),
+          );
+          await env.ACTIONS_LOGS.put("late-owned-work", "late");
+          events.push("write");
+        }),
+      );
+      return new Response("request");
+    });
+    await ownedWork.finish();
+    expect((await response).status).toBe(200);
+    await ledger.clear();
+    await clearActionLogs(env.ACTIONS_LOGS);
+    events.push("cleanup");
+    expect(events).toEqual(["write", "cleanup"]);
+    expect(await ledger.caches.default.match(request)).toBeUndefined();
+    expect(await env.ACTIONS_LOGS.get("late-owned-work")).toBeNull();
+  });
+
+  it.each(["fetch", "scheduled"] as const)(
+    "drains the context when the %s handler throws",
+    async (kind) => {
+      const gate = ownedWork.gate();
+      const error = new Error("handler failed");
+      const handler = (ctx: ExecutionContext): never => {
+        ctx.waitUntil(
+          gate.promise.then(async () => {
+            await env.ACTIONS_LOGS.put("thrown-handler", "drained");
+          }),
+        );
+        throw error;
+      };
+      if (kind === "fetch")
+        vi.spyOn(worker, "fetch").mockImplementation((_request, _env, ctx) => handler(ctx));
+      else
+        vi.spyOn(worker, "scheduled").mockImplementation((_controller, _env, ctx) => handler(ctx));
+      const request = kind === "fetch" ? callWarmWorker("/") : runScheduled();
+      const rejected = expect(request).rejects.toBe(error);
+      gate.release();
+      await rejected;
+      expect(await (await env.ACTIONS_LOGS.get("thrown-handler"))?.text()).toBe("drained");
+      // This test intentionally expects the tracked failure as well as the caller's.
+      await expect(ownedWork.drain()).rejects.toBe(error);
+    },
+  );
+});

--- a/test/e2e/storage-isolation.ts
+++ b/test/e2e/storage-isolation.ts
@@ -1,0 +1,119 @@
+import { evictDurableObject, listDurableObjectIds, runInDurableObject } from "cloudflare:test";
+import { restoreD1Baseline, type D1Baseline } from "./d1-baseline";
+import { OwnedWork } from "./owned-work";
+
+// All caches stay native. Only puts forwarded through this ledger are owned;
+// this is deliberately not a purge of arbitrary, untracked Cache API contents.
+export class CacheWriteLedger {
+  readonly caches: CacheStorage;
+  private readonly writes = new OwnedWork();
+  private readonly entries = new Map<Cache, Request[]>();
+  private readonly wrapped = new WeakMap<Cache, Cache>();
+
+  constructor(native: CacheStorage) {
+    const receivers = new WeakMap<Cache, Cache>();
+    const wrap = (cache: Cache): Cache => {
+      const existing = this.wrapped.get(cache);
+      if (existing) return existing;
+      const { writes, entries: ownedEntries } = this;
+      const methods = new Map<PropertyKey, unknown>();
+      const proxy = new Proxy(cache, {
+        get(target, key) {
+          const value: unknown = Reflect.get(target, key, target);
+          if (typeof value !== "function" || !["put", "match", "delete"].includes(String(key)))
+            return value;
+          if (methods.has(key)) return methods.get(key);
+          const method = function (this: unknown, ...args: unknown[]) {
+            const receiver = receivers.get(this as Cache) ?? this;
+            const result: unknown = Reflect.apply(value, receiver, args);
+            if (key === "put") {
+              return writes.track(
+                (result as Promise<void>).then(() => {
+                  const request = new Request(args[0] as RequestInfo | URL);
+                  const entries = ownedEntries.get(receiver as Cache) ?? [];
+                  entries.push(request);
+                  ownedEntries.set(receiver as Cache, entries);
+                }),
+              );
+            }
+            return result;
+          };
+          methods.set(key, method);
+          return method;
+        },
+      });
+      receivers.set(proxy, cache);
+      this.wrapped.set(cache, proxy);
+      return proxy;
+    };
+    let open: CacheStorage["open"] | undefined;
+    const proxy = new Proxy(native, {
+      get(target, key) {
+        const value: unknown = Reflect.get(target, key, target);
+        if (key === "default") return wrap(value as Cache);
+        if (key !== "open" || typeof value !== "function") return value;
+        open ??= function (this: unknown, ...args: unknown[]) {
+          const receiver = this === proxy ? target : this;
+          const result: unknown = Reflect.apply(value, receiver, args);
+          return (result as Promise<Cache>).then(wrap);
+        };
+        return open;
+      },
+    });
+    this.caches = proxy;
+  }
+
+  async drain(): Promise<void> {
+    await this.writes.drain();
+  }
+
+  async clear(): Promise<void> {
+    await this.drain();
+    for (const [cache, requests] of this.entries) {
+      // Retain each request's headers for native Vary matching. Failed deletes
+      // must keep their ledger entries so cleanup cannot silently lose ownership.
+      for (const request of requests) await cache.delete(request);
+      this.entries.delete(cache);
+    }
+  }
+}
+
+export async function clearCoordinators(namespace: Env["POOL_COORDINATOR"]): Promise<void> {
+  // listDurableObjectIds enumerates persisted .sqlite files, including IDs whose
+  // instances are dormant and absent from native reset's live-actor map.
+  for (const id of await listDurableObjectIds(namespace)) {
+    const stub = namespace.get(id);
+    await runInDurableObject(stub, async (_instance, state) => {
+      await state.storage.deleteAlarm();
+      await state.storage.deleteAll();
+    });
+    // deleteAll removes SQL but not the instance's cached state/timers/waiters.
+    // A new instance must rerun the constructor before its next SQL access.
+    await evictDurableObject(stub);
+  }
+}
+
+export async function clearActionLogs(bucket: R2Bucket, pageSize = 1_000): Promise<void> {
+  if (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > 1_000) {
+    throw new Error("R2 cleanup page size must be between 1 and 1000");
+  }
+  let cursor: string | undefined;
+  do {
+    const page = await bucket.list({ limit: pageSize, ...(cursor ? { cursor } : {}) });
+    if (page.objects.length) await bucket.delete(page.objects.map(({ key }) => key));
+    cursor = page.truncated ? page.cursor : undefined;
+    if (page.truncated && !cursor)
+      throw new Error("R2 cleanup received a truncated page without a cursor");
+  } while (cursor);
+}
+
+export async function restoreStorage(
+  env: Pick<Env, "DB" | "POOL_COORDINATOR" | "ACTIONS_LOGS">,
+  baseline: D1Baseline,
+  caches: CacheWriteLedger,
+): Promise<void> {
+  await caches.clear();
+  await clearCoordinators(env.POOL_COORDINATOR);
+  await clearActionLogs(env.ACTIONS_LOGS);
+  await restoreD1Baseline(env.DB, baseline);
+}

--- a/test/e2e/string-rewrites.test.ts
+++ b/test/e2e/string-rewrites.test.ts
@@ -1,16 +1,16 @@
 import { env } from "cloudflare:workers";
-import { createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
 import { describe, expect, it, vi } from "vitest";
-import worker from "../../src/index";
 import {
   CALLER_TOKEN,
   callWorker,
+  callWarmWorker,
   githubUpstream,
   jsonResponse,
   POOL,
   relay,
   seedPool,
 } from "./harness";
+import { ownedWork } from "./owned-work";
 
 const adminPath = "/v1/admin/string-rewrites";
 const callerPath = `/v1/pools/${POOL}/string-rewrites`;
@@ -206,11 +206,8 @@ describe("canonical relay egress protection", () => {
   it("keeps concurrent policy snapshots isolated across a redirect", async () => {
     await seedPool();
     await put([{ pattern: "cobalt-mint", replacement: "public" }]);
-    let release!: () => void;
     let started!: () => void;
-    const waiting = new Promise<void>((resolve) => {
-      release = resolve;
-    });
+    const { promise: waiting, release } = ownedWork.gate();
     const reached = new Promise<void>((resolve) => {
       started = resolve;
     });
@@ -230,12 +227,13 @@ describe("canonical relay egress protection", () => {
     const first = relay("/repos/example/demo/pulls/17", CALLER_TOKEN, {
       headers: { accept: "application/vnd.github.v3.diff" },
     });
-    await reached;
     try {
+      await reached;
       expect((await put([{ pattern: "azure-sage", replacement: "public" }], 2)).status).toBe(200);
       expect((await relay("/repos/example/cobalt-mint")).status).toBe(200);
     } finally {
       release();
+      await Promise.allSettled([first]);
     }
     expect((await first).status).toBe(403);
     expect(upstream).toHaveBeenCalledTimes(2);
@@ -493,16 +491,7 @@ describe("server read enforcement", () => {
     await seedPool();
     const upstream = githubUpstream({ primary: jsonResponse({ number: 17 }) });
     vi.stubGlobal("fetch", upstream);
-    const warm = async (path: string, init?: RequestInit): Promise<Response> => {
-      const ctx = createExecutionContext();
-      const response = await worker.fetch(
-        new Request(`https://octopool.dev${path}`, init),
-        env,
-        ctx,
-      );
-      await waitOnExecutionContext(ctx);
-      return response;
-    };
+    const warm = callWarmWorker;
     const request = {
       method: "POST",
       headers: { authorization: `Bearer ${CALLER_TOKEN}`, "content-type": "application/json" },

--- a/test/e2e/worker.test.ts
+++ b/test/e2e/worker.test.ts
@@ -19,6 +19,7 @@ import {
   seedPool,
   seedWebSession,
 } from "./harness";
+import { ownedWork } from "./owned-work";
 
 type RelayEnvelope = {
   status: number;
@@ -357,11 +358,8 @@ describe("Worker end-to-end relay", () => {
 
   it("coalesces concurrent cache misses into one authenticated GitHub request", async () => {
     await seedPool();
-    let releasePrimary!: () => void;
     let primaryStarted!: () => void;
-    const primaryGate = new Promise<void>((resolve) => {
-      releasePrimary = resolve;
-    });
+    const { promise: primaryGate, release: releasePrimary } = ownedWork.gate();
     const started = new Promise<void>((resolve) => {
       primaryStarted = resolve;
     });
@@ -380,33 +378,40 @@ describe("Worker end-to-end relay", () => {
     vi.stubGlobal("fetch", upstream);
 
     const firstPromise = relay("/repos/openclaw/octopool");
-    await started;
-    const secondPromise = relay("/repos/openclaw/octopool");
-    await new Promise((resolve) => setTimeout(resolve, 150));
-    releasePrimary();
-    const envelopes = await Promise.all(
-      [firstPromise, secondPromise].map(async (responsePromise) => {
-        const response = await responsePromise;
-        expect(response.status).toBe(200);
-        return response.json<RelayEnvelope>();
-      }),
-    );
+    const requests = [firstPromise];
+    try {
+      await started;
+      const secondPromise = relay("/repos/openclaw/octopool");
+      requests.push(secondPromise);
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      releasePrimary();
+      const envelopes = await Promise.all(
+        [firstPromise, secondPromise].map(async (responsePromise) => {
+          const response = await responsePromise;
+          expect(response.status).toBe(200);
+          return response.json<RelayEnvelope>();
+        }),
+      );
 
-    expect(envelopes.map(({ relay: result }) => result.cache).sort()).toEqual(["hit", "miss"]);
-    // Miniflare may not schedule the follower until the leader has published the cache entry.
-    const coalesced = envelopes.some(({ relay: result }) => result.coalesced === true);
-    expect(
-      upstream.mock.calls.filter(
-        ([request, init]) => bearer(request, init) === "test-primary-token",
-      ),
-    ).toHaveLength(1);
-    const audits = await env.DB.prepare(
-      "SELECT cache_status, coalesced FROM audit_events ORDER BY cache_status",
-    ).all<{ cache_status: string; coalesced: number }>();
-    expect(audits.results).toEqual([
-      { cache_status: "hit", coalesced: coalesced ? 1 : 0 },
-      { cache_status: "miss", coalesced: 0 },
-    ]);
+      expect(envelopes.map(({ relay: result }) => result.cache).sort()).toEqual(["hit", "miss"]);
+      // Miniflare may not schedule the follower until the leader has published the cache entry.
+      const coalesced = envelopes.some(({ relay: result }) => result.coalesced === true);
+      expect(
+        upstream.mock.calls.filter(
+          ([request, init]) => bearer(request, init) === "test-primary-token",
+        ),
+      ).toHaveLength(1);
+      const audits = await env.DB.prepare(
+        "SELECT cache_status, coalesced FROM audit_events ORDER BY cache_status",
+      ).all<{ cache_status: string; coalesced: number }>();
+      expect(audits.results).toEqual([
+        { cache_status: "hit", coalesced: coalesced ? 1 : 0 },
+        { cache_status: "miss", coalesced: 0 },
+      ]);
+    } finally {
+      releasePrimary();
+      await Promise.allSettled(requests);
+    }
   });
 
   it("serves a stale cache entry when the only identity becomes rate limited", async () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Worker E2E checks could start a test against stale D1 storage after its runtime actor went idle, causing duplicate fixture keys. Setup also replayed the entire migration chain before every test, spending unnecessary time inside the hook deadline.

This is separate from [PR #70](https://github.com/openclaw/octopool/pull/70), which did not change the Worker or its test setup.

## Why This Change Was Made

The fixture now runs the real migrations once per isolated file, captures their schema and seed data through Miniflare's existing export mechanism, and restores the current application schema in one atomic batch independently of actor liveness. A test-owned lifecycle also clears persisted coordinator state and alarms, paginated R2 objects, and tracked native-cache writes, while draining requests, execution contexts, and registered gates before restoring mocks.

The native reset defect is avoided rather than hidden with duplicate-tolerant inserts or an actor-warming workaround. Full-schema restoration preserves tests that rename or drop tables; unsupported snapshot/schema shapes fail explicitly. The Miniflare-specific export contract and ownership limits are documented.

## User Impact

No production Worker behavior, policy, migration SQL, or dependency changes. Developers retain the existing 10-second hook and 15-second test deadlines, default file parallelism, fixture IDs, assertions, and intentional concurrency tests.

## Evidence

- **Reproduction:** natural 11-second D1 idle, followed by native reset, real migrations, and the unchanged seed, fails with `UNIQUE constraint failed: pools.id`. The active-database control passes. A verified global-abort control reproduces the same failure without a sleep; the permanent regression uses that control.
- **Red/green:** atomic baseline restoration passes both the natural-idle and global-abort cases, including renamed/dropped schema, unexpected objects, exact migration markers and policy seed data, and unchanged fixed-ID reseeding.
- **Focused Workerd regression:** 16/16 cases passed, covering transactional rollback, mixed-case foreign keys, sequences and multiline exports, dormant coordinator storage/alarms/instances, real R2 pagination, native default/named caches, streaming writes, and context draining on thrown handlers.
- **Full `pnpm check`:** passed on both the original macOS host and a clean Linux/Node 24 host: 537 unit tests, 234 Worker E2Es, formatting/lint, generated-code checks, TypeScript build, Go tests, and Go vet. No skipped cases or serial overrides.
- **Setup cost:** D1 restoration uses three requests instead of 18 sequential migration requests per test. Paired instrumented clean-host runs passed both complete suites; cold migration/export initialization remained within the unchanged hook deadline (maximum 27 ms across 20 files), and after-test cleanup hooks completed within 1 ms. These measurements are diagnostic observations, not cross-host latency guarantees.
- **Independent Codex autoreview:** scoped clean, with no accepted/actionable findings.
