### PR TITLE
feat: guard draft release asset snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  release-asset-windows:
+    name: Windows release asset helpers
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Test native Windows staging and filesystem protection
+        run: go test -v ./cmd/octopool -run '^TestReleaseAssets(Windows.*|Filename(Validation|SourceDirectories)|StagingFilesystemSyntax|LimitsAndIdentity|BoundedCopyFailures|SnapshotWriteCloseAndCancellationCleanup|ExactBasenameAndTextBudget)$' -count=1
+
   check:
     name: Check
     runs-on: ubuntu-latest

--- a/cmd/octopool/gh_fallback.go
+++ b/cmd/octopool/gh_fallback.go
@@ -115,6 +115,9 @@ func execRealGHWithStdinAndEnv(
 		return err
 	}
 	defer prepared.cleanup()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if len(prepared.preflight) != 0 {
 		if err := execRealGHWithStdinAndEnv(ctx, prepared.preflight, strings.NewReader(""), io.Discard, io.Discard, env); err != nil {
 			return errRewriteBlocked

--- a/cmd/octopool/string_rewrites_args.go
+++ b/cmd/octopool/string_rewrites_args.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"context"
 	"io"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -78,6 +78,8 @@ func rewriteFlagNames(spec string) map[string]string {
 func (flags rewriteFlags) has(name string) bool { _, ok := flags.values[name]; return ok }
 
 type rewritePreparation struct {
+	ctx               context.Context
+	closeDirectory    func()
 	preflight         []string
 	args              []string
 	stdin             io.Reader
@@ -90,6 +92,10 @@ type rewritePreparation struct {
 }
 
 func (prepared *rewritePreparation) cleanup() {
+	if prepared.closeDirectory != nil {
+		prepared.closeDirectory()
+		prepared.closeDirectory = nil
+	}
 	if prepared.directory != "" {
 		_ = os.RemoveAll(prepared.directory)
 	}
@@ -113,12 +119,8 @@ func (prepared *rewritePreparation) snapshot(data []byte) (string, error) {
 	if len(data) > rewriteMaxContent {
 		return "", errRewriteBlocked
 	}
-	if prepared.directory == "" {
-		directory, err := os.MkdirTemp("", "octopool-content-")
-		if err != nil {
-			return "", errRewriteBlocked
-		}
-		prepared.directory = directory
+	if err := prepared.ensureSnapshotDirectory(); err != nil {
+		return "", err
 	}
 	file, err := os.CreateTemp(prepared.directory, "snapshot-")
 	if err != nil {
@@ -130,12 +132,7 @@ func (prepared *rewritePreparation) snapshot(data []byte) (string, error) {
 	if writeErr != nil || closeErr != nil {
 		return "", errRewriteBlocked
 	}
-	path = filepath.Clean(path)
-	if prepared.snapshots == nil {
-		prepared.snapshots = map[string]bool{}
-	}
-	prepared.snapshots[path] = true
-	return path, nil
+	return prepared.registerSnapshot(path), nil
 }
 
 var rewriteRepoPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
@@ -222,12 +219,16 @@ func prepareRewriteContent(policy stringRewritePolicy, args []string, stdin io.R
 	}
 	create := args[1] == "create"
 	release := args[0] == "release"
+	assetMode := command == "release create" && len(flags.positionals) > 1
+	if assetMode && (flags.values["--draft"] != "true" || flags.values["--verify-tag"] != "true") {
+		return errRewriteBlocked
+	}
 	if create && !release {
 		if len(flags.positionals) != 0 {
 			return errRewriteBlocked
 		}
 	} else {
-		if len(flags.positionals) != 1 {
+		if len(flags.positionals) != 1 && !assetMode {
 			return errRewriteBlocked
 		}
 		selector := flags.positionals[0]
@@ -295,7 +296,16 @@ func prepareRewriteContent(policy stringRewritePolicy, args []string, stdin io.R
 			return errRewriteBlocked
 		}
 	}
-	prepared.args = append([]string{args[0], args[1]}, flags.positionals...)
+	positionals := flags.positionals
+	var assets []rewriteReleaseAsset
+	if assetMode {
+		assets, err = prepared.releaseAssets(policy, positionals[1:], defaultRewriteReleaseLimits)
+		if err != nil {
+			return err
+		}
+		positionals = positionals[:1]
+	}
+	prepared.args = append([]string{args[0], args[1]}, positionals...)
 	prepared.args = append(prepared.args, "--repo="+flags.values["--repo"])
 	attachmentArgs := make([]string, 0, len(attachments))
 	attachmentSnapshots := make([]rewriteAttachmentSnapshot, 0, len(attachments))
@@ -348,9 +358,13 @@ func prepareRewriteContent(policy stringRewritePolicy, args []string, stdin io.R
 				}
 				text = string(data)
 			}
+			original := text
 			text, err = prepared.text(policy, text)
 			if err != nil {
 				return err
+			}
+			if assetMode && text != original {
+				return errRewriteBlocked
 			}
 			if flag.name != "--title" {
 				previousLength := len(text)
@@ -381,6 +395,15 @@ func prepareRewriteContent(policy stringRewritePolicy, args []string, stdin io.R
 		}
 	}
 	prepared.args = append(prepared.args, attachmentArgs...)
+	remaining := defaultRewriteReleaseLimits.total
+	for _, asset := range assets {
+		path, size, err := prepared.snapshotReleaseAsset(asset, min(remaining, defaultRewriteReleaseLimits.file), copyRewriteSnapshot)
+		if err != nil || !validRewriteReleasePath(path) || policy.check(path) != nil {
+			return errRewriteBlocked
+		}
+		remaining -= size
+		prepared.args = append(prepared.args, path)
+	}
 	prepared.stdin = strings.NewReader("")
 	return nil
 }

--- a/cmd/octopool/string_rewrites_attachments.go
+++ b/cmd/octopool/string_rewrites_attachments.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"errors"
-	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -461,12 +459,8 @@ func (prepared *rewritePreparation) snapshotAttachment(attachment rewriteAttachm
 	if err != nil || !info.Mode().IsRegular() || info.Size() == 0 || info.Size() > limit || !os.SameFile(attachment.info, info) {
 		return "", 0, errRewriteBlocked
 	}
-	if prepared.directory == "" {
-		directory, err := os.MkdirTemp("", "octopool-content-")
-		if err != nil {
-			return "", 0, errRewriteBlocked
-		}
-		prepared.directory = directory
+	if err := prepared.ensureSnapshotDirectory(); err != nil {
+		return "", 0, err
 	}
 	extension := strings.ToLower(filepath.Ext(attachment.source))
 	output, err := os.CreateTemp(prepared.directory, "attachment-*"+extension)
@@ -474,18 +468,9 @@ func (prepared *rewritePreparation) snapshotAttachment(attachment rewriteAttachm
 		return "", 0, errRewriteBlocked
 	}
 	path := output.Name()
-	copied, copyErr := io.CopyN(output, input, limit+1)
-	if errors.Is(copyErr, io.EOF) {
-		copyErr = nil
-	}
-	closeErr := output.Close()
-	if copyErr != nil || closeErr != nil || copied != info.Size() || copied > limit {
+	copied, copyErr := copyRewriteSnapshot(prepared.context(), output, input, info.Size(), limit)
+	if copyErr != nil {
 		return "", 0, errRewriteBlocked
 	}
-	path = filepath.Clean(path)
-	if prepared.snapshots == nil {
-		prepared.snapshots = map[string]bool{}
-	}
-	prepared.snapshots[path] = true
-	return path, copied, nil
+	return prepared.registerSnapshot(path), copied, nil
 }

--- a/cmd/octopool/string_rewrites_guard.go
+++ b/cmd/octopool/string_rewrites_guard.go
@@ -332,7 +332,7 @@ func rewriteBootstrapInvocation(args []string) bool {
 }
 
 func prepareProtectedGH(ctx context.Context, args []string, stdin io.Reader) (*rewritePreparation, error) {
-	prepared := &rewritePreparation{args: args, stdin: stdin}
+	prepared := &rewritePreparation{ctx: ctx, args: args, stdin: stdin}
 	if rewriteBootstrapInvocation(args) {
 		prepared.forceGitHubHost = true
 		return prepared, nil

--- a/cmd/octopool/string_rewrites_process_test.go
+++ b/cmd/octopool/string_rewrites_process_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -45,8 +46,16 @@ func TestRewriteCaptureProcess(t *testing.T) {
 	capture := rewriteCapture{Args: args, Files: map[string]string{}, FileData: map[string][]byte{}, Modes: map[string]uint32{}, DirectoryModes: map[string]uint32{}, Env: map[string]string{"GH_HOST": os.Getenv("GH_HOST"), "GH_REPO": os.Getenv("GH_REPO")}}
 	input, _ := io.ReadAll(os.Stdin)
 	capture.Stdin = string(input)
-	for _, arg := range args {
+	if path := os.Getenv("OCTOPOOL_TEST_REWRITE_MUTATE_FILE"); path != "" {
+		if err := os.WriteFile(path, []byte("later source bytes"), 0600); err != nil {
+			os.Exit(83)
+		}
+	}
+	for index, arg := range args {
 		paths := []string{}
+		if len(args) > 2 && args[0] == "release" && args[1] == "create" && index > 2 && !strings.HasPrefix(arg, "-") {
+			paths = append(paths, arg)
+		}
 		for _, prefix := range []string{"--body-file=", "--notes-file=", "--input=", "--attach="} {
 			if path, ok := strings.CutPrefix(arg, prefix); ok {
 				if prefix == "--attach=" {
@@ -77,6 +86,13 @@ func TestRewriteCaptureProcess(t *testing.T) {
 	data, _ := json.Marshal(capture)
 	if err := os.WriteFile(capturePath, data, 0600); err != nil {
 		os.Exit(81)
+	}
+	if os.Getenv("OCTOPOOL_TEST_REWRITE_WAIT") == "1" {
+		interrupt := make(chan os.Signal, 1)
+		signal.Notify(interrupt, os.Interrupt)
+		_, _ = io.WriteString(os.Stdout, "child ready\n")
+		<-interrupt
+		os.Exit(82)
 	}
 	_, _ = io.WriteString(os.Stdout, "child stdout\n")
 	_, _ = io.WriteString(os.Stderr, "child stderr\n")

--- a/cmd/octopool/string_rewrites_release_assets.go
+++ b/cmd/octopool/string_rewrites_release_assets.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const rewriteMaxReleaseBasename = 255
+
+type rewriteReleaseLimits struct {
+	count       int
+	file, total int64
+}
+
+var defaultRewriteReleaseLimits = rewriteReleaseLimits{16, 1 << 30, 4 << 30}
+
+type rewriteReleaseAsset struct {
+	source, resolved, name string
+	info                   os.FileInfo
+	change                 rewriteAssetChange
+}
+
+func validRewriteReleaseName(name string) bool {
+	if !validRewriteFilesystemComponent(name) || strings.HasPrefix(name, ".") || strings.HasPrefix(name, "-") {
+		return false
+	}
+	// An explicit public-name subset avoids guessing GitHub's filename rewrites.
+	for _, c := range []byte(name) {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '.' || c == '_' || c == '-') {
+			return false
+		}
+	}
+	return true
+}
+
+func validRewriteFilesystemComponent(name string) bool {
+	if name == "" || name == "." || name == ".." || len(name) > rewriteMaxReleaseBasename || !utf8.ValidString(name) || strings.HasSuffix(name, ".") || strings.HasSuffix(name, " ") || strings.ContainsAny(name, "<>:\"/\\|?*") {
+		return false
+	}
+	for _, r := range name {
+		if unicode.IsControl(r) || unicode.Is(unicode.Cf, r) {
+			return false
+		}
+	}
+	base, _, _ := strings.Cut(strings.ToUpper(name), ".")
+	base = strings.TrimRight(base, " ")
+	if base == "CON" || base == "PRN" || base == "AUX" || base == "NUL" || base == "CONIN$" || base == "CONOUT$" {
+		return false
+	}
+	if strings.HasPrefix(base, "COM") || strings.HasPrefix(base, "LPT") {
+		if suffix := []rune(base[3:]); len(suffix) == 1 && strings.ContainsRune("123456789¹²³", suffix[0]) {
+			return false
+		}
+	}
+	return true
+}
+
+// Release operands have label/glob syntax that ordinary filesystem paths do not.
+// Check both original and generated operands before handing them to native gh.
+func validRewriteReleasePath(path string) bool {
+	return !strings.ContainsAny(path, "#*?[]{}") && validRewriteFilesystemPath(path)
+}
+
+// Lexical checks precede operand access, including on Windows where a UNC/device
+// path could otherwise contact a server or open a named pipe.
+func validRewriteFilesystemPath(path string) bool {
+	if path == "" || !utf8.ValidString(path) || strings.HasPrefix(path, `\`) || strings.HasPrefix(path, "//") {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		path = filepath.ToSlash(path)
+		if len(path) >= 2 && path[1] == ':' {
+			if len(path) < 3 || path[2] != '/' || !((path[0] >= 'a' && path[0] <= 'z') || (path[0] >= 'A' && path[0] <= 'Z')) {
+				return false
+			}
+			path = path[2:]
+		}
+	}
+	parts := strings.Split(path, "/")
+	for i, part := range parts {
+		if i == 0 && (part == "" || part == ".") {
+			continue
+		}
+		if !validRewriteFilesystemComponent(part) {
+			return false
+		}
+	}
+	return true
+}
+
+func (prepared *rewritePreparation) unchangedReleaseText(policy stringRewritePolicy, value string) error {
+	result, err := prepared.text(policy, value)
+	if err != nil || result != value {
+		return errRewriteBlocked
+	}
+	return nil
+}
+
+func (prepared *rewritePreparation) releaseAssets(policy stringRewritePolicy, paths []string, limits rewriteReleaseLimits) ([]rewriteReleaseAsset, error) {
+	if len(paths) == 0 || len(paths) > limits.count {
+		return nil, errRewriteBlocked
+	}
+	for _, path := range paths {
+		if !validRewriteReleaseName(filepath.Base(path)) || !validRewriteReleasePath(path) || prepared.unchangedReleaseText(policy, path) != nil || prepared.unchangedReleaseText(policy, filepath.Base(path)) != nil {
+			return nil, errRewriteBlocked
+		}
+	}
+	assets := make([]rewriteReleaseAsset, 0, len(paths))
+	var total int64
+	for _, path := range paths {
+		if err := prepared.context().Err(); err != nil {
+			return nil, err
+		}
+		resolved, info, change, err := inspectRewriteReleaseAsset(path)
+		if err != nil || !validRewriteReleasePath(resolved) || prepared.unchangedReleaseText(policy, resolved) != nil || !info.Mode().IsRegular() || info.Size() <= 0 || info.Size() > limits.file || info.Size() > limits.total-total {
+			return nil, errRewriteBlocked
+		}
+		name := filepath.Base(path)
+		for _, seen := range assets {
+			if strings.EqualFold(seen.name, name) || os.SameFile(seen.info, info) {
+				return nil, errRewriteBlocked
+			}
+		}
+		total += info.Size()
+		assets = append(assets, rewriteReleaseAsset{path, resolved, name, info, change})
+	}
+	return assets, nil
+}
+
+func sameRewriteAssetInfo(a, b os.FileInfo) bool {
+	return a != nil && b != nil && os.SameFile(a, b) && a.Mode() == b.Mode() && a.Size() == b.Size() && a.ModTime() == b.ModTime()
+}
+
+type rewriteSnapshotCopy func(context.Context, io.WriteCloser, io.Reader, int64, int64) (int64, error)
+
+func (prepared *rewritePreparation) snapshotReleaseAsset(asset rewriteReleaseAsset, limit int64, copySnapshot rewriteSnapshotCopy) (string, int64, error) {
+	if err := prepared.context().Err(); err != nil {
+		return "", 0, err
+	}
+	input, closeInput, err := openRewriteReleaseAsset(asset.resolved)
+	if err != nil {
+		return "", 0, errRewriteBlocked
+	}
+	defer closeInput()
+	info, err := input.Stat()
+	change, changeErr := rewriteReleaseChange(input, info)
+	if err != nil || changeErr != nil || !sameRewriteAssetInfo(asset.info, info) || change != asset.change {
+		return "", 0, errRewriteBlocked
+	}
+	if err := prepared.ensureSnapshotDirectory(); err != nil {
+		return "", 0, err
+	}
+	directory := filepath.Join(prepared.directory, "assets")
+	if err := os.Mkdir(directory, 0700); err != nil && !os.IsExist(err) {
+		return "", 0, errRewriteBlocked
+	}
+	path := filepath.Join(directory, asset.name)
+	output, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return "", 0, errRewriteBlocked
+	}
+	copied, err := copySnapshot(prepared.context(), output, input, info.Size(), limit)
+	if err != nil {
+		return "", 0, errRewriteBlocked
+	}
+	after, err := input.Stat()
+	afterChange, changeErr := rewriteReleaseChange(input, after)
+	if err != nil || changeErr != nil || !sameRewriteAssetInfo(info, after) || change != afterChange {
+		return "", 0, errRewriteBlocked
+	}
+	// Also check the names, since a valid open descriptor survives path replacement.
+	for _, source := range []string{asset.source, asset.resolved} {
+		resolved, current, currentChange, err := inspectRewriteReleaseAsset(source)
+		if err != nil || resolved != asset.resolved || !sameRewriteAssetInfo(info, current) || currentChange != change {
+			return "", 0, errRewriteBlocked
+		}
+	}
+	if err := prepared.context().Err(); err != nil {
+		return "", 0, err
+	}
+	return prepared.registerSnapshot(path), copied, nil
+}

--- a/cmd/octopool/string_rewrites_release_assets_darwin.go
+++ b/cmd/octopool/string_rewrites_release_assets_darwin.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func rewriteReleaseChange(_ *os.File, info os.FileInfo) (rewriteAssetChange, error) {
+	if info == nil {
+		return rewriteAssetChange{}, errRewriteBlocked
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return rewriteAssetChange{}, errRewriteBlocked
+	}
+	return rewriteAssetChange{stat.Ctimespec.Sec, stat.Ctimespec.Nsec}, nil
+}

--- a/cmd/octopool/string_rewrites_release_assets_filenames_test.go
+++ b/cmd/octopool/string_rewrites_release_assets_filenames_test.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReleaseAssetsStagingProcessRejectsSpecialTempRoots(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	// Create the original before selecting a special temp root: only the generated
+	// operand should contain native gh label/pattern syntax.
+	source := releaseAssetFile(t, "asset.zip", []byte{0, 0xff, 1})
+	if !validRewriteReleasePath(source) {
+		t.Fatal("source fixture is not a literal release operand")
+	}
+	for _, name := range []string{"label#root", "glob[ab]", "glob{a,b}", "glob*", "glob?"} {
+		t.Run(name, func(t *testing.T) {
+			capture := captureRewriteGH(t)
+			temporary := filepath.Join(t.TempDir(), name)
+			if err := os.Mkdir(temporary, 0700); err != nil {
+				t.Fatal(err)
+			}
+			for _, variable := range []string{"TMPDIR", "TMP", "TEMP"} {
+				t.Setenv(variable, temporary)
+			}
+			if err := execRealGHWithStdin(t.Context(), releaseAssetArgs(source), strings.NewReader(""), io.Discard, io.Discard); err != errRewriteBlocked {
+				t.Errorf("nonliteral generated operand was not blocked: %v", err)
+			}
+			if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				got := readRewriteCapture(t, capture)
+				path := got.Args[len(got.Args)-1]
+				if path == source || !strings.Contains(path, name) || filepath.Base(path) != "asset.zip" {
+					t.Fatalf("unexpected reproduction operand: %q", path)
+				}
+				t.Errorf("native child received unsafe generated release operand %q", path)
+			}
+			assertReleaseAssetTempEmpty(t, temporary)
+		})
+	}
+}
+
+func TestReleaseAssetsStagingProcessPreservesMetadata(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	for _, name := range []string{"notes#staging", "notes[staging]"} {
+		t.Run(name, func(t *testing.T) {
+			for _, test := range []struct {
+				name string
+				args []string
+			}{
+				{"issue", []string{"issue", "create", "--repo=acme/repo", "--title=Safe", "--body=internal-model"}},
+				{"assetless release", []string{"release", "create", "v1", "--repo=acme/repo", "--verify-tag", "--title=Safe", "--notes=internal-model"}},
+			} {
+				t.Run(test.name, func(t *testing.T) {
+					capture := captureRewriteGH(t)
+					temporary := filepath.Join(t.TempDir(), name)
+					if err := os.Mkdir(temporary, 0700); err != nil {
+						t.Fatal(err)
+					}
+					for _, variable := range []string{"TMPDIR", "TMP", "TEMP"} {
+						t.Setenv(variable, temporary)
+					}
+					if err := execRealGHWithStdin(t.Context(), test.args, strings.NewReader(""), io.Discard, io.Discard); err != nil {
+						t.Fatal(err)
+					}
+					got := readRewriteCapture(t, capture)
+					if len(got.FileData) != 1 || !rewriteCaptureHasContent(got, "public") {
+						t.Fatal("metadata snapshot changed")
+					}
+					for path := range got.FileData {
+						if !strings.Contains(path, name) {
+							t.Fatalf("special temp root not used: %q", path)
+						}
+					}
+					assertReleaseAssetTempEmpty(t, temporary)
+				})
+			}
+		})
+	}
+}
+
+func TestReleaseAssetsStagingFilesystemSyntax(t *testing.T) {
+	for _, test := range []struct {
+		component           string
+		filesystem, operand bool
+	}{
+		{"hash#root", true, false},
+		{"glob[ab]", true, false},
+		{"glob{a,b}", true, false},
+		{"glob*", false, false},
+		{"glob?", false, false},
+		{".claude", true, true},
+		{"space bearing", true, true},
+		{"日本語", true, true},
+		{"..", false, false},
+		{"NUL", false, false},
+		{"stream:dir", false, false},
+		{"control\n", false, false},
+	} {
+		t.Run(test.component, func(t *testing.T) {
+			path := "source/" + test.component + "/asset.zip"
+			if got := validRewriteFilesystemPath(path); got != test.filesystem {
+				t.Errorf("filesystem path=%v want=%v", got, test.filesystem)
+			}
+			if got := validRewriteReleasePath(path); got != test.operand {
+				t.Errorf("release operand=%v want=%v", got, test.operand)
+			}
+		})
+	}
+	for _, path := range []string{`\\server\share\asset.zip`, `\\?\C:\asset.zip`, `\\.\pipe\input`} {
+		if validRewriteFilesystemPath(path) || validRewriteReleasePath(path) {
+			t.Errorf("unsafe filesystem namespace accepted: %q", path)
+		}
+	}
+}
+
+func TestReleaseAssetsFilenameProcessRejectsRenamedPublicNames(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	for _, name := range []string{".asset.zip", "asset name.zip", "日本語.zip", "asset+build.zip", "asset@build.zip", "asset(1).zip"} {
+		t.Run(name, func(t *testing.T) {
+			capture := captureRewriteGH(t)
+			source := releaseAssetFile(t, name, []byte{0, 0xff, 1})
+			temporary := releaseAssetTemp(t)
+			if err := execRealGHWithStdin(t.Context(), releaseAssetArgs(source), strings.NewReader(""), io.Discard, io.Discard); err != errRewriteBlocked {
+				t.Errorf("existing unsupported public name was not blocked: %v", err)
+			}
+			if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Error("native child executed for an unsupported public name")
+			}
+			assertReleaseAssetTempEmpty(t, temporary)
+		})
+	}
+}
+
+func releaseAssetFilenameSourceDirectory(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), ".claude", "release candidates + symbols", "日本語")
+	if err := os.MkdirAll(path, 0700); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// This filesystem proof runs natively on Windows too, without the shell harness.
+func TestReleaseAssetsFilenameSourceDirectories(t *testing.T) {
+	sourceDirectory := releaseAssetFilenameSourceDirectory(t)
+	temporary := filepath.Join(t.TempDir(), ".private staging", "日本語")
+	if err := os.MkdirAll(temporary, 0700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"TMPDIR", "TMP", "TEMP"} {
+		t.Setenv(name, temporary)
+	}
+	policy, err := compileStringRewriteRules([]stringRewriteRule{{Pattern: "private-term", Replacement: "public"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared := &rewritePreparation{ctx: t.Context()}
+	defer prepared.cleanup()
+	names := []string{"_asset-1.2.3.zip", "checksums.txt", "provenance.json"}
+	paths := make([]string, len(names))
+	payload := []byte{0, 0xff, 1, 2}
+	for i, name := range names {
+		paths[i] = filepath.Join(sourceDirectory, name)
+		if err := os.WriteFile(paths[i], payload, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	assets, err := prepared.releaseAssets(policy, paths, defaultRewriteReleaseLimits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, asset := range assets {
+		path, size, err := prepared.snapshotReleaseAsset(asset, defaultRewriteReleaseLimits.file, copyRewriteSnapshot)
+		if err != nil || size != int64(len(payload)) || filepath.Base(path) != names[i] || !prepared.snapshots[path] {
+			t.Fatalf("snapshot %d: path=%q size=%d error=%v", i, path, size, err)
+		}
+		if data, err := os.ReadFile(path); err != nil || !bytes.Equal(data, payload) {
+			t.Fatalf("snapshot %d changed opaque bytes: %v", i, err)
+		}
+	}
+	prepared.cleanup()
+	assertReleaseAssetTempEmpty(t, temporary)
+}
+
+func TestReleaseAssetsFilenameValidation(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		public, source bool
+	}{
+		{"asset-1.2_amd64.tar.gz", true, true},
+		{"_asset.zip", true, true},
+		{"_", true, true},
+		{"asset_", true, true},
+		{"asset-", true, true},
+		{"asset..zip", true, true},
+		{".asset.zip", false, true},
+		{".claude", false, true},
+		{"asset name.zip", false, true},
+		{"日本語.zip", false, true},
+		{"asset+build.zip", false, true},
+		{"asset@build.zip", false, true},
+		{"asset(1).zip", false, true},
+		{"ARCHIV~1.ZIP", false, true},
+		{"", false, false},
+		{".", false, false},
+		{"..", false, false},
+		{"asset.zip.", false, false},
+		{"asset.zip ", false, false},
+		{"-asset.zip", false, true},
+		{"CON.zip", false, false},
+		{"nul", false, false},
+		{"LPT1.zip", false, false},
+		{"COM¹.zip", false, false},
+		{"asset#label", false, false},
+		{"asset:stream", false, false},
+		{"asset*.zip", false, false},
+		{"asset\n.zip", false, false},
+		{"asset\xff.zip", false, false},
+		{strings.Repeat("a", 255), true, true},
+		{strings.Repeat("a", 256), false, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := validRewriteReleaseName(test.name); got != test.public {
+				t.Errorf("public-name validation=%v want=%v", got, test.public)
+			}
+			if got := validRewriteReleasePath("source/" + test.name); got != test.source {
+				t.Errorf("source-path validation=%v want=%v", got, test.source)
+			}
+		})
+	}
+	for _, path := range []string{"source/../asset.zip", "source/./asset.zip", "source/CON/asset.zip", `\\server\share\asset.zip`, `\\?\C:\asset.zip`} {
+		if validRewriteReleasePath(path) {
+			t.Errorf("unsafe source path accepted: %q", path)
+		}
+	}
+}

--- a/cmd/octopool/string_rewrites_release_assets_linux.go
+++ b/cmd/octopool/string_rewrites_release_assets_linux.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func rewriteReleaseChange(_ *os.File, info os.FileInfo) (rewriteAssetChange, error) {
+	if info == nil {
+		return rewriteAssetChange{}, errRewriteBlocked
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return rewriteAssetChange{}, errRewriteBlocked
+	}
+	return rewriteAssetChange{int64(stat.Ctim.Sec), int64(stat.Ctim.Nsec)}, nil
+}

--- a/cmd/octopool/string_rewrites_release_assets_other.go
+++ b/cmd/octopool/string_rewrites_release_assets_other.go
@@ -1,0 +1,20 @@
+//go:build !darwin && !linux && !windows
+
+package main
+
+import "os"
+
+type rewriteAssetChange struct{}
+
+// Asset snapshots are modeled only on the platforms in the release matrix.
+func inspectRewriteReleaseAsset(string) (string, os.FileInfo, rewriteAssetChange, error) {
+	return "", nil, rewriteAssetChange{}, errRewriteBlocked
+}
+
+func openRewriteReleaseAsset(string) (*os.File, func(), error) {
+	return nil, nil, errRewriteBlocked
+}
+
+func rewriteReleaseChange(*os.File, os.FileInfo) (rewriteAssetChange, error) {
+	return rewriteAssetChange{}, errRewriteBlocked
+}

--- a/cmd/octopool/string_rewrites_release_assets_test.go
+++ b/cmd/octopool/string_rewrites_release_assets_test.go
@@ -1,0 +1,503 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReleaseAssetsProcessEightOpaqueSnapshots(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	capturePath := captureRewriteGH(t)
+	t.Setenv("GH_HOST", "other.example")
+	t.Setenv("GH_REPO", "other/repo")
+	directory := releaseAssetFilenameSourceDirectory(t)
+	notes := "# Toolkit 1.2.3\r\n\nReviewed release notes. 🦞\n"
+	notesPath := filepath.Join(directory, "notes.md")
+	if err := os.WriteFile(notesPath, []byte(notes), 0600); err != nil {
+		t.Fatal(err)
+	}
+	names := []string{"toolkit_1.2.3_darwin_amd64.tar.gz", "toolkit_1.2.3_darwin_arm64.tar.gz", "toolkit_1.2.3_linux_amd64.tar.gz", "toolkit_1.2.3_linux_arm64.tar.gz", "toolkit_1.2.3_windows_amd64.zip", "toolkit_1.2.3_windows_arm64.zip", "checksums.txt", "provenance.json"}
+	args := []string{"release", "create", "v1.2.3", "--repo", "acme/toolkit", "--draft", "--verify-tag", "--title", "Toolkit 1.2.3", "--notes-file", notesPath}
+	payloads := make([][]byte, len(names))
+	for i, name := range names {
+		payloads[i] = append([]byte{byte(i), 0, 0xff, 0xfe}, []byte("internal-model\n"+rewriteActiveTestPolicy)...)
+		if name == "provenance.json" {
+			payloads[i] = []byte(rewriteActiveTestPolicy)
+		}
+		path := filepath.Join(directory, name)
+		if err := os.WriteFile(path, payloads[i], 0600); err != nil {
+			t.Fatal(err)
+		}
+		args = append(args, path)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := execRealGHWithStdin(context.Background(), args, strings.NewReader("must not reach child"), &stdout, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	capture := readRewriteCapture(t, capturePath)
+	if !slices.Equal(capture.Args[:3], []string{"release", "create", "v1.2.3"}) || !slices.Contains(capture.Args, "--title=Toolkit 1.2.3") || !slices.Contains(capture.Args, "--repo=acme/toolkit") || !slices.Contains(capture.Args, "--draft=true") || !slices.Contains(capture.Args, "--verify-tag=true") {
+		t.Fatalf("metadata: %v", capture.Args)
+	}
+	if capture.Stdin != "" || capture.Env["GH_HOST"] != "github.com" || capture.Env["GH_REPO"] != "" {
+		t.Fatalf("stdin/host: %+v", capture)
+	}
+	if stdout.String() != "child stdout\n" || stderr.String() != "child stderr\n" {
+		t.Fatalf("streams: %q %q", stdout.String(), stderr.String())
+	}
+	if len(capture.FileData) != 9 || !rewriteCaptureHasContent(capture, notes) {
+		t.Fatal("canonical notes or asset count changed")
+	}
+	assets := []string{}
+	for _, arg := range capture.Args[3:] {
+		if !strings.HasPrefix(arg, "-") {
+			assets = append(assets, arg)
+		}
+	}
+	if len(assets) != len(names) {
+		t.Fatalf("assets: %v", assets)
+	}
+	for i, path := range assets {
+		if filepath.Base(path) != names[i] || !bytes.Equal(capture.FileData[path], payloads[i]) || path == filepath.Join(directory, names[i]) {
+			t.Fatalf("asset %d changed", i)
+		}
+	}
+	for path := range capture.FileData {
+		if capture.Modes[path] != 0600 || capture.DirectoryModes[path] != 0700 {
+			t.Fatal("nonprivate snapshot")
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatal("snapshot leaked")
+		}
+		if _, err := os.Stat(filepath.Dir(path)); !os.IsNotExist(err) {
+			t.Fatal("snapshot directory leaked")
+		}
+	}
+}
+
+func releaseAssetArgs(paths ...string) []string {
+	return append([]string{"release", "create", "v1.2.3", "--repo=acme/toolkit", "--draft", "--verify-tag", "--title=Toolkit 1.2.3", "--notes=Reviewed notes.\n"}, paths...)
+}
+
+func releaseAssetFile(t *testing.T, name string, data []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func releaseAssetTemp(t *testing.T) string {
+	t.Helper()
+	path := t.TempDir()
+	t.Setenv("TMPDIR", path)
+	t.Setenv("TMP", path)
+	t.Setenv("TEMP", path)
+	return path
+}
+
+func assertReleaseAssetTempEmpty(t *testing.T, path string) {
+	t.Helper()
+	entries, err := os.ReadDir(path)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("leaked preparation: %v %v", entries, err)
+	}
+}
+
+func TestReleaseAssetsProcessRejectsUnsafeInputs(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	safe := releaseAssetFile(t, "safe.zip", []byte("opaque"))
+	names := []string{"-", "https://example.com/asset.zip", "//server/share/a.zip", `\\server\share\a.zip`, `\\?\C:\a.zip`, `\\.\pipe\input`, "../a.zip", "a/../b.zip", "a/*", "a/[ab].zip", "a/{b,c}.zip", "a#label", "a\n.zip", "a\x00.zip", "a\xff.zip", "a:b.zip", "a ", "a.", "CON", "con.zip", "PRN.txt", "COM1.zip", "LPT².zip", "NUL", "CONIN$", "a\u202e.zip", strings.Repeat("a", 256)}
+	cases := map[string][]string{
+		"missing draft":      slices.Delete(slices.Clone(releaseAssetArgs(safe)), 4, 5),
+		"false draft":        append(slices.Delete(slices.Clone(releaseAssetArgs(safe)), 4, 5), "--draft=false"),
+		"missing verify":     slices.Delete(slices.Clone(releaseAssetArgs(safe)), 5, 6),
+		"false verify":       append(slices.Delete(slices.Clone(releaseAssetArgs(safe)), 5, 6), "--verify-tag=false"),
+		"conflicting draft":  append(releaseAssetArgs(safe), "-d=false"),
+		"duplicate verify":   append(releaseAssetArgs(safe), "--verify-tag"),
+		"unknown flag":       append(releaseAssetArgs(safe), "--target=main"),
+		"label flag":         append(releaseAssetArgs(safe), "--clobber"),
+		"changed title":      append(slices.Delete(slices.Clone(releaseAssetArgs(safe)), 6, 7), "--title=internal-model"),
+		"changed notes":      append(slices.Delete(slices.Clone(releaseAssetArgs(safe)), 7, 8), "--notes=internal-model"),
+		"blank title":        append(slices.Delete(slices.Clone(releaseAssetArgs(safe)), 6, 7), "--title= \t"),
+		"blank notes":        append(slices.Delete(slices.Clone(releaseAssetArgs(safe)), 7, 8), "--notes= \n"),
+		"invalid utf8 title": append(slices.Delete(slices.Clone(releaseAssetArgs(safe)), 6, 7), "--title=\xff"),
+		"invalid utf8 notes": append(slices.Delete(slices.Clone(releaseAssetArgs(safe)), 7, 8), "--notes=\xff"),
+		"policy material":    append(slices.Delete(slices.Clone(releaseAssetArgs(safe)), 7, 8), "--notes="+rewriteActiveTestPolicy),
+		"notes conflict":     append(releaseAssetArgs(safe), "--notes-file=missing"),
+		"missing title":      slices.Delete(slices.Clone(releaseAssetArgs(safe)), 6, 7),
+		"missing notes":      slices.Delete(slices.Clone(releaseAssetArgs(safe)), 7, 8),
+		"too much text":      append(slices.Delete(slices.Clone(releaseAssetArgs(safe)), 7, 8), "--notes="+strings.Repeat("x", rewriteMaxContent)),
+		"duplicate source":   releaseAssetArgs(safe, safe),
+		"duplicate basename": releaseAssetArgs(safe, releaseAssetFile(t, "safe.zip", []byte("different"))),
+		"case collision":     releaseAssetArgs(safe, releaseAssetFile(t, "SAFE.ZIP", []byte("different"))),
+		"fold collision":     releaseAssetArgs(releaseAssetFile(t, "k.zip", []byte("a")), releaseAssetFile(t, "K.zip", []byte("b"))),
+		"missing file":       releaseAssetArgs(filepath.Join(t.TempDir(), "missing.zip")),
+		"empty file":         releaseAssetArgs(releaseAssetFile(t, "empty.zip", nil)),
+		"directory":          releaseAssetArgs(t.TempDir()),
+		"changed source":     releaseAssetArgs(releaseAssetFile(t, "internal-model.zip", []byte("data"))),
+	}
+	for i, name := range names {
+		cases[fmt.Sprintf("bad path %d", i)] = releaseAssetArgs(name)
+	}
+	tooMany := []string{}
+	for i := 0; i < 17; i++ {
+		tooMany = append(tooMany, safe)
+	}
+	cases["too many files"] = releaseAssetArgs(tooMany...)
+	edit := releaseAssetArgs(safe)
+	edit[1] = "edit"
+	edit = slices.Delete(edit, 5, 6)
+	cases["edit arity"] = edit
+	for name, args := range cases {
+		t.Run(name, func(t *testing.T) {
+			capture := captureRewriteGH(t)
+			temporary := releaseAssetTemp(t)
+			if err := execRealGHWithStdin(t.Context(), args, strings.NewReader(""), io.Discard, io.Discard); err != errRewriteBlocked {
+				t.Fatalf("error=%v", err)
+			}
+			if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Fatal("child executed")
+			}
+			assertReleaseAssetTempEmpty(t, temporary)
+		})
+	}
+}
+
+func TestReleaseAssetsLimitsAndIdentity(t *testing.T) {
+	policy, err := compileStringRewriteRules([]stringRewriteRule{{Pattern: "private-term", Replacement: "public"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := releaseAssetFile(t, "one.zip", []byte("1234"))
+	second := releaseAssetFile(t, "two.zip", []byte("5678"))
+	alias := filepath.Join(t.TempDir(), "alias.zip")
+	if err := os.Link(first, alias); err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name   string
+		paths  []string
+		limits rewriteReleaseLimits
+		ok     bool
+	}{
+		{"at limits", []string{first, second}, rewriteReleaseLimits{2, 4, 8}, true},
+		{"file limit", []string{first}, rewriteReleaseLimits{2, 3, 8}, false},
+		{"total limit", []string{first, second}, rewriteReleaseLimits{2, 4, 7}, false},
+		{"count limit", []string{first, second}, rewriteReleaseLimits{1, 4, 8}, false},
+		{"hardlink", []string{first, alias}, defaultRewriteReleaseLimits, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			prepared := &rewritePreparation{}
+			_, err := prepared.releaseAssets(policy, test.paths, test.limits)
+			if (err == nil) != test.ok {
+				t.Fatalf("error=%v", err)
+			}
+			if prepared.directory != "" {
+				t.Fatal("inventory staged bytes")
+			}
+		})
+	}
+	if defaultRewriteReleaseLimits != (rewriteReleaseLimits{16, 1 << 30, 4 << 30}) || rewriteSnapshotBuffer != 65536 || rewriteMaxReleaseBasename != 255 || rewriteMaxContent != 1048576 {
+		t.Fatal("resource contract changed")
+	}
+	if !validRewriteReleaseName(strings.Repeat("a", 255)) || validRewriteReleaseName(strings.Repeat("é", 128)) {
+		t.Fatal("basename budget is not bytes")
+	}
+}
+
+func TestReleaseAssetsPostStagingSourceChange(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	capturePath := captureRewriteGH(t)
+	source := releaseAssetFile(t, "frozen.zip", []byte{0, 0xff, 3, 4})
+	temporary := releaseAssetTemp(t)
+	// The child mutates the original after preparation, before reading argv files.
+	t.Setenv("OCTOPOOL_TEST_REWRITE_MUTATE_FILE", source)
+	if err := execRealGHWithStdin(t.Context(), releaseAssetArgs(source), strings.NewReader("ignored"), io.Discard, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	capture := readRewriteCapture(t, capturePath)
+	if !rewriteCaptureHasData(capture, []byte{0, 0xff, 3, 4}) {
+		t.Fatal("child did not receive the completed snapshot")
+	}
+	if data, err := os.ReadFile(source); err != nil || string(data) != "later source bytes" {
+		t.Fatal("child did not mutate the original")
+	}
+	assertReleaseAssetTempEmpty(t, temporary)
+}
+
+func TestReleaseAssetsProcessFailureCleanup(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	source := releaseAssetFile(t, "safe.zip", []byte("data"))
+	for _, kind := range []string{"child", "start", "canceled"} {
+		t.Run(kind, func(t *testing.T) {
+			capture := captureRewriteGH(t)
+			invalidGH := releaseAssetFile(t, "invalid-gh", []byte("not an executable format"))
+			if err := os.Chmod(invalidGH, 0700); err != nil {
+				t.Fatal(err)
+			}
+			temporary := releaseAssetTemp(t)
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			if kind == "child" {
+				t.Setenv("OCTOPOOL_TEST_REWRITE_EXIT", "37")
+			}
+			if kind == "start" {
+				t.Setenv("OCTOPOOL_GH_PATH", invalidGH)
+			}
+			if kind == "canceled" {
+				cancel()
+			}
+			var stdout, stderr bytes.Buffer
+			err := execRealGHWithStdin(ctx, releaseAssetArgs(source), strings.NewReader(""), &stdout, &stderr)
+			if err == nil {
+				t.Fatal("expected failure")
+			}
+			if kind == "child" {
+				var exit exitCodeError
+				if !errors.As(err, &exit) || exit.Code != 37 {
+					t.Fatalf("exit=%v", err)
+				}
+				if stdout.String() != "child stdout\n" || stderr.String() != "child stderr\n" {
+					t.Fatal("streams changed")
+				}
+				readRewriteCapture(t, capture)
+			} else if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Fatal("child executed")
+			}
+			assertReleaseAssetTempEmpty(t, temporary)
+		})
+	}
+}
+
+type failingSnapshotOutput struct {
+	bytes.Buffer
+	failWrite, shortWrite, failClose bool
+	closed                           bool
+}
+
+func (w *failingSnapshotOutput) Write(p []byte) (int, error) {
+	if w.failWrite {
+		return 0, io.ErrClosedPipe
+	}
+	if w.shortWrite {
+		return len(p) - 1, nil
+	}
+	return w.Buffer.Write(p)
+}
+func (w *failingSnapshotOutput) Close() error {
+	w.closed = true
+	if w.failClose {
+		return io.ErrClosedPipe
+	}
+	return nil
+}
+
+type releaseChunkReader struct {
+	reader io.Reader
+	after  func()
+	calls  int
+}
+
+func (r *releaseChunkReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	r.calls++
+	if r.calls == 1 && r.after != nil {
+		r.after()
+	}
+	return n, err
+}
+
+func TestReleaseAssetsBoundedCopyFailures(t *testing.T) {
+	for _, kind := range []string{"write", "short write", "close", "truncated", "grown", "canceled", "read"} {
+		t.Run(kind, func(t *testing.T) {
+			output := &failingSnapshotOutput{failWrite: kind == "write", shortWrite: kind == "short write", failClose: kind == "close"}
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			data := bytes.Repeat([]byte("z"), rewriteSnapshotBuffer+8)
+			expected := int64(len(data))
+			if kind == "truncated" {
+				expected++
+			}
+			if kind == "grown" {
+				expected--
+			}
+			var input io.Reader = bytes.NewReader(data)
+			if kind == "read" {
+				input = errReleaseReader{}
+			}
+			if kind == "canceled" {
+				input = &releaseChunkReader{reader: input, after: cancel}
+			}
+			_, err := copyRewriteSnapshot(ctx, output, input, expected, expected)
+			if err == nil || !output.closed {
+				t.Fatalf("error=%v closed=%v", err, output.closed)
+			}
+			if kind == "canceled" && output.Len() > rewriteSnapshotBuffer {
+				t.Fatal("read continued after cancellation")
+			}
+		})
+	}
+}
+
+type errReleaseReader struct{}
+
+func (errReleaseReader) Read([]byte) (int, error) { return 0, io.ErrUnexpectedEOF }
+
+func TestReleaseAssetsExistingPublicationCommands(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	sha := strings.Repeat("a", 40)
+	for _, test := range []struct {
+		name string
+		args []string
+		body string
+	}{
+		{"asset verifier inputs", []string{"workflow", "run", "verify-assets.yml", "--repo=acme/toolkit", "--ref=main", "-f", "release_id=123", "-f", "tag=v1.2.3", "-f", "tag_object=" + sha, "-f", "tag_commit=" + sha, "-f", "verifier_commit=" + sha, "-f", "workflow_commit=" + sha, "-f", "draft=true"}, ""},
+		{"package verifier inputs", []string{"workflow", "run", "verify-package.yml", "--repo=acme/toolkit", "--ref=main", "-f", "tag=v1.2.3", "-f", "tag_object=" + sha, "-f", "source_commit=" + sha, "-f", "verifier_commit=" + sha, "-f", "release_id=123", "-f", "public_verifier_run_id=456"}, ""},
+		{"numeric publication patch", []string{"api", "repos/acme/toolkit/releases/123", "--method=PATCH", "--input=-"}, `{"draft":false}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			capturePath := captureRewriteGH(t)
+			if err := execRealGHWithStdin(t.Context(), test.args, strings.NewReader(test.body), io.Discard, io.Discard); err != nil {
+				t.Fatal(err)
+			}
+			capture := readRewriteCapture(t, capturePath)
+			if test.body != "" {
+				if len(capture.FileData) != 1 || !rewriteCaptureHasContent(capture, test.body) {
+					t.Fatal("publication patch changed")
+				}
+				return
+			}
+			for i, arg := range test.args {
+				if i > 0 && test.args[i-1] == "-f" && !slices.Contains(capture.Args, arg) {
+					t.Fatalf("workflow input lost: %s in %v", arg, capture.Args)
+				}
+			}
+		})
+	}
+}
+
+func TestReleaseAssetsSnapshotWriteCloseAndCancellationCleanup(t *testing.T) {
+	policy, err := compileStringRewriteRules([]stringRewriteRule{{Pattern: "private-term", Replacement: "public"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := releaseAssetFile(t, "archive.zip", bytes.Repeat([]byte("x"), rewriteSnapshotBuffer+1))
+	for _, kind := range []string{"write", "close", "canceled after copy", "exclusive create"} {
+		t.Run(kind, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			prepared := &rewritePreparation{ctx: ctx}
+			defer prepared.cleanup()
+			assets, err := prepared.releaseAssets(policy, []string{source}, defaultRewriteReleaseLimits)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if kind == "exclusive create" {
+				if _, _, err := prepared.snapshotReleaseAsset(assets[0], defaultRewriteReleaseLimits.file, copyRewriteSnapshot); err != nil {
+					t.Fatal(err)
+				}
+			}
+			copySnapshot := func(ctx context.Context, out io.WriteCloser, in io.Reader, expected, limit int64) (int64, error) {
+				if kind == "write" || kind == "close" {
+					out = &releaseFailingCloser{WriteCloser: out, failWrite: kind == "write", failClose: kind == "close"}
+				}
+				n, err := copyRewriteSnapshot(ctx, out, in, expected, limit)
+				if kind == "canceled after copy" {
+					cancel()
+				}
+				return n, err
+			}
+			if _, _, err := prepared.snapshotReleaseAsset(assets[0], defaultRewriteReleaseLimits.file, copySnapshot); err == nil {
+				t.Fatal("failure accepted")
+			}
+			directory := prepared.directory
+			prepared.cleanup()
+			if _, err := os.Stat(directory); !os.IsNotExist(err) {
+				t.Fatal("failed snapshot leaked")
+			}
+		})
+	}
+}
+
+type releaseFailingCloser struct {
+	io.WriteCloser
+	failWrite, failClose bool
+}
+
+func (w *releaseFailingCloser) Write(p []byte) (int, error) {
+	if w.failWrite {
+		return 0, io.ErrClosedPipe
+	}
+	return w.WriteCloser.Write(p)
+}
+func (w *releaseFailingCloser) Close() error {
+	err := w.WriteCloser.Close()
+	if w.failClose {
+		return io.ErrClosedPipe
+	}
+	return err
+}
+
+func TestReleaseAssetsProcessCancellationCleansStaging(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	capturePath := captureRewriteGH(t)
+	source := releaseAssetFile(t, "archive.zip", []byte("opaque"))
+	temporary := releaseAssetTemp(t)
+	t.Setenv("OCTOPOOL_TEST_REWRITE_WAIT", "1")
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	output := &releaseCancelWriter{cancel: cancel}
+	err := execRealGHWithStdin(ctx, releaseAssetArgs(source), strings.NewReader(""), output, io.Discard)
+	if err == nil || !output.ready || ctx.Err() != context.Canceled {
+		t.Fatalf("cancellation error=%v ready=%v context=%v", err, output.ready, ctx.Err())
+	}
+	capture := readRewriteCapture(t, capturePath)
+	if len(capture.FileData) != 2 {
+		t.Fatal("child ran before staging completed")
+	}
+	assertReleaseAssetTempEmpty(t, temporary)
+}
+
+type releaseCancelWriter struct {
+	cancel context.CancelFunc
+	ready  bool
+	data   string
+}
+
+func (w *releaseCancelWriter) Write(p []byte) (int, error) {
+	w.data += string(p)
+	if strings.Contains(w.data, "child ready\n") {
+		w.ready = true
+		w.cancel()
+	}
+	return len(p), nil
+}
+
+func TestReleaseAssetsExactBasenameAndTextBudget(t *testing.T) {
+	source := releaseAssetFile(t, "archive.zip", []byte("opaque"))
+	policy, err := compileStringRewriteRules([]stringRewriteRule{{Pattern: "^archive[.]zip$", Replacement: "renamed.zip"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := (&rewritePreparation{}).releaseAssets(policy, []string{source}, defaultRewriteReleaseLimits); err == nil {
+		t.Fatal("basename-only policy match accepted")
+	}
+	policy, err = compileStringRewriteRules([]stringRewriteRule{{Pattern: "private-term", Replacement: "public"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared := &rewritePreparation{inputBytes: rewriteMaxContent - len(source), outputBytes: rewriteMaxContent - len(source)}
+	if _, err := prepared.releaseAssets(policy, []string{source}, defaultRewriteReleaseLimits); err == nil {
+		t.Fatal("aggregate text metadata budget bypassed")
+	}
+}

--- a/cmd/octopool/string_rewrites_release_assets_unix.go
+++ b/cmd/octopool/string_rewrites_release_assets_unix.go
@@ -1,0 +1,38 @@
+//go:build darwin || linux
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+type rewriteAssetChange struct{ seconds, nanos int64 }
+
+func inspectRewriteReleaseAsset(path string) (string, os.FileInfo, rewriteAssetChange, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", nil, rewriteAssetChange{}, err
+	}
+	// Resolve parent aliases (including macOS /tmp), but never a symlink operand.
+	parent, err := filepath.EvalSymlinks(filepath.Dir(absolute))
+	if err != nil {
+		return "", nil, rewriteAssetChange{}, err
+	}
+	resolved := filepath.Join(parent, filepath.Base(absolute))
+	info, err := os.Lstat(resolved)
+	if err != nil || !info.Mode().IsRegular() {
+		return "", nil, rewriteAssetChange{}, errRewriteBlocked
+	}
+	change, err := rewriteReleaseChange(nil, info)
+	return resolved, info, change, err
+}
+
+func openRewriteReleaseAsset(path string) (*os.File, func(), error) {
+	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	return file, func() { _ = file.Close() }, nil
+}

--- a/cmd/octopool/string_rewrites_release_assets_unix_test.go
+++ b/cmd/octopool/string_rewrites_release_assets_unix_test.go
@@ -1,0 +1,213 @@
+//go:build darwin || linux
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestReleaseAssetsUnixReplacementAndMutation(t *testing.T) {
+	policy, err := compileStringRewriteRules([]stringRewriteRule{{Pattern: "private-term", Replacement: "public"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, kind := range []string{"replacement before open", "symlink before open", "fifo before open", "replacement during copy", "truncate", "growth", "in-place", "restored mtime", "cancel"} {
+		t.Run(kind, func(t *testing.T) {
+			data := bytes.Repeat([]byte{0, 0xff, 'a', 'b'}, rewriteSnapshotBuffer)
+			source := releaseAssetFile(t, "original.zip", data)
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			prepared := &rewritePreparation{ctx: ctx}
+			defer prepared.cleanup()
+			assets, err := prepared.releaseAssets(policy, []string{source}, defaultRewriteReleaseLimits)
+			if err != nil {
+				t.Fatal(err)
+			}
+			before := assets[0].info
+			replace := func() {
+				t.Helper()
+				if err := os.Rename(source, source+".old"); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(source, data, 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			switch kind {
+			case "replacement before open":
+				replace()
+			case "symlink before open", "fifo before open":
+				if err := os.Remove(source); err != nil {
+					t.Fatal(err)
+				}
+				if kind == "symlink before open" {
+					if err := os.Symlink(releaseAssetFile(t, "other.zip", data), source); err != nil {
+						t.Fatal(err)
+					}
+				} else {
+					if err := syscall.Mkfifo(source, 0600); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			copySnapshot := func(ctx context.Context, out io.WriteCloser, in io.Reader, expected, limit int64) (int64, error) {
+				reader := &releaseChunkReader{reader: in, after: func() {
+					switch kind {
+					case "replacement during copy":
+						replace()
+					case "truncate":
+						if err := os.Truncate(source, int64(len(data)/2)); err != nil {
+							t.Fatal(err)
+						}
+					case "growth":
+						if err := os.Truncate(source, int64(len(data)+1)); err != nil {
+							t.Fatal(err)
+						}
+					case "in-place", "restored mtime":
+						f, err := os.OpenFile(source, os.O_WRONLY, 0)
+						if err != nil {
+							t.Fatal(err)
+						}
+						_, writeErr := f.WriteAt([]byte("changed"), rewriteSnapshotBuffer+10)
+						closeErr := f.Close()
+						if writeErr != nil || closeErr != nil {
+							t.Fatal(writeErr, closeErr)
+						}
+						mod := time.Unix(123456789, 0)
+						if kind == "restored mtime" {
+							mod = before.ModTime()
+						}
+						if err := os.Chtimes(source, mod, mod); err != nil {
+							t.Fatal(err)
+						}
+					case "cancel":
+						cancel()
+					}
+				}}
+				return copyRewriteSnapshot(ctx, out, reader, expected, limit)
+			}
+			// Timeout is a deadlock assertion, not race synchronization. The mutation
+			// happens synchronously at the first completed copy-buffer read.
+			done := make(chan error, 1)
+			go func() {
+				_, _, err := prepared.snapshotReleaseAsset(assets[0], defaultRewriteReleaseLimits.file, copySnapshot)
+				done <- err
+			}()
+			select {
+			case err := <-done:
+				if err == nil {
+					t.Fatal("mutation accepted")
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("nonfollowing open/copy hung")
+			}
+			directory := prepared.directory
+			prepared.cleanup()
+			if directory != "" {
+				if _, err := os.Stat(directory); !os.IsNotExist(err) {
+					t.Fatal("partial snapshot leaked")
+				}
+			}
+		})
+	}
+}
+
+func TestReleaseAssetsUnixAliasesAndPermissions(t *testing.T) {
+	policy, err := compileStringRewriteRules([]stringRewriteRule{{Pattern: "private-term", Replacement: "public"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := releaseAssetFile(t, "archive.zip", []byte("opaque"))
+	alias := filepath.Join(t.TempDir(), "alias.zip")
+	if err := os.Symlink(source, alias); err != nil {
+		t.Fatal(err)
+	}
+	prepared := &rewritePreparation{}
+	if _, err := prepared.releaseAssets(policy, []string{alias}, defaultRewriteReleaseLimits); err == nil {
+		t.Fatal("symlink operand accepted")
+	}
+	parent := filepath.Join(t.TempDir(), "parent")
+	if err := os.Symlink(filepath.Dir(source), parent); err != nil {
+		t.Fatal(err)
+	}
+	assets, err := prepared.releaseAssets(policy, []string{filepath.Join(parent, filepath.Base(source))}, defaultRewriteReleaseLimits)
+	if err != nil {
+		t.Fatal("parent alias rejected", err)
+	}
+	defer prepared.cleanup()
+	if _, _, err := prepared.snapshotReleaseAsset(assets[0], defaultRewriteReleaseLimits.file, copyRewriteSnapshot); err != nil {
+		t.Fatal(err)
+	}
+	forbiddenDir := filepath.Join(t.TempDir(), "private-term")
+	if err := os.Mkdir(forbiddenDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(forbiddenDir, "archive.zip"), []byte("opaque"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	hidden := filepath.Join(t.TempDir(), "alias")
+	if err := os.Symlink(forbiddenDir, hidden); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := (&rewritePreparation{}).releaseAssets(policy, []string{filepath.Join(hidden, "archive.zip")}, defaultRewriteReleaseLimits); err == nil {
+		t.Fatal("resolved policy match accepted")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("permission denial requires a non-root user; alias checks completed")
+	}
+	if err := os.Chmod(source, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(source, 0600) })
+	// The inventory may stat it; the protected descriptor open must fail.
+	unreadable, err := (&rewritePreparation{}).releaseAssets(policy, []string{source}, defaultRewriteReleaseLimits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := prepared.snapshotReleaseAsset(unreadable[0], defaultRewriteReleaseLimits.file, copyRewriteSnapshot); err == nil {
+		t.Fatal("unreadable file accepted")
+	}
+}
+
+func TestReleaseAssetsUnixSparseLimitsAndPartialPreparation(t *testing.T) {
+	policy, err := compileStringRewriteRules([]stringRewriteRule{{Pattern: "private-term", Replacement: "public"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sparse := releaseAssetFile(t, "large.zip", []byte("x"))
+	if err := os.Truncate(sparse, defaultRewriteReleaseLimits.file+1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := (&rewritePreparation{}).releaseAssets(policy, []string{sparse}, defaultRewriteReleaseLimits); err == nil {
+		t.Fatal("oversized sparse file accepted")
+	}
+	first := releaseAssetFile(t, "first.zip", []byte("1234"))
+	second := releaseAssetFile(t, "second.zip", []byte("5678"))
+	prepared := &rewritePreparation{}
+	defer prepared.cleanup()
+	assets, err := prepared.releaseAssets(policy, []string{first, second}, defaultRewriteReleaseLimits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := prepared.snapshotReleaseAsset(assets[0], 4, copyRewriteSnapshot); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Truncate(second, 2); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := prepared.snapshotReleaseAsset(assets[1], 4, copyRewriteSnapshot); err == nil {
+		t.Fatal("partial preparation succeeded")
+	}
+	directory := prepared.directory
+	prepared.cleanup()
+	if _, err := os.Stat(directory); !os.IsNotExist(err) {
+		t.Fatal("first snapshot leaked")
+	}
+}

--- a/cmd/octopool/string_rewrites_release_assets_windows.go
+++ b/cmd/octopool/string_rewrites_release_assets_windows.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// FILE_BASIC_INFO, as defined by WinBase.h. Access time deliberately excluded
+// from the change stamp: reading the file can update it.
+type rewriteWindowsBasicInfo struct {
+	creationTime, accessTime, writeTime, changeTime int64
+	attributes                                      uint32
+	padding                                         uint32
+}
+
+type rewriteAssetChange struct {
+	creationTime, changeTime int64
+	attributes               uint32
+}
+
+func rewriteReleaseChange(file *os.File, _ os.FileInfo) (rewriteAssetChange, error) {
+	var info rewriteWindowsBasicInfo
+	err := windows.GetFileInformationByHandleEx(windows.Handle(file.Fd()), windows.FileBasicInfo, (*byte)(unsafe.Pointer(&info)), uint32(unsafe.Sizeof(info)))
+	return rewriteAssetChange{info.creationTime, info.changeTime, info.attributes}, err
+}
+
+// Pin every directory without delete sharing before opening its descendant.
+// OPEN_REPARSE_POINT applies only to the last component of a CreateFile call.
+func openRewriteWindowsPath(path string, directory bool) (*os.File, func(), error) {
+	for _, part := range strings.Split(filepath.ToSlash(path), "/") {
+		if part == ".." {
+			return nil, nil, errRewriteBlocked
+		}
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil || !validRewriteFilesystemPath(absolute) {
+		return nil, nil, errRewriteBlocked
+	}
+	volume := filepath.VolumeName(absolute)
+	if len(volume) != 2 || volume[1] != ':' {
+		return nil, nil, errRewriteBlocked
+	}
+	current := volume + `\`
+	root, err := windows.UTF16PtrFromString(current)
+	if err != nil || windows.GetDriveType(root) == windows.DRIVE_REMOTE {
+		return nil, nil, errRewriteBlocked
+	}
+	parts := strings.Split(strings.TrimPrefix(absolute, current), `\`)
+	paths := []string{current}
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		current = filepath.Join(current, part)
+		paths = append(paths, current)
+	}
+	files := []*os.File{}
+	closeFiles := func() {
+		for i := len(files) - 1; i >= 0; i-- {
+			_ = files[i].Close()
+		}
+	}
+	for i, path := range paths {
+		isDirectory := i < len(paths)-1 || directory
+		access, share := uint32(windows.GENERIC_READ), uint32(windows.FILE_SHARE_READ)
+		if isDirectory {
+			access, share = windows.FILE_READ_ATTRIBUTES|windows.READ_CONTROL, windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE
+		}
+		name, err := windows.UTF16PtrFromString(path)
+		if err != nil {
+			closeFiles()
+			return nil, nil, err
+		}
+		handle, err := windows.CreateFile(name, access, share, nil, windows.OPEN_EXISTING, windows.FILE_FLAG_OPEN_REPARSE_POINT|windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
+		if err != nil {
+			closeFiles()
+			return nil, nil, err
+		}
+		file := os.NewFile(uintptr(handle), path)
+		files = append(files, file)
+		var info windows.ByHandleFileInformation
+		err = windows.GetFileInformationByHandle(handle, &info)
+		kind, typeErr := windows.GetFileType(handle)
+		if err != nil || typeErr != nil || kind != windows.FILE_TYPE_DISK || info.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 || (info.FileAttributes&windows.FILE_ATTRIBUTE_DIRECTORY != 0) != isDirectory {
+			closeFiles()
+			return nil, nil, errRewriteBlocked
+		}
+	}
+	return files[len(files)-1], closeFiles, nil
+}
+
+func openRewriteReleaseAsset(path string) (*os.File, func(), error) {
+	if !validRewriteReleasePath(path) {
+		return nil, nil, errRewriteBlocked
+	}
+	return openRewriteWindowsPath(path, false)
+}
+
+func inspectRewriteReleaseAsset(path string) (string, os.FileInfo, rewriteAssetChange, error) {
+	file, closeFile, err := openRewriteReleaseAsset(path)
+	if err != nil {
+		return "", nil, rewriteAssetChange{}, err
+	}
+	defer closeFile()
+	info, err := file.Stat()
+	if err != nil {
+		return "", nil, rewriteAssetChange{}, err
+	}
+	change, err := rewriteReleaseChange(file, info)
+	if err != nil {
+		return "", nil, rewriteAssetChange{}, err
+	}
+	// Resolve DOS drive and short-name aliases from the opened handle too.
+	// A lexical absolute path alone can hide policy matches behind those aliases.
+	buffer := make([]uint16, 32768)
+	length, err := windows.GetFinalPathNameByHandle(windows.Handle(file.Fd()), &buffer[0], uint32(len(buffer)), 0)
+	if err != nil || length == 0 || length >= uint32(len(buffer)) {
+		return "", nil, rewriteAssetChange{}, errRewriteBlocked
+	}
+	resolved := windows.UTF16ToString(buffer[:length])
+	resolved, ok := strings.CutPrefix(resolved, `\\?\`)
+	if !ok || len(resolved) < 3 || resolved[1] != ':' || !validRewriteReleasePath(resolved) {
+		return "", nil, rewriteAssetChange{}, errRewriteBlocked
+	}
+	return resolved, info, change, nil
+}

--- a/cmd/octopool/string_rewrites_release_assets_windows.go
+++ b/cmd/octopool/string_rewrites_release_assets_windows.go
@@ -68,7 +68,9 @@ func openRewriteWindowsPath(path string, directory bool) (*os.File, func(), erro
 		isDirectory := i < len(paths)-1 || directory
 		access, share := uint32(windows.GENERIC_READ), uint32(windows.FILE_SHARE_READ)
 		if isDirectory {
-			access, share = windows.FILE_READ_ATTRIBUTES|windows.READ_CONTROL, windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE
+			// Attribute/security-only access does not participate in sharing checks.
+			// Directory list access makes omitting FILE_SHARE_DELETE pin the name.
+			access, share = windows.FILE_LIST_DIRECTORY|windows.FILE_READ_ATTRIBUTES|windows.READ_CONTROL, windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE
 		}
 		name, err := windows.UTF16PtrFromString(path)
 		if err != nil {

--- a/cmd/octopool/string_rewrites_release_assets_windows_test.go
+++ b/cmd/octopool/string_rewrites_release_assets_windows_test.go
@@ -11,6 +11,77 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// Clean the destination after deferred handle closure even if a pinning assertion
+// unexpectedly moves the tree away from the preparation's cleanup path.
+func rewriteWindowsRenameDestination(t *testing.T, path string) string {
+	t.Helper()
+	moved := path + "-moved"
+	if _, err := os.Lstat(moved); !os.IsNotExist(err) {
+		t.Fatalf("rename destination already exists or cannot be checked: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(moved); err != nil {
+			t.Errorf("remove rename destination: %v", err)
+		}
+	})
+	return moved
+}
+
+func TestReleaseAssetsWindowsPinsDirectoryAncestors(t *testing.T) {
+	for _, target := range []string{"staging", "parent", "ancestor"} {
+		t.Run(target, func(t *testing.T) {
+			ancestor := filepath.Join(t.TempDir(), "ancestor")
+			parent := filepath.Join(ancestor, "parent")
+			if err := os.MkdirAll(parent, 0700); err != nil {
+				t.Fatal(err)
+			}
+			for _, variable := range []string{"TMPDIR", "TMP", "TEMP"} {
+				t.Setenv(variable, parent)
+			}
+			prepared := &rewritePreparation{ctx: t.Context()}
+			defer prepared.cleanup()
+			snapshot, err := prepared.snapshot([]byte("snapshot"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := prepared.directory
+			if target == "parent" {
+				path = parent
+			} else if target == "ancestor" {
+				path = ancestor
+			}
+			moved := rewriteWindowsRenameDestination(t, path)
+			if err := os.Rename(path, moved); err == nil {
+				t.Fatalf("%s directory was not pinned", target)
+			}
+			if target == "staging" {
+				// Exercise the owned release callback without deleting the directory
+				// so its name can be renamed after the handles are closed.
+				prepared.closeDirectory()
+				prepared.closeDirectory = nil
+			} else {
+				prepared.cleanup()
+				if _, err := os.Stat(prepared.directory); !os.IsNotExist(err) {
+					t.Fatalf("private directory leaked after cleanup: %v", err)
+				}
+			}
+			if err := os.Rename(path, moved); err != nil {
+				t.Fatalf("%s remained pinned after handle release: %v", target, err)
+			}
+			if err := os.Rename(moved, path); err != nil {
+				t.Fatalf("restore %s after rename: %v", target, err)
+			}
+			if target == "staging" {
+				if data, err := os.ReadFile(snapshot); err != nil || string(data) != "snapshot" {
+					t.Fatalf("snapshot changed after rename: %q, %v", data, err)
+				}
+			}
+			prepared.cleanup()
+			assertReleaseAssetTempEmpty(t, parent)
+		})
+	}
+}
+
 func TestReleaseAssetsWindowsMetadataStagingSpecialTemp(t *testing.T) {
 	policy, err := compileStringRewriteRules([]stringRewriteRule{{Pattern: "private-term", Replacement: "public"}})
 	if err != nil {
@@ -94,7 +165,8 @@ func TestReleaseAssetsWindowsMetadataStagingSpecialTemp(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					if err := os.Rename(prepared.directory, prepared.directory+"-moved"); err == nil {
+					moved := rewriteWindowsRenameDestination(t, prepared.directory)
+					if err := os.Rename(prepared.directory, moved); err == nil {
 						t.Fatal("staging directory was not pinned")
 					}
 					prepared.cleanup()
@@ -124,7 +196,8 @@ func TestReleaseAssetsWindowsPrivateStaging(t *testing.T) {
 		t.Fatal(err)
 	}
 	closeDir()
-	if err := os.Rename(prepared.directory, prepared.directory+"-moved"); err == nil {
+	moved := rewriteWindowsRenameDestination(t, prepared.directory)
+	if err := os.Rename(prepared.directory, moved); err == nil {
 		t.Fatal("private staging directory was not pinned")
 	}
 	source := releaseAssetFile(t, "archive.zip", []byte{0, 0xff, 0xfe, 3})

--- a/cmd/octopool/string_rewrites_release_assets_windows_test.go
+++ b/cmd/octopool/string_rewrites_release_assets_windows_test.go
@@ -1,0 +1,290 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestReleaseAssetsWindowsMetadataStagingSpecialTemp(t *testing.T) {
+	policy, err := compileStringRewriteRules([]stringRewriteRule{{Pattern: "private-term", Replacement: "public"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := releaseAssetFile(t, "asset.zip", []byte("opaque"))
+	media := releaseAssetFile(t, "source.png", []byte{0, 0xff, 1})
+	link := filepath.Join(t.TempDir(), "source-link.png")
+	if err := os.Symlink(media, link); err != nil {
+		t.Fatalf("native attachment symlink proof requires symlink support: %v", err)
+	}
+	for _, name := range []string{"notes#staging", "notes[staging]"} {
+		t.Run(name, func(t *testing.T) {
+			temporary := filepath.Join(t.TempDir(), name)
+			if err := os.Mkdir(temporary, 0700); err != nil {
+				t.Fatal(err)
+			}
+			for _, variable := range []string{"TMPDIR", "TMP", "TEMP"} {
+				t.Setenv(variable, temporary)
+			}
+			for _, test := range []struct {
+				name    string
+				args    []string
+				blocked bool
+			}{
+				{"issue metadata", []string{"issue", "create", "--repo=acme/repo", "--title=Safe", "--body=private-term"}, false},
+				{"assetless release", []string{"release", "create", "v1", "--repo=acme/repo", "--verify-tag", "--title=Safe", "--notes=private-term"}, false},
+				{"attachment symlink", []string{"pr", "comment", "1", "--repo=acme/repo", "--body=private-term", "--attach", link}, false},
+				{"release asset", releaseAssetArgs(source), true},
+			} {
+				t.Run(test.name, func(t *testing.T) {
+					prepared := &rewritePreparation{ctx: t.Context()}
+					defer prepared.cleanup()
+					err := prepareRewriteContent(policy, test.args, strings.NewReader(""), prepared)
+					if test.blocked {
+						if err != errRewriteBlocked {
+							t.Fatalf("nonliteral asset operand error=%v", err)
+						}
+					} else {
+						if err != nil {
+							t.Fatal(err)
+						}
+						found := false
+						for _, arg := range prepared.args {
+							for _, prefix := range []string{"--body-file=", "--notes-file="} {
+								if path, ok := strings.CutPrefix(arg, prefix); ok {
+									data, err := os.ReadFile(path)
+									if err != nil || string(data) != "public" || !strings.Contains(path, name) {
+										t.Fatalf("metadata snapshot=%q error=%v", data, err)
+									}
+									found = true
+								}
+							}
+						}
+						if !found {
+							t.Fatal("metadata snapshot missing")
+						}
+						if test.name == "attachment symlink" {
+							path := capturedAttachmentSnapshot(prepared.args, ".png")
+							data, err := os.ReadFile(path)
+							if err != nil || !bytes.Equal(data, []byte{0, 0xff, 1}) {
+								t.Fatal("attachment source symlink contract changed", err)
+							}
+						}
+					}
+					// Shared filesystem staging must work even when the release
+					// operand boundary subsequently rejects its generated path.
+					if prepared.directory == "" {
+						t.Fatal("filesystem staging was blocked")
+					}
+					dir, closeDir, err := openRewriteWindowsPath(prepared.directory, true)
+					if err != nil {
+						t.Fatal(err)
+					}
+					err = checkRewritePrivateWindowsDirectory(dir, user.User.Sid)
+					closeDir()
+					if err != nil {
+						t.Fatal(err)
+					}
+					if err := os.Rename(prepared.directory, prepared.directory+"-moved"); err == nil {
+						t.Fatal("staging directory was not pinned")
+					}
+					prepared.cleanup()
+					assertReleaseAssetTempEmpty(t, temporary)
+				})
+			}
+		})
+	}
+}
+
+func TestReleaseAssetsWindowsPrivateStaging(t *testing.T) {
+	prepared := &rewritePreparation{}
+	if err := prepared.ensureSnapshotDirectory(); err != nil {
+		t.Fatal(err)
+	}
+	defer prepared.cleanup()
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir, closeDir, err := openRewriteWindowsPath(prepared.directory, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := checkRewritePrivateWindowsDirectory(dir, user.User.Sid); err != nil {
+		closeDir()
+		t.Fatal(err)
+	}
+	closeDir()
+	if err := os.Rename(prepared.directory, prepared.directory+"-moved"); err == nil {
+		t.Fatal("private staging directory was not pinned")
+	}
+	source := releaseAssetFile(t, "archive.zip", []byte{0, 0xff, 0xfe, 3})
+	policy, err := compileStringRewriteRules([]stringRewriteRule{{Pattern: "private-term", Replacement: "public"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assets, err := prepared.releaseAssets(policy, []string{source}, defaultRewriteReleaseLimits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path, _, err := prepared.snapshotReleaseAsset(assets[0], defaultRewriteReleaseLimits.file, copyRewriteSnapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || !bytes.Equal(data, []byte{0, 0xff, 0xfe, 3}) {
+		t.Fatal("snapshot bytes", err)
+	}
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handle, err := windows.CreateFile(name, windows.READ_CONTROL, windows.FILE_SHARE_READ, nil, windows.OPEN_EXISTING, windows.FILE_FLAG_OPEN_REPARSE_POINT, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sd, err := windows.GetSecurityInfo(handle, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	_ = windows.CloseHandle(handle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dacl, _, err := sd.DACL()
+	if err != nil || dacl == nil || dacl.AceCount != 1 {
+		t.Fatal("file did not inherit private ACL", err)
+	}
+	var ace *windows.ACCESS_ALLOWED_ACE
+	if err := windows.GetAce(dacl, 0, &ace); err != nil {
+		t.Fatal(err)
+	}
+	if ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE || !windows.EqualSid((*windows.SID)(unsafe.Pointer(&ace.SidStart)), user.User.Sid) {
+		t.Fatal("file ACL grants another principal")
+	}
+	directory := prepared.directory
+	prepared.cleanup()
+	if _, err := os.Stat(directory); !os.IsNotExist(err) {
+		t.Fatal("private directory leaked", err)
+	}
+}
+
+func TestReleaseAssetsWindowsRejectsReparseAndLocksSource(t *testing.T) {
+	source := releaseAssetFile(t, "archive.zip", []byte("opaque"))
+	link := filepath.Join(t.TempDir(), "link.zip")
+	if err := os.Symlink(source, link); err != nil {
+		t.Fatalf("native reparse proof requires symlink support: %v", err)
+	}
+	if file, closeFile, err := openRewriteReleaseAsset(link); err == nil {
+		closeFile()
+		t.Fatalf("followed reparse operand %v", file)
+	}
+	parentLink := filepath.Join(t.TempDir(), "parent")
+	if err := os.Symlink(filepath.Dir(source), parentLink); err != nil {
+		t.Fatal(err)
+	}
+	if _, closeFile, err := openRewriteReleaseAsset(filepath.Join(parentLink, filepath.Base(source))); err == nil {
+		closeFile()
+		t.Fatal("followed reparse ancestor")
+	}
+	file, closeFile, err := openRewriteReleaseAsset(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if writer, err := os.OpenFile(source, os.O_WRONLY, 0); err == nil {
+		writer.Close()
+		closeFile()
+		t.Fatal("source allowed writing while captured")
+	}
+	if err := os.Rename(source, source+".old"); err == nil {
+		closeFile()
+		t.Fatal("source allowed replacement while captured")
+	}
+	info, err := file.Stat()
+	if err != nil {
+		closeFile()
+		t.Fatal(err)
+	}
+	before, err := rewriteReleaseChange(file, info)
+	if err != nil {
+		closeFile()
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(source)
+	if err != nil {
+		closeFile()
+		t.Fatal(err)
+	}
+	after, err := rewriteReleaseChange(file, info)
+	closeFile()
+	if err != nil || before != after || string(data) != "opaque" {
+		t.Fatal("read changed mutation stamp", err)
+	}
+	writer, err := os.OpenFile(source, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, closeFile, err := openRewriteReleaseAsset(source); err == nil {
+		closeFile()
+		writer.Close()
+		t.Fatal("accepted preexisting write handle")
+	}
+	writer.Close()
+}
+
+func TestReleaseAssetsWindowsRejectsAliasesAndReplacements(t *testing.T) {
+	for _, path := range []string{`\\server\share\a.zip`, `\\?\C:\a.zip`, `\\.\pipe\a`, `C:a.zip`, `C:\a.zip:stream`, `C:\NUL.zip`, `C:\dir\..\a.zip`, `C:\dir\a.zip.`, `C:\dir\a.zip `} {
+		if validRewriteReleasePath(path) {
+			t.Fatalf("unsafe Windows path accepted: %q", path)
+		}
+	}
+	policy, err := compileStringRewriteRules([]stringRewriteRule{{Pattern: "private-term", Replacement: "public"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := releaseAssetFile(t, "archive.zip", []byte("opaque"))
+	prepared := &rewritePreparation{}
+	defer prepared.cleanup()
+	assets, err := prepared.releaseAssets(policy, []string{source}, defaultRewriteReleaseLimits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(source, source+".old"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(source, []byte("opaque"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := prepared.snapshotReleaseAsset(assets[0], defaultRewriteReleaseLimits.file, copyRewriteSnapshot); err == nil {
+		t.Fatal("replacement accepted")
+	}
+	if prepared.directory != "" {
+		t.Fatal("replaced input created staging")
+	}
+}
+
+func TestReleaseAssetsWindowsChecksResolvedCaseAlias(t *testing.T) {
+	source := releaseAssetFile(t, "ArchiveMixed.zip", []byte("opaque"))
+	alias := filepath.Join(filepath.Dir(source), "archivemixed.zip")
+	resolved, info, _, err := inspectRewriteReleaseAsset(alias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original, err := os.Stat(source)
+	if err != nil || !os.SameFile(info, original) || filepath.Base(resolved) != "ArchiveMixed.zip" {
+		t.Fatalf("canonical alias path=%q error=%v", resolved, err)
+	}
+	policy, err := compileStringRewriteRules([]stringRewriteRule{{Pattern: "ArchiveMixed", Replacement: "public"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := (&rewritePreparation{}).releaseAssets(policy, []string{alias}, defaultRewriteReleaseLimits); err == nil {
+		t.Fatal("resolved path policy match was hidden by case alias")
+	}
+}

--- a/cmd/octopool/string_rewrites_snapshots.go
+++ b/cmd/octopool/string_rewrites_snapshots.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+)
+
+const rewriteSnapshotBuffer = 64 << 10
+
+func (prepared *rewritePreparation) context() context.Context {
+	if prepared.ctx != nil {
+		return prepared.ctx
+	}
+	return context.Background()
+}
+
+func (prepared *rewritePreparation) ensureSnapshotDirectory() error {
+	if prepared.directory != "" {
+		return nil
+	}
+	directory, closeDirectory, err := newRewritePrivateDirectory()
+	if err != nil {
+		return errRewriteBlocked
+	}
+	prepared.directory, prepared.closeDirectory = directory, closeDirectory
+	return nil
+}
+
+func (prepared *rewritePreparation) registerSnapshot(path string) string {
+	path = filepath.Clean(path)
+	if prepared.snapshots == nil {
+		prepared.snapshots = map[string]bool{}
+	}
+	prepared.snapshots[path] = true
+	return path
+}
+
+// Always close the output, including on cancellation and failed/short writes.
+// Read one byte beyond the expected length to detect growth without truncation.
+func copyRewriteSnapshot(ctx context.Context, output io.WriteCloser, input io.Reader, expected, limit int64) (copied int64, err error) {
+	defer func() {
+		if closeErr := output.Close(); closeErr != nil {
+			err = errRewriteBlocked
+		}
+	}()
+	if expected < 0 || expected > limit {
+		return 0, errRewriteBlocked
+	}
+	buffer := make([]byte, rewriteSnapshotBuffer)
+	for {
+		if err := ctx.Err(); err != nil {
+			return copied, err
+		}
+		n, readErr := input.Read(buffer[:min(int64(len(buffer)), expected-copied+1)])
+		if n > 0 {
+			if int64(n) > expected-copied {
+				return copied, errRewriteBlocked
+			}
+			written, writeErr := output.Write(buffer[:n])
+			copied += int64(written)
+			if writeErr != nil || written != n {
+				return copied, errRewriteBlocked
+			}
+		}
+		if readErr == io.EOF {
+			if copied != expected {
+				return copied, errRewriteBlocked
+			}
+			return copied, ctx.Err()
+		}
+		if readErr != nil || n == 0 {
+			return copied, errRewriteBlocked
+		}
+	}
+}

--- a/cmd/octopool/string_rewrites_snapshots_unix.go
+++ b/cmd/octopool/string_rewrites_snapshots_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package main
+
+import "os"
+
+func newRewritePrivateDirectory() (string, func(), error) {
+	path, err := os.MkdirTemp("", "octopool-content-")
+	return path, nil, err
+}

--- a/cmd/octopool/string_rewrites_snapshots_windows.go
+++ b/cmd/octopool/string_rewrites_snapshots_windows.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func newRewritePrivateDirectory() (string, func(), error) {
+	parent, closeParent, err := openRewriteWindowsPath(os.TempDir(), true)
+	if err != nil {
+		return "", nil, err
+	}
+	defer closeParent()
+	var flags uint32
+	if err := windows.GetVolumeInformationByHandle(windows.Handle(parent.Fd()), nil, 0, nil, nil, &flags, nil, 0); err != nil || flags&windows.FILE_PERSISTENT_ACLS == 0 {
+		return "", nil, errRewriteBlocked
+	}
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		return "", nil, err
+	}
+	// Set a protected, inheritable current-user-only DACL at creation, never
+	// after creating a directory with permissive inherited access.
+	sd, err := windows.SecurityDescriptorFromString("O:" + user.User.Sid.String() + "D:P(A;OICI;FA;;;" + user.User.Sid.String() + ")")
+	if err != nil {
+		return "", nil, err
+	}
+	attributes := windows.SecurityAttributes{Length: uint32(unsafe.Sizeof(windows.SecurityAttributes{})), SecurityDescriptor: sd}
+	for attempt := 0; attempt < 10; attempt++ {
+		var random [16]byte
+		if _, err := rand.Read(random[:]); err != nil {
+			return "", nil, err
+		}
+		path := filepath.Join(parent.Name(), "octopool-content-"+hex.EncodeToString(random[:]))
+		name, err := windows.UTF16PtrFromString(path)
+		if err != nil {
+			return "", nil, err
+		}
+		if err := windows.CreateDirectory(name, &attributes); err != nil {
+			if err == windows.ERROR_ALREADY_EXISTS {
+				continue
+			}
+			return "", nil, err
+		}
+		file, closeFile, err := openRewriteWindowsPath(path, true)
+		if err != nil {
+			_ = os.Remove(path)
+			return "", nil, err
+		}
+		if err := checkRewritePrivateWindowsDirectory(file, user.User.Sid); err != nil {
+			closeFile()
+			_ = os.Remove(path)
+			return "", nil, err
+		}
+		return path, closeFile, nil
+	}
+	return "", nil, errRewriteBlocked
+}
+
+func checkRewritePrivateWindowsDirectory(file *os.File, sid *windows.SID) error {
+	sd, err := windows.GetSecurityInfo(windows.Handle(file.Fd()), windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		return err
+	}
+	owner, _, err := sd.Owner()
+	if err != nil || !windows.EqualSid(owner, sid) {
+		return errRewriteBlocked
+	}
+	control, _, err := sd.Control()
+	if err != nil || control&windows.SE_DACL_PROTECTED == 0 {
+		return errRewriteBlocked
+	}
+	dacl, _, err := sd.DACL()
+	if err != nil || dacl == nil || dacl.AceCount != 1 {
+		return errRewriteBlocked
+	}
+	var ace *windows.ACCESS_ALLOWED_ACE
+	if err := windows.GetAce(dacl, 0, &ace); err != nil {
+		return err
+	}
+	// FILE_ALL_ACCESS from WinNT.h (all nine file-specific access rights).
+	const fileAllAccess = windows.STANDARD_RIGHTS_REQUIRED | windows.SYNCHRONIZE | 0x1ff
+	if ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE || ace.Header.AceFlags != windows.OBJECT_INHERIT_ACE|windows.CONTAINER_INHERIT_ACE || ace.Mask != fileAllAccess || !windows.EqualSid((*windows.SID)(unsafe.Pointer(&ace.SidStart)), sid) {
+		return errRewriteBlocked
+	}
+	return nil
+}

--- a/cmd/octopool/string_rewrites_test.go
+++ b/cmd/octopool/string_rewrites_test.go
@@ -185,6 +185,7 @@ func TestStringRewritePreparationRejectsUnknownShapes(t *testing.T) {
 		{"pr", "comment", "1", "--body", "safe", "--editor", "--repo", "acme/repo"},
 		{"pr", "review", "1", "--body", "safe", "--repo", "acme/repo"},
 		{"pr", "review", "1", "--approve", "--comment", "--body", "safe", "--repo", "acme/repo"},
+		// Asset-bearing creation requires an explicit draft, even with verify-tag.
 		{"release", "create", "v1", "asset.zip", "--notes", "safe", "--title", "safe", "--verify-tag", "--repo", "acme/repo"},
 		{"release", "create", "v1", "--notes", "safe", "--title", "safe", "--repo", "acme/repo"},
 		{"release", "create", "v1", "--notes", "safe", "--title", "safe", "--verify-tag=false", "--repo", "acme/repo"},

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -457,9 +457,11 @@ With active rules, the initial local publication vocabulary is deliberately cons
   while PR/issue edits accept metadata-only add/remove label and assignee flags. Assignees may
   include native `@me` or `@copilot`. PR create/edit/comment and issue create also accept repeated
   `--attach` image/video files as described below.
-- Release `create`/`edit`: explicit title/notes or notes files; one tag and no asset uploads.
+- Release `create`/`edit`: explicit title/notes or notes files and one tag.
   Creation requires `--verify-tag`, so gh cannot create a missing tag. Generated notes,
-  notes from tags, and other implicit content sources are blocked.
+  notes from tags, and other implicit content sources are blocked. Asset-bearing creation
+  additionally requires explicit `--draft=true` (or `--draft`) and unchanged metadata,
+  as described below. Release editing still accepts exactly one tag and no assets.
 - Raw REST API equivalents: allowlisted issue/PR/review/comment/release endpoints with
   `-f`/`--raw-field`, `-F`/`--field`, or `--input` JSON. Literal and typed fields retain
   their distinction; only typed `@file`/`@-` values read files/stdin. Nested review comments
@@ -478,6 +480,61 @@ explicit `https://github.com/owner/repo` and GitHub SSH forms are accepted, whil
 are blocked. Input files are read into bounded snapshots, never modified, and never reopened
 by the child. Sanitized snapshots use a private 0700 directory and 0600 files, removed
 after execution, including nonzero exits. These modeled commands do not retain live stdin.
+
+With active rules, `gh release create TAG --repo OWNER/REPO --draft --verify-tag
+--title TITLE --notes-file NOTES FILE...` accepts up to 16 explicit local asset paths
+on macOS, Linux, and Windows. Each asset must be a nonempty regular file, at most 1 GiB;
+the aggregate asset limit is 4 GiB. Public basenames are limited to 255 bytes and use
+only ASCII letters, digits, internal periods, underscores, and hyphens. A basename
+cannot start with a period or hyphen, or end with a period; a leading underscore is
+allowed. Empty and Windows reserved names remain rejected. GitHub
+[documents filename rewriting during asset uploads](https://docs.github.com/en/rest/releases/assets?apiVersion=2022-11-28#upload-a-release-asset)
+without specifying a complete normalization algorithm. This is Octopool's conservative
+supported subset; other public names are rejected rather than silently sanitized.
+The existing 1 MiB text budget remains unchanged. Title, notes, original/resolved source
+paths, and exact public basenames undergo policy, material, residual, and UTF-8 checks;
+if filtering would change any of them, the entire command is rejected. Canonical notes
+are preserved byte for byte. Assetless release creation retains its existing filtering.
+
+Asset operands cannot be stdin, URLs, unexpanded globs, `#label` forms, traversal paths,
+symlinks, Windows UNC/device paths, or unsafe portable filenames (including control
+characters, Windows reserved names, and trailing dots/spaces). Public-name restrictions
+apply to the original basename before filesystem access. Source components have separate
+validation: `.claude`, spaces, Unicode, and leading hyphens are allowed in parent
+directories and private staging paths, subject to the existing path and policy checks.
+Duplicate basenames, case-fold collisions, hard links to the same file, and resource-limit
+violations are rejected. Parent directory aliases such as macOS `/tmp` are resolved and checked;
+Windows reparse points, including ancestor reparse points, are rejected.
+
+Generated release asset paths undergo the same literal-operand validation as source
+operands, in addition to policy checks. A temp-root path containing `#` or glob syntax
+therefore blocks asset-bearing creation and cleans up staging before native `gh` starts:
+[`gh release create` interprets asset operands as filenames/patterns with optional `#label` syntax](https://cli.github.com/manual/gh_release_create).
+Ordinary metadata snapshots use filesystem paths rather than release operand syntax;
+legal `#` or bracket characters in a private temp directory remain supported there.
+Windows shared staging still enforces local filesystem, device, traversal, reparse,
+handle-pinning and private ACL checks. Hidden, space-bearing and Unicode temp directories
+remain supported for release assets when their paths contain no release operand syntax.
+
+Every asset is copied in 64 KiB chunks into exclusively created private snapshot files
+before native `gh` starts, preserving names, order, and opaque bytes. Descriptor identity
+and before/after file metadata reject observed replacement, size changes, or in-place
+mutation. Unix opens do not follow symlink operands and cannot block on a substituted
+FIFO. Windows requires persistent filesystem ACLs, creates staging with a protected
+current-user-only inheritable ACL, pins directory handles against deletion, and excludes
+source write/delete sharing while capturing. Cancellation is checked between chunks and
+before execution. Snapshots are removed on preparation/start/child failures and handled
+cancellation; uncatchable termination and power loss can leave temporary files behind.
+
+Assets, including checksums and provenance, are opaque: Octopool does not rewrite,
+unpack, rebuild, sign, or certify their contents as secret-free. The caller owns artifact
+review, provenance, and a reviewed, frozen source directory. Staging isolates subsequent
+source changes; metadata checks cannot prove correspondence with earlier verification
+against arbitrary hostile local writers before capture. There is no digest handoff.
+Local preparation is all-or-nothing, but remote draft creation and upload are not a
+transaction. A failed child can leave a partial remote draft. Octopool does not delete
+drafts, replace assets, clobber, retry uploads, or publish after failure. This capability
+does not add modeled standalone `release upload` support or new release-edit forms.
 
 Protected PR create/edit/comment and issue create commands accept up to 16 repeated `--attach FILE`
 or `--attach=FILE` values. Raster image extensions are GIF, JPEG/JPG, PNG, and WebP; video

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/openclaw/octopool
 go 1.26
 
 require github.com/yuin/goldmark v1.8.5
+
+require golang.org/x/sys v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/yuin/goldmark v1.8.5 h1:r6N5afV5qj/5S4UTch8agZHJ8UxNCMwX7WjkkJam2NA=
 github.com/yuin/goldmark v1.8.5/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=


### PR DESCRIPTION
## Summary

Allow the strict protected `gh release create` path to accept explicit release assets, but only with `--draft`, `--verify-tag`, and unchanged canonical title/notes. Previously, the handler rejected every asset-bearing invocation.

All files are validated and privately snapshotted before native gh starts. Preserve exact bytes, public basenames, argument order, and canonical notes; reject unsafe operands, policy-changing metadata, duplicate names/identities, excess count/size, and detected source replacement or mutation. Public names use a documented conservative ASCII subset. Generated staging paths are validated too, so a temporary-directory `#` or glob cannot become native operand syntax.

Reuse the existing execution/cleanup owner and bounded snapshot machinery. Add Unix no-follow/nonblocking opens and Windows reparse rejection, pinned handles, and protected current-user ACLs through `golang.org/x/sys/windows`. Separate filesystem syntax from release-operand syntax so ordinary metadata and attachment snapshots retain legal Windows temporary paths. Existing assetless, attachment, merge, workflow-input, and numeric publication-PATCH contracts remain covered.

Assets remain opaque and caller-reviewed; this does not certify payload secrecy or bind arbitrary earlier verification. Local preparation is all-or-nothing, but remote uploads are not transactional. No retry, clobber, partial-draft deletion, standalone upload, publication, auth/policy change, or Worker deployment is added.

## Validation

- Eight-asset process regression: rejected before implementation; exact binary bytes, names/order, CRLF notes, streams, host pinning, empty stdin, and cleanup pass afterward.
- Public-filename and special-temp-root regressions: unsafe operands reached the fake child before the fixes; afterward they are blocked before execution and staging is cleaned. Hidden/space/Unicode source directories remain accepted.
- Final Go 1.26.4 race suite: 307 top-level tests, 1,592 passing test/subtest events, zero failures or skips. Vet, formatting, docs generation, and Windows/Linux amd64/arm64 test cross-compilation passed.
- Initial implementation also passed `pnpm check` (572 unit and 242 controlled Workerd tests) and the 28-test consumer release-workflow contract. Subsequent changes are confined to the Go guard/tests, CLI docs, and Windows CI selection; exact-head CI reruns the repository gate.
- GoReleaser 2.17.1 snapshot gate built all six archives and verified their checksums with an isolated HOME and no publishing/signing credentials. Nothing was published or installed.
- Independent isolated Codex autoreview: scoped-clean at the required blocking-priority threshold.

Exact-head [CI passed](https://github.com/openclaw/octopool/actions/runs/33356582351) at `8535f1a1a86d1ee29e456cfed450ba9520c45052`, including the repository Check and native Windows lane. The saved native log confirms 13 top-level tests and 85 passing test/subtest events, with zero failures or skips. Reparse rejection, source locks, private ACL inheritance, replacement/case aliases, filename/path handling, metadata/attachment compatibility, staging/ancestor pinning, handle release, and cleanup were executed on Windows. CodeQL also passed.

The [first native run failed](https://github.com/openclaw/octopool/actions/runs/33355754861), correctly exposing ineffective directory pins: Windows excludes attribute/security-only handles from sharing checks. The fix requests directory-list access so denying delete sharing actually prevents renames; no assertion was weakened. New native tests also prove parent/ancestor pinning and successful rename after handle release. Independent review and the pinned six-archive packaging gate passed again after this correction.

Changelog serialization remains with the coordinated maintainer release cut; no version or tag is changed here.
