### PR TITLE
fix: pin login credential lookup to GitHub.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Pin CLI login credential lookup to GitHub.com so Enterprise host settings cannot select an Enterprise token.
 - Block cross-origin redirects and HTTPS downgrades for CLI login and authenticated JSON requests to prevent credential replay.
 - Preserve exact raw Markdown in release-view JSON via the anonymous API and retire cached HTML-derived release summaries for existing clients.
 - Return native uppercase PR-list lifecycle states and lowercase merged PR-search states from nested merge metadata before `--jq`, preserving raw API and cache payloads.

--- a/cmd/octopool/cli_e2e_test.go
+++ b/cmd/octopool/cli_e2e_test.go
@@ -321,8 +321,12 @@ func writeCLIFallback(t *testing.T, w http.ResponseWriter, reason string) {
 
 func fakeGH(t *testing.T) string {
 	t.Helper()
+	return writeFakeGH(t, "#!/bin/sh\nprintf 'real-gh:%s\\n' \"$*\"\n")
+}
+
+func writeFakeGH(t *testing.T, content string) string {
+	t.Helper()
 	path := filepath.Join(t.TempDir(), executableName("fake-gh"))
-	content := "#!/bin/sh\nprintf 'real-gh:%s\\n' \"$*\"\n"
 	if runtime.GOOS == "windows" {
 		t.Skip("shell fixture is Unix-only")
 	}

--- a/cmd/octopool/login.go
+++ b/cmd/octopool/login.go
@@ -289,7 +289,7 @@ func localGitHubToken(ctx context.Context, ghPath string) (string, error) {
 	}
 	child, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(child, path, "auth", "token")
+	cmd := exec.CommandContext(child, path, "auth", "token", "--hostname", "github.com")
 	out, err := cmd.Output()
 	if err != nil {
 		return "", localGitHubAuthError(path, err)

--- a/cmd/octopool/login_token_test.go
+++ b/cmd/octopool/login_token_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestLoginGitHubTokenSelection(t *testing.T) {
+	const ghToken = "synthetic-gh-env-token"
+	const githubToken = "synthetic-github-env-token"
+	const storedToken = "synthetic-github-com-stored-token"
+	const enterpriseToken = "synthetic-enterprise-token"
+	const callerToken = "synthetic-caller-token"
+	for _, tt := range []struct {
+		name        string
+		ghToken     string
+		githubToken string
+		storedToken string
+		wantToken   string
+		wantError   string
+	}{
+		{name: "GH_TOKEN precedes GITHUB_TOKEN", ghToken: " \t" + ghToken + "\n", githubToken: githubToken, wantToken: ghToken},
+		{name: "GITHUB_TOKEN precedes native lookup", githubToken: " \t" + githubToken + "\n", wantToken: githubToken},
+		{name: "blank GH_TOKEN uses GITHUB_TOKEN", ghToken: " \t\n", githubToken: githubToken, wantToken: githubToken},
+		{name: "native github.com overrides Enterprise host", storedToken: storedToken + "\n", wantToken: storedToken},
+		{name: "missing github.com token rejects Enterprise fallback", wantError: "gh auth token failed"},
+		{name: "empty github.com token rejects Enterprise fallback", storedToken: " \t\n", wantError: "gh auth token returned empty output"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			isolateHTTPTestConfig(t)
+			t.Setenv("GH_TOKEN", tt.ghToken)
+			t.Setenv("GITHUB_TOKEN", tt.githubToken)
+			t.Setenv("GH_HOST", "ghe.example.test")
+			t.Setenv("GH_ENTERPRISE_TOKEN", enterpriseToken)
+			t.Setenv("GITHUB_ENTERPRISE_TOKEN", "synthetic-secondary-enterprise-token")
+			t.Setenv("OCTOPOOL_POOL", "")
+			capture := filepath.Join(t.TempDir(), "argv")
+			t.Setenv("OCTOPOOL_TEST_AUTH_ARGV", capture)
+			t.Setenv("OCTOPOOL_TEST_GITHUB_COM_TOKEN", tt.storedToken)
+			// Model native gh host selection independently of the login implementation.
+			ghPath := writeFakeGH(t, `#!/bin/sh
+printf '%s\n' "$@" >> "$OCTOPOOL_TEST_AUTH_ARGV"
+[ "$1" = auth ] && [ "$2" = token ] || exit 2
+shift 2
+host="${GH_HOST:-github.com}"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --hostname|-h) host="$2"; shift 2 ;;
+    --hostname=*) host="${1#--hostname=}"; shift ;;
+    *) exit 2 ;;
+  esac
+done
+case "$host" in
+  github.com)
+    [ -n "$OCTOPOOL_TEST_GITHUB_COM_TOKEN" ] || exit 1
+    printf '%s\n' "$OCTOPOOL_TEST_GITHUB_COM_TOKEN"
+    ;;
+  ghe.example.test)
+    printf '%s\n' "${GH_ENTERPRISE_TOKEN:-$GITHUB_ENTERPRISE_TOKEN}"
+    ;;
+  *) exit 1 ;;
+esac
+`)
+			var exchanges atomic.Int32
+			var server *httptest.Server
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/.well-known/octopool":
+					writeRedirectTestDiscovery(w, server.URL)
+				case "/v1/login/github-cli":
+					exchanges.Add(1)
+					var body map[string]string
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						t.Error("invalid login request JSON")
+						http.Error(w, "invalid JSON", http.StatusBadRequest)
+						return
+					}
+					if body["github_token"] == enterpriseToken {
+						t.Error("login exchange received the synthetic Enterprise credential")
+					} else if body["github_token"] != tt.wantToken {
+						t.Error("login exchange did not receive the expected GitHub.com credential")
+					}
+					_, _ = io.WriteString(w, `{"caller":{"github_login":"alice","pool":"core","client_name":"test-mac"},"token":"`+callerToken+`"}`)
+				default:
+					t.Errorf("unexpected request path: %s", r.URL.Path)
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			var stdout bytes.Buffer
+			err := runLogin(t.Context(), []string{server.URL, "--client", "test-mac", "--gh-path", ghPath}, &stdout)
+			if tt.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+					t.Errorf("expected credential lookup failure containing %q", tt.wantError)
+				}
+				if exchanges.Load() != 0 || stdout.Len() != 0 {
+					t.Error("failed credential lookup must not exchange credentials or report login success")
+				}
+				authFilePath, pathErr := authPath()
+				if pathErr != nil {
+					t.Fatal(pathErr)
+				}
+				if _, statErr := os.Stat(authFilePath); !os.IsNotExist(statErr) {
+					t.Error("failed credential lookup must not save caller auth")
+				}
+			} else if err != nil || exchanges.Load() != 1 {
+				t.Error("expected one successful login exchange")
+			} else {
+				auth, loadErr := loadAuth()
+				if loadErr != nil || auth.Token != callerToken || auth.Login != "alice" {
+					t.Error("login did not save the returned caller auth")
+				}
+			}
+			output := stdout.String()
+			if err != nil {
+				output += err.Error()
+			}
+			for _, token := range []string{ghToken, githubToken, storedToken, enterpriseToken, callerToken} {
+				if strings.Contains(output, token) {
+					t.Error("login exposed a credential in its output")
+				}
+			}
+			argv, readErr := os.ReadFile(capture)
+			if strings.TrimSpace(tt.ghToken) != "" || strings.TrimSpace(tt.githubToken) != "" {
+				if !os.IsNotExist(readErr) {
+					t.Error("environment token must bypass native gh")
+				}
+			} else if readErr != nil {
+				t.Fatal(readErr)
+			} else if string(argv) != "auth\ntoken\n--hostname\ngithub.com\n" {
+				t.Errorf("native argv = %q; want exactly one auth token --hostname github.com call", argv)
+			}
+		})
+	}
+}

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -59,8 +59,10 @@ Flow:
 
 1. The CLI discovers the server with `GET /.well-known/octopool`, then chooses the
    discovered `api_base` and `default_pool` unless flags override them.
-2. Body carries `github_token` (the user's `gh auth token`), a hostname-derived
-   `client_name`, and an optional `pool`.
+2. Body carries `github_token` (the user's GitHub.com token from `GH_TOKEN`,
+   `GITHUB_TOKEN`, or `gh auth token --hostname github.com`, in that order), a
+   hostname-derived `client_name`, and an optional `pool`. Enterprise credentials
+   are never a fallback for this GitHub.com-only exchange.
 3. The Worker resolves the GitHub user (`GET /user`) and verifies that user is a member
    of `ALLOWED_GITHUB_ORG` using the supplied token.
 4. The caller row and requested default-pool grant are created or refreshed by immutable

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -59,9 +59,12 @@ zsh -c 'command -v gh'
 
 ### `octopool login [server]`
 
-Reads a local GitHub token (`GH_TOKEN`, `GITHUB_TOKEN`, or `gh auth token`), exchanges it
-with `POST /v1/login/github-cli`, and saves the returned caller token. The server can be
-passed as a positional argument, `--server`, or the older `--url` flag:
+Reads a local GitHub.com token (`GH_TOKEN`, then `GITHUB_TOKEN`, then
+`gh auth token --hostname github.com`), exchanges it with `POST /v1/login/github-cli`,
+and saves the returned caller token. Native lookup always targets GitHub.com regardless
+of `GH_HOST`; a missing or empty GitHub.com token fails login without falling back to
+Enterprise credentials. The server can be passed as a positional argument, `--server`,
+or the older `--url` flag:
 
 ```sh
 octopool login


### PR DESCRIPTION
## Summary

Fixes Octopool login selecting an Enterprise token when native `gh` credential lookup follows an Enterprise host setting. Pin the lookup to `gh auth token --hostname github.com`, matching the GitHub.com-only login exchange while preserving `GH_TOKEN` then `GITHUB_TOKEN` precedence.

Missing or empty GitHub.com credentials fail before the login exchange or caller-auth persistence. Synthetic subprocess and local-HTTP tests cover environment precedence, hostname routing, missing and empty credentials, and credential non-disclosure. Update the auth and CLI docs and changelog.

## Tests

- Confirmed the new regression fails against the previous lookup and passes with the hostname pin.
- `GOTOOLCHAIN=go1.26.7 go test -race ./cmd/octopool -run '^TestLoginGitHubTokenSelection$' -count=1`
- `GOTOOLCHAIN=go1.26.7 pnpm check`
- Supplied Go 1.27 focused login and CLI compatibility checks pass.
