### PR TITLE
fix: preserve contributor credit in protected squash merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Preserve contributor credit in protected exact-head squash merges by accepting merge body files through the existing text rewriting and private snapshot checks.
 - Keep CLI caller tokens bound to the loaded server URL when another login replaces saved auth during request setup.
 - Pin CLI login credential lookup to GitHub.com so Enterprise host settings cannot select an Enterprise token.
 - Block cross-origin redirects and HTTPS downgrades for CLI login and authenticated JSON requests to prevent credential replay.

--- a/cmd/octopool/string_rewrites_api.go
+++ b/cmd/octopool/string_rewrites_api.go
@@ -338,7 +338,7 @@ func rewriteAPIPayload(policy stringRewritePolicy, prepared *rewritePreparation,
 		spec = "title:text body:text"
 		required = ""
 	case "pull-merge":
-		spec = "sha:string merge_method:squash"
+		spec = "sha:string merge_method:squash commit_message:text"
 		required = "sha merge_method"
 	case "release-create":
 		spec = "name:text body:text tag_name:string draft:bool prerelease:bool make_latest:string"

--- a/cmd/octopool/string_rewrites_guard.go
+++ b/cmd/octopool/string_rewrites_guard.go
@@ -361,7 +361,7 @@ func prepareProtectedGH(ctx context.Context, args []string, stdin io.Reader) (*r
 			err = prepareRewriteBestEffort(policy, args, stdin, prepared)
 		}
 	case len(args) >= 2 && args[0] == "pr" && (args[1] == "ready" || args[1] == "merge"):
-		err = prepareRewritePRLifecycle(policy, args, prepared)
+		err = prepareRewritePRLifecycle(policy, args, stdin, prepared)
 	default:
 		// Modeled reads retain structural pinning. Unknown commands and flag
 		// shapes still receive bounded argv/stdin filtering before native gh.

--- a/cmd/octopool/string_rewrites_merge_body_test.go
+++ b/cmd/octopool/string_rewrites_merge_body_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestStringRewritePinnedMergeBody(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	sha := strings.Repeat("a", 40)
+	body := "Reviewed internal-model fix\n\nCo-authored-by: Contributor <contributor@example.com>\n"
+	file := filepath.Join(t.TempDir(), "body.md")
+	if err := os.WriteFile(file, []byte(body), 0600); err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name  string
+		flags []string
+	}{
+		{"long file", []string{"--body-file", file}},
+		{"long equals", []string{"--body-file=" + file}},
+		{"short file", []string{"-F", file}},
+		{"short attached", []string{"-F" + file}},
+		{"stdin", []string{"--body-file=-"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			for _, exit := range []string{"0", "19"} {
+				t.Run("child exit "+exit, func(t *testing.T) {
+					capturePath := captureRewriteGH(t)
+					t.Setenv("OCTOPOOL_TEST_REWRITE_EXIT", exit)
+					args := []string{"pr", "merge", "123", "--repo", "https://github.com/acme/repo", "--squash", "--match-head-commit", sha}
+					args = append(args, test.flags...)
+					err := execRealGHWithStdin(t.Context(), args, strings.NewReader(body), io.Discard, io.Discard)
+					if exit == "0" && err != nil {
+						t.Fatal(err)
+					}
+					if exit != "0" {
+						var exitErr exitCodeError
+						if !errors.As(err, &exitErr) || exitErr.Code != 19 {
+							t.Fatalf("child exit was not preserved: %v", err)
+						}
+					}
+					capture := readRewriteCapture(t, capturePath)
+					if capture.Stdin != "" || len(capture.Files) != 1 || !slices.Contains(capture.Args, "repos/acme/repo/pulls/123/merge") || !slices.Contains(capture.Args, "--method=PUT") {
+						t.Fatalf("merge was not an immediate snapshotted REST request: %+v", capture)
+					}
+					for path, content := range capture.Files {
+						var payload map[string]string
+						if err := json.Unmarshal([]byte(content), &payload); err != nil || len(payload) != 3 || payload["sha"] != sha || payload["merge_method"] != "squash" || payload["commit_message"] != strings.ReplaceAll(body, "internal-model", "public") {
+							t.Fatalf("unexpected protected merge payload: %q", content)
+						}
+						if capture.Modes[path] != 0600 || capture.DirectoryModes[path] != 0700 {
+							t.Fatal("snapshot permissions are not private")
+						}
+						if _, err := os.Stat(path); !os.IsNotExist(err) {
+							t.Fatal("snapshot survived child completion")
+						}
+					}
+					got, err := os.ReadFile(file)
+					if err != nil || string(got) != body {
+						t.Fatal("source body file was modified")
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestStringRewritePinnedMergeBodyRejectsUnsafeRequests(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	sha := strings.Repeat("a", 40)
+	file := filepath.Join(t.TempDir(), "body.md")
+	if err := os.WriteFile(file, []byte("safe"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name  string
+		sha   string
+		flags []string
+	}{
+		{"short head", "short", nil},
+		{"missing head", "", nil},
+		{"auto", sha, []string{"--auto"}},
+		{"admin", sha, []string{"--admin"}},
+		{"merge method", sha, []string{"--merge"}},
+		{"rebase method", sha, []string{"--rebase"}},
+		{"subject", sha, []string{"--subject", "safe"}},
+		{"inline body", sha, []string{"--body", "safe"}},
+		{"duplicate body aliases", sha, []string{"-F", file}},
+		{"conflicting squash", sha, []string{"--squash=false"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			capturePath := captureRewriteGH(t)
+			args := []string{"pr", "merge", "123", "--repo", "acme/repo", "--squash", "--body-file", file}
+			if test.sha != "" {
+				args = append(args, "--match-head-commit", test.sha)
+			}
+			args = append(args, test.flags...)
+			if err := execRealGHWithStdin(t.Context(), args, strings.NewReader("unused"), io.Discard, io.Discard); err != errRewriteBlocked {
+				t.Fatalf("request was not rejected: %v", err)
+			}
+			if _, err := os.Stat(capturePath); !os.IsNotExist(err) {
+				t.Fatal("rejected request spawned a child")
+			}
+		})
+	}
+	for _, test := range []struct {
+		name    string
+		content []byte
+	}{
+		{"invalid UTF-8", []byte{255}},
+		{"oversized", []byte(strings.Repeat("a", rewriteMaxContent+1))},
+		{"active policy material", []byte(`{"pattern":"internal-model","replacement":"public"}`)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			capturePath := captureRewriteGH(t)
+			badFile := filepath.Join(t.TempDir(), "body.md")
+			if err := os.WriteFile(badFile, test.content, 0600); err != nil {
+				t.Fatal(err)
+			}
+			args := []string{"pr", "merge", "123", "--repo", "acme/repo", "--squash", "--match-head-commit", sha, "--body-file", badFile}
+			if err := execRealGH(t.Context(), args, io.Discard, io.Discard); err != errRewriteBlocked {
+				t.Fatalf("invalid body was not rejected: %v", err)
+			}
+			if _, err := os.Stat(capturePath); !os.IsNotExist(err) {
+				t.Fatal("invalid body spawned a child")
+			}
+		})
+	}
+}
+
+func TestStringRewriteMergeMessageAPI(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	sha := strings.Repeat("a", 40)
+	for _, test := range []struct {
+		name    string
+		message any
+		want    string
+		blocked bool
+	}{
+		{"text", "reviewed internal-model fix", "reviewed public fix", false},
+		{"wrong type", false, "", true},
+		{"policy material", `{"pattern":"internal-model","replacement":"public"}`, "", true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			capturePath := captureRewriteGH(t)
+			input, err := json.Marshal(map[string]any{"sha": sha, "merge_method": "squash", "commit_message": test.message})
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = execRealGHWithStdin(t.Context(), []string{"api", "repos/acme/repo/pulls/123/merge", "--method=PUT", "--input=-"}, strings.NewReader(string(input)), io.Discard, io.Discard)
+			if test.blocked {
+				if err != errRewriteBlocked {
+					t.Fatalf("invalid merge message was not rejected: %v", err)
+				}
+				if _, err := os.Stat(capturePath); !os.IsNotExist(err) {
+					t.Fatal("invalid merge message reached the child")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			capture := readRewriteCapture(t, capturePath)
+			if len(capture.Files) != 1 || capture.Stdin != "" {
+				t.Fatal("merge message did not use a snapshot")
+			}
+			for _, content := range capture.Files {
+				var payload map[string]string
+				if err := json.Unmarshal([]byte(content), &payload); err != nil || payload["commit_message"] != test.want || payload["sha"] != sha || payload["merge_method"] != "squash" || len(payload) != 3 {
+					t.Fatalf("unexpected merge payload: %q", content)
+				}
+			}
+		})
+	}
+}

--- a/cmd/octopool/string_rewrites_pr.go
+++ b/cmd/octopool/string_rewrites_pr.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -9,7 +10,7 @@ import (
 var rewriteCommitSHA = regexp.MustCompile(`^[0-9a-fA-F]{40}$`)
 var rewriteGitHubLogin = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$`)
 
-func prepareRewritePRLifecycle(policy stringRewritePolicy, args []string, prepared *rewritePreparation) error {
+func prepareRewritePRLifecycle(policy stringRewritePolicy, args []string, stdin io.Reader, prepared *rewritePreparation) error {
 	if len(args) < 2 || args[0] != "pr" {
 		return errRewriteBlocked
 	}
@@ -20,7 +21,7 @@ func prepareRewritePRLifecycle(policy stringRewritePolicy, args []string, prepar
 	case "pr ready":
 		booleans = rewriteFlagNames("--undo")
 	case "pr merge":
-		values = rewriteFlagNames("--repo,-R --match-head-commit")
+		values = rewriteFlagNames("--repo,-R --match-head-commit --body-file,-F")
 		booleans = rewriteFlagNames("--squash")
 	default:
 		return errRewriteBlocked
@@ -66,10 +67,15 @@ func prepareRewritePRLifecycle(policy stringRewritePolicy, args []string, prepar
 		// Use GitHub's immediate merge endpoint so the checked head SHA remains the
 		// commit being merged; queue-required branches fail instead of weakening it.
 		endpoint := "repos/" + flags.values["--repo"] + "/pulls/" + selector + "/merge"
-		return prepareRewriteAPI(policy, []string{
+		apiArgs := []string{
 			"api", endpoint, "--method=PUT", "--raw-field=sha=" + sha,
 			"--raw-field=merge_method=squash", "--silent",
-		}, strings.NewReader(""), prepared)
+		}
+		if flags.has("--body-file") {
+			// The API owner reads, rewrites, and snapshots the body before dispatch.
+			apiArgs = append(apiArgs, "--field=commit_message=@"+flags.values["--body-file"])
+		}
+		return prepareRewriteAPI(policy, apiArgs, stdin, prepared)
 	}
 	prepared.args = []string{"pr", args[1], flags.positionals[0], "--repo=" + flags.values["--repo"]}
 	for _, flag := range flags.ordered {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -471,7 +471,8 @@ With active rules, the initial local publication vocabulary is deliberately cons
   `-f`/`--raw-field`, `-F`/`--field`, or `--input` JSON. Literal and typed fields retain
   their distinction; only typed `@file`/`@-` values read files/stdin. Nested review comments
   use `--input` JSON. Exact issue-assignee POSTs accept repeated raw `assignees[]` values;
-  exact pull-request merge PUTs require only a full 40-hex `sha` and `merge_method: squash`.
+  exact pull-request merge PUTs require a full 40-hex `sha` and `merge_method: squash`,
+  with an optional rewritten `commit_message` string.
   Other bracket accumulation, duplicate keys, mixed input/field sources, unknown properties,
   and custom authentication headers are rejected. Raw release creation first verifies the
   existing remote tag with a local authenticated GET.
@@ -612,8 +613,11 @@ GraphQL shapes are not representable by the relay. Numeric `pr ready` (or a chec
 current/explicit nonnumeric Git branch) and metadata-only PR/issue edits with add/remove label
 or assignee flags are also allowed without free-form text. Exact-head
 `pr merge --squash --match-head-commit` is converted to the immediate pull-request merge REST
-endpoint with only the checked SHA and squash method; it never enables auto-merge, so a branch
-that requires a merge queue fails closed. Subject/body merge flags, admin/auto merge variants,
+endpoint with the checked SHA and squash method; it never enables auto-merge, so a branch
+that requires a merge queue fails closed. An explicit `--body-file`/`-F` (including `-` for
+stdin) supplies an optional commit message through the same bounded text rewriting and private
+JSON snapshot as REST content. The child receives neither the original body path nor live stdin.
+Subject/inline-body merge flags, admin/auto merge variants,
 URL selectors, numeric inferred branches, and unpinned merges remain blocked on that strict
 lifecycle path. Other editor/web/template/fill modes, unmodeled uploads, aliases/extensions, raw
 GraphQL, and newly introduced native commands/flags use best-effort filtering and retain


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers preserving contributor credit in an exact-head squash merge were blocked when the native workflow supplied `gh pr merge --body-file`. The protected lifecycle route rejected the command before dispatch, even though the body could use the existing text rewriting and snapshot owner.

## Why This Change Was Made

Accept `--body-file` / `-F`, including stdin, and carry the optional message through the existing API payload owner as `commit_message`. The body is read once with existing bounds, rewritten, checked, and placed in the same private immutable JSON snapshot as other protected content. No second filter or fallback path is introduced. The protection owner explicitly approved this extension to the protected publication contract.

## User Impact

Maintainers can retain reviewed contributor trailers in immediate squash merges. Full head-SHA pinning, explicit repository validation, text scanning, and snapshot cleanup remain enforced. Admin/auto/queue variants, alternate merge methods, inline body and subject flags remain excluded from the strict lifecycle route. Production delta is +12/-6: six lines carry the optional body source into the existing owner. Tests add 182 lines; docs and the unreleased changelog describe the supported form.

## Evidence

Ten positive file/stdin subprocess cases failed on the unchanged baseline with the protection error and passed with the repair. Cases cover five flag spellings and both successful and nonzero downstream exits. They verify rewritten text and retained synthetic contributor credit, exact SHA/squash fields, immediate REST dispatch, no live child stdin, private 0700/0600 snapshots, cleanup, and unchanged source files.

Negative tests still reject missing/short heads, admin/auto/alternate methods, subject/inline body, duplicate aliases, conflicting squash, invalid UTF-8, oversized bodies, and active synthetic policy material before child spawn. Direct REST message tests cover rewritten text, invalid types, and policy-material rejection. The broader rewrite suite passed. After mechanically rebasing onto current main, a fresh full-candidate Codex review found no actionable P0 issues. Full `go test ./...` passed (74.508s), `go vet ./...` passed, and [hosted CI](https://github.com/openclaw/octopool/actions/runs/33359615551) passed: full repository checks, native Windows protection tests, docs build, and cross-platform snapshot builds. CodeQL also passed.

The subprocess proof uses a synthetic policy and fake downstream child; it performs no live merge. Installed merged commit `5f3990e5d8ee170ef8c01d1ded8393d90176ce9d` through the documented source installer and canonical `install-shim` command. Both login and non-interactive shells resolve the shim correctly. The native [OpenClaw #132083 recovery](https://github.com/openclaw/openclaw/pull/132083) then merged the exact reviewed head as `607a49ed5271e432648da09be2e96ec80c844f18`; Git parsed the contributor credit from the final terminal trailer block. This supplies real installed-binary proof in addition to the synthetic subprocess tests.
