### PR TITLE
fix: allow protected clones with nested destinations and Git flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Validate protected `gh repo clone` repository inputs according to native argument ownership, preserving destination paths and Git flags while retaining visible-argument filtering and GitHub.com-only source checks.
 - Keep issue timelines and issue-event reads anonymous-only, retiring cached private cross-references and preserving safe conditional and native fallback behavior.
 - Preserve contributor credit in protected exact-head squash merges by accepting merge body files through the existing text rewriting and private snapshot checks.
 - Keep CLI caller tokens bound to the loaded server URL when another login replaces saved auth during request setup.

--- a/cmd/octopool/string_rewrites_fallback.go
+++ b/cmd/octopool/string_rewrites_fallback.go
@@ -465,6 +465,9 @@ func pinBestEffortPositionalRepositories(policy stringRewritePolicy, args []stri
 	}
 	switch out[0] {
 	case "repo":
+		if out[1] == "clone" {
+			return out, validateBestEffortCloneRepository(policy, out[2:])
+		}
 		for _, value := range out[2:] {
 			candidate, err := validateBestEffortRepoValue(policy, value)
 			if candidate && err != nil {
@@ -480,6 +483,50 @@ func pinBestEffortPositionalRepositories(policy stringRewritePolicy, args []stri
 		}
 	}
 	return out, nil
+}
+
+func validateBestEffortCloneRepository(policy stringRewritePolicy, args []string) error {
+	// Native gh uses the first positional as the source, even after --.
+	help := false
+	for index := 0; index < len(args); index++ {
+		value := args[index]
+		switch {
+		case value == "--":
+			index++
+			if index >= len(args) {
+				return errRewriteBlocked
+			}
+			value = args[index]
+		case value == "--upstream-remote-name" || value == "-u":
+			index++
+			if index >= len(args) {
+				return errRewriteBlocked
+			}
+			continue
+		case value == "--no-upstream" || strings.HasPrefix(value, "--no-upstream="):
+			continue
+		case value == "--help" || value == "-h" || strings.HasPrefix(value, "--help=") || strings.HasPrefix(value, "-h="):
+			help = true
+			continue
+		case strings.HasPrefix(value, "--upstream-remote-name=") || strings.HasPrefix(value, "-u"):
+			continue
+		case strings.HasPrefix(value, "-"):
+			return errRewriteBlocked
+		}
+		if !strings.ContainsAny(value, "/:") {
+			// Bare names resolve under the authenticated user on the pinned host.
+			if !rewriteRepoPattern.MatchString("owner/"+value) || strings.Contains(value, "..") {
+				return errRewriteBlocked
+			}
+			return policy.checkStructural("github.com/" + value)
+		}
+		_, err := normalizeBestEffortRepo(policy, value)
+		return err
+	}
+	if help {
+		return nil
+	}
+	return errRewriteBlocked
 }
 
 func validateBestEffortRepoValue(policy stringRewritePolicy, value string) (bool, error) {

--- a/cmd/octopool/string_rewrites_process_test.go
+++ b/cmd/octopool/string_rewrites_process_test.go
@@ -1062,6 +1062,120 @@ func TestStringRewriteReadFallbackCompatibility(t *testing.T) {
 	}
 }
 
+func TestStringRewriteBestEffortClone(t *testing.T) {
+	policyStore, _ := rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	t.Setenv("GH_HOST", "ghe.example")
+	t.Setenv("GH_REPO", "ghe.example/other/repo")
+	for _, test := range []struct {
+		name    string
+		args    []string
+		want    []string
+		blocked bool
+		policy  string
+	}{
+		{name: "dotted destination", args: []string{"https://github.com/openclaw/openclaw", ".artifacts/proof/live-project"}},
+		{name: "long help", args: []string{"--help"}},
+		{name: "short help", args: []string{"-h"}},
+		{name: "help option before source", args: []string{"--help=false", "acme/repo"}},
+		{name: "nested destination", args: []string{"acme/repo", "workspace/proof/repo"}},
+		{name: "absolute destination", args: []string{"acme/repo", "/tmp/proof/repo"}},
+		{name: "current directory", args: []string{"acme/repo", "."}},
+		{name: "dot relative destination", args: []string{"acme/repo", "./proof/repo"}},
+		{name: "parent relative destination", args: []string{"acme/repo", "../proof/repo"}},
+		{name: "git flags without destination", args: []string{"acme/repo", "--", "-c", "core.hooksPath=/dev/null"}},
+		{name: "git flags with destination", args: []string{"acme/repo", ".artifacts/proof/repo", "--", "-c", "core.hooksPath=/dev/null"}},
+		{name: "destination after delimiter", args: []string{"acme/repo", "--", ".artifacts/proof/repo", "-c", "core.hooksPath=/dev/null"}},
+		{name: "source after delimiter", args: []string{"--", "https://github.com/acme/repo", ".artifacts/proof/repo"}},
+		{name: "boolean before source", args: []string{"--no-upstream", "acme/repo", ".artifacts/proof/repo"}},
+		{name: "boolean equals before source", args: []string{"--no-upstream=false", "acme/repo"}},
+		{name: "long value before source", args: []string{"--upstream-remote-name", "ghe.example/acme/upstream", "acme/repo"}},
+		{name: "long equals before source", args: []string{"--upstream-remote-name=upstream", "acme/repo"}},
+		{name: "short value before source", args: []string{"-u", "upstream", "acme/repo"}},
+		{name: "short attached before source", args: []string{"-uupstream", "acme/repo"}},
+		{name: "short equals before source", args: []string{"-u=upstream", "acme/repo"}},
+		{name: "delimiter as option value", args: []string{"-u", "--", "acme/repo"}},
+		{name: "native option after source", args: []string{"acme/repo", "--upstream-remote-name", "ghe.example/acme/upstream", ".artifacts/proof/repo"}},
+		{name: "bare repository", args: []string{"myrepo", ".artifacts/proof/repo"}},
+		{name: "host qualified github source", args: []string{"github.com/acme/repo", ".artifacts/proof/repo"}},
+		{name: "https protocol", args: []string{"https://github.com/acme/repo.git", ".artifacts/proof/repo"}},
+		{name: "ssh protocol", args: []string{"ssh://git@github.com/acme/repo.git", ".artifacts/proof/repo"}},
+		{name: "scp protocol", args: []string{"git@github.com:acme/repo.git", ".artifacts/proof/repo"}},
+		{
+			name: "visible destination and git values rewritten",
+			args: []string{"acme/repo", ".artifacts/internal-model/repo", "--", "-c", "core.hooksPath=/internal-model/null", "--branch=internal-model"},
+			want: []string{"acme/repo", ".artifacts/public/repo", "--", "-c", "core.hooksPath=/public/null", "--branch=public"},
+		},
+		{
+			name: "native option value rewritten",
+			args: []string{"-u", "internal-model", "acme/repo"},
+			want: []string{"-u", "public", "acme/repo"},
+		},
+		{name: "enterprise https", args: []string{"https://ghe.example/acme/repo", ".artifacts/proof/repo"}, blocked: true},
+		{name: "enterprise host qualified", args: []string{"ghe.example/acme/repo"}, blocked: true},
+		{name: "enterprise scp", args: []string{"ghe.example:acme/repo"}, blocked: true},
+		{name: "enterprise scp user", args: []string{"alice@ghe.example:acme/repo"}, blocked: true},
+		{name: "enterprise ssh", args: []string{"ssh://git@ghe.example/acme/repo.git"}, blocked: true},
+		{name: "enterprise ssh without user", args: []string{"ssh://ghe.example/acme/repo.git"}, blocked: true},
+		{name: "enterprise deep url", args: []string{"https://ghe.example/acme/repo/tree/main"}, blocked: true},
+		{name: "enterprise single label host", args: []string{"enterprise/acme/repo"}, blocked: true},
+		{name: "enterprise after delimiter", args: []string{"--", "https://ghe.example/acme/repo"}, blocked: true},
+		{name: "enterprise after option value", args: []string{"-u", "acme/safe", "ghe.example/acme/repo"}, blocked: true},
+		{name: "enterprise after consumed delimiter", args: []string{"--upstream-remote-name", "--", "ssh://git@ghe.example/acme/repo.git"}, blocked: true},
+		{name: "unknown option before source", args: []string{"--future-option", "acme/safe", "ghe.example/acme/repo"}, blocked: true},
+		{name: "unknown option with safe source", args: []string{"--future-option", "acme/repo"}, blocked: true},
+		{name: "missing option value", args: []string{"-u"}, blocked: true},
+		{name: "missing source after delimiter", args: []string{"--"}, blocked: true},
+		{name: "matching source", args: []string{"https://github.com/acme/internal-model", ".artifacts/proof/repo"}, blocked: true},
+		{name: "matching bare source", args: []string{"internal-model"}, blocked: true},
+		{
+			name:    "rewritten option exposes enterprise source",
+			args:    []string{"--upstream-remote-name", "ghe.example/acme/repo", "acme/safe"},
+			blocked: true,
+			policy:  `{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"--upstream-remote-name","replacement":"--no-upstream"}]}`,
+		},
+		{
+			name:    "rewritten source protocol revalidated",
+			args:    []string{"https://github.com/acme/repo"},
+			blocked: true,
+			policy:  `{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"^https://github[.]com/","replacement":"ssh://git@ghe.example/"}]}`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			policy := test.policy
+			if policy == "" {
+				policy = rewriteActiveTestPolicy
+			}
+			policyStore.Store(policy)
+			capturePath := captureRewriteGH(t)
+			args := append([]string{"repo", "clone"}, test.args...)
+			err := runGH(t.Context(), args, io.Discard, io.Discard)
+			if test.blocked {
+				if err != errRewriteBlocked {
+					t.Errorf("clone denial error=%v", err)
+				}
+				if _, err := os.Stat(capturePath); !os.IsNotExist(err) {
+					t.Fatal("denied clone reached child")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := args
+			if test.want != nil {
+				want = append([]string{"repo", "clone"}, test.want...)
+			}
+			capture := readRewriteCapture(t, capturePath)
+			if !slices.Equal(capture.Args, want) {
+				t.Fatalf("clone argv=%q, want %q", capture.Args, want)
+			}
+			if capture.Env["GH_HOST"] != "github.com" || capture.Env["GH_REPO"] != "" {
+				t.Fatalf("clone host was not pinned: %v", capture.Env)
+			}
+		})
+	}
+}
+
 func TestStringRewriteBestEffortFallback(t *testing.T) {
 	policyStore, _ := rewriteTestServer(t, rewriteActiveTestPolicy, nil)
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -578,6 +578,13 @@ Alternate API/repository hosts, explicit credential headers,
 unresolved API placeholders, invalid UTF-8, policy
 material, residual matches, and bounded-read failures remain blocked.
 
+For `gh repo clone`, positional repository checks apply only to the source, accounting for
+native clone options and their values. A `--` ends native option parsing; if the source has
+not appeared yet, the next argument is still the source. Unknown options before the source
+fail closed. Source protocol is preserved, with structural and GitHub.com host validation
+before and after rewriting. Destination paths and forwarded Git flags and values still
+receive visible-argument filtering without being treated as additional repository inputs.
+
 Best effort is intentionally not the same guarantee as a modeled snapshot. Live terminal
 input is passed through so native prompts still work, and deferred content sources other than
 `--input` and typed field `@source` files—for example an editor, generated notes,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `gh repo clone` under active string-rewrite protection would have valid destination directories or forwarded Git option values rejected as unsafe repository hosts. Examples include `.artifacts/proof/live-project` and `-- -c core.hooksPath=/dev/null`.

## Why This Change Was Made

Clone repository validation now follows native argument ownership: the first positional is the source, with clone options, their values, and `--` handled explicitly. Destination paths and forwarded Git arguments still receive visible-argument rewriting, but are not treated as additional repository inputs.

The source remains GitHub.com-only, structurally checked before and after rewriting, with its protocol preserved and the child host pinned. Unknown options before the source fail closed. Other command paths and the general repository heuristic are unchanged.

## User Impact

Protected clones accept nested, dotted, relative, and absolute destinations and ordinary forwarded Git arguments without disabling protection. Actual enterprise repository sources remain blocked before native-command dispatch. The CLI documentation and Unreleased changelog describe the corrected boundary.

## Evidence

- Added 48 synthetic native-command-capture cases covering destination paths, Git arguments, clone options and delimiters, protocol preservation, visible-argument rewrites, and enterprise-source denial.
- The reported destination and Git-value cases failed before the implementation change and pass with the fix. Successful cases assert exact child arguments and pinned environment; denied cases assert that the child never ran.
- Full Go tests, `go vet`, and focused clone/fallback race tests passed. A full-suite verification attempt hit the default 10-minute timeout during heavy host load; the unchanged suite passed with bounded concurrency and the same timeout.
- No live clone, private rule content, authentication changes, or protection bypass was used.
