### PR TITLE
fix: keep run watches off personal GitHub quota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Preserve contributor credit in protected exact-head squash merges by accepting merge body files through the existing text rewriting and private snapshot checks.
+- Keep supported `gh run watch` on the relay when pagination or relay requests fail, rejecting incomplete job summaries without spending personal GitHub quota.
 - Keep CLI caller tokens bound to the loaded server URL when another login replaces saved auth during request setup.
 - Pin CLI login credential lookup to GitHub.com so Enterprise host settings cannot select an Enterprise token.
 - Block cross-origin redirects and HTTPS downgrades for CLI login and authenticated JSON requests to prevent credential replay.

--- a/cmd/octopool/cli_e2e_test.go
+++ b/cmd/octopool/cli_e2e_test.go
@@ -141,12 +141,13 @@ func TestCLIEndToEndRelayAndFallback(t *testing.T) {
 		name     string
 		args     []string
 		exitCode int
+		native   bool
 		serve    func(*testing.T, map[string]any, http.ResponseWriter)
 	}{
 		{
-			name:     "run watch exit 0",
+			name:     "run watch fails without native handoff",
 			args:     []string{"gh", "run", "watch", "42", "-R", "openclaw/octopool", "--exit-status", "-i", "5"},
-			exitCode: 0,
+			exitCode: 1,
 			serve: func(t *testing.T, body map[string]any, w http.ResponseWriter) {
 				headers, _ := body["headers"].(map[string]any)
 				if headers["cache-control"] == "max-age=0" {
@@ -160,6 +161,7 @@ func TestCLIEndToEndRelayAndFallback(t *testing.T) {
 			name:     "pr checks watch exit 7",
 			args:     []string{"gh", "pr", "checks", "7", "-R", "openclaw/octopool", "--watch", "--interval=5"},
 			exitCode: 7,
+			native:   true,
 			serve: func(t *testing.T, body map[string]any, w http.ResponseWriter) {
 				path := body["path"].(string)
 				switch {
@@ -203,6 +205,14 @@ func TestCLIEndToEndRelayAndFallback(t *testing.T) {
 				if !errors.As(result.err, &exitErr) || exitErr.ExitCode() != command.exitCode {
 					t.Fatalf("err=%v, want exit %d", result.err, command.exitCode)
 				}
+			}
+			if !command.native {
+				if strings.Contains(result.stdout, fakeGHArgvPrefix) ||
+					!strings.Contains(result.stdout, "Watching run") ||
+					!strings.Contains(result.stderr, "run watch stopped without local gh fallback") {
+					t.Fatalf("stdout=%q stderr=%q", result.stdout, result.stderr)
+				}
+				return
 			}
 			wantArgv := strings.Join(floorGHWatchDelegateArgs(command.args[1:]), " ")
 			wantChild := fakeGHArgvPrefix + wantArgv

--- a/cmd/octopool/gh_run_watch_ownership_test.go
+++ b/cmd/octopool/gh_run_watch_ownership_test.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGHRunWatchKeepsRelayOwnership(t *testing.T) {
+	for _, phase := range []string{"initial", "poll", "confirmation", "jobs"} {
+		for _, reason := range []string{"pagination_exhausted", "relay_overloaded", "repo_not_public", "route_denied"} {
+			if phase == "initial" && reason == "repo_not_public" {
+				continue // The initial private-repository lookup deliberately delegates.
+			}
+			t.Run(phase+"/"+reason, func(t *testing.T) {
+				t.Setenv("OCTOPOOL_NO_FALLBACK", "")
+				t.Setenv("OCTOPOOL_RELAY_RETRIES", "2")
+				useTestRelayRetryDelays(t, time.Millisecond, time.Millisecond)
+				t.Setenv("OCTOPOOL_GH_PATH", fakeGHExit(t, 0))
+				sleeps := recordWatchSleeps(t)
+				runCalls, failedCalls := 0, 0
+				relayTestServer(t, func(body map[string]any) any {
+					isJobs := strings.HasSuffix(body["path"].(string), "/jobs")
+					if !isJobs {
+						runCalls++
+					}
+					fail := phase == "initial" || phase == "jobs" && isJobs ||
+						(phase == "poll" || phase == "confirmation") && runCalls > 1
+					if fail {
+						failedCalls++
+						return relayFallbackFixture(reason)
+					}
+					status := "completed"
+					if phase == "poll" {
+						status = "in_progress"
+					}
+					return map[string]any{"status": status, "conclusion": "success", "run_attempt": 2}
+				})
+				var stdout, stderr bytes.Buffer
+				err := runGH(t.Context(), []string{"run", "watch", "42", "-R", "openclaw/octopool", "--exit-status"}, &stdout, &stderr)
+				if err == nil || shouldRunRealGH(err) || !strings.Contains(err.Error(), reason) ||
+					strings.Contains(stdout.String(), fakeGHArgvPrefix) || strings.Contains(stderr.String(), "real gh") {
+					t.Fatalf("err=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+				}
+				wantFailures := 1
+				if reason == "relay_overloaded" {
+					wantFailures = 3
+				}
+				wantSleeps := 0
+				if phase == "poll" {
+					wantSleeps = 1
+				}
+				wantSleeps += wantFailures - 1 // The relay client shares the sleep hook.
+				if failedCalls != wantFailures || len(*sleeps) != wantSleeps {
+					t.Fatalf("failed calls=%d sleeps=%v", failedCalls, *sleeps)
+				}
+				if strings.Contains(stdout.String(), "completed with") || strings.Contains(stdout.String(), "job ") {
+					t.Fatalf("failure printed a final summary: %q", stdout.String())
+				}
+			})
+		}
+	}
+}
+
+func TestGHRunWatchRejectsIncompleteJobs(t *testing.T) {
+	for _, variant := range []string{"rerun count mismatch", "missing count", "fractional count", "changed count", "next link", "short next page", "cap"} {
+		t.Run(variant, func(t *testing.T) {
+			t.Setenv("OCTOPOOL_GH_PATH", fakeGHExit(t, 0))
+			t.Setenv("OCTOPOOL_NO_FALLBACK", "")
+			recordWatchSleeps(t)
+			jobCalls := 0
+			relayTestServer(t, func(body map[string]any) any {
+				if !strings.HasSuffix(body["path"].(string), "/jobs") {
+					return map[string]any{"status": "completed", "conclusion": "success", "run_attempt": 2}
+				}
+				jobCalls++
+				count, total := 1, any(3)
+				headers := map[string]string{}
+				switch variant {
+				case "missing count":
+					total = nil
+				case "fractional count":
+					total = 1.5
+				case "changed count":
+					count, total = relayPageSize, 150
+					if jobCalls == 2 {
+						count, total = 50, 151
+					}
+				case "next link":
+					total = 1
+					headers["Link"] = `<https://api.github.com/repos/openclaw/octopool/actions/runs/42/attempts/2/jobs?page=2>; rel="next"`
+				case "short next page":
+					count, total = relayPageSize, 150
+					if jobCalls == 2 {
+						count = 1
+					}
+				case "cap":
+					count, total = relayPageSize, maxRelayPages*relayPageSize+1
+				}
+				jobs := make([]map[string]any, count)
+				for index := range jobs {
+					jobs[index] = map[string]any{"id": jobCalls*relayPageSize + index, "name": "Swift", "conclusion": "success"}
+				}
+				return relayTestResponse{Headers: headers, Body: map[string]any{"total_count": total, "jobs": jobs}}
+			})
+			var stdout, stderr bytes.Buffer
+			err := runGH(t.Context(), []string{"run", "watch", "42", "-R", "openclaw/octopool"}, &stdout, &stderr)
+			if err == nil || strings.Contains(stdout.String(), fakeGHArgvPrefix) || strings.Contains(stdout.String(), "job ") || strings.Contains(stdout.String(), "completed with") {
+				t.Fatalf("err=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+			}
+			wantCalls := 1
+			if variant == "changed count" || variant == "short next page" {
+				wantCalls = 2
+			} else if variant == "cap" {
+				wantCalls = maxRelayPages
+			}
+			if jobCalls != wantCalls {
+				t.Fatalf("job calls=%d, want %d", jobCalls, wantCalls)
+			}
+		})
+	}
+}
+
+func TestGHRunWatchRerunAttemptAndExitStatus(t *testing.T) {
+	for _, conclusion := range []string{"success", "failure", "cancelled", "timed_out"} {
+		for _, exitStatus := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/exit-status=%t", conclusion, exitStatus), func(t *testing.T) {
+				runCalls, jobCalls := 0, 0
+				recordWatchSleeps(t)
+				relayTestServer(t, func(body map[string]any) any {
+					switch body["path"] {
+					case "/repos/openclaw/octopool/actions/runs/42":
+						runCalls++
+						if runCalls == 1 {
+							return map[string]any{"status": "completed", "conclusion": "failure", "run_attempt": 1}
+						}
+						if body["headers"].(map[string]any)["cache-control"] != "max-age=0" {
+							t.Error("confirmation must be fresh")
+						}
+						return map[string]any{"status": "completed", "conclusion": conclusion, "run_attempt": 2}
+					case "/repos/openclaw/octopool/actions/runs/42/attempts/2/jobs":
+						jobCalls++
+						// Preserve reused successes if the attempt endpoint returns them;
+						// never fetch attempt 1 to reconstruct or replace this snapshot.
+						return map[string]any{"total_count": 3, "jobs": []map[string]any{
+							{"id": 1, "name": "actions", "run_attempt": 1, "conclusion": "success"},
+							{"id": 2, "name": "JavaScript", "run_attempt": 1, "conclusion": "success"},
+							{"id": 3, "name": "Swift", "run_attempt": 2, "conclusion": conclusion},
+						}}
+					default:
+						t.Errorf("unexpected path %v", body["path"])
+						return nil
+					}
+				})
+				var stdout bytes.Buffer
+				args := []string{"watch", "42", "-R", "openclaw/octopool"}
+				if exitStatus {
+					args = append(args, "--exit-status")
+				}
+				result := handleGHRun(t.Context(), args, &stdout)
+				if exitStatus && conclusion != "success" {
+					assertExitCode(t, result.err, 1)
+				} else if result.action != ghComplete || result.err != nil {
+					t.Fatalf("action=%v err=%v", result.action, result.err)
+				}
+				if runCalls != 2 || jobCalls != 1 || strings.Count(stdout.String(), "job ") != 3 ||
+					!strings.Contains(stdout.String(), "Run 42 completed with '"+conclusion+"'") {
+					t.Fatalf("runs=%d jobs=%d stdout=%q", runCalls, jobCalls, stdout.String())
+				}
+			})
+		}
+	}
+}
+
+func TestCLIRunWatchPaginationFailureDoesNotLaunchNative(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds and executes the CLI binary")
+	}
+	bin := buildCLIBinary(t)
+	for _, phase := range []string{"initial", "confirmation", "jobs"} {
+		t.Run(phase, func(t *testing.T) {
+			calls := 0
+			server := cliRelayServer(t, func(w http.ResponseWriter, _ *http.Request) {
+				calls++
+				failAt := map[string]int{"initial": 1, "confirmation": 2, "jobs": 3}[phase]
+				if calls >= failAt {
+					writeCLIFallback(t, w, "pagination_exhausted")
+					return
+				}
+				writeCLIEnvelope(t, w, map[string]any{"status": "completed", "conclusion": "success", "run_attempt": 2})
+			})
+			result := runCLI(t, bin, server.URL, map[string]string{
+				"OCTOPOOL_GH_PATH": fakeGHExit(t, 0), "OCTOPOOL_NO_FALLBACK": "", "OCTOPOOL_RELAY_RETRIES": "0",
+			}, "gh", "run", "watch", "42", "-R", "openclaw/octopool", "--exit-status")
+			if result.err == nil || strings.Contains(result.stdout, fakeGHArgvPrefix) || !strings.Contains(result.stderr, "pagination_exhausted") {
+				t.Fatalf("calls=%d err=%v stdout=%q stderr=%q", calls, result.err, result.stdout, result.stderr)
+			}
+		})
+	}
+}
+
+func TestGHRunWatchMissingMetadataStops(t *testing.T) {
+	for _, phase := range []string{"initial status", "confirmed status", "confirmed conclusion"} {
+		t.Run(phase, func(t *testing.T) {
+			t.Setenv("OCTOPOOL_GH_PATH", fakeGHExit(t, 0))
+			sleeps := recordWatchSleeps(t)
+			calls := 0
+			relayTestServer(t, func(map[string]any) any {
+				calls++
+				if calls > 2 {
+					return relayFallbackFixture("metadata_request_bound")
+				}
+				body := map[string]any{"status": "completed", "conclusion": "success", "run_attempt": 2}
+				if phase == "initial status" || calls > 1 {
+					field := "status"
+					if phase == "confirmed conclusion" {
+						field = "conclusion"
+					}
+					delete(body, field)
+				}
+				return body
+			})
+			var stdout, stderr bytes.Buffer
+			err := runGH(t.Context(), []string{"run", "watch", "42", "-R", "openclaw/octopool"}, &stdout, &stderr)
+			if err == nil || strings.Contains(stdout.String(), fakeGHArgvPrefix) || strings.Contains(stdout.String(), "completed with") || calls > 2 || len(*sleeps) != 0 {
+				t.Fatalf("err=%v calls=%d sleeps=%v stdout=%q", err, calls, *sleeps, stdout.String())
+			}
+		})
+	}
+}

--- a/cmd/octopool/gh_top_run.go
+++ b/cmd/octopool/gh_top_run.go
@@ -157,9 +157,21 @@ func runJobs(envelope relayEnvelope) ([]any, error) {
 }
 
 func runJobsPage(envelope relayEnvelope) ([]any, int, error) {
-	rawJobs, total, err := envelopeCollectionPage(envelope, "jobs")
+	body, err := envelopeBodyBytes(envelope)
 	if err != nil {
 		return nil, 0, err
+	}
+	var response map[string]any
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, 0, err
+	}
+	rawJobs, ok := response["jobs"].([]any)
+	if !ok {
+		return nil, 0, errors.New("workflow jobs response did not include jobs")
+	}
+	total, ok := jsonNumericInt(response["total_count"])
+	if !ok {
+		return nil, 0, localFallbackError{Reason: "workflow jobs response did not include a valid total_count"}
 	}
 	jobs := make([]any, 0, len(rawJobs))
 	for _, rawJob := range rawJobs {

--- a/cmd/octopool/gh_top_watch.go
+++ b/cmd/octopool/gh_top_watch.go
@@ -118,7 +118,7 @@ func handleGHRunWatch(ctx context.Context, args []string, stdout io.Writer) ghRe
 		return ghDelegated()
 	}
 	opts.repo = repo
-	return ghWatchCompleted(relayRunWatch(ctx, stdout, opts))
+	return ghCompleted(relayRunWatch(ctx, stdout, opts))
 }
 
 func parseGHRunWatchOptions(args []string) (ghRunWatchOptions, bool) {
@@ -173,7 +173,7 @@ func attachedWatchInterval(arg string) string {
 func relayRunWatch(ctx context.Context, stdout io.Writer, opts ghRunWatchOptions) error {
 	client, err := newGHRelayClient()
 	if err != nil {
-		return err
+		return runWatchError(err, false)
 	}
 	backoff := newWatchBackoff(opts.interval)
 	previousStatus := ""
@@ -186,11 +186,11 @@ func relayRunWatch(ctx context.Context, stdout io.Writer, opts ghRunWatchOptions
 			return pollErr
 		})
 		if err != nil {
-			return watchError(err, progressPrinted)
+			return runWatchError(err, progressPrinted)
 		}
 		status := watchSafeText(firstString(run, "status"))
 		if status == "" {
-			return watchError(errors.New("workflow run response did not include status"), progressPrinted)
+			return runWatchError(errors.New("workflow run response did not include status"), progressPrinted)
 		}
 		if !progressPrinted {
 			if _, err := fmt.Fprintf(stdout, "Watching run %s in %s (status: %s)\n", opts.id, opts.repo, status); err != nil {
@@ -214,9 +214,12 @@ func relayRunWatch(ctx context.Context, stdout io.Writer, opts ghRunWatchOptions
 				return pollErr
 			})
 			if err != nil {
-				return watchError(err, progressPrinted)
+				return runWatchError(err, progressPrinted)
 			}
 			confirmedStatus := watchSafeText(firstString(confirmed, "status"))
+			if confirmedStatus == "" {
+				return errors.New("workflow run confirmation did not include status")
+			}
 			if confirmedStatus != "completed" {
 				if confirmedStatus != "" && confirmedStatus != status {
 					if _, err := fmt.Fprintf(stdout, "run %s: %s -> %s\n", opts.id, status, confirmedStatus); err != nil {
@@ -231,16 +234,19 @@ func relayRunWatch(ctx context.Context, stdout io.Writer, opts ghRunWatchOptions
 			}
 			attempt, ok := positiveJSONInt(confirmed["run_attempt"])
 			if !ok {
-				return watchError(localFallbackError{Reason: "workflow run response did not include run_attempt"}, progressPrinted)
+				return runWatchError(localFallbackError{Reason: "workflow run response did not include run_attempt"}, progressPrinted)
+			}
+			conclusion := watchSafeText(firstString(confirmed, "conclusion"))
+			if conclusion == "" {
+				return errors.New("workflow run confirmation did not include conclusion")
 			}
 			jobs, err := relayWatchRunJobs(ctx, client, opts.repo, opts.id, attempt, &backoff)
 			if err != nil {
-				return watchError(err, true)
+				return runWatchError(err, true)
 			}
 			if err := printWatchRunJobs(stdout, jobs); err != nil {
 				return err
 			}
-			conclusion := watchSafeText(firstString(confirmed, "conclusion"))
 			if _, err := fmt.Fprintf(stdout, "Run %s completed with '%s'\n", opts.id, conclusion); err != nil {
 				return err
 			}
@@ -309,10 +315,27 @@ func relayWatchRunJobs(ctx context.Context, client ghRelayClient, repo string, i
 			}
 			if page == 1 {
 				total = pageTotal
+			} else if pageTotal != total {
+				return localFallbackError{Reason: "workflow jobs total_count changed during pagination"}
 			}
 			jobs = append(jobs, pageJobs...)
-			if len(jobs) >= total || len(pageJobs) < relayPageSize {
+			link, linked := relayResponseHeader(envelope.Headers, "link")
+			next, hasNext := relayNextLink(link)
+			if len(jobs) > total || (len(jobs) == total && hasNext) {
+				return localFallbackError{Reason: "workflow jobs pagination contradicts total_count"}
+			}
+			if len(jobs) == total {
 				return nil
+			}
+			// A short page is not proof of completion when the advertised total
+			// still includes missing jobs (for example, partial rerun metadata).
+			if len(pageJobs) < relayPageSize || (linked && !hasNext) {
+				return localFallbackError{Reason: "workflow jobs response is incomplete"}
+			}
+			if hasNext {
+				if nextPage, ok := relayLinkNumericPage(next); !ok || nextPage != page+1 {
+					return localFallbackError{Reason: "workflow jobs pagination link is inconsistent"}
+				}
 			}
 		}
 		return localFallbackError{Reason: "workflow jobs pagination exhausted"}
@@ -582,6 +605,18 @@ func bodySafeText(raw string) string {
 		}
 		return r
 	}, raw)
+}
+
+func runWatchError(err error, progressPrinted bool) error {
+	if fallback, ok := explicitRelayFallback(err); ok && !progressPrinted && fallback.Reason == "repo_not_public" {
+		return err
+	}
+	if shouldRunRealGH(err) {
+		// The run watcher owns the whole polling session. A failed hydration
+		// must not restart that session using the caller's personal quota.
+		return fmt.Errorf("run watch stopped without local gh fallback: %v", err)
+	}
+	return err
 }
 
 func watchError(err error, progressPrinted bool) error {

--- a/cmd/octopool/gh_top_watch_test.go
+++ b/cmd/octopool/gh_top_watch_test.go
@@ -695,10 +695,10 @@ func TestWatchErrorClassification(t *testing.T) {
 	}
 }
 
-func TestGHWatchExplicitRelayFallbackBeforeProgressDelegates(t *testing.T) {
+func TestGHRunWatchPrivateRepoBeforeProgressDelegates(t *testing.T) {
 	t.Setenv("OCTOPOOL_RELAY_RETRIES", "0")
 	t.Setenv("OCTOPOOL_GH_PATH", fakeGHExit(t, 0))
-	relayTestServer(t, func(map[string]any) any { return relayFallbackFixture("relay_overloaded") })
+	relayTestServer(t, func(map[string]any) any { return relayFallbackFixture("repo_not_public") })
 	var stdout, stderr bytes.Buffer
 	if err := runGH(t.Context(), []string{"run", "watch", "42", "-R", "openclaw/octopool"}, &stdout, &stderr); err != nil {
 		t.Fatal(err)

--- a/cmd/octopool/string_rewrites_guard.go
+++ b/cmd/octopool/string_rewrites_guard.go
@@ -161,6 +161,9 @@ func prepareRewriteRead(policy stringRewritePolicy, args []string, prepared *rew
 	case "run view":
 		values += " --attempt"
 		booleans = "--log --log-failed --exit-status"
+	case "run watch":
+		values += " --interval,-i"
+		booleans = "--exit-status --compact"
 	case "run list":
 		values += " --limit,-L --branch --workflow --status"
 	case "pr checks":

--- a/cmd/octopool/string_rewrites_process_test.go
+++ b/cmd/octopool/string_rewrites_process_test.go
@@ -1860,9 +1860,11 @@ func TestStringRewriteRelayReadAndAuthFailure(t *testing.T) {
 	}
 }
 
-func TestStringRewriteTopLevelWatchFallbackIsBestEffort(t *testing.T) {
+func TestStringRewritePrivateRunWatchFallback(t *testing.T) {
 	recordWatchSleeps(t)
+	relayCalls := 0
 	rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+		relayCalls++
 		var request map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 			t.Error(err)
@@ -1870,16 +1872,54 @@ func TestStringRewriteTopLevelWatchFallbackIsBestEffort(t *testing.T) {
 		if request["path"] != "/repos/acme/repo/actions/runs/42" {
 			t.Error("unexpected watch path")
 		}
-		writeCLIFallback(t, w, "route_denied")
+		writeCLIFallback(t, w, "repo_not_public")
 	})
 	capture := captureRewriteGH(t)
 	args := []string{"run", "watch", "42", "-Racme/repo", "-i5", "--exit-status"}
 	if err := runGH(t.Context(), args, io.Discard, io.Discard); err != nil {
-		t.Fatalf("native watch best-effort fallback failed: %v", err)
+		t.Fatalf("private watch fallback failed: %v", err)
 	}
-	want := []string{"run", "watch", "42", "--repo=github.com/acme/repo", "-i5", "--exit-status"}
+	if relayCalls != 1 {
+		t.Fatalf("relay calls=%d, want initial lookup before private fallback", relayCalls)
+	}
+	want := []string{"run", "watch", "42", "--repo=acme/repo", "--interval=30", "--exit-status"}
 	if got := readRewriteCapture(t, capture); !slices.Equal(got.Args, want) || got.Env["GH_HOST"] != "github.com" {
 		t.Fatalf("native watch args=%v env=%v", got.Args, got.Env)
+	}
+}
+
+func TestStringRewriteRunWatchKeepsRelayOwnership(t *testing.T) {
+	recordWatchSleeps(t)
+	for _, failAt := range []int{1, 2, 3} {
+		t.Run(strconv.Itoa(failAt), func(t *testing.T) {
+			calls := 0
+			rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+				var request map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+					t.Error(err)
+				}
+				calls++
+				wantPath := "/repos/acme/repo/actions/runs/42"
+				if calls == 3 {
+					wantPath += "/attempts/2/jobs"
+				}
+				if request["path"] != wantPath {
+					t.Errorf("path=%v want=%s", request["path"], wantPath)
+				}
+				if calls == failAt {
+					writeCLIFallback(t, w, "pagination_exhausted")
+					return
+				}
+				writeCLIEnvelope(t, w, map[string]any{"status": "completed", "conclusion": "success", "run_attempt": 2})
+			})
+			t.Setenv("OCTOPOOL_GH_PATH", fakeGHExit(t, 0))
+			t.Setenv("OCTOPOOL_NO_FALLBACK", "")
+			var stdout, stderr bytes.Buffer
+			err := runGH(t.Context(), []string{"run", "watch", "42", "-Racme/repo", "-i120", "--exit-status", "--compact"}, &stdout, &stderr)
+			if err == nil || shouldRunRealGH(err) || calls != failAt || strings.Contains(stdout.String(), fakeGHArgvPrefix) {
+				t.Fatalf("calls=%d err=%v stdout=%q stderr=%q", calls, err, stdout.String(), stderr.String())
+			}
+		})
 	}
 }
 

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -274,11 +274,19 @@ Before granting the one-hour job-list TTL, Octopool separately verifies that exa
 run endpoint is completed; a list of currently completed jobs alone is not treated as proof.
 
 Equivalent shaped `page=1`, omitted/`latest` filter, and `per_page` values up to 100 share one
-100-job attempt-qualified cache entry. Octopool truncates that complete superset locally and
-removes upstream representation validators, lengths, and pagination links. If `total_count`
-exceeds the returned jobs—or is missing or invalid—the shaped request fails over to real `gh`
-without publishing or returning the partial page. `filter=all`, later pages, unshaped REST
-requests, active attempt data, and unsupported query variants retain exact semantics.
+attempt-qualified cache entry, filled from at most three 100-job API pages. Octopool slices
+that complete superset locally and removes upstream representation validators, lengths,
+and pagination links. All pages must have consistent valid `total_count` metadata and the
+merged list must match that count. A remaining `Link: rel="next"` also prevents completion,
+even when the count matches; the first page's link is removed only after a complete merge.
+
+If a partial rerun exposes count metadata that disagrees with the returned job set, a count
+disagreement alone does not establish another page or prove which successful jobs were
+reused. Octopool rejects that ambiguous shaped response with `pagination_exhausted`, without
+caching it, inventing jobs, or treating a short page as a complete summary. Supported
+`gh run watch` stops with an explicit error on that refusal and never starts real `gh`;
+ordinary run-view fallback remains available. `filter=all`, later pages, unshaped REST
+requests, and unsupported query variants retain exact upstream semantics.
 
 ## Cache-hit integrity
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -266,12 +266,27 @@ verified PR head SHA, allowing file pages to share a five-minute state-scoped ca
 head-SHA lookup sends `cache-control: max-age=60` so concurrent CI-polling sessions share
 one upstream PR read at most 60 seconds old, and the check/status reads for that SHA use
 the normal cache TTLs. Native `gh run watch` and `gh pr checks --watch` polling also stays
-on the relay, floors intervals at 30 seconds, and backs off to 120 seconds. If the relay
-explicitly returns `fallback_local` during an active watch, the shim prints one handoff
-boundary and continues the original command with real `gh`; real `gh` then owns output and
-the exact exit status. Its first snapshot may repeat the last relay-rendered state. Client-side
-incompleteness, auth reinterpretation, transport/decode failures, and ordinary relay service
-errors remain terminal after progress and do not spend local GitHub quota. Ask for raw `gh api`
+on the relay, floors intervals at 30 seconds, and backs off to 120 seconds.
+
+Supported `gh run watch` commands keep polling on the relay, including under active rewrite
+rules. Relay failures, including
+`fallback_local` for pagination or exhausted pool retries, stop the watch with an error;
+they never start a personal-token watcher. This applies to the initial read, later polls,
+fresh completion confirmation, and final job hydration. Jobs are fetched only after a fresh
+completed run response, using its exact `run_attempt`. Missing or inconsistent job metadata
+fails explicitly without printing a partial job summary or a successful completion message.
+Octopool preserves the job set returned for that attempt, including reused successes when
+present, and does not reconstruct missing jobs from earlier attempts. With complete data,
+`--exit-status` returns 1 for a non-successful run; without it, a completed run returns 0.
+Read failures return nonzero with or without `--exit-status`. Unsupported command shapes
+still delegate, and an explicit `repo_not_public` refusal on the initial run lookup retains
+guarded native fallback. A refusal after watch progress never hands off.
+
+For `gh pr checks --watch`, an explicit relay `fallback_local` after progress still prints a
+handoff boundary and continues the command with real `gh`, which owns output and exit status.
+Its first snapshot may repeat the last relay-rendered state. Client-side incompleteness,
+auth, transport/decode failures, and ordinary relay service errors remain terminal after
+progress and do not spend local GitHub quota. Ask for raw `gh api`
 conditional requests only when instant freshness matters more than quota.
 `--jq` runs after `--json` filtering, matching the usual agent workflow for small
 machine-readable reads.
@@ -724,8 +739,9 @@ These are dev/CI escape hatches, not the everyday UX:
   (`identities_cooling_down`, `identity_pool_depleted`, `github_identity_depleted`,
   `github_rate_limited`, `relay_overloaded`), relay `5xx internal_error` responses, and
   malformed 502/503/504 gateway responses are retried against the relay (1s, then 3s for
-  subsequent retries). Exhausted transient fallbacks may delegate to real `gh`; exhausted
-  service errors remain failures instead of spending local GitHub quota. Default `2`; `0`
+  subsequent retries). Exhausted transient fallbacks may delegate to real `gh` except for
+  supported `gh run watch`, which fails explicitly. Exhausted service errors remain failures
+  instead of spending local GitHub quota. Default `2`; `0`
   disables retries.
 - `OCTOPOOL_ADMIN_TOKEN` — admin token for `octopool admin`.
 - `OCTOPOOL_ALLOW_INSECURE_LOGIN=1` — permit non-HTTPS login for local dev.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -77,7 +77,8 @@ Durable Object partition key: `pool:<pool_id>`.
 9. Sanitize and publish eligible `200` responses to D1 and the edge cache.
 10. Return the relay envelope; asynchronously record the authenticated/validated outcome.
 11. If a safe read cannot be served, return `424 fallback_local` with a reason. The CLI
-    reruns the original command with real `gh` unless local fallback is disabled.
+    reruns the original command with real `gh` unless local fallback is disabled or the
+    supported run-watch ownership rules below require an explicit failure.
 12. Complete the owned fill immediately after publication; every other owned exit completes
     `failed`, while lost/stale tokens cannot release a newer owner.
 
@@ -215,6 +216,9 @@ failures occur before audit context exists. Bodies, credentials, and raw tokens 
   their shape is unknown.
 - Safe requests contact Octopool first and delegate only on explicit `fallback_local` or
   stale/invalid Octopool auth. `OCTOPOOL_NO_FALLBACK` disables delegation.
+- Supported `gh run watch` fails explicitly on relay or pagination failures, including
+  initial reads and final job hydration, without starting a personal-token watcher. Only an
+  initial `repo_not_public` refusal retains guarded fallback; unsupported shapes still delegate.
 - The canonical relay client loop retries selected transient pool fallbacks and
   `5xx internal_error` responses plus malformed 502/503/504 gateway responses with bounded
   backoff; exhausted service failures do not delegate to local GitHub quota.

--- a/src/run-jobs-superset.ts
+++ b/src/run-jobs-superset.ts
@@ -57,7 +57,9 @@ export function runJobsSupersetIncomplete(
     typeof total !== "number" ||
     !Number.isSafeInteger(total) ||
     total < 0 ||
-    total !== response.body.jobs.length
+    total > MAX_API_JOBS ||
+    total !== response.body.jobs.length ||
+    hasNextJobsPage(response)
   );
 }
 
@@ -80,14 +82,22 @@ export async function completeRunJobsSuperset(
     typeof total !== "number" ||
     !Number.isSafeInteger(total) ||
     total <= response.body.jobs.length ||
-    total > MAX_API_JOBS
+    total > MAX_API_JOBS ||
+    response.body.jobs.length !== MAX_PAGE_SIZE
   ) {
     return response;
   }
 
   const jobs = [...response.body.jobs];
   const pageCount = Math.ceil(total / MAX_PAGE_SIZE);
+  let last = response;
   for (let page = 2; page <= pageCount; page++) {
+    if (
+      Object.keys(last.headers).some((key) => key.toLowerCase() === "link") &&
+      !hasNextJobsPage(last)
+    ) {
+      return response;
+    }
     let next: GitHubRelayResponse | undefined;
     try {
       next = await fetchPage({
@@ -103,19 +113,38 @@ export async function completeRunJobsSuperset(
       next.status >= 300 ||
       !isRecord(next.body) ||
       next.body.total_count !== total ||
-      !Array.isArray(next.body.jobs)
+      !Array.isArray(next.body.jobs) ||
+      next.body.jobs.length !== Math.min(MAX_PAGE_SIZE, total - jobs.length)
     ) {
       return response;
     }
     jobs.push(...next.body.jobs);
+    last = next;
   }
-  if (jobs.length !== total) {
+  if (jobs.length !== total || hasNextJobsPage(last)) {
     return response;
   }
   return {
     ...response,
+    // The first page's next link no longer describes the merged collection.
+    headers: Object.fromEntries(
+      Object.entries(response.headers).filter(([key]) => key.toLowerCase() !== "link"),
+    ),
     body: { ...response.body, total_count: total, jobs },
   };
+}
+
+function hasNextJobsPage(response: GitHubRelayResponse): boolean {
+  const link = Object.entries(response.headers).find(([key]) => key.toLowerCase() === "link")?.[1];
+  if (link === undefined) {
+    return false;
+  }
+  for (const match of link.matchAll(/;\s*rel\s*=\s*(?:"([^"]*)"|([^;,\s]+))/gi)) {
+    if ((match[1] ?? match[2] ?? "").toLowerCase().split(/\s+/).includes("next")) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function filterRunJobsSuperset(

--- a/test/e2e/actions-cache-run-jobs.test.ts
+++ b/test/e2e/actions-cache-run-jobs.test.ts
@@ -188,6 +188,130 @@ describe("Actions attempt job-list cache", () => {
     ).toEqual({ count: 0 });
   });
 
+  it.each(["rerun count mismatch", "next link with matching count", "next link at cap"])(
+    "rejects %s without caching or inventing successful jobs",
+    async (variant) => {
+      const pages: string[] = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>(async (input) => {
+          const url = new URL(new Request(input).url);
+          if (url.hostname === "github.com") {
+            return jsonResponse({ message: "public parser unavailable" }, 404);
+          }
+          expect(url.pathname).toBe("/repos/openclaw/octopool/actions/runs/42/attempts/2/jobs");
+          const page = Number(url.searchParams.get("page"));
+          pages.push(String(page));
+          const atCap = variant === "next link at cap";
+          return jsonResponse(
+            {
+              total_count: atCap ? 300 : variant === "rerun count mismatch" ? 3 : 1,
+              jobs: Array.from({ length: atCap ? 100 : 1 }, (_, index) => ({
+                id: (page - 1) * 100 + index + 1,
+                name: "Swift",
+                run_attempt: 2,
+                status: "completed",
+                conclusion: "success",
+              })),
+            },
+            200,
+            variant === "rerun count mismatch"
+              ? {}
+              : {
+                  Link: `<https://api.github.com${url.pathname}?page=${page + 1}>; rel="next"`,
+                },
+          );
+        }),
+      );
+      const response = await relay(
+        "/repos/openclaw/octopool/actions/runs/42/attempts/2/jobs",
+        undefined,
+        {
+          query: { per_page: "100" },
+          headers: { "x-octopool-public-shape": "actions-jobs-v1" },
+        },
+      );
+      expect(response.status).toBe(424);
+      expect(await response.json()).toMatchObject({
+        error: { code: "fallback_local", details: { reason: "pagination_exhausted" } },
+      });
+      expect(pages).toEqual(variant === "next link at cap" ? ["1", "2", "3"] : ["1"]);
+      expect(
+        await env.DB.prepare(
+          "SELECT COUNT(*) AS count FROM github_cache_entries WHERE route_kind = 'run_jobs'",
+        ).first(),
+      ).toEqual({ count: 0 });
+    },
+  );
+
+  it.each([false, true])(
+    "preserves the exact attempt job set (reused successes: %s)",
+    async (includeReused) => {
+      const jobs = [
+        ...(includeReused
+          ? [
+              {
+                id: 1,
+                name: "actions",
+                run_attempt: 1,
+                status: "completed",
+                conclusion: "success",
+              },
+              {
+                id: 2,
+                name: "JavaScript",
+                run_attempt: 1,
+                status: "completed",
+                conclusion: "success",
+              },
+            ]
+          : []),
+        { id: 3, name: "Swift", run_attempt: 2, status: "completed", conclusion: "failure" },
+      ];
+      const apiPaths: string[] = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>(async (input) => {
+          const url = new URL(new Request(input).url);
+          if (url.hostname === "github.com") {
+            return jsonResponse({ message: "public parser unavailable" }, 404);
+          }
+          apiPaths.push(url.pathname);
+          if (url.pathname.endsWith("/attempts/2")) {
+            return jsonResponse({
+              id: 42,
+              run_attempt: 2,
+              status: "completed",
+              conclusion: "failure",
+            });
+          }
+          return jsonResponse({ total_count: jobs.length, jobs });
+        }),
+      );
+      const path = "/repos/openclaw/octopool/actions/runs/42/attempts/2/jobs";
+      const response = await relay(path, undefined, {
+        query: { per_page: "100" },
+        headers: { "x-octopool-public-shape": "actions-jobs-v1" },
+      });
+      expect(response.status).toBe(200);
+      expect((await response.json<RelayEnvelope>()).body).toEqual({
+        total_count: jobs.length,
+        jobs,
+      });
+      expect(apiPaths).toEqual([path, path.replace(/\/jobs$/, "")]);
+    },
+  );
+
+  it("keeps raw REST metadata exact even when the count includes absent rerun jobs", async () => {
+    const body = { total_count: 3, jobs: [{ id: 3, name: "Swift", run_attempt: 2 }] };
+    const upstream = vi.fn<typeof fetch>(async () => jsonResponse(body));
+    vi.stubGlobal("fetch", upstream);
+    const response = await relay("/repos/openclaw/octopool/actions/runs/42/attempts/2/jobs");
+    expect(response.status).toBe(200);
+    expect((await response.json<RelayEnvelope>()).body).toEqual(body);
+    expect(upstream).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back without caching a partial merge when page two fails", async () => {
     const apiRequests: Request[] = [];
     vi.stubGlobal(

--- a/test/run-jobs-superset.test.ts
+++ b/test/run-jobs-superset.test.ts
@@ -64,7 +64,7 @@ describe("Actions job-list superset", () => {
       status: 200,
       headers: {
         etag: '"canonical"',
-        link: '<https://api.github.com/jobs?page=2>; rel="next"',
+        link: '<https://api.github.com/jobs?page=1>; rel="prev"',
         "content-length": "123",
         "content-type": "application/json",
       },
@@ -99,7 +99,10 @@ describe("Actions job-list superset", () => {
     const response = await completeRunJobsSuperset(
       {
         status: 200,
-        headers: { "content-type": "application/json" },
+        headers: {
+          "content-type": "application/json",
+          link: '<https://api.github.com/jobs?page=2>; rel="next"',
+        },
         body: { total_count: 250, jobs: jobs(1, 100) },
         body_encoding: "json",
       },
@@ -109,7 +112,10 @@ describe("Actions job-list superset", () => {
         pages.push(page);
         return {
           status: 200,
-          headers: { "content-type": "application/json" },
+          headers: {
+            "content-type": "application/json",
+            link: `<https://api.github.com/jobs?page=${page === "2" ? 3 : 2}>; rel="${page === "2" ? "next" : "prev"}"`,
+          },
           body: {
             total_count: 250,
             jobs: page === "2" ? jobs(101, 100) : jobs(201, 50),
@@ -122,6 +128,53 @@ describe("Actions job-list superset", () => {
     expect(pages).toEqual(["2", "3"]);
     expect(response.body).toMatchObject({ total_count: 250 });
     expect((response.body as { jobs: unknown[] }).jobs).toHaveLength(250);
+    expect(response.headers).not.toHaveProperty("link");
+  });
+
+  it.each([
+    { name: "partial rerun metadata", total: 3, jobs: jobs(3, 1), link: undefined },
+    {
+      name: "next link despite matching count",
+      total: 1,
+      jobs: jobs(3, 1),
+      link: '<https://api.github.com/jobs?page=2>; rel="next"',
+    },
+    {
+      name: "next link at the cap",
+      total: 300,
+      jobs: jobs(1, 100),
+      link: '<https://api.github.com/jobs?page=2>; rel="next"',
+    },
+  ])("rejects $name without publishing a partial superset", async (test) => {
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/actions/runs/42/attempts/2/jobs",
+      headers: { "x-octopool-public-shape": "actions-jobs-v1" },
+    });
+    const view = runJobsSupersetView(request, classifyRoute(request, policy));
+    const pages: string[] = [];
+    const response = await completeRunJobsSuperset(
+      {
+        status: 200,
+        headers: test.link ? { Link: test.link } : {},
+        body: { total_count: test.total, jobs: test.jobs },
+        body_encoding: "json",
+      },
+      view,
+      async (pageRequest) => {
+        const page = Number(pageRequest.query?.page);
+        pages.push(String(page));
+        return {
+          status: 200,
+          headers: { link: `<https://api.github.com/jobs?page=${page + 1}>; rel="next"` },
+          body: { total_count: test.total, jobs: jobs((page - 1) * 100 + 1, 100) },
+          body_encoding: "json",
+        };
+      },
+    );
+    expect(runJobsSupersetIncomplete(response, view)).toBe(true);
+    expect(pages).toEqual(test.total === 300 ? ["2", "3"] : []);
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users watching Actions runs could silently spend their personal GitHub API quota when active outbound rewrite rules caused a supported `gh run watch` command to bypass the relay. A relay or job-pagination refusal could also hand the entire polling session to native `gh`.

## Why This Change Was Made

Keep supported run watches at the cache-owned boundary: recognize them during structural rewrite preparation, and fail explicitly on relay or pagination errors rather than starting a personal-token watcher. Initial private-repository refusals retain guarded native fallback; unsupported command shapes and PR-check watches keep their existing contracts.

Final job summaries require consistent counts and pagination metadata for the freshly confirmed run attempt. The existing three-page server cap remains unchanged, genuine multipage results still work, and contradictory or incomplete responses are not cached or printed as complete. Reused successful jobs are preserved when GitHub returns them, never reconstructed from an ambiguous count. Raw REST responses retain upstream semantics.

## User Impact

Supported run watches remain on the relay under active rewrite rules. If the relay cannot provide a complete result, the command returns a visible error without quietly switching GitHub identities or quota pools. Successful completion and `--exit-status` behavior remain intact for complete results.

## Evidence

- Bounded regressions fail against the previous implementation: active-rule dispatch made zero relay calls and invoked a fake native CLI; initial and mid-watch refusals transferred ownership; incomplete job summaries could report success.
- A native-execution trap verified installed 0.5.17 attempted direct delegation even with `OCTOPOOL_NO_FALLBACK=1`, while the patched local binary stayed relay-owned and completed successfully. The trap prevented personal-token requests.
- Focused Go watch, rewrite-policy, CLI process, and job-pagination tests passed, including request-count bounds, attempt-2 reused successes, genuine multipage data, cap enforcement, and exit statuses.
- Full Go suite, 575 TypeScript unit tests, and 248 mocked Worker tests passed. Type checks, Go vet, lint, formatting, and diff checks passed.
- One initial local Worker run exceeded an isolation-hook deadline; a fresh runtime passed the focused and full suites without changing the isolation harness.

CLI/cache documentation and the changelog describe the ownership and failure behavior. No credentials, installed CLI, or production relay configuration are changed by this PR.
