### PR TITLE
fix: keep CLI credentials on the intended origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Block cross-origin redirects and HTTPS downgrades for CLI login and authenticated JSON requests to prevent credential replay.
 - Preserve exact raw Markdown in release-view JSON via the anonymous API and retire cached HTML-derived release summaries for existing clients.
 - Return native uppercase PR-list lifecycle states and lowercase merged PR-search states from nested merge metadata before `--jq`, preserving raw API and cache payloads.
 - Cache page-derived closed issues for one hour, matching REST closed issues while preserving response state casing and cached bodies.

--- a/cmd/octopool/http_client.go
+++ b/cmd/octopool/http_client.go
@@ -57,6 +57,10 @@ func doJSONRequest(req *http.Request) (*http.Response, error) {
 		}
 		if redirectErr == nil {
 			followedRedirect = true
+			// Older Go versions drop Authorization when only hostname casing changes.
+			if authorization := req.Header.Get("Authorization"); authorization != "" {
+				next.Header.Set("Authorization", authorization)
+			}
 		}
 		return redirectErr
 	}

--- a/cmd/octopool/http_client.go
+++ b/cmd/octopool/http_client.go
@@ -3,14 +3,103 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
 
 var httpClient = &http.Client{Timeout: 30 * time.Second}
+
+var errInvalidRedirectLocation = errors.New("invalid redirect Location header")
+
+type jsonRedirectTransport struct {
+	base http.RoundTripper
+}
+
+func (transport jsonRedirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := transport.base.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	switch resp.StatusCode {
+	case http.StatusMovedPermanently, http.StatusFound, http.StatusSeeOther, http.StatusTemporaryRedirect, http.StatusPermanentRedirect:
+		if location := resp.Header.Get("Location"); location != "" {
+			// net/http parses Location before CheckRedirect and quotes it on failure.
+			if _, err := req.URL.Parse(location); err != nil {
+				resp.Body.Close()
+				return nil, errInvalidRedirectLocation
+			}
+		}
+	}
+	return resp, nil
+}
+
+func doJSONRequest(req *http.Request) (*http.Response, error) {
+	// Login carries its credential in the body, so protect every JSON request.
+	// Keep credential-free discovery's redirect behavior on the shared client.
+	client := *httpClient
+	transport := client.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	client.Transport = jsonRedirectTransport{base: transport}
+	var redirectErr error
+	var followedRedirect bool
+	client.CheckRedirect = func(next *http.Request, via []*http.Request) error {
+		if !sameURLOrigin(req.URL, next.URL) {
+			redirectErr = errors.New("refusing cross-origin redirect for credential-bearing request")
+		} else if len(via) >= 10 {
+			redirectErr = errors.New("stopped after 10 redirects")
+		}
+		if redirectErr == nil {
+			followedRedirect = true
+		}
+		return redirectErr
+	}
+	resp, err := client.Do(req)
+	if redirectErr != nil {
+		// net/http wraps redirect errors with the untrusted Location URL.
+		return nil, redirectErr
+	}
+	if errors.Is(err, errInvalidRedirectLocation) {
+		// A previous same-origin redirect may also have reflected secrets in its URL.
+		return nil, errInvalidRedirectLocation
+	}
+	if followedRedirect && err != nil {
+		var requestErr *url.Error
+		if errors.As(err, &requestErr) {
+			// Keep the transport cause without printing reflected redirect query values.
+			safeErr := *requestErr
+			safeErr.URL = req.URL.Redacted()
+			return resp, &safeErr
+		}
+	}
+	return resp, err
+}
+
+func sameURLOrigin(left, right *url.URL) bool {
+	return strings.EqualFold(left.Scheme, right.Scheme) &&
+		strings.EqualFold(left.Hostname(), right.Hostname()) &&
+		effectiveURLPort(left) == effectiveURLPort(right)
+}
+
+func effectiveURLPort(value *url.URL) string {
+	if port := value.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(value.Scheme) {
+	case "http":
+		return "80"
+	case "https":
+		return "443"
+	default:
+		return ""
+	}
+}
 
 func getJSON(ctx context.Context, stdout io.Writer, url string, token string) error {
 	resp, err := getJSONRaw(ctx, url, token)
@@ -26,7 +115,7 @@ func getJSONRaw(ctx context.Context, url string, token string) (*http.Response, 
 		return nil, err
 	}
 	req.Header.Set("authorization", "Bearer "+token)
-	return httpClient.Do(req)
+	return doJSONRequest(req)
 }
 
 func postJSON(ctx context.Context, stdout io.Writer, url string, token string, body map[string]any) error {
@@ -55,7 +144,7 @@ func postJSONRaw(
 		req.Header.Set("authorization", "Bearer "+token)
 	}
 	req.Header.Set("content-type", "application/json")
-	return httpClient.Do(req)
+	return doJSONRequest(req)
 }
 
 func writeJSONResponse(stdout io.Writer, resp *http.Response) error {

--- a/cmd/octopool/http_client_test.go
+++ b/cmd/octopool/http_client_test.go
@@ -1,0 +1,397 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func isolateHTTPTestConfig(t *testing.T) {
+	t.Helper()
+	root := t.TempDir()
+	for _, name := range []string{"HOME", "XDG_CONFIG_HOME", "AppData", "APPDATA", "USERPROFILE", "GH_CONFIG_DIR"} {
+		t.Setenv(name, filepath.Join(root, name))
+	}
+}
+
+func useHTTPTestTransport(t *testing.T, transport http.RoundTripper) {
+	t.Helper()
+	original := httpClient
+	client := *original
+	client.Transport = transport
+	httpClient = &client
+	t.Cleanup(func() { httpClient = original })
+}
+
+type redirectProbe struct {
+	requests    atomic.Int32
+	credentials atomic.Int32
+}
+
+func (probe *redirectProbe) observe(r *http.Request, token string) {
+	probe.requests.Add(1)
+	body, _ := io.ReadAll(r.Body)
+	if strings.Contains(r.Header.Get("Authorization"), token) || strings.Contains(string(body), token) {
+		probe.credentials.Add(1)
+	}
+}
+
+func requireBlockedRedirect(t *testing.T, err error, probe *redirectProbe, secrets ...string) {
+	t.Helper()
+	if err == nil || !strings.Contains(err.Error(), "redirect") {
+		t.Errorf("expected a redirect error, got %v", err)
+	}
+	if err != nil {
+		for _, secret := range secrets {
+			if strings.Contains(err.Error(), secret) {
+				t.Error("redirect error exposed a credential")
+			}
+		}
+	}
+	if requests, credentials := probe.requests.Load(), probe.credentials.Load(); requests != 0 || credentials != 0 {
+		t.Errorf("redirect target received %d requests, %d with credentials; want zero", requests, credentials)
+	}
+}
+
+func TestAuthenticatedJSONRedirects(t *testing.T) {
+	for _, method := range []string{http.MethodGet, http.MethodPost} {
+		for _, code := range []int{301, 302, 303, 307, 308} {
+			for _, destination := range []string{"direct", "same-origin", "cross-port", "cross-host", "downgrade", "same-origin-then-cross-port"} {
+				t.Run(method+"/"+strconv.Itoa(code)+"/"+destination, func(t *testing.T) {
+					isolateHTTPTestConfig(t)
+					token := "synthetic-caller-token"
+					if method == http.MethodPost {
+						token = "synthetic-admin-token"
+					}
+					var targetProbe, originProbe redirectProbe
+					target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						targetProbe.observe(r, token)
+						_, _ = io.WriteString(w, `{"ok":true}`)
+					}))
+					defer target.Close()
+					redirectURL := target.URL + "/capture?token=" + token
+					if destination == "cross-host" {
+						redirectURL = strings.Replace(redirectURL, "127.0.0.1", "localhost", 1)
+					}
+					origin := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						if r.Header.Get("Authorization") != "Bearer "+token {
+							t.Error("origin did not receive expected bearer credential")
+						}
+						body, _ := io.ReadAll(r.Body)
+						wantMethod := method
+						if r.URL.Path != "/start" && code < 307 {
+							wantMethod = http.MethodGet
+						}
+						if r.Method != wantMethod || (wantMethod == http.MethodPost && string(body) != `{"payload":"synthetic-body"}`) {
+							t.Error("origin request method or body changed unexpectedly")
+						}
+						originProbe.requests.Add(1)
+						if destination == "direct" || r.URL.Path == "/final" {
+							_, _ = io.WriteString(w, `{"ok":true}`)
+							return
+						}
+						location := redirectURL
+						if destination == "same-origin" {
+							location = "/final"
+						} else if destination == "same-origin-then-cross-port" && r.URL.Path == "/start" {
+							location = "/middle"
+						}
+						http.Redirect(w, r, location, code)
+					}))
+					if destination == "downgrade" {
+						origin.StartTLS()
+					} else {
+						origin.Start()
+					}
+					defer origin.Close()
+					useHTTPTestTransport(t, origin.Client().Transport)
+
+					var response *http.Response
+					var err error
+					if method == http.MethodGet {
+						response, err = getJSONRaw(t.Context(), origin.URL+"/start", token)
+					} else {
+						response, err = postJSONRaw(t.Context(), origin.URL+"/start", token, map[string]any{"payload": "synthetic-body"})
+					}
+					if response != nil {
+						defer response.Body.Close()
+					}
+					if destination == "direct" || destination == "same-origin" {
+						if err != nil {
+							t.Fatal(err)
+						}
+						body, err := io.ReadAll(response.Body)
+						if err != nil || response.StatusCode != http.StatusOK || string(body) != `{"ok":true}` {
+							t.Fatalf("unexpected success response: status=%d, read error=%v", response.StatusCode, err)
+						}
+					} else {
+						requireBlockedRedirect(t, err, &targetProbe, token, "synthetic-body")
+					}
+					wantRequests := int32(1)
+					if destination == "same-origin" || destination == "same-origin-then-cross-port" {
+						wantRequests = 2
+					}
+					if got := originProbe.requests.Load(); got != wantRequests {
+						t.Errorf("origin requests = %d, want %d", got, wantRequests)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestAuthenticatedJSONRedirectEffectiveOrigin(t *testing.T) {
+	for _, scheme := range []string{"http", "https"} {
+		for _, explicitFirst := range []bool{false, true} {
+			t.Run(scheme+"/explicit-first="+strconv.FormatBool(explicitFirst), func(t *testing.T) {
+				isolateHTTPTestConfig(t)
+				host, port := "LOCALHOST", "80"
+				if scheme == "https" {
+					host, port = "127.0.0.1", "443"
+				}
+				first, next := scheme+"://"+host, scheme+"://"+strings.ToLower(host)+":"+port
+				if explicitFirst {
+					first, next = next, first
+				}
+				var requests atomic.Int32
+				server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					requests.Add(1)
+					if r.Header.Get("Authorization") != "Bearer synthetic-token" {
+						t.Error("same-origin request lost its credential")
+					}
+					if r.URL.Path == "/start" {
+						http.Redirect(w, r, next+"/final", http.StatusTemporaryRedirect)
+						return
+					}
+					_, _ = io.WriteString(w, `{"ok":true}`)
+				}))
+				if scheme == "https" {
+					server.StartTLS()
+				} else {
+					server.Start()
+				}
+				defer server.Close()
+				transport := server.Client().Transport.(*http.Transport).Clone()
+				transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+					return (&net.Dialer{}).DialContext(ctx, network, server.Listener.Addr().String())
+				}
+				defer transport.CloseIdleConnections()
+				useHTTPTestTransport(t, transport)
+				response, err := getJSONRaw(t.Context(), first+"/start", "synthetic-token")
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer response.Body.Close()
+				if response.StatusCode != http.StatusOK || requests.Load() != 2 {
+					t.Fatalf("status=%d, requests=%d", response.StatusCode, requests.Load())
+				}
+			})
+		}
+	}
+}
+
+func TestAuthenticatedJSONRedirectLimit(t *testing.T) {
+	isolateHTTPTestConfig(t)
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		http.Redirect(w, r, "/loop", http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+	_, err := getJSONRaw(t.Context(), server.URL, "synthetic-token")
+	if err == nil || !strings.Contains(err.Error(), "10 redirects") || requests.Load() != 10 {
+		t.Fatalf("redirect loop: error=%v, requests=%d", err, requests.Load())
+	}
+}
+
+func TestAuthenticatedJSONMalformedRedirects(t *testing.T) {
+	for _, method := range []string{http.MethodGet, http.MethodPost} {
+		for _, code := range []int{307, 308} {
+			for _, location := range []string{"token-escape", "token-port", "nonsecret", "same-origin-then-malformed"} {
+				t.Run(method+"/"+strconv.Itoa(code)+"/"+location, func(t *testing.T) {
+					isolateHTTPTestConfig(t)
+					token := "synthetic-caller-token"
+					if method == http.MethodPost {
+						token = "synthetic-admin-token"
+					}
+					var targetProbe redirectProbe
+					target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						targetProbe.observe(r, token)
+						_, _ = io.WriteString(w, `{"ok":true}`)
+					}))
+					defer target.Close()
+					var originRequests atomic.Int32
+					origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						originRequests.Add(1)
+						if r.Method != method || r.Header.Get("Authorization") != "Bearer "+token {
+							t.Error("origin did not receive the authenticated request")
+						}
+						reflected := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+						value := target.URL + "/%zz/" + reflected
+						switch location {
+						case "token-port":
+							value = target.URL + ":" + reflected + "/capture"
+						case "nonsecret":
+							value = target.URL + "/%zz/nonsecret"
+						case "same-origin-then-malformed":
+							if r.URL.Path == "/start" {
+								value = "/middle?token=" + reflected
+							}
+						}
+						w.Header().Set("Location", value)
+						w.WriteHeader(code)
+					}))
+					defer origin.Close()
+					var response *http.Response
+					var err error
+					if method == http.MethodGet {
+						response, err = getJSONRaw(t.Context(), origin.URL+"/start", token)
+					} else {
+						response, err = postJSONRaw(t.Context(), origin.URL+"/start", token, map[string]any{"payload": "synthetic-body"})
+					}
+					if response != nil {
+						response.Body.Close()
+						t.Error("malformed redirect returned a response")
+					}
+					requireBlockedRedirect(t, err, &targetProbe, token, "synthetic-body")
+					wantRequests := int32(1)
+					if location == "same-origin-then-malformed" {
+						wantRequests = 2
+					}
+					if originRequests.Load() != wantRequests {
+						t.Errorf("origin requests = %d, want %d", originRequests.Load(), wantRequests)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestAuthenticatedJSONIgnoresUnusedLocations(t *testing.T) {
+	for _, code := range []int{200, 300, 304, 307, 308} {
+		t.Run(strconv.Itoa(code), func(t *testing.T) {
+			isolateHTTPTestConfig(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if code < 307 {
+					w.Header().Set("Location", "/%zz/nonsecret")
+				}
+				w.WriteHeader(code)
+			}))
+			defer server.Close()
+			response, err := getJSONRaw(t.Context(), server.URL, "synthetic-token")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer response.Body.Close()
+			if response.StatusCode != code {
+				t.Errorf("status = %d, want %d", response.StatusCode, code)
+			}
+		})
+	}
+}
+
+func TestAuthenticatedJSONRequestErrors(t *testing.T) {
+	for _, failure := range []string{"canceled", "deadline", "connection-refused"} {
+		t.Run(failure, func(t *testing.T) {
+			isolateHTTPTestConfig(t)
+			var requests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests.Add(1)
+			}))
+			defer server.Close()
+			ctx := t.Context()
+			var want error
+			switch failure {
+			case "canceled":
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+				want = context.Canceled
+			case "deadline":
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithDeadline(ctx, time.Now().Add(-time.Second))
+				defer cancel()
+				want = context.DeadlineExceeded
+			case "connection-refused":
+				server.Close()
+			}
+			_, err := getJSONRaw(ctx, server.URL, "synthetic-token")
+			var requestErr *url.Error
+			if !errors.As(err, &requestErr) || requestErr.URL != server.URL || requestErr.Op != "Get" {
+				t.Fatalf("ordinary request lost its URL error: %v", err)
+			}
+			if want != nil && (!errors.Is(err, want) || !strings.Contains(err.Error(), want.Error())) {
+				t.Errorf("context error lost its cause: %v", err)
+			}
+			if failure == "deadline" && !requestErr.Timeout() {
+				t.Error("deadline error lost its timeout classification")
+			}
+			if failure == "connection-refused" {
+				var networkErr *net.OpError
+				if !errors.As(err, &networkErr) || networkErr.Op != "dial" || !strings.Contains(err.Error(), "dial tcp") {
+					t.Errorf("transport error lost its network cause: %v", err)
+				}
+			}
+			if requests.Load() != 0 {
+				t.Error("failed request unexpectedly reached server")
+			}
+		})
+	}
+}
+
+func TestAuthenticatedJSONRedirectRequestErrors(t *testing.T) {
+	for _, method := range []string{http.MethodGet, http.MethodPost} {
+		for _, code := range []int{307, 308} {
+			t.Run(method+"/"+strconv.Itoa(code), func(t *testing.T) {
+				isolateHTTPTestConfig(t)
+				const token = "synthetic-reflected-credential"
+				var followed atomic.Bool
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/start" {
+						http.Redirect(w, r, "/next?token="+token, code)
+						return
+					}
+					followed.Store(true)
+					conn, _, err := w.(http.Hijacker).Hijack()
+					if err != nil {
+						t.Error(err)
+						return
+					}
+					conn.Close()
+				}))
+				defer server.Close()
+				originalURL := server.URL + "/start"
+				var response *http.Response
+				var err error
+				if method == http.MethodGet {
+					response, err = getJSONRaw(t.Context(), originalURL, token)
+				} else {
+					response, err = postJSONRaw(t.Context(), originalURL, token, map[string]any{"github_token": token})
+				}
+				if response != nil {
+					response.Body.Close()
+				}
+				if !followed.Load() || err == nil {
+					t.Fatal("expected a transport failure after a same-origin redirect")
+				}
+				if strings.Contains(err.Error(), token) {
+					t.Error("redirected request error exposed a reflected credential")
+				}
+				var requestErr *url.Error
+				if !errors.As(err, &requestErr) || requestErr.URL != originalURL || !errors.Is(err, io.EOF) {
+					t.Error("redirected request error lost its original URL or transport cause")
+				}
+			})
+		}
+	}
+}

--- a/cmd/octopool/login_redirect_test.go
+++ b/cmd/octopool/login_redirect_test.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestLoginRedirects(t *testing.T) {
+	const githubToken = "synthetic-github-token"
+	const loginJSON = `{"caller":{"github_login":"alice","pool":"core","client_name":"test-mac"},"token":"synthetic-caller-token"}`
+	for _, code := range []int{307, 308} {
+		for _, destination := range []string{"direct", "same-origin", "cross-port", "cross-host", "downgrade", "same-origin-then-cross-port", "trusted-discovery", "trusted-discovery-same-origin", "insecure-opt-in"} {
+			t.Run(strconv.Itoa(code)+"/"+destination, func(t *testing.T) {
+				isolateHTTPTestConfig(t)
+				t.Setenv("GH_TOKEN", githubToken)
+				t.Setenv("GITHUB_TOKEN", "")
+				t.Setenv("OCTOPOOL_POOL", "")
+				t.Setenv("OCTOPOOL_ALLOW_INSECURE_LOGIN", "")
+				t.Setenv("OCTOPOOL_GH_PATH", filepath.Join(t.TempDir(), "must-not-run-gh"))
+				if destination == "insecure-opt-in" {
+					t.Setenv("OCTOPOOL_ALLOW_INSECURE_LOGIN", "1")
+				}
+				var targetProbe redirectProbe
+				target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					targetProbe.observe(r, githubToken)
+					_, _ = io.WriteString(w, loginJSON)
+				}))
+				defer target.Close()
+				redirectURL := target.URL + "/capture?github_token=" + githubToken
+				if destination == "cross-host" {
+					redirectURL = strings.Replace(redirectURL, "127.0.0.1", "localhost", 1)
+				}
+				var loginRequests atomic.Int32
+				var api *httptest.Server
+				api = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/.well-known/octopool" {
+						writeRedirectTestDiscovery(w, api.URL)
+						return
+					}
+					loginRequests.Add(1)
+					var body map[string]string
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil || r.Method != http.MethodPost || body["github_token"] != githubToken || body["pool"] != "core" || body["client_name"] != "test-mac" {
+						t.Error("login did not preserve its POST body")
+						http.Error(w, "unexpected login body", http.StatusBadRequest)
+						return
+					}
+					if destination == "direct" || r.URL.Path == "/complete" {
+						_, _ = io.WriteString(w, loginJSON)
+						return
+					}
+					location := redirectURL
+					if destination == "same-origin" || destination == "trusted-discovery-same-origin" {
+						location = "/complete"
+					} else if destination == "same-origin-then-cross-port" && r.URL.Path == "/v1/login/github-cli" {
+						location = "/middle"
+					}
+					http.Redirect(w, r, location, code)
+				}))
+				if destination == "downgrade" || destination == "insecure-opt-in" {
+					api.StartTLS()
+				} else {
+					api.Start()
+				}
+				defer api.Close()
+				useHTTPTestTransport(t, api.Client().Transport)
+				args := []string{api.URL, "--client", "test-mac"}
+				if strings.HasPrefix(destination, "trusted-discovery") {
+					discovery := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						if r.Header.Get("Authorization") != "" || r.Method != http.MethodGet {
+							t.Error("discovery received credentials or an unexpected method")
+						}
+						writeRedirectTestDiscovery(w, api.URL)
+					}))
+					defer discovery.Close()
+					args[0] = discovery.URL
+					args = append(args, "--trust-discovery-redirect")
+				}
+
+				var stdout bytes.Buffer
+				err := runLogin(t.Context(), args, &stdout)
+				if destination == "direct" || destination == "same-origin" || destination == "trusted-discovery-same-origin" {
+					if err != nil {
+						t.Fatal(err)
+					}
+					auth, err := loadAuth()
+					if err != nil || auth.URL != api.URL || auth.Token != "synthetic-caller-token" || auth.Pool != "core" || auth.Client != "test-mac" || auth.Login != "alice" {
+						t.Fatalf("login did not save the expected auth: %v", err)
+					}
+					if !strings.Contains(stdout.String(), "logged in to "+api.URL) {
+						t.Error("missing successful login output")
+					}
+				} else {
+					requireBlockedRedirect(t, err, &targetProbe, githubToken, "synthetic-caller-token")
+					if stdout.Len() != 0 {
+						t.Error("rejected login printed success output")
+					}
+					authFilePath, pathErr := authPath()
+					if pathErr != nil {
+						t.Fatal(pathErr)
+					}
+					if _, statErr := os.Stat(authFilePath); !os.IsNotExist(statErr) {
+						t.Errorf("rejected login wrote auth: stat error=%v", statErr)
+					}
+				}
+				wantRequests := int32(1)
+				if destination == "same-origin" || destination == "same-origin-then-cross-port" || destination == "trusted-discovery-same-origin" {
+					wantRequests = 2
+				}
+				if got := loginRequests.Load(); got != wantRequests {
+					t.Errorf("login requests = %d, want %d", got, wantRequests)
+				}
+			})
+		}
+	}
+}
+
+func writeRedirectTestDiscovery(w http.ResponseWriter, apiBase string) {
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"service": "octopool", "version": 1, "api_base": apiBase, "default_pool": "core",
+		"auth": map[string]bool{"cli_github_token": true},
+	})
+}
+
+func TestLoginDiscoveryHTTPRedirect(t *testing.T) {
+	isolateHTTPTestConfig(t)
+	var targetRequests atomic.Int32
+	var discoveryURL string
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetRequests.Add(1)
+		if r.Header.Get("Authorization") != "" || r.Method != http.MethodGet {
+			t.Error("discovery redirect received credentials or an unexpected method")
+		}
+		writeRedirectTestDiscovery(w, discoveryURL)
+	}))
+	defer target.Close()
+	discovery := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer discovery.Close()
+	discoveryURL = discovery.URL
+	resolved, err := discoverLoginServer(t.Context(), discovery.URL, "core", false)
+	if err != nil || resolved.APIBase != discovery.URL || targetRequests.Load() != 1 {
+		t.Fatalf("discovery redirect: error=%v, target requests=%d", err, targetRequests.Load())
+	}
+}
+
+func TestLoginMalformedRedirects(t *testing.T) {
+	const token = "synthetic-github-token"
+	for _, code := range []int{307, 308} {
+		t.Run(strconv.Itoa(code), func(t *testing.T) {
+			isolateHTTPTestConfig(t)
+			t.Setenv("GH_TOKEN", token)
+			t.Setenv("GITHUB_TOKEN", "")
+			t.Setenv("OCTOPOOL_POOL", "")
+			t.Setenv("OCTOPOOL_GH_PATH", filepath.Join(t.TempDir(), "must-not-run-gh"))
+			var targetProbe redirectProbe
+			target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				targetProbe.observe(r, token)
+			}))
+			defer target.Close()
+			var loginRequests atomic.Int32
+			var api *httptest.Server
+			api = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/.well-known/octopool" {
+					writeRedirectTestDiscovery(w, api.URL)
+					return
+				}
+				loginRequests.Add(1)
+				var body map[string]string
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil || r.Method != http.MethodPost || body["github_token"] != token {
+					t.Error("origin did not receive the login credential")
+					http.Error(w, "unexpected login body", http.StatusBadRequest)
+					return
+				}
+				w.Header().Set("Location", target.URL+"/%zz/"+body["github_token"])
+				w.WriteHeader(code)
+			}))
+			defer api.Close()
+			var stdout bytes.Buffer
+			err := runLogin(t.Context(), []string{api.URL, "--client", "test-mac"}, &stdout)
+			requireBlockedRedirect(t, err, &targetProbe, token)
+			if stdout.Len() != 0 || loginRequests.Load() != 1 {
+				t.Errorf("rejected login: output bytes=%d, login requests=%d", stdout.Len(), loginRequests.Load())
+			}
+			authFilePath, err := authPath()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Stat(authFilePath); !os.IsNotExist(err) {
+				t.Errorf("rejected login wrote auth: stat error=%v", err)
+			}
+		})
+	}
+}

--- a/cmd/octopool/login_test.go
+++ b/cmd/octopool/login_test.go
@@ -133,8 +133,7 @@ func TestFormatLoginFailureQuotesProvisioningCommandArguments(t *testing.T) {
 
 func TestLoginAcceptsPositionalServerAndStoresDiscoveredAuth(t *testing.T) {
 	t.Setenv("GH_TOKEN", "gh_test")
-	homeDir := t.TempDir()
-	t.Setenv("HOME", homeDir)
+	isolateHTTPTestConfig(t)
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -72,6 +72,14 @@ Flow:
    The caller row is refreshed with the current login, user id, and verification time.
 6. The plaintext token is returned once, for the CLI to store locally.
 
+The CLI follows login and authenticated JSON request redirects only within the
+request's original origin: the same scheme, hostname, and effective port (80 for HTTP,
+443 for HTTPS when omitted). Cross-origin redirects, including HTTPS downgrades, fail
+before sending a request to the redirect target. `--trust-discovery-redirect` trusts
+only the discovered `api_base`; neither it nor `OCTOPOOL_ALLOW_INSECURE_LOGIN=1` allows
+later credential-bearing requests to redirect to another origin. Credential-free
+discovery keeps its existing redirect behavior.
+
 Clients are 1-80 hostname-safe characters. New CLI versions send the local hostname and
 can override it with `--client`; older clients use `legacy`. Audit rows retain the matched
 caller-token id so stats can separate machines without storing caller token values.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -80,6 +80,8 @@ octopool login --client build-mac
 - If discovery points `api_base` at a different host, login fails unless
   `--trust-discovery-redirect` is passed. This keeps a mistyped or compromised discovery
   host from silently receiving your local GitHub token.
+- After discovery, the login exchange follows only same-origin HTTP redirects. Trusting
+  a discovered `api_base` does not authorize later redirects to other origins.
 - The token is stored 0600 at `<user-config-dir>/octopool/auth.json` (URL, pool, token,
   login, client, timestamp).
 - The default client name is the local hostname. `--client` overrides it; re-login rotates
@@ -619,6 +621,14 @@ invalidation.
   `OCTOPOOL_URL`) to a different host requires an explicit `OCTOPOOL_TOKEN`, or a fresh
   `octopool login` for that URL. This prevents leaking the token to an attacker-supplied
   endpoint.
+- Login, caller, and admin JSON requests follow redirects only to the same scheme,
+  hostname, and effective port as the original request (omitted ports mean 80 for HTTP
+  and 443 for HTTPS). Cross-origin redirects and HTTPS downgrades fail before the target
+  receives a request. Neither `--trust-discovery-redirect` nor
+  `OCTOPOOL_ALLOW_INSECURE_LOGIN=1` bypasses this restriction. Configure the intended API
+  base directly when moving a server to another origin. Credential-free discovery
+  keeps its existing redirect behavior; string-rewrite policy requests still reject
+  all redirects.
 - Once a request reaches Octopool, relay policy denials fail closed; they are not
   silently retried against the real `gh` unless Octopool returns the explicit
   `fallback_local` signal for a safe read.


### PR DESCRIPTION
## Summary

Credential-bearing JSON requests could follow redirects beyond the intended server origin. Keep login token bodies and caller/admin bearer credentials on the original scheme, hostname, and effective port while preserving same-origin redirects and credential-free discovery.

The shared JSON request layer rejects cross-origin redirects before target delivery and sanitizes malformed or failed redirect errors while preserving transport causes. It restores the original Authorization header only after origin and redirect-limit validation succeeds, preserving same-origin authentication across Go versions when hostname casing changes. Synthetic local regressions verify credential boundaries, redirect chains, discovery compatibility, and no auth-file writes after rejected login. Update the CLI/auth docs and changelog.

## Tests

- Passed `GOTOOLCHAIN=go1.26.7 go test -race ./cmd/octopool -run 'Test(LoginRedirects|LoginDiscoveryHTTPRedirect|LoginMalformedRedirects|AuthenticatedJSON.*|LoginAcceptsPositionalServerAndStoresDiscoveredAuth)$' -count=1`.
- Passed `GOTOOLCHAIN=go1.26.7 pnpm check`: route/SQL generation checks, formatting, lint, 572 unit tests, 242 Worker end-to-end tests, TypeScript checks, full Go tests, and Go vet.
- Red/green regression proof covers target-delivery rejection, malformed/reflected redirect-error disclosure, and Go 1.26 same-origin Authorization preservation. Focused Go 1.27 compatibility checks also passed.
