### PR TITLE
fix: preserve public visibility for issue events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Keep issue timelines and issue-event reads anonymous-only, retiring cached private cross-references and preserving safe conditional and native fallback behavior.
 - Preserve contributor credit in protected exact-head squash merges by accepting merge body files through the existing text rewriting and private snapshot checks.
 - Keep CLI caller tokens bound to the loaded server URL when another login replaces saved auth during request setup.
 - Pin CLI login credential lookup to GitHub.com so Enterprise host settings cannot select an Enterprise token.

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -49,6 +49,14 @@ from edge, D1, stale fallback, fill coalescing, or conditional revalidation. Onl
 shaped release keys change; raw REST entries retain their keys. The generation applies
 to metadata-only projections too, since they share the same response body.
 
+Issue timelines and the three issue-event list/view routes include `issue-events-public-v2`
+for every representation, including raw REST and identity-specific keys. Older pooled bodies
+may retain private cross-reference details, even after anonymous revalidation removed their
+identity attribution. All old keys are retired across edge, D1, stale fallback, fill coalescing,
+and revalidation. Only anonymous responses populate the new generation. Caller conditionals
+bypass storage and use the anonymous API; a `304` never revives an old server-cached body.
+Repository/network activity feeds and unrelated cache keys are unchanged.
+
 PR file-list routes may include a validated
 `route_hint.pr_head_sha` or closed/merged `route_hint.pr_state` discriminator. Clients
 that already know the current PR state can use that to avoid mixing entries across head
@@ -129,6 +137,9 @@ The main transport classes are:
 - release list/latest/tag/id/asset reads via unauthenticated `api.github.com` requests so pooled
   credentials never expose draft releases; top-level `gh release view` also uses exact API
   data, preserving raw Markdown strings through fills, cache reads, and revalidation
+- issue timeline and issue-event list/view reads via the anonymous API, so cross-repository
+  issue and commit references retain public visibility; outages can use only the new cache
+  generation with the existing age, retention, and repository-proof checks
 
 Release bodies are never reconstructed from rendered HTML or replaced with changelog
 text. Whitespace, line endings, and Markdown syntax remain exactly as returned by the

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -89,6 +89,12 @@ and patch hosts.
   local-`gh` fallback. Raw API requests retain exact REST response semantics.
   Octopool does not use pooled credentials for releases, so draft/private release visibility
   is not shared.
+- Issue timelines, per-issue events, repository issue-event lists, and individual issue events
+  use only the anonymous API, including conditional requests. A public target repository
+  does not prove that referenced issues or commits are public. Anonymous failures use bounded
+  public stale data or `424 fallback_local` (`web_only_unavailable`); pooled credentials and
+  legacy event cache entries cannot widen visibility. Public JSON and response validators
+  are preserved, and native fallback uses the caller's own credentials.
 - Supported top-level `gh run view --json jobs` reads prefer job and step metadata composed
   from public GitHub pages. Raw `/actions/runs/{id}/jobs` requests retain exact REST response
   semantics, and log bodies still require authenticated API access.

--- a/docs/token-free.md
+++ b/docs/token-free.md
@@ -143,6 +143,22 @@ exact cached response may be served through the existing bounded stale policy; o
 the existing guarded local-`gh` fallback applies. Releases never use pooled credentials,
 and draft filtering remains in place.
 
+### Public issue-event visibility
+
+Issue timelines (`/issues/{number}/timeline`), per-issue events (`/issues/{number}/events`),
+repository issue events (`/issues/events`), and individual events (`/issues/events/{id}`)
+are anonymous-only, including caller conditional requests. GitHub's
+[cross-references](https://docs.github.com/en/rest/using-the-rest-api/issue-event-types#cross-referenced)
+and [closing-commit references](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-an-issues-only-repository)
+depend on access to the source repository. Proving the target public or removing a nested
+repository object does not prove the enclosing issue/commit details public.
+
+These routes preserve anonymous REST bodies and headers. Anonymous quota exhaustion or
+unavailability uses eligible public stale data or guarded native fallback; unsupported media
+also falls back locally. Old event representations are retired by the server's cache generation.
+Repository activity events use a different payload schema, and network events explicitly list
+public activity; neither is changed by this issue-reference restriction.
+
 ### Generated route catalog
 
 <!-- token-free-api-routes:start -->

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -10,6 +10,7 @@ import { defaultGitHubJSONAccept } from "./github-response";
 import { PUBLIC_SHAPES } from "./github-public-shapes";
 import { isRecord } from "./object";
 import { parseSQLiteTimestamp, sqliteTimestamp } from "./sqlite-time";
+import { isIssueEventRoute } from "./route-manifest";
 import type { CacheFillOutcome } from "./cache-fill";
 import type { GitHubRelayResponse, Identity, RelayRequest, RouteInfo } from "./types";
 
@@ -83,6 +84,9 @@ export async function githubCacheKey(
     ["release_view", "release_latest"].includes(route.kind)
       ? { representation: "release-summary-raw-v2" }
       : {}),
+    // Old raw event bodies may contain privileged references, even after a 304
+    // republished an identity entry as anonymous. Retire every variant together.
+    ...(isIssueEventRoute(route.kind) ? { representation: "issue-events-public-v2" } : {}),
     ...(identity === undefined ? {} : { identity: `${identity.kind}:${identity.id}` }),
   };
   return hashToken(JSON.stringify(stable));

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -37,7 +37,7 @@ import {
   ensurePublicGitHubRepo,
   recordPublicGitHubRepo,
 } from "./public-repos";
-import { capabilitiesForRouteKind, isNativeReadRoute } from "./route-manifest";
+import { capabilitiesForRouteKind, isIssueEventRoute, isNativeReadRoute } from "./route-manifest";
 import {
   exactRunListRequest,
   filterRunListSuperset,
@@ -653,11 +653,22 @@ async function restoreSharedCacheFillState(
 }
 
 async function callTokenFreeBackend(state: ActiveRelay): Promise<Response | undefined> {
-  if (state.cacheKey === undefined) {
+  if (state.cacheKey === undefined && !isIssueEventRoute(state.route.kind)) {
     return undefined;
   }
-  const response = await callGitHubWeb(state.env, state.cacheRequest, state.route);
+  // Caller conditionals bypass storage, but must still use anonymous visibility.
+  const response =
+    state.cacheKey === undefined
+      ? await callAnonymousGitHubAPI(state.env, state.cacheRequest, state.route)
+      : await callGitHubWeb(state.env, state.cacheRequest, state.route);
   if (response === undefined) {
+    if (isIssueEventRoute(state.route.kind)) {
+      // No response to prove public: hand off before credentialed repo probes.
+      // The error handler may serve only a covered entry from the new generation.
+      throw new HttpError(424, "fallback_local", "Run this request with local GitHub credentials", {
+        reason: "web_only_unavailable",
+      });
+    }
     return undefined;
   }
   const completed =
@@ -665,12 +676,15 @@ async function callTokenFreeBackend(state: ActiveRelay): Promise<Response | unde
       ? await completeRunJobsSuperset(response, state.runJobsSuperset, anonymousRunJobsPage(state))
       : response;
   const github = sanitizeGitHubResponse(state.route, completed);
-  if (anonymousGitHubResponseProvesPublicRepo(state.route)) {
+  if (response.status !== 304 && anonymousGitHubResponseProvesPublicRepo(state.route)) {
     await recordPublicGitHubRepo(state.env, state.route);
   } else {
     await ensurePublicGitHubRepo(state.env, state.route, undefined, state.coordinator);
   }
-  return finalizeRelaySuccess(state, { github, backend: "web" });
+  return finalizeRelaySuccess(state, {
+    github,
+    backend: state.cacheKey === undefined ? "github_public" : "web",
+  });
 }
 
 async function callPublicBackend(state: ActiveRelay): Promise<Response> {

--- a/src/route-manifest.ts
+++ b/src/route-manifest.ts
@@ -133,6 +133,11 @@ export function isNativeReadRoute(route: { capabilities: RouteCapabilities }): b
   return !route.capabilities.publicApi && route.capabilities.fallback === "local";
 }
 
+// These responses can include cross-repository references visible only to a token.
+export function isIssueEventRoute(kind: RouteKind): boolean {
+  return ["issue_timeline", "issue_events", "issue_event_list", "issue_event_view"].includes(kind);
+}
+
 function normalizeRouteKeyTemplate(template: string): string {
   return template
     .replace(/^\/users\/\{login\}/, "/users/:login")
@@ -280,12 +285,12 @@ export const ROUTES = [
   route("/repos/{owner}/{repo}/issues/comments", "issue_comment_list"),
   route("/repos/{owner}/{repo}/issues/comments/{id}", "issue_comment_view"),
   route("/repos/{owner}/{repo}/issues/comments/{id}/reactions", "issue_comment_reactions"),
-  route("/repos/{owner}/{repo}/issues/{number}/events", "issue_events"),
-  route("/repos/{owner}/{repo}/issues/events", "issue_event_list"),
-  route("/repos/{owner}/{repo}/issues/events/{id}", "issue_event_view"),
+  localRoute("/repos/{owner}/{repo}/issues/{number}/events", "issue_events"),
+  localRoute("/repos/{owner}/{repo}/issues/events", "issue_event_list"),
+  localRoute("/repos/{owner}/{repo}/issues/events/{id}", "issue_event_view"),
   route("/repos/{owner}/{repo}/issues/{number}/labels", "issue_labels"),
   route("/repos/{owner}/{repo}/issues/{number}/reactions", "issue_reactions"),
-  route("/repos/{owner}/{repo}/issues/{number}/timeline", "issue_timeline"),
+  localRoute("/repos/{owner}/{repo}/issues/{number}/timeline", "issue_timeline"),
   route("/repos/{owner}/{repo}/assignees", "assignee_list"),
   route("/repos/{owner}/{repo}/assignees/{login}", "assignee_view"),
   route("/repos/{owner}/{repo}/labels", "label_list"),

--- a/test/e2e/issue-event-visibility.test.ts
+++ b/test/e2e/issue-event-visibility.test.ts
@@ -1,0 +1,349 @@
+import { env } from "cloudflare:workers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { githubCacheKey, writeGitHubCache } from "../../src/cache";
+import { deleteEdgeJSON } from "../../src/edge-cache";
+import { sanitizeGitHubResponse } from "../../src/github-sanitize";
+import { classifyRoute, defaultPolicy, validateRelayRequest } from "../../src/policy";
+import { recordPublicGitHubRepo } from "../../src/public-repos";
+import type { Identity } from "../../src/types";
+import { issueEventCases, legacyIssueEventKey } from "../fixtures/issue-event-visibility";
+import { jsonResponse, rateHeaders, relay, seedPool } from "./harness";
+
+type Envelope = {
+  status: number;
+  body: unknown;
+  identity?: unknown;
+  headers: Record<string, string>;
+  relay: { cache: string; stale_ok: boolean; stale_reason?: string };
+};
+
+const legacyIdentity: Identity = {
+  id: "primary",
+  kind: "pat",
+  login: "primary",
+  secret_ref: "TEST_PAT_PRIMARY",
+  installation_id: null,
+  weight: 200,
+};
+
+describe.each(issueEventCases)("$kind anonymous visibility at the Worker boundary", (fixture) => {
+  const { path, publicBody, privilegedBody } = fixture;
+  const request = validateRelayRequest({ pool: "maintainers", method: "GET", path });
+  const route = classifyRoute(request, defaultPolicy("openclaw"));
+  beforeEach(seedPool);
+
+  function mockUpstream(publicResponse: (request: Request) => Response) {
+    const calls: Request[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        const upstream = new Request(input, init);
+        calls.push(upstream);
+        if (upstream.url === "https://api.github.com/repos/openclaw/octopool") {
+          return jsonResponse({ private: false });
+        }
+        if (new URL(upstream.url).pathname !== path) {
+          return jsonResponse({ message: "unavailable" }, 503);
+        }
+        return upstream.headers.has("authorization")
+          ? jsonResponse(privilegedBody, 200, apiHeaders('"private"'))
+          : publicResponse(upstream);
+      }),
+    );
+    return calls;
+  }
+
+  it.each(["if-none-match", "if-modified-since"])(
+    "keeps %s on the anonymous transport despite a proven-public target",
+    async (header) => {
+      await recordPublicGitHubRepo(env, route);
+      const calls = mockUpstream(() => jsonResponse(publicBody, 200, apiHeaders('"public"')));
+      const value = header === "if-none-match" ? '"old-client"' : "Sat, 01 Aug 2026 12:00:00 GMT";
+      const response = await relay(path, undefined, { headers: { [header]: value } });
+      expect(response.status).toBe(200);
+      const envelope = await response.json<Envelope>();
+      // Red proof exposes the enclosing source.issue after repository becomes null.
+      expect(envelope.body).toEqual(publicBody);
+      expect(envelope.identity).toBeUndefined();
+      expect(envelope.relay.cache).toBe("bypass");
+      expect(calls).toHaveLength(1);
+      expect(calls[0]!.headers.has("authorization")).toBe(false);
+      expect(calls[0]!.headers.get(header)).toBe(value);
+      expect(await cacheRows()).toEqual([]);
+      expect(
+        await env.DB.prepare("SELECT identity_id, backend, cache_status FROM audit_events").first(),
+      ).toEqual({ identity_id: null, backend: "github_api", cache_status: "bypass" });
+    },
+  );
+
+  it("serves exact public events directly and from edge and D1 without a repo probe", async () => {
+    const calls = mockUpstream(() => jsonResponse(publicBody, 200, apiHeaders('"public"')));
+    for (const layer of ["miss", "edge", "shared"]) {
+      if (layer === "shared")
+        await deleteEdgeJSON("github-v1", await githubCacheKey(request.pool, request, route));
+      const response = await relay(path);
+      expect(response.status).toBe(200);
+      const envelope = await response.json<Envelope>();
+      expect(envelope.body).toEqual(publicBody);
+      expect(envelope.identity).toBeUndefined();
+      expect(envelope.relay.cache).toBe(layer === "miss" ? "miss" : "hit");
+    }
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(`https://api.github.com${path}`);
+    expect(calls[0]!.headers.has("authorization")).toBe(false);
+    expect(await cacheRows()).toEqual([
+      expect.objectContaining({ identity_id: null, body_json: JSON.stringify(publicBody) }),
+    ]);
+  });
+
+  it("passes anonymous 304 through without reviving a legacy body", async () => {
+    const oldKey = await legacyIssueEventKey(request, route);
+    await writeGitHubCache(env, oldKey, request, route, {
+      status: 200,
+      headers: apiHeaders('"legacy-private"'),
+      body: privilegedBody,
+      body_encoding: "json",
+    });
+    const before = await cacheRows();
+    const calls = mockUpstream(
+      () => new Response(null, { status: 304, headers: apiHeaders('"public"') }),
+    );
+    const response = await relay(path, undefined, { headers: { "if-none-match": '"client"' } });
+    expect(response.status).toBe(200);
+    const envelope = await response.json<Envelope>();
+    expect(envelope).toMatchObject({
+      status: 304,
+      body: null,
+      headers: { etag: '"public"' },
+      relay: { cache: "bypass" },
+    });
+    expect(envelope.identity).toBeUndefined();
+    const eventCalls = calls.filter((call) => new URL(call.url).pathname === path);
+    expect(eventCalls).toHaveLength(1);
+    expect(eventCalls[0]!.headers.has("authorization")).toBe(false);
+    expect(eventCalls[0]!.headers.get("if-none-match")).toBe('"client"');
+    // A 304 is not a new repository proof; the existing metadata guard still runs.
+    expect(
+      calls.filter((call) => new URL(call.url).pathname === "/repos/openclaw/octopool"),
+    ).toHaveLength(1);
+    expect(await cacheRows()).toEqual(before);
+  });
+
+  it("preserves pagination, API version, response headers, and no-content status", async () => {
+    const link = `<https://api.github.com${path}?page=3>; rel="next"`;
+    const calls = mockUpstream(
+      () => new Response(null, { status: 204, headers: { etag: '"empty"', link } }),
+    );
+    const response = await relay(path, undefined, {
+      query: { page: "2", per_page: "10" },
+      headers: { "x-github-api-version": "2022-11-28", "if-none-match": '"client"' },
+    });
+    expect(await response.json()).toMatchObject({
+      status: 204,
+      body: null,
+      body_encoding: "text",
+      headers: { etag: '"empty"', link },
+      relay: { cache: "bypass" },
+    });
+    expect(calls).toHaveLength(1);
+    expect(new URL(calls[0]!.url).searchParams.toString()).toBe("page=2&per_page=10");
+    expect(calls[0]!.headers.get("x-github-api-version")).toBe("2022-11-28");
+    expect(calls[0]!.headers.has("authorization")).toBe(false);
+    expect(await cacheRows()).toEqual([]);
+  });
+
+  it("hands unsupported media to native credentials without trying a pool", async () => {
+    const calls = mockUpstream(() => jsonResponse(publicBody));
+    const response = await relay(path, undefined, {
+      headers: { accept: "application/vnd.github.full+json" },
+    });
+    expect(response.status).toBe(424);
+    expect(await response.json()).toMatchObject({
+      error: { code: "fallback_local", details: { reason: "web_only_unavailable" } },
+    });
+    expect(calls).toEqual([]);
+    expect(await cacheRows()).toEqual([]);
+  });
+
+  it.each([403, 429, 503])(
+    "falls back safely on anonymous %i without using a pool",
+    async (status) => {
+      await recordPublicGitHubRepo(env, route);
+      const calls = mockUpstream(() =>
+        jsonResponse({ message: "unavailable" }, status, rateHeaders({ remaining: 0 })),
+      );
+      for (const headers of [{}, { "if-none-match": '"old-client"' }]) {
+        const response = await relay(path, undefined, { headers });
+        expect(await response.json()).toMatchObject({
+          error: { code: "fallback_local", details: { reason: "web_only_unavailable" } },
+        });
+        expect(response.status).toBe(424);
+      }
+      expect(calls).toHaveLength(2);
+      expect(calls.every((call) => !call.headers.has("authorization"))).toBe(true);
+      expect(await cacheRows()).toEqual([]);
+    },
+  );
+
+  it.each(["edge", "shared", "stale"])(
+    "retires legacy privileged %s bodies and validators",
+    async (layer) => {
+      await recordPublicGitHubRepo(env, route);
+      const oldKeys: string[] = [];
+      for (const identity of [undefined, legacyIdentity]) {
+        const key = await legacyIssueEventKey(request, route, identity);
+        oldKeys.push(key);
+        await writeGitHubCache(
+          env,
+          key,
+          request,
+          route,
+          sanitizeGitHubResponse(route, {
+            status: 200,
+            headers: apiHeaders('"legacy-private"'),
+            body: privilegedBody,
+            body_encoding: "json",
+          }),
+          identity,
+        );
+        if (layer === "stale") await expire(key);
+        if (layer === "shared") await deleteEdgeJSON("github-v1", key);
+      }
+      const before = await cacheRows();
+      const calls = mockUpstream((upstream) =>
+        upstream.headers.has("if-none-match")
+          ? new Response(null, { status: 304, headers: apiHeaders('"legacy-private"') })
+          : jsonResponse(publicBody, 200, apiHeaders('"public"')),
+      );
+      const response = await relay(path);
+      const envelope = await response.json<Envelope>();
+      expect(envelope.body).toEqual(publicBody);
+      expect(envelope.relay.cache).toBe("miss");
+      expect(envelope.identity).toBeUndefined();
+      expect(calls).toHaveLength(1);
+      expect(calls[0]!.headers.has("authorization")).toBe(false);
+      expect(calls[0]!.headers.has("if-none-match")).toBe(false);
+      const key = await githubCacheKey(request.pool, request, route);
+      expect(oldKeys).not.toContain(key);
+      expect((await cacheRows()).filter((row) => oldKeys.includes(row.cache_key))).toEqual(before);
+    },
+  );
+
+  it("never uses legacy stale data during anonymous failure", async () => {
+    await recordPublicGitHubRepo(env, route);
+    for (const identity of [undefined, legacyIdentity]) {
+      const key = await legacyIssueEventKey(request, route, identity);
+      await writeGitHubCache(
+        env,
+        key,
+        request,
+        route,
+        {
+          status: 200,
+          headers: apiHeaders('"legacy"'),
+          body: privilegedBody,
+          body_encoding: "json",
+        },
+        identity,
+      );
+      await expire(key);
+    }
+    const before = await cacheRows();
+    const calls = mockUpstream(() => jsonResponse({ message: "unavailable" }, 503));
+    const response = await relay(path);
+    expect(response.status).toBe(424);
+    expect(await response.json()).toMatchObject({
+      error: { code: "fallback_local", details: { reason: "web_only_unavailable" } },
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.headers.has("authorization")).toBe(false);
+    expect(calls[0]!.headers.has("if-none-match")).toBe(false);
+    expect(await cacheRows()).toEqual(before);
+  });
+
+  it("revalidates new anonymous data and bounds stale fallback by age and retention", async () => {
+    let phase: "fill" | "revalidate" | "outage" = "fill";
+    const calls = mockUpstream((upstream) => {
+      if (phase === "outage") return jsonResponse({ message: "unavailable" }, 503);
+      if (phase === "revalidate") {
+        expect(upstream.headers.get("if-none-match")).toBe('"public"');
+        return new Response(null, { status: 304, headers: apiHeaders('"public"') });
+      }
+      return jsonResponse(publicBody, 200, apiHeaders('"public"'));
+    });
+    expect((await relay(path)).status).toBe(200);
+    const key = await githubCacheKey(request.pool, request, route);
+    await expire(key);
+    phase = "revalidate";
+    const revalidated = await (await relay(path)).json<Envelope>();
+    expect(revalidated.body).toEqual(publicBody);
+    expect(revalidated.relay.cache).toBe("hit");
+    phase = "outage";
+    await expire(key);
+    const stale = await (await relay(path)).json<Envelope>();
+    expect(stale.body).toEqual(publicBody);
+    expect(stale.relay).toMatchObject({
+      cache: "stale",
+      stale_ok: true,
+      stale_reason: "web_only_unavailable",
+    });
+    expect(
+      (await relay(path, undefined, { headers: { "cache-control": "max-age=0" } })).status,
+    ).toBe(424);
+    await env.DB.prepare(
+      "UPDATE github_cache_entries SET stale_expires_at = datetime('now', '-1 second') WHERE cache_key = ?",
+    )
+      .bind(key)
+      .run();
+    expect((await relay(path)).status).toBe(424);
+    expect(calls.every((call) => !call.headers.has("authorization"))).toBe(true);
+  });
+
+  it("rejects stale public events after the target repository becomes private", async () => {
+    mockUpstream(() => jsonResponse(publicBody, 200, apiHeaders('"public"')));
+    expect((await relay(path)).status).toBe(200);
+    await expire(await githubCacheKey(request.pool, request, route));
+    await env.DB.prepare("DELETE FROM github_public_repos").run();
+    await deleteEdgeJSON("public-repo-v1", "openclaw/octopool");
+    const calls: Request[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        const upstream = new Request(input, init);
+        calls.push(upstream);
+        return new URL(upstream.url).pathname === path
+          ? jsonResponse({ message: "unavailable" }, 503)
+          : jsonResponse({ private: true });
+      }),
+    );
+    const response = await relay(path);
+    expect(response.status).toBe(424);
+    expect(await response.json()).toMatchObject({ error: { code: "fallback_local" } });
+    expect(
+      calls
+        .filter((call) => new URL(call.url).pathname === path)
+        .every((call) => !call.headers.has("authorization")),
+    ).toBe(true);
+  });
+});
+
+async function expire(key: string) {
+  await env.DB.prepare(
+    "UPDATE github_cache_entries SET expires_at = datetime('now', '-1 second'), stale_expires_at = datetime('now', '+1 hour') WHERE cache_key = ?",
+  )
+    .bind(key)
+    .run();
+  await deleteEdgeJSON("github-v1", key);
+}
+
+function cacheRows() {
+  return env.DB.prepare(
+    "SELECT cache_key, identity_id, body_json FROM github_cache_entries ORDER BY cache_key",
+  )
+    .all<{ cache_key: string; identity_id: string | null; body_json: string }>()
+    .then((rows) => rows.results);
+}
+
+function apiHeaders(etag: string) {
+  return { ...rateHeaders({ remaining: 59 }), etag };
+}

--- a/test/fixtures/issue-event-visibility.ts
+++ b/test/fixtures/issue-event-visibility.ts
@@ -1,0 +1,126 @@
+import { hashToken } from "../../src/auth";
+import type { RelayRequest, RouteInfo } from "../../src/types";
+
+// Synthetic public/privileged views of GitHub's documented issue-event shapes:
+// https://docs.github.com/en/rest/using-the-rest-api/issue-event-types#cross-referenced
+// https://docs.github.com/en/rest/using-the-rest-api/issue-event-types#closed
+// Visibility contract (private commits can close public issues without exposing details):
+// https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-an-issues-only-repository
+const actor = { login: "octocat", id: 1, html_url: "https://github.com/octocat" };
+const created_at = "2026-08-01T12:00:00Z";
+const publicIssue = {
+  id: 42,
+  number: 42,
+  title: "Public issue",
+  body: "Public **Markdown**.\r\n",
+  state: "closed",
+  url: "https://api.github.com/repos/openclaw/octopool/issues/42",
+  html_url: "https://github.com/openclaw/octopool/issues/42",
+  repository_url: "https://api.github.com/repos/openclaw/octopool",
+};
+const publicClosed = {
+  id: 100,
+  node_id: "synthetic-event-100",
+  url: "https://api.github.com/repos/openclaw/octopool/issues/events/100",
+  actor,
+  event: "closed",
+  commit_id: null,
+  commit_url: null,
+  created_at,
+};
+const privateClosed = {
+  ...publicClosed,
+  commit_id: "a".repeat(40),
+  commit_url: `https://api.github.com/repos/acme/private-source/commits/${"a".repeat(40)}`,
+};
+const publicCrossReference = {
+  actor,
+  event: "cross-referenced",
+  created_at,
+  updated_at: created_at,
+  source: {
+    type: "issue",
+    issue: {
+      ...publicIssue,
+      id: 43,
+      number: 43,
+      title: "Public follow-up",
+      url: "https://api.github.com/repos/openclaw/octopool/issues/43",
+      html_url: "https://github.com/openclaw/octopool/issues/43",
+      repository: {
+        full_name: "openclaw/octopool",
+        html_url: "https://github.com/openclaw/octopool",
+        private: false,
+      },
+    },
+  },
+};
+const privateCrossReference = {
+  ...publicCrossReference,
+  source: {
+    type: "issue",
+    issue: {
+      id: 7,
+      number: 7,
+      title: "PRIVATE cross-reference title",
+      body: "PRIVATE incident details",
+      state: "open",
+      url: "https://api.github.com/repos/acme/private-source/issues/7",
+      html_url: "https://github.com/acme/private-source/issues/7",
+      repository_url: "https://api.github.com/repos/acme/private-source",
+      repository: {
+        full_name: "acme/private-source",
+        html_url: "https://github.com/acme/private-source",
+        private: true,
+      },
+    },
+  },
+};
+
+// Cross-referenced source.issue belongs to timelines, not the issue-event REST schema.
+export const issueEventCases = [
+  {
+    kind: "issue_timeline",
+    path: "/repos/openclaw/octopool/issues/42/timeline",
+    publicBody: [publicClosed, publicCrossReference],
+    privilegedBody: [privateClosed, publicCrossReference, privateCrossReference],
+  },
+  {
+    kind: "issue_events",
+    path: "/repos/openclaw/octopool/issues/42/events",
+    publicBody: [publicClosed],
+    privilegedBody: [privateClosed],
+  },
+  {
+    kind: "issue_event_list",
+    path: "/repos/openclaw/octopool/issues/events",
+    publicBody: [{ ...publicClosed, issue: publicIssue }],
+    privilegedBody: [{ ...privateClosed, issue: publicIssue }],
+  },
+  {
+    kind: "issue_event_view",
+    path: "/repos/openclaw/octopool/issues/events/100",
+    publicBody: { ...publicClosed, issue: publicIssue },
+    privilegedBody: { ...privateClosed, issue: publicIssue },
+  },
+] as const;
+
+// Frozen pre-fix key layout for default-query/default-JSON requests. Do not derive
+// it from the current key function: old identity and anonymously revalidated rows matter.
+export function legacyIssueEventKey(
+  request: RelayRequest,
+  route: RouteInfo,
+  identity?: { kind: string; id: string },
+) {
+  return hashToken(
+    JSON.stringify({
+      pool: request.pool,
+      method: request.method,
+      path: request.path,
+      query: {},
+      headers: {},
+      route_key: route.routeKey,
+      ...(identity === undefined ? {} : { identity: `${identity.kind}:${identity.id}` }),
+    }),
+  );
+}

--- a/test/issue-event-cache-generation.test.ts
+++ b/test/issue-event-cache-generation.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { githubCacheKey } from "../src/cache";
+import { classifyRoute, defaultPolicy, validateRelayRequest } from "../src/policy";
+import { issueEventCases, legacyIssueEventKey } from "./fixtures/issue-event-visibility";
+
+describe("public issue-event cache generation", () => {
+  it.each(issueEventCases)("retires every old $kind identity namespace", async ({ path }) => {
+    const request = validateRelayRequest({ pool: "maintainers", method: "GET", path });
+    const route = classifyRoute(request, defaultPolicy("openclaw"));
+    for (const identity of [
+      undefined,
+      { kind: "pat" as const, id: "primary" },
+      { kind: "github_app" as const, id: "installation" },
+    ]) {
+      expect(await githubCacheKey(request.pool, request, route, identity)).not.toBe(
+        await legacyIssueEventKey(request, route, identity),
+      );
+    }
+    const defaults = {
+      ...request,
+      query: { page: "1", per_page: "30" },
+      headers: { accept: "application/json" },
+    };
+    expect(await githubCacheKey(request.pool, defaults, route)).toBe(
+      await githubCacheKey(request.pool, request, route),
+    );
+    for (const variant of [
+      { ...request, query: { page: "2" } },
+      { ...request, headers: { accept: "application/vnd.github.full+json" } },
+    ]) {
+      expect(await githubCacheKey(request.pool, variant, route)).not.toBe(
+        await githubCacheKey(request.pool, request, route),
+      );
+    }
+  });
+
+  it.each([
+    "/repos/openclaw/octopool/events",
+    "/networks/openclaw/octopool/events",
+    "/repos/openclaw/octopool/issues/42",
+    "/repos/openclaw/octopool/issues/42/comments",
+  ])("preserves neighboring %s cache keys", async (path) => {
+    const request = validateRelayRequest({ pool: "maintainers", method: "GET", path });
+    const route = classifyRoute(request, defaultPolicy("openclaw"));
+    expect(await githubCacheKey(request.pool, request, route)).toBe(
+      await legacyIssueEventKey(request, route),
+    );
+  });
+});

--- a/test/route-manifest.test.ts
+++ b/test/route-manifest.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { cachePolicyForRouteKind } from "../src/cache-policy";
-import { isNativeReadRoute, ROUTES } from "../src/route-manifest";
+import { isIssueEventRoute, isNativeReadRoute, ROUTES } from "../src/route-manifest";
 
 describe("route manifest", () => {
   it("has unique route identities and patterns", () => {
@@ -22,7 +22,7 @@ describe("route manifest", () => {
 
   it("defines backend eligibility on every concrete route", () => {
     expect(ROUTES.filter((route) => route.capabilities.publicApi)).toHaveLength(116);
-    expect(ROUTES.filter((route) => route.capabilities.fallback === "local")).toHaveLength(40);
+    expect(ROUTES.filter((route) => route.capabilities.fallback === "local")).toHaveLength(44);
     expect(ROUTES.filter((route) => route.capabilities.fallback === "github_public")).toHaveLength(
       1,
     );
@@ -50,6 +50,26 @@ describe("route manifest", () => {
       fresh: { kind: "static", seconds: 86_400 },
       staleSeconds: 86_400,
     });
+  });
+
+  it("keeps permission-dependent issue events anonymous while preserving activity feeds", () => {
+    const events = ROUTES.filter((route) => isIssueEventRoute(route.kind));
+    expect(events.map((route) => route.template)).toEqual([
+      "/repos/{owner}/{repo}/issues/{number}/events",
+      "/repos/{owner}/{repo}/issues/events",
+      "/repos/{owner}/{repo}/issues/events/{id}",
+      "/repos/{owner}/{repo}/issues/{number}/timeline",
+    ]);
+    for (const route of events) {
+      expect(route.capabilities).toEqual({
+        publicApi: true,
+        fallback: "local",
+        anonymousRepoProof: true,
+      });
+    }
+    for (const kind of ["repo_event_list", "network_event_list"]) {
+      expect(ROUTES.find((route) => route.kind === kind)?.capabilities.fallback).toBe("pool");
+    }
   });
 
   it("splits SHA-shaped and ref-named commit paths onto distinct routes", () => {


### PR DESCRIPTION
## Summary

Fixes issue timelines and issue-event list/view reads exposing private cross-repository source issues or closing commits when pooled GitHub permissions can see more than the caller. A public target repository does not establish public visibility for those references.

Use anonymous GitHub API reads for all four affected routes, including caller conditionals. Retire every legacy cache-key variant, including raw entries and entries that lost their privileged identity attribution during anonymous 304 revalidation, so edge, D1, stale responses, and revalidation cannot reuse privileged bodies. Preserve public response bodies and headers, bounded public stale behavior, the existing repository-metadata proof guard, and caller-owned native fallback. The repository-proof verifier remains; repository and network activity feeds are unchanged.

## Tests

All execution proof uses synthetic data.

- Fresh exact-head [CI](https://github.com/openclaw/octopool/actions/runs/33361258969) passed: full `pnpm check` with 581 unit tests and 302 Worker tests, Go tests/vet, native Windows helpers, docs, and the snapshot build. [CodeQL](https://github.com/openclaw/octopool/actions/runs/33361257486) passed for Go, JavaScript/TypeScript, and Actions.
- Fresh macOS CLI validation passed with `GOTOOLCHAIN=go1.26.7 go test ./... -count=1` and `GOTOOLCHAIN=go1.26.7 go vet ./...`; Go tests completed in 184.064 seconds.
- Historical proof before the rebase: 40 visibility regressions failed and 4 controls passed before the fix; the final visibility suite passed 60/60, with an independent 60/60 rerun. Relevant unit and Worker suites passed 224 and 105 tests; the prior full check also passed.
- Local Worker attempts after the rebase remain unsuccessful: the first run had 10 passes and 50 failures after a 15-second test timeout triggered the isolation safeguard. Two unchanged diagnostic attempts then exceeded the existing 10-second shared baseline-initialization deadline before any test body ran. No source, fixture, timeout, or isolation guard was changed, and no specific code defect or runtime root cause has been established.

Landing validation uses the fresh exact-head CI and macOS CLI results. The local Worker timeout remains an unresolved follow-up; it is not represented as fixed or as passing local Worker proof.
