### PR TITLE
fix: bind membership verification to immutable GitHub accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Bind org membership checks to the enrolled GitHub account on every page, isolate verification timestamps across rolling upgrades, and preserve safe legacy re-login and typed upstream errors.
 - Validate protected `gh repo clone` repository inputs according to native argument ownership, preserving destination paths and Git flags while retaining visible-argument filtering and GitHub.com-only source checks.
 - Keep issue timelines and issue-event reads anonymous-only, retiring cached private cross-references and preserving safe conditional and native fallback behavior.
 - Preserve contributor credit in protected exact-head squash merges by accepting merge body files through the existing text rewriting and private snapshot checks.

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -10,8 +10,9 @@ Source: `src/provisioning.ts`, `src/router.ts`, `cmd/octopool/main.go`.
 ## Provision a caller
 
 Registers a GitHub org member as a relay caller and grants them a pool. The Worker
-verifies org membership and resolves the immutable GitHub user id, then returns a
-one-time caller token.
+resolves the immutable GitHub user id and verifies that same account's org membership, then returns a
+one-time caller token. Enrollment stores the identity-bound verification time in
+`org_identity_verified_at`, so the issued token uses the normal membership TTL immediately.
 
 API: `POST /v1/admin/callers`
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -18,8 +18,9 @@ Relay and health requests send `Authorization: Bearer <octopool_caller_token>`.
 - The caller must be `active` and granted the requested pool (`caller_pools`).
 - The caller's `org_login` must equal `ALLOWED_GITHUB_ORG`, else `403 org_denied`.
 - Org membership is re-verified on use once it goes stale (`ORG_VERIFY_TTL_SECONDS`,
-  default 24h), using the org verifier token. A member who leaves the org loses access at
-  the next check.
+  default 24h), using the org verifier token. Every verification page must resolve the
+  enrolled immutable `github_user_id`; a matching organization on a replacement account
+  cannot refresh the caller. A member who leaves the org loses access at the next check.
 
 A missing/invalid token returns `401`; a valid token without the pool grant returns
 `401 invalid_auth`.
@@ -100,9 +101,50 @@ Two helpers query the user's visible organizations through GitHub GraphQL:
 - During login, with the user's own token.
 - During background freshness checks, with the configured `OCTOPOOL_GITHUB_ORG_TOKEN`.
 
-The query paginates organization memberships and confirms the configured org by login. A
-completed query without the org denies (`403 org_member_denied`); transport, credential,
-rate-limit, or malformed-response failures surface as `502 org_verification_failed`. Using
-the GraphQL budget keeps org verification independent from REST core quota consumed by
-release and repository workflows. If the verifier token is unset, verification returns
-`503 org_verification_unavailable`.
+The query requests GitHub's [User.databaseId](https://docs.github.com/en/graphql/reference/users#user)
+and organization memberships together. Every fetched page must contain a positive integer
+database ID equal to the enrolled account (refresh) or the account just resolved by `/user`
+or `/users/{login}` (login/provisioning), before any membership is accepted. Admin provisioning
+resolves the account before checking membership. No opaque node IDs are synthesized.
+
+A completed query for the expected account without the org denies (`403 org_member_denied`).
+A different account or an absent user returns `403 github_identity_mismatch`; missing or
+malformed upstream IDs, organization nodes, or pagination, invalid JSON, transport, credential,
+and rate-limit failures return `502 org_verification_failed`. Failed verification never refreshes
+the timestamp. Responses omit upstream bodies and exception text. Requests retain timeouts,
+response-size caps, and relay egress protection; protection denials remain `403 string_rewrite_denied`.
+Membership checks use GraphQL, without adding a REST core-quota dependency. An unset verifier
+token still returns `503 org_verification_unavailable` when a refresh is required.
+
+### Immutable membership upgrade
+
+The 0.5.18 migration `0017_org_identity_verification.sql` adds nullable
+`callers.org_identity_verified_at` without backfilling it. Only successful identity-bound
+verification writes this column, including CLI/OAuth login, admin provisioning, and caller/session
+refresh. New auth TTL decisions use only this proof. A verified login stores it immediately, so the
+next authenticated request does not need a redundant membership check.
+
+Apply the additive schema migration before rolling out the new Worker. The old `org_verified_at`
+database column and its existing values remain intact for mixed-version deployment compatibility.
+Old Workers can continue writing their column, but those writes cannot create or extend a proof
+trusted by new Workers, even if an old timestamp is fresh or future-dated. No authentication shutdown
+or access-policy change is required. Complete the normal rollout and drain old requests before
+claiming the fix is fully deployed; requests still served by old code retain its old behavior.
+
+The public `Caller.org_verified_at` field keeps its name and nullable timestamp shape through explicit
+SQL aliases of `org_identity_verified_at` in bearer and web-session reads. This is the public API
+compatibility contract, not a fallback to the legacy database column. New code neither reads nor
+dual-writes the old proof. Existing accounts without a new proof require an identity-bound GraphQL
+check on their first request to new code; normal membership TTL and the 30-second caller config
+cache apply after success. This causes a one-time increase in verification requests during rollout.
+
+Legacy rows with null/missing or invalid `github_user_id` fail closed as
+`403 github_identity_required`, even with a fresh timestamp. Run `octopool login` again, sign in
+again on the website, or ask an admin to reprovision. A fresh proven login creates a separate
+enrollment when no matching immutable ID exists; it never binds the legacy row by username or
+revives its old caller tokens or web sessions. Old pool grants and dashboard roles do not transfer;
+an admin must explicitly regrant any additional access to the new enrollment.
+
+For an enrolled account that has renamed, sign in again with that GitHub account. Verified login
+updates the username on the same immutable-ID enrollment. Merely owning the old username is
+insufficient: GitHub permits [another account to claim it](https://docs.github.com/en/account-and-profile/concepts/username-changes).

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -204,6 +204,8 @@ D1 schema lives in `migrations/`:
 - `0015_drop_oauth_states.sql` — remove obsolete database-backed OAuth state.
 - `0016_string_rewrites.sql` — authoritative deployment-wide singleton string policy;
   seeds explicit empty rules at revision 1.
+- `0017_org_identity_verification.sql` — add a separate nullable identity-bound proof timestamp without backfill or changes to old data;
+  apply before the [rolling Worker upgrade](auth.md#immutable-membership-upgrade). Old timestamp writes cannot authorize new Workers.
 
 Apply with `wrangler d1 migrations apply DB` (add `--remote` for production).
 

--- a/migrations/0017_org_identity_verification.sql
+++ b/migrations/0017_org_identity_verification.sql
@@ -1,0 +1,2 @@
+-- Only identity-bound verification can populate this proof; never backfill legacy timestamps.
+ALTER TABLE callers ADD COLUMN org_identity_verified_at TEXT;

--- a/sql/queries/d1.sql
+++ b/sql/queries/d1.sql
@@ -1,5 +1,6 @@
 -- name: AuthenticateCaller :one
-SELECT callers.id, callers.name, callers.github_login, callers.org_login, callers.org_verified_at,
+SELECT callers.id, callers.name, callers.github_login, callers.github_user_id, callers.org_login,
+       callers.org_identity_verified_at AS org_verified_at,
        caller_tokens.id AS caller_token_id, caller_tokens.client_name
 FROM caller_tokens
 JOIN callers ON callers.id = caller_tokens.caller_id
@@ -9,9 +10,9 @@ WHERE caller_tokens.token_hash = ?1
   AND caller_pools.pool_id = ?2
 LIMIT 1;
 
--- name: UpdateCallerOrgVerifiedAt :exec
+-- name: UpdateCallerOrgIdentityVerifiedAt :exec
 UPDATE callers
-SET org_verified_at = ?1,
+SET org_identity_verified_at = ?1,
     updated_at = CURRENT_TIMESTAMP
 WHERE id = ?2;
 
@@ -317,7 +318,7 @@ WHERE github_user_id = ?1
 LIMIT 1;
 
 -- name: InsertCaller :exec
-INSERT INTO callers (id, name, token_hash, github_login, github_user_id, org_login, org_verified_at, status)
+INSERT INTO callers (id, name, token_hash, github_login, github_user_id, org_login, org_identity_verified_at, status)
 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'active');
 
 -- name: UpsertCallerToken :exec
@@ -372,7 +373,7 @@ UPDATE callers
 SET name = ?1,
     github_login = ?2,
     github_user_id = ?3,
-    org_verified_at = ?4,
+    org_identity_verified_at = ?4,
     updated_at = CURRENT_TIMESTAMP
 WHERE id = ?5;
 
@@ -389,8 +390,9 @@ SELECT
   callers.id,
   callers.name,
   callers.github_login,
+  callers.github_user_id,
   callers.org_login,
-  callers.org_verified_at,
+  callers.org_identity_verified_at AS org_verified_at,
   callers.dashboard_role,
   web_sessions.expires_at
 FROM web_sessions

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,16 +1,18 @@
 import { bytesToBase64URL } from "./encoding";
 import { cachedConfigLookup } from "./config-cache";
 import { normalizeClientName } from "./client-name";
-import { requestTimeoutMs } from "./github-limits";
+import { requestTimeoutMs, responseCapBytes } from "./github-limits";
 import { HttpError, requestBearer } from "./http";
 import { queries } from "./generated/sql";
-import type { GitHubEgressEnv } from "./github-egress";
+import { rethrowStringRewriteDenial, type GitHubEgressEnv } from "./github-egress";
+import { readBodyCapped } from "./response-body";
 import type { Caller } from "./types";
 
 type CallerRow = {
   id: string;
   name: string;
   github_login: string;
+  github_user_id: number | null;
   org_login: string;
   org_verified_at: string | null;
   caller_token_id: string;
@@ -97,7 +99,7 @@ export async function githubUserFromToken(
   const login = (body as { login?: unknown }).login;
   const id = (body as { id?: unknown }).id;
   const name = (body as { name?: unknown }).name;
-  if (typeof login !== "string" || typeof id !== "number") {
+  if (typeof login !== "string" || login.trim() === "" || !isGitHubUserId(id)) {
     throw new HttpError(502, "github_auth_failed", "GitHub user response was incomplete");
   }
   return {
@@ -149,7 +151,7 @@ export async function githubUserByLogin(
   }
   const resolvedLogin = (body as { login?: unknown }).login;
   const id = (body as { id?: unknown }).id;
-  if (typeof resolvedLogin !== "string" || typeof id !== "number") {
+  if (typeof resolvedLogin !== "string" || resolvedLogin.trim() === "" || !isGitHubUserId(id)) {
     throw new HttpError(502, "github_user_lookup_failed", "GitHub user response was incomplete");
   }
   return { id, login: resolvedLogin };
@@ -158,6 +160,7 @@ export async function githubUserByLogin(
 export async function verifyGitHubOrgMember(
   env: Env,
   login: string,
+  expectedUserId: number,
   egress?: GitHubEgressEnv["githubEgress"],
 ): Promise<string> {
   const token = envSecret(env, "OCTOPOOL_GITHUB_ORG_TOKEN");
@@ -168,31 +171,41 @@ export async function verifyGitHubOrgMember(
       "GitHub org verifier token is not configured",
     );
   }
-  return verifyGitHubOrgMemberWithToken(env, token, login, egress);
+  return verifyGitHubOrgMemberWithToken(env, token, login, expectedUserId, egress);
 }
 
 export async function verifyGitHubOrgMemberWithToken(
   env: Env,
   token: string,
   login: string,
+  expectedUserId: number,
   egress?: GitHubEgressEnv["githubEgress"],
 ): Promise<string> {
+  requireGitHubUserId(expectedUserId);
   const org = env.ALLOWED_GITHUB_ORG;
   let after: string | null = null;
+  const seenCursors = new Set<string>();
 
   while (true) {
-    const response = await (egress?.fetch ?? fetch)("https://api.github.com/graphql", {
-      method: "POST",
-      headers: {
-        ...githubHeaders(token),
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({
-        query: ORG_MEMBERSHIP_QUERY,
-        variables: { login, after },
-      }),
-      signal: githubRequestSignal(env),
-    });
+    let response: Response;
+    try {
+      response = await (egress?.fetch ?? fetch)("https://api.github.com/graphql", {
+        method: "POST",
+        redirect: "manual",
+        headers: {
+          ...githubHeaders(token),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          query: ORG_MEMBERSHIP_QUERY,
+          variables: { login, after },
+        }),
+        signal: githubRequestSignal(env),
+      });
+    } catch (error) {
+      rethrowStringRewriteDenial(error);
+      throw new HttpError(502, "org_verification_failed", "GitHub membership request failed");
+    }
     if (!response.ok) {
       throw new HttpError(
         502,
@@ -202,23 +215,32 @@ export async function verifyGitHubOrgMemberWithToken(
       );
     }
 
-    const page = await parseOrgMembershipPage(response);
+    const page = await parseOrgMembershipPage(response, responseCapBytes(env));
+    if (page === null || page.userId !== expectedUserId) {
+      throw new HttpError(
+        403,
+        "github_identity_mismatch",
+        "GitHub account no longer matches this login; sign in again or ask an admin to reprovision",
+      );
+    }
+    if (page.hasNextPage && (page.endCursor === null || seenCursors.has(page.endCursor))) {
+      throw new HttpError(502, "org_verification_failed", "GitHub membership page was invalid");
+    }
     if (page.organizations.some((candidate) => candidate.toLowerCase() === org.toLowerCase())) {
       return new Date().toISOString();
     }
     if (!page.hasNextPage) {
       throw new HttpError(403, "org_member_denied", `${login} is not a ${org} org member`);
     }
-    if (page.endCursor === null || page.endCursor === after) {
-      throw new HttpError(502, "org_verification_failed", "GitHub membership page was invalid");
-    }
     after = page.endCursor;
+    seenCursors.add(after!);
   }
 }
 
 const ORG_MEMBERSHIP_QUERY = `
   query OctopoolOrgMembership($login: String!, $after: String) {
     user(login: $login) {
+      databaseId
       organizations(first: 100, after: $after) {
         nodes { login }
         pageInfo { endCursor hasNextPage }
@@ -227,18 +249,41 @@ const ORG_MEMBERSHIP_QUERY = `
   }
 `;
 
-async function parseOrgMembershipPage(response: Response): Promise<{
+async function parseOrgMembershipPage(
+  response: Response,
+  capBytes: number,
+): Promise<{
+  userId: number;
   organizations: string[];
   endCursor: string | null;
   hasNextPage: boolean;
-}> {
-  const body: unknown = await response.json();
+} | null> {
+  let body: unknown;
+  try {
+    body = JSON.parse(
+      new TextDecoder().decode(
+        await readBodyCapped(
+          response,
+          capBytes,
+          () =>
+            new HttpError(
+              502,
+              "org_verification_failed",
+              "GitHub membership response was too large",
+            ),
+        ),
+      ),
+    );
+  } catch {
+    throw new HttpError(502, "org_verification_failed", "GitHub membership response was invalid");
+  }
   if (typeof body !== "object" || body === null || Array.isArray(body)) {
     throw new HttpError(502, "org_verification_failed", "GitHub membership response was invalid");
   }
   const payload = body as {
     data?: {
       user?: {
+        databaseId?: unknown;
         organizations?: {
           nodes?: unknown;
           pageInfo?: { endCursor?: unknown; hasNextPage?: unknown };
@@ -247,30 +292,40 @@ async function parseOrgMembershipPage(response: Response): Promise<{
     };
     errors?: unknown;
   };
-  if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+  if (
+    payload.errors !== undefined &&
+    (!Array.isArray(payload.errors) || payload.errors.length > 0)
+  ) {
     throw new HttpError(502, "org_verification_failed", "GitHub membership query failed");
   }
   if (payload.data?.user === null) {
-    return { organizations: [], endCursor: null, hasNextPage: false };
+    return null;
   }
+  const userId = payload.data?.user?.databaseId;
   const connection = payload.data?.user?.organizations;
   const nodes = connection?.nodes;
   const pageInfo = connection?.pageInfo;
   if (
+    !isGitHubUserId(userId) ||
     !Array.isArray(nodes) ||
     typeof pageInfo?.hasNextPage !== "boolean" ||
-    !(typeof pageInfo.endCursor === "string" || pageInfo.endCursor === null)
+    !(typeof pageInfo.endCursor === "string" || pageInfo.endCursor === null) ||
+    (typeof pageInfo.endCursor === "string" && pageInfo.endCursor.trim() === "")
   ) {
     throw new HttpError(502, "org_verification_failed", "GitHub membership response was invalid");
   }
-  const organizations = nodes.flatMap((node) => {
+  const organizations = nodes.map((node) => {
     if (typeof node !== "object" || node === null || Array.isArray(node)) {
-      return [];
+      throw new HttpError(502, "org_verification_failed", "GitHub membership node was invalid");
     }
     const candidate = (node as { login?: unknown }).login;
-    return typeof candidate === "string" ? [candidate] : [];
+    if (typeof candidate !== "string" || candidate.trim() === "") {
+      throw new HttpError(502, "org_verification_failed", "GitHub membership node was invalid");
+    }
+    return candidate;
   });
   return {
+    userId,
     organizations,
     endCursor: pageInfo.endCursor,
     hasNextPage: pageInfo.hasNextPage,
@@ -282,14 +337,30 @@ export async function ensureFreshOrgMembership(
   caller: CallerRow,
   egress?: GitHubEgressEnv["githubEgress"],
 ): Promise<void> {
+  // A timestamp alone must never authorize credentials with no enrolled account.
+  requireGitHubUserId(caller.github_user_id);
   const ttlSeconds = Number.parseInt(env.ORG_VERIFY_TTL_SECONDS, 10);
   const ttlMs = Number.isFinite(ttlSeconds) && ttlSeconds > 0 ? ttlSeconds * 1000 : 86_400_000;
   const verifiedAt = caller.org_verified_at === null ? 0 : Date.parse(caller.org_verified_at);
   if (Number.isFinite(verifiedAt) && Date.now() - verifiedAt < ttlMs) {
     return;
   }
-  const now = await verifyGitHubOrgMember(env, caller.github_login, egress);
-  await env.DB.prepare(queries.updateCallerOrgVerifiedAt).bind(now, caller.id).run();
+  const now = await verifyGitHubOrgMember(env, caller.github_login, caller.github_user_id, egress);
+  await env.DB.prepare(queries.updateCallerOrgIdentityVerifiedAt).bind(now, caller.id).run();
+}
+
+function isGitHubUserId(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function requireGitHubUserId(value: unknown): asserts value is number {
+  if (!isGitHubUserId(value)) {
+    throw new HttpError(
+      403,
+      "github_identity_required",
+      "GitHub account identity is missing; sign in again or ask an admin to reprovision",
+    );
+  }
 }
 
 async function constantTimeEqual(left: string, right: string): Promise<boolean> {

--- a/src/callers.ts
+++ b/src/callers.ts
@@ -21,34 +21,34 @@ export async function ensureCliCaller(
   env: Env,
   pool: string,
   user: GitHubLoginUser,
-  verifiedAt: string,
+  identityVerifiedAt: string,
   token: string,
   clientName: string,
 ): Promise<LoginCaller> {
-  return ensureCaller(env, pool, user, verifiedAt, { token, clientName });
+  return ensureCaller(env, pool, user, identityVerifiedAt, { token, clientName });
 }
 
 export async function ensureWebCaller(
   env: Env,
   pool: string,
   user: GitHubLoginUser,
-  verifiedAt: string,
+  identityVerifiedAt: string,
 ): Promise<LoginCaller> {
-  return ensureCaller(env, pool, user, verifiedAt);
+  return ensureCaller(env, pool, user, identityVerifiedAt);
 }
 
 async function ensureCaller(
   env: Env,
   pool: string,
   user: GitHubLoginUser,
-  verifiedAt: string,
+  identityVerifiedAt: string,
   client?: { token: string; clientName: string },
 ): Promise<LoginCaller> {
   await ensurePool(env, pool);
   const name = user.name ?? user.login;
   const existing = await findLoginCaller(env, pool, user.id);
   if (existing === null) {
-    return insertCaller(env, pool, user, name, verifiedAt, client);
+    return insertCaller(env, pool, user, name, identityVerifiedAt, client);
   }
 
   const statements = [
@@ -56,7 +56,7 @@ async function ensureCaller(
       name,
       user.login,
       user.id,
-      verifiedAt,
+      identityVerifiedAt,
       existing.id,
     ),
     env.DB.prepare(queries.insertCallerPool).bind(existing.id, pool),
@@ -109,7 +109,7 @@ async function insertCaller(
   pool: string,
   user: GitHubLoginUser,
   name: string,
-  verifiedAt: string,
+  identityVerifiedAt: string,
   client?: { token: string; clientName: string },
 ): Promise<LoginCaller> {
   const callerId = `caller_${crypto.randomUUID()}`;
@@ -122,7 +122,7 @@ async function insertCaller(
       user.login,
       user.id,
       env.ALLOWED_GITHUB_ORG,
-      verifiedAt,
+      identityVerifiedAt,
     ),
     env.DB.prepare(queries.insertCallerPool).bind(callerId, pool),
     ...(client === undefined

--- a/src/generated/sql.ts
+++ b/src/generated/sql.ts
@@ -36,9 +36,9 @@ export const queries = {
   completeCacheFill:
     "DELETE FROM cache_fills\nWHERE cache_key = ?1\n  AND owner_token = ?2\n  AND expires_at > ?3",
   authenticateCaller:
-    "SELECT callers.id, callers.name, callers.github_login, callers.org_login, callers.org_verified_at,\n       caller_tokens.id AS caller_token_id, caller_tokens.client_name\nFROM caller_tokens\nJOIN callers ON callers.id = caller_tokens.caller_id\nJOIN caller_pools ON caller_pools.caller_id = callers.id\nWHERE caller_tokens.token_hash = ?1\n  AND callers.status = 'active'\n  AND caller_pools.pool_id = ?2\nLIMIT 1",
-  updateCallerOrgVerifiedAt:
-    "UPDATE callers\nSET org_verified_at = ?1,\n    updated_at = CURRENT_TIMESTAMP\nWHERE id = ?2",
+    "SELECT callers.id, callers.name, callers.github_login, callers.github_user_id, callers.org_login,\n       callers.org_identity_verified_at AS org_verified_at,\n       caller_tokens.id AS caller_token_id, caller_tokens.client_name\nFROM caller_tokens\nJOIN callers ON callers.id = caller_tokens.caller_id\nJOIN caller_pools ON caller_pools.caller_id = callers.id\nWHERE caller_tokens.token_hash = ?1\n  AND callers.status = 'active'\n  AND caller_pools.pool_id = ?2\nLIMIT 1",
+  updateCallerOrgIdentityVerifiedAt:
+    "UPDATE callers\nSET org_identity_verified_at = ?1,\n    updated_at = CURRENT_TIMESTAMP\nWHERE id = ?2",
   ensurePool:
     "INSERT INTO pools (id, name, policy_json)\nVALUES (?1, ?1, ?2)\nON CONFLICT(id) DO NOTHING",
   getPoolPolicy: "SELECT policy_json\nFROM pools\nWHERE id = ?1",
@@ -95,7 +95,7 @@ export const queries = {
   findActiveCallerByGitHubUser:
     "SELECT id\nFROM callers\nWHERE github_user_id = ?1\n  AND org_login = ?2\n  AND status = 'active'\nLIMIT 1",
   insertCaller:
-    "INSERT INTO callers (id, name, token_hash, github_login, github_user_id, org_login, org_verified_at, status)\nVALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'active')",
+    "INSERT INTO callers (id, name, token_hash, github_login, github_user_id, org_login, org_identity_verified_at, status)\nVALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'active')",
   upsertCallerToken:
     "INSERT INTO caller_tokens (id, caller_id, token_hash, client_name, updated_at)\nVALUES (?1, ?2, ?3, ?4, strftime('%Y-%m-%d %H:%M:%f', 'now'))\nON CONFLICT(caller_id, client_name) DO UPDATE SET\n  token_hash = excluded.token_hash,\n  updated_at = excluded.updated_at",
   pruneCallerTokens:
@@ -108,12 +108,12 @@ export const queries = {
   insertIdentityScope:
     "INSERT INTO identity_scopes (identity_id, owner, repo, permission, allow_private)\nVALUES (?1, ?2, ?3, 'read', ?4)",
   updateCallerWebLogin:
-    "UPDATE callers\nSET name = ?1,\n    github_login = ?2,\n    github_user_id = ?3,\n    org_verified_at = ?4,\n    updated_at = CURRENT_TIMESTAMP\nWHERE id = ?5",
+    "UPDATE callers\nSET name = ?1,\n    github_login = ?2,\n    github_user_id = ?3,\n    org_identity_verified_at = ?4,\n    updated_at = CURRENT_TIMESTAMP\nWHERE id = ?5",
   insertWebSession:
     "INSERT INTO web_sessions (session_hash, caller_id, expires_at)\nVALUES (?1, ?2, ?3)",
   deleteWebSession: "DELETE FROM web_sessions\nWHERE session_hash = ?1",
   getWebSession:
-    "SELECT\n  callers.id,\n  callers.name,\n  callers.github_login,\n  callers.org_login,\n  callers.org_verified_at,\n  callers.dashboard_role,\n  web_sessions.expires_at\nFROM web_sessions\nJOIN callers ON callers.id = web_sessions.caller_id\nWHERE web_sessions.session_hash = ?1\n  AND web_sessions.expires_at > CURRENT_TIMESTAMP\n  AND callers.status = 'active'\n  AND callers.org_login = ?2",
+    "SELECT\n  callers.id,\n  callers.name,\n  callers.github_login,\n  callers.github_user_id,\n  callers.org_login,\n  callers.org_identity_verified_at AS org_verified_at,\n  callers.dashboard_role,\n  web_sessions.expires_at\nFROM web_sessions\nJOIN callers ON callers.id = web_sessions.caller_id\nWHERE web_sessions.session_hash = ?1\n  AND web_sessions.expires_at > CURRENT_TIMESTAMP\n  AND callers.status = 'active'\n  AND callers.org_login = ?2",
   getCallerPoolGrant:
     "SELECT 1\nFROM caller_pools\nWHERE caller_id = ?1\n  AND pool_id = ?2\nLIMIT 1",
   touchWebSession:

--- a/src/provisioning.ts
+++ b/src/provisioning.ts
@@ -19,7 +19,7 @@ export async function loginGitHubCLI(request: Request, env: Env): Promise<Respon
   const clientName = body.client_name === undefined ? "legacy" : parseClientName(body.client_name);
   const pool = requestedLoginPool(env, body.pool);
   const user = await githubUserFromToken(env, githubToken);
-  const verifiedAt = await verifyGitHubOrgMemberWithToken(env, githubToken, user.login);
+  const verifiedAt = await verifyGitHubOrgMemberWithToken(env, githubToken, user.login, user.id);
   const token = newToken("op");
   const caller = await ensureCliCaller(env, pool, user, verifiedAt, token, clientName);
   // Admin/login mutations invalidate this isolate's config cache immediately;
@@ -41,8 +41,8 @@ export async function createCaller(request: Request, env: Env): Promise<Response
   const name =
     typeof body.name === "string" && body.name.trim() !== "" ? body.name.trim() : githubLogin;
   await ensurePool(env, pool);
-  const verifiedAt = await verifyGitHubOrgMember(env, githubLogin);
   const githubUser = await githubUserByLogin(env, githubLogin);
+  const verifiedAt = await verifyGitHubOrgMember(env, githubUser.login, githubUser.id);
   const token = newToken("op");
   const caller = await ensureCliCaller(
     env,

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,9 @@ export type Caller = {
   id: string;
   name: string;
   github_login: string;
+  github_user_id: number | null;
   org_login: string;
+  // Public field name; SQL aliases only org_identity_verified_at, never the legacy proof.
   org_verified_at: string | null;
   caller_token_id: string;
   client_name: string;

--- a/src/web-session.ts
+++ b/src/web-session.ts
@@ -74,7 +74,7 @@ export async function finishGitHubWebLogin(
 
   const githubToken = await exchangeGitHubCode(request, env, code);
   const user = await githubUserFromToken(env, githubToken);
-  const verifiedAt = await verifyGitHubOrgMember(env, user.login);
+  const verifiedAt = await verifyGitHubOrgMember(env, user.login, user.id);
   const pool = defaultLoginPool(env);
   const caller = await ensureWebCaller(env, pool, user, verifiedAt);
 

--- a/test/cli-worker-e2e.sh
+++ b/test/cli-worker-e2e.sh
@@ -25,7 +25,7 @@ if ! pnpm exec wrangler d1 migrations apply DB \
   exit 1
 fi
 
-seed_sql="INSERT INTO pools (id, name, policy_json) VALUES ('maintainers', 'maintainers', '{\"allowed_owners\":[\"openclaw\"],\"allow_public_repos\":true,\"allow_search\":true,\"allow_logs\":true}'); INSERT INTO callers (id, name, token_hash, github_login, org_login, org_verified_at, status, github_user_id) VALUES ('cli-e2e', 'CLI E2E', '$caller_hash', 'cli-e2e', 'openclaw', CURRENT_TIMESTAMP, 'active', 424242); INSERT INTO caller_tokens (id, caller_id, token_hash, client_name) VALUES ('cli-e2e-token', 'cli-e2e', '$caller_hash', 'cli-e2e'); INSERT INTO caller_pools (caller_id, pool_id) VALUES ('cli-e2e', 'maintainers');"
+seed_sql="INSERT INTO pools (id, name, policy_json) VALUES ('maintainers', 'maintainers', '{\"allowed_owners\":[\"openclaw\"],\"allow_public_repos\":true,\"allow_search\":true,\"allow_logs\":true}'); INSERT INTO callers (id, name, token_hash, github_login, org_login, org_identity_verified_at, status, github_user_id) VALUES ('cli-e2e', 'CLI E2E', '$caller_hash', 'cli-e2e', 'openclaw', CURRENT_TIMESTAMP, 'active', 424242); INSERT INTO caller_tokens (id, caller_id, token_hash, client_name) VALUES ('cli-e2e-token', 'cli-e2e', '$caller_hash', 'cli-e2e'); INSERT INTO caller_pools (caller_id, pool_id) VALUES ('cli-e2e', 'maintainers');"
 pnpm exec wrangler d1 execute DB \
   --local --persist-to "$state_dir" --command "$seed_sql" --json >/dev/null
 

--- a/test/e2e/control-plane.test.ts
+++ b/test/e2e/control-plane.test.ts
@@ -5,6 +5,7 @@ import { poolHealth } from "../../src/health";
 import {
   bearer,
   callWorker,
+  callWarmWorker,
   CALLER_TOKEN,
   jsonResponse,
   orgMembershipResponse,
@@ -16,6 +17,43 @@ import {
 } from "./harness";
 
 describe("Worker end-to-end control plane", () => {
+  it("rejects membership from a replacement account without refreshing the enrolled caller", async () => {
+    await seedPool();
+    const stale = "2020-01-01T00:00:00.000Z";
+    await env.DB.prepare(
+      "UPDATE callers SET github_user_id = 101, github_login = 'old-name', org_identity_verified_at = ? WHERE id = 'caller'",
+    )
+      .bind(stale)
+      .run();
+    const upstream = vi.fn<typeof fetch>(async () =>
+      jsonResponse({
+        data: {
+          user: {
+            databaseId: 202,
+            organizations: {
+              nodes: [{ login: "openclaw" }],
+              pageInfo: { endCursor: null, hasNextPage: false },
+            },
+          },
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", upstream);
+
+    const response = await authenticatedGet(`/v1/pools/${POOL}/health`);
+    const stored = await env.DB.prepare(
+      "SELECT github_user_id, github_login, org_identity_verified_at AS org_verified_at FROM callers WHERE id = 'caller'",
+    ).first();
+    expect.soft(response.status).toBe(403);
+    expect
+      .soft(await response.json())
+      .toMatchObject({ error: { code: "github_identity_mismatch" } });
+    expect
+      .soft(stored)
+      .toEqual({ github_user_id: 101, github_login: "old-name", org_verified_at: stale });
+    expect(upstream).toHaveBeenCalledTimes(1);
+  });
+
   it("attributes legacy macOS .local client aliases to the canonical host", async () => {
     await seedPool();
     await env.DB.prepare(
@@ -28,6 +66,307 @@ describe("Worker end-to-end control plane", () => {
       operator: { client_name: "clawstudio" },
     });
   });
+
+  it("refreshes the same account across pages and preserves fresh and warm-cache membership", async () => {
+    await seedPool();
+    await setEnrollment(101, "old-name", STALE);
+    const upstream = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(membershipPage(101, ["other"], "next"))
+      .mockResolvedValueOnce(membershipPage(101, ["OpenClaw"]));
+    vi.stubGlobal("fetch", upstream);
+
+    expect((await authenticatedGet(`/v1/pools/${POOL}/health`)).status).toBe(200);
+    const stored = await enrollment();
+    expect(stored).toMatchObject({ github_user_id: 101, github_login: "old-name" });
+    expect(Date.now() - Date.parse(stored!.org_verified_at!)).toBeLessThan(60_000);
+    expect(upstream).toHaveBeenCalledTimes(2);
+    const requests = upstream.mock.calls.map(([, init]) => JSON.parse(String(init?.body)));
+    expect(requests[0].query).toContain("databaseId");
+    expect(requests.map((request) => request.variables)).toEqual([
+      { login: "old-name", after: null },
+      { login: "old-name", after: "next" },
+    ]);
+    expect(
+      (
+        await callWarmWorker(`/v1/pools/${POOL}/health`, {
+          headers: { authorization: `Bearer ${CALLER_TOKEN}` },
+        })
+      ).status,
+    ).toBe(200);
+    expect((await authenticatedGet(`/v1/pools/${POOL}/health`)).status).toBe(200);
+    expect(upstream).toHaveBeenCalledTimes(2);
+    expect(await enrollment()).toEqual(stored);
+  });
+
+  it("rejects account substitution on a later organization page", async () => {
+    await seedPool();
+    await setEnrollment(101, "old-name", STALE);
+    const upstream = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(membershipPage(101, ["other"], "next"))
+      .mockResolvedValueOnce(membershipPage(202, ["openclaw"]));
+    vi.stubGlobal("fetch", upstream);
+    const response = await authenticatedGet(`/v1/pools/${POOL}/health`);
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({ error: { code: "github_identity_mismatch" } });
+    expect((await enrollment())!.org_verified_at).toBe(STALE);
+    expect(upstream).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    ["completed nonmembership", () => membershipPage(101, ["other"]), 403, "org_member_denied"],
+    [
+      "missing account",
+      () => jsonResponse({ data: { user: null } }),
+      403,
+      "github_identity_mismatch",
+    ],
+    [
+      "missing database ID",
+      () =>
+        jsonResponse({
+          data: {
+            user: {
+              organizations: {
+                nodes: [{ login: "openclaw" }],
+                pageInfo: { endCursor: null, hasNextPage: false },
+              },
+            },
+          },
+        }),
+      502,
+      "org_verification_failed",
+    ],
+    [
+      "malformed node",
+      () =>
+        jsonResponse({
+          data: {
+            user: {
+              databaseId: 101,
+              organizations: {
+                nodes: [null],
+                pageInfo: { endCursor: null, hasNextPage: false },
+              },
+            },
+          },
+        }),
+      502,
+      "org_verification_failed",
+    ],
+    [
+      "malformed node alongside membership",
+      () =>
+        jsonResponse({
+          data: {
+            user: {
+              databaseId: 101,
+              organizations: {
+                nodes: [{ login: "openclaw" }, { login: 123 }],
+                pageInfo: { endCursor: null, hasNextPage: false },
+              },
+            },
+          },
+        }),
+      502,
+      "org_verification_failed",
+    ],
+    [
+      "missing pagination",
+      () =>
+        jsonResponse({
+          data: {
+            user: {
+              databaseId: 101,
+              organizations: {
+                nodes: [{ login: "openclaw" }],
+              },
+            },
+          },
+        }),
+      502,
+      "org_verification_failed",
+    ],
+    [
+      "invalid JSON",
+      () => new Response("synthetic-private-upstream"),
+      502,
+      "org_verification_failed",
+    ],
+    [
+      "query failure",
+      () => jsonResponse({ errors: [{ message: "synthetic-private-upstream" }] }),
+      502,
+      "org_verification_failed",
+    ],
+    [
+      "HTTP failure",
+      () => jsonResponse({ message: "synthetic-private-upstream" }, 401),
+      502,
+      "org_verification_failed",
+    ],
+    [
+      "transport failure",
+      () => {
+        throw new Error("synthetic-private-upstream");
+      },
+      502,
+      "org_verification_failed",
+    ],
+  ] as const)(
+    "keeps the timestamp unchanged for %s",
+    async (_name, responseForFetch, statusCode, code) => {
+      await seedPool();
+      await setEnrollment(101, "old-name", STALE);
+      const upstream = vi.fn<typeof fetch>(async () => responseForFetch());
+      vi.stubGlobal("fetch", upstream);
+      const response = await authenticatedGet(`/v1/pools/${POOL}/health`);
+      expect(response.status).toBe(statusCode);
+      const body = await response.text();
+      expect(JSON.parse(body)).toMatchObject({ error: { code } });
+      expect(body).not.toContain("synthetic-private-upstream");
+      expect(body).not.toContain("test-org-token");
+      expect((await enrollment())!.org_verified_at).toBe(STALE);
+      expect(upstream).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(["stale", "fresh"])(
+    "fails closed for a legacy null ID with a %s timestamp on bearer and web auth",
+    async (freshness) => {
+      await seedPool();
+      const timestamp = freshness === "fresh" ? new Date().toISOString() : STALE;
+      await setEnrollment(null, "old-name", timestamp);
+      const session = await seedWebSession();
+      const upstream = vi.fn<typeof fetch>(async () => membershipPage(202, ["openclaw"]));
+      vi.stubGlobal("fetch", upstream);
+      for (const response of [
+        await authenticatedGet(`/v1/pools/${POOL}/health`),
+        await callWorker("https://octopool.openclaw.ai/v1/me", {
+          headers: { cookie: `octopool_session=${session}` },
+        }),
+      ]) {
+        expect(response.status).toBe(403);
+        expect(await response.json()).toMatchObject({
+          error: {
+            code: "github_identity_required",
+            message: expect.stringContaining("sign in again"),
+          },
+        });
+      }
+      expect(await enrollment()).toEqual({
+        github_user_id: null,
+        github_login: "old-name",
+        org_verified_at: timestamp,
+      });
+      expect(upstream).not.toHaveBeenCalled();
+    },
+  );
+
+  it("recovers a renamed account only through a fresh verified login by the same ID", async () => {
+    await seedPool();
+    await setEnrollment(101, "old-name", STALE);
+    const upstream = vi.fn<typeof fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      if (new URL(request.url).pathname === "/user")
+        return jsonResponse({ id: 101, login: "new-name" });
+      const { variables } = await request.json<{ variables: { login: string } }>();
+      return membershipPage(variables.login === "new-name" ? 101 : 202, ["openclaw"]);
+    });
+    vi.stubGlobal("fetch", upstream);
+    expect((await authenticatedGet(`/v1/pools/${POOL}/health`)).status).toBe(403);
+    const login = await postJSON("/v1/login/github-cli", {
+      github_token: "renamed-user-token",
+      client_name: "new-client",
+    });
+    expect(login.status).toBe(201);
+    expect(await login.json()).toMatchObject({
+      caller: { id: "caller", github_login: "new-name" },
+    });
+    expect(await enrollment()).toMatchObject({ github_user_id: 101, github_login: "new-name" });
+    expect((await enrollment())!.org_verified_at).not.toBe(STALE);
+    expect((await authenticatedGet(`/v1/pools/${POOL}/health`)).status).toBe(200);
+    expect(upstream).toHaveBeenCalledTimes(3);
+  });
+
+  it("enrolls a legacy user's fresh login separately without reviving old credentials or grants", async () => {
+    await seedPool();
+    await setEnrollment(null, "old-name", STALE);
+    const session = await seedWebSession();
+    const upstream = vi.fn<typeof fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      return new URL(request.url).pathname === "/user"
+        ? jsonResponse({ id: 202, login: "old-name" })
+        : membershipPage(202, ["openclaw"]);
+    });
+    vi.stubGlobal("fetch", upstream);
+    const login = await postJSON("/v1/login/github-cli", { github_token: "fresh-user-token" });
+    expect(login.status).toBe(201);
+    const body = await login.json<{ caller: { id: string }; token: string }>();
+    expect(body.caller.id).not.toBe("caller");
+    expect(
+      (
+        await callWorker(`/v1/pools/${POOL}/health`, {
+          headers: { authorization: `Bearer ${body.token}` },
+        })
+      ).status,
+    ).toBe(200);
+    expect((await authenticatedGet(`/v1/pools/${POOL}/health`)).status).toBe(403);
+    expect(
+      (
+        await callWorker("https://octopool.openclaw.ai/v1/me", {
+          headers: { cookie: `octopool_session=${session}` },
+        })
+      ).status,
+    ).toBe(403);
+    expect(await enrollment()).toEqual({
+      github_user_id: null,
+      github_login: "old-name",
+      org_verified_at: STALE,
+    });
+    expect(
+      await env.DB.prepare("SELECT dashboard_role FROM callers WHERE id = ?")
+        .bind(body.caller.id)
+        .first(),
+    ).toEqual({ dashboard_role: "none" });
+    expect(upstream).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["CLI", "admin"])(
+    "binds %s enrollment to the account resolved before membership",
+    async (surface) => {
+      await seedPool();
+      const upstream = vi.fn<typeof fetch>(async (input, init) => {
+        const request = new Request(input, init);
+        const path = new URL(request.url).pathname;
+        return path === "/graphql"
+          ? membershipPage(202, ["openclaw"])
+          : jsonResponse({ id: 101, login: "old-name" });
+      });
+      vi.stubGlobal("fetch", upstream);
+      const response =
+        surface === "CLI"
+          ? await postJSON("/v1/login/github-cli", { github_token: "fresh-user-token" })
+          : await postJSON(
+              "/v1/admin/callers",
+              { pool: POOL, github_login: "old-name" },
+              "test-admin-token",
+            );
+      expect(response.status).toBe(403);
+      expect(await response.json()).toMatchObject({ error: { code: "github_identity_mismatch" } });
+      expect(upstream.mock.calls.map(([input]) => new URL(String(input)).pathname)).toEqual([
+        surface === "CLI" ? "/user" : "/users/old-name",
+        "/graphql",
+      ]);
+      expect(await env.DB.prepare("SELECT count(*) AS count FROM callers").first()).toEqual({
+        count: 1,
+      });
+      expect(await env.DB.prepare("SELECT count(*) AS count FROM caller_tokens").first()).toEqual({
+        count: 1,
+      });
+    },
+  );
 
   it("reports active, disabled, empty, and missing pool health correctly", async () => {
     await seedPool({ secondary: true });
@@ -105,7 +444,7 @@ describe("Worker end-to-end control plane", () => {
       const request = new Request(input, init);
       const url = new URL(request.url);
       if (url.pathname === "/graphql" && bearer(request) === "test-org-token") {
-        return orgMembershipResponse(true);
+        return orgMembershipResponse(true, 99);
       }
       if (url.pathname === "/users/new-user") {
         return jsonResponse({ id: 99, login: "new-user" });
@@ -136,6 +475,12 @@ describe("Worker end-to-end control plane", () => {
       headers: { authorization: `Bearer ${body.token}` },
     });
     expect(health.status).toBe(200);
+    expect(upstream).toHaveBeenCalledTimes(2);
+    expect(
+      await env.DB.prepare(
+        "SELECT org_verified_at, org_identity_verified_at FROM callers WHERE github_user_id = 99",
+      ).first(),
+    ).toEqual({ org_verified_at: null, org_identity_verified_at: expect.any(String) });
   });
 
   it("keeps different CLI clients active while rotating only a re-logged client", async () => {
@@ -146,7 +491,7 @@ describe("Worker end-to-end control plane", () => {
         return jsonResponse({ id: 101, login: "cli-user", name: "CLI User" });
       }
       if (url.pathname === "/graphql" && bearer(request) === "github-user-token") {
-        return orgMembershipResponse(true);
+        return orgMembershipResponse(true, 101);
       }
       return jsonResponse({ message: "unexpected request" }, 500);
     });
@@ -187,6 +532,12 @@ describe("Worker end-to-end control plane", () => {
       headers: { authorization: `Bearer ${body.token}` },
     });
     expect(firstHealth.status).toBe(200);
+    expect(upstream).toHaveBeenCalledTimes(2);
+    expect(
+      await env.DB.prepare(
+        "SELECT org_verified_at, org_identity_verified_at FROM callers WHERE github_user_id = 101",
+      ).first(),
+    ).toEqual({ org_verified_at: null, org_identity_verified_at: expect.any(String) });
 
     const studioResponse = await postJSON("/v1/login/github-cli", {
       github_token: "github-user-token",
@@ -325,6 +676,44 @@ describe("Worker end-to-end control plane", () => {
     expect(cache.results).toEqual([{ cache_key: "fresh-cache" }]);
   });
 });
+
+const STALE = "2020-01-01T00:00:00.000Z";
+
+function membershipPage(userId: number, logins: string[], cursor: string | null = null): Response {
+  return jsonResponse({
+    data: {
+      user: {
+        databaseId: userId,
+        organizations: {
+          nodes: logins.map((login) => ({ login })),
+          pageInfo: { endCursor: cursor, hasNextPage: cursor !== null },
+        },
+      },
+    },
+  });
+}
+
+async function setEnrollment(
+  userId: number | null,
+  login: string,
+  timestamp: string,
+): Promise<void> {
+  await env.DB.prepare(
+    "UPDATE callers SET github_user_id = ?, github_login = ?, org_identity_verified_at = ? WHERE id = 'caller'",
+  )
+    .bind(userId, login, timestamp)
+    .run();
+}
+
+function enrollment() {
+  return env.DB.prepare(
+    "SELECT github_user_id, github_login, org_identity_verified_at AS org_verified_at FROM callers WHERE id = 'caller'",
+  ).first<{
+    github_user_id: number | null;
+    github_login: string;
+    org_verified_at: string | null;
+  }>();
+}
 
 function authenticatedGet(path: string): Promise<Response> {
   return callWorker(path, { headers: { authorization: `Bearer ${CALLER_TOKEN}` } });

--- a/test/e2e/harness.ts
+++ b/test/e2e/harness.ts
@@ -89,7 +89,7 @@ export async function seedPool(options: { secondary?: boolean } = {}): Promise<v
     ),
     env.DB.prepare(
       `INSERT INTO callers (
-        id, name, token_hash, github_login, org_login, org_verified_at, status, github_user_id,
+        id, name, token_hash, github_login, org_login, org_identity_verified_at, status, github_user_id,
         dashboard_role
       ) VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, 'active', ?, 'admin')`,
     ).bind("caller", "Caller", await hashToken(CALLER_TOKEN), "caller", "openclaw", 42),
@@ -112,7 +112,7 @@ export async function seedCaller(id: string, token: string, login: string): Prom
   await env.DB.batch([
     env.DB.prepare(
       `INSERT INTO callers (
-        id, name, token_hash, github_login, org_login, org_verified_at, status, github_user_id
+        id, name, token_hash, github_login, org_login, org_identity_verified_at, status, github_user_id
       ) VALUES (?, ?, ?, ?, 'openclaw', CURRENT_TIMESTAMP, 'active', ?)`,
     ).bind(id, login, await hashToken(token), login, id === "other" ? 43 : 44),
     env.DB.prepare("INSERT INTO caller_pools (caller_id, pool_id) VALUES (?, ?)").bind(id, POOL),
@@ -204,10 +204,11 @@ export function jsonResponse(body: unknown, status = 200, headers?: HeadersInit)
   });
 }
 
-export function orgMembershipResponse(member: boolean): Response {
+export function orgMembershipResponse(member: boolean, userId: number): Response {
   return jsonResponse({
     data: {
       user: {
+        databaseId: userId,
         organizations: {
           nodes: member ? [{ login: "openclaw" }] : [],
           pageInfo: { endCursor: null, hasNextPage: false },

--- a/test/e2e/org-membership-upgrade.test.ts
+++ b/test/e2e/org-membership-upgrade.test.ts
@@ -1,0 +1,296 @@
+import type { D1Migration } from "@cloudflare/vitest-pool-workers";
+import { applyD1Migrations } from "cloudflare:test";
+import { env } from "cloudflare:workers";
+import { describe, expect, it, vi } from "vitest";
+import { authenticateCaller, hashToken } from "../../src/auth";
+import { requireDashboardAdmin } from "../../src/web-session";
+import { restoreD1Baseline } from "./d1-baseline";
+import {
+  callWorker,
+  CALLER_TOKEN,
+  jsonResponse,
+  orgMembershipResponse,
+  POOL,
+  seedPool,
+  seedWebSession,
+} from "./harness";
+
+const LEGACY_PROOF = "2020-01-01T00:00:00.000Z";
+const FUTURE_LEGACY_PROOF = "2099-01-01T00:00:00.000Z";
+
+describe("immutable membership rolling upgrade", () => {
+  it("isolates a legacy refresh after migration from new bearer and browser authentication", async () => {
+    await seedOldSchema();
+    const before = await env.DB.prepare("SELECT * FROM callers WHERE id = 'caller'").first();
+    const session = await seedWebSession();
+    await applyUpgrade();
+    expect
+      .soft(await env.DB.prepare("SELECT * FROM callers WHERE id = 'caller'").first())
+      .toEqual({ ...before, org_identity_verified_at: null });
+
+    // The old Worker's exact timestamp writer can still finish after migration.
+    await legacyRefresh(FUTURE_LEGACY_PROOF);
+    const upstream = vi.fn<typeof fetch>(async () => orgMembershipResponse(true, 202));
+    vi.stubGlobal("fetch", upstream);
+    for (const response of [await health(), await browserSession(session)]) {
+      expect.soft(response.status).toBe(403);
+      expect
+        .soft(await response.json())
+        .toMatchObject({ error: { code: "github_identity_mismatch" } });
+    }
+    expect.soft(upstream).toHaveBeenCalledTimes(2);
+    expect(
+      await env.DB.prepare("SELECT org_verified_at FROM callers WHERE id = 'caller'").first(),
+    ).toEqual({ org_verified_at: FUTURE_LEGACY_PROOF });
+    expect((await storedProof())!.org_identity_verified_at).toBeNull();
+  });
+
+  it.each(["fresh", "future"])(
+    "does not extend an expired identity proof with a %s legacy write",
+    async (freshness) => {
+      await seedOldSchema();
+      const session = await seedWebSession();
+      await applyUpgrade();
+      const upstream = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(orgMembershipResponse(true, 101))
+        .mockImplementation(async () => orgMembershipResponse(true, 202));
+      vi.stubGlobal("fetch", upstream);
+      expect((await health()).status).toBe(200);
+      const proof = await storedProof();
+      expect(proof!.org_verified_at).toBe(LEGACY_PROOF);
+      expect(Date.now() - Date.parse(proof!.org_identity_verified_at!)).toBeLessThan(60_000);
+
+      // Age an actually successful proof; neither old writer timestamp may extend its TTL.
+      await env.DB.prepare("UPDATE callers SET org_identity_verified_at = ? WHERE id = 'caller'")
+        .bind(LEGACY_PROOF)
+        .run();
+      const oldTimestamp = freshness === "fresh" ? new Date().toISOString() : FUTURE_LEGACY_PROOF;
+      await legacyRefresh(oldTimestamp);
+      for (const response of [await health(), await browserSession(session)]) {
+        expect(response.status).toBe(403);
+        expect(await response.json()).toMatchObject({
+          error: { code: "github_identity_mismatch" },
+        });
+      }
+      expect(upstream).toHaveBeenCalledTimes(3);
+      expect(await storedProof()).toEqual({
+        org_verified_at: oldTimestamp,
+        org_identity_verified_at: LEGACY_PROOF,
+      });
+    },
+  );
+
+  it("preserves the public caller field as an alias of only the new proof", async () => {
+    await seedOldSchema();
+    const session = await seedWebSession();
+    await applyUpgrade();
+    await legacyRefresh(FUTURE_LEGACY_PROOF);
+    const upstream = vi.fn<typeof fetch>(async () => orgMembershipResponse(true, 101));
+    vi.stubGlobal("fetch", upstream);
+    expect((await health()).status).toBe(200);
+    // Cold auth re-reads the completed proof, then warm auth preserves its normal cache.
+    expect((await health()).status).toBe(200);
+    const caller = await authenticateCaller(
+      new Request("https://octopool.dev/", {
+        headers: { authorization: `Bearer ${CALLER_TOKEN}` },
+      }),
+      env,
+      POOL,
+    );
+    const webSession = await requireDashboardAdmin(
+      new Request("https://octopool.openclaw.ai/", {
+        headers: { cookie: `octopool_session=${session}` },
+      }),
+      env,
+      POOL,
+    );
+    const proof = await storedProof();
+    expect(proof!.org_verified_at).toBe(FUTURE_LEGACY_PROOF);
+    expect(proof!.org_identity_verified_at).not.toBe(FUTURE_LEGACY_PROOF);
+    for (const authenticated of [caller, webSession]) {
+      expect(authenticated.org_verified_at).toBe(proof!.org_identity_verified_at);
+      expect(authenticated).not.toHaveProperty("org_identity_verified_at");
+    }
+    expect(upstream).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([null, 0, -1, 1.5])(
+    "rejects enrolled ID %s before either fresh timestamp can authorize",
+    async (id) => {
+      await seedPool();
+      const session = await seedWebSession();
+      const fresh = new Date().toISOString();
+      await env.DB.prepare(
+        "UPDATE callers SET github_user_id = ?, org_verified_at = ?, org_identity_verified_at = ? WHERE id = 'caller'",
+      )
+        .bind(id, FUTURE_LEGACY_PROOF, fresh)
+        .run();
+      const upstream = vi.fn<typeof fetch>(async () => orgMembershipResponse(true, 202));
+      vi.stubGlobal("fetch", upstream);
+      for (const response of [await health(), await browserSession(session)]) {
+        expect(response.status).toBe(403);
+        expect(await response.json()).toMatchObject({
+          error: { code: "github_identity_required" },
+        });
+      }
+      expect(await storedProof()).toEqual({
+        org_verified_at: FUTURE_LEGACY_PROOF,
+        org_identity_verified_at: fresh,
+      });
+      expect(upstream).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["CLI", "admin"])(
+    "stores only the new proof on an existing account's verified %s login",
+    async (surface) => {
+      await seedOldSchema();
+      const session = await seedWebSession();
+      await applyUpgrade();
+      const upstream = vi.fn<typeof fetch>(async (input, init) => {
+        const request = new Request(input, init);
+        const path = new URL(request.url).pathname;
+        if (path === "/graphql") return orgMembershipResponse(true, 101);
+        if (path === "/user" || path === "/users/new-name")
+          return jsonResponse({ id: 101, login: "new-name" });
+        return jsonResponse({}, 500);
+      });
+      vi.stubGlobal("fetch", upstream);
+      const response = await callWorker(
+        surface === "CLI" ? "/v1/login/github-cli" : "/v1/admin/callers",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            ...(surface === "admin" ? { authorization: "Bearer test-admin-token" } : {}),
+          },
+          body: JSON.stringify(
+            surface === "CLI"
+              ? { github_token: "synthetic-login-token", client_name: "new-client" }
+              : { pool: POOL, github_login: "new-name" },
+          ),
+        },
+      );
+      expect(response.status).toBe(201);
+      const body = await response.json<{
+        caller: { id: string; github_login: string };
+        token: string;
+      }>();
+      expect(body.caller).toMatchObject({ id: "caller", github_login: "new-name" });
+      const proof = await storedProof();
+      expect(proof!.org_verified_at).toBe(LEGACY_PROOF);
+      expect(Date.now() - Date.parse(proof!.org_identity_verified_at!)).toBeLessThan(60_000);
+      expect(
+        (
+          await callWorker(`/v1/pools/${POOL}/health`, {
+            headers: { authorization: `Bearer ${body.token}` },
+          })
+        ).status,
+      ).toBe(200);
+      expect((await browserSession(session)).status).toBe(200);
+      expect(await storedProof()).toEqual(proof);
+      expect(upstream).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it("stores the new proof on an existing account's verified OAuth login without refreshing again", async () => {
+    await seedOldSchema();
+    const session = await seedWebSession();
+    await applyUpgrade();
+    const upstream = vi.fn<typeof fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      const path = new URL(request.url).pathname;
+      if (path === "/login/oauth/access_token")
+        return jsonResponse({ access_token: "synthetic-oauth-token" });
+      if (path === "/user") return jsonResponse({ id: 101, login: "new-name" });
+      if (path === "/graphql") return orgMembershipResponse(true, 101);
+      return jsonResponse({}, 500);
+    });
+    vi.stubGlobal("fetch", upstream);
+    const start = await callWorker("https://octopool.openclaw.ai/login/github");
+    const state = new URL(start.headers.get("location")!).searchParams.get("state")!;
+    const callback = await callWorker(
+      `https://octopool.openclaw.ai/login/github/callback?code=synthetic-code&state=${encodeURIComponent(state)}`,
+      {
+        headers: { cookie: `octopool_oauth_state=${encodeURIComponent(state)}` },
+      },
+    );
+    expect(callback.status).toBe(302);
+    expect(callback.headers.get("set-cookie")).toContain("octopool_session=");
+    const proof = await storedProof();
+    expect(proof!.org_verified_at).toBe(LEGACY_PROOF);
+    expect(Date.now() - Date.parse(proof!.org_identity_verified_at!)).toBeLessThan(60_000);
+    const response = await browserSession(session);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      caller: { id: "caller", github_login: "new-name", dashboard_role: "admin" },
+    });
+    expect(await storedProof()).toEqual(proof);
+    expect(upstream).toHaveBeenCalledTimes(3);
+  });
+});
+
+function storedProof() {
+  return env.DB.prepare(
+    "SELECT org_verified_at, org_identity_verified_at FROM callers WHERE id = 'caller'",
+  ).first<{ org_verified_at: string | null; org_identity_verified_at: string | null }>();
+}
+
+async function seedOldSchema(): Promise<void> {
+  // Rebuild from the actual pre-upgrade migrations, using the existing isolated D1 lifecycle.
+  await restoreD1Baseline(env.DB, ["PRAGMA defer_foreign_keys=TRUE;"]);
+  await applyD1Migrations(
+    env.DB,
+    migrations().filter(({ name }) => name < "0017_"),
+  );
+  const columns = await env.DB.prepare("PRAGMA table_info(callers)").all<{ name: string }>();
+  expect(columns.results.map(({ name }) => name)).not.toContain("org_identity_verified_at");
+  const tokenHash = await hashToken(CALLER_TOKEN);
+  await env.DB.batch([
+    env.DB.prepare("INSERT INTO pools (id, name, policy_json) VALUES (?, ?, '{}')").bind(
+      POOL,
+      POOL,
+    ),
+    env.DB.prepare(`INSERT INTO callers (
+      id, name, token_hash, github_login, github_user_id, org_login, org_verified_at, status, dashboard_role
+    ) VALUES ('caller', 'Legacy Caller', ?, 'old-name', 101, 'openclaw', ?, 'active', 'admin')`).bind(
+      tokenHash,
+      LEGACY_PROOF,
+    ),
+    env.DB.prepare("INSERT INTO caller_pools (caller_id, pool_id) VALUES ('caller', ?)").bind(POOL),
+    env.DB.prepare(
+      "INSERT INTO caller_tokens (id, caller_id, token_hash, client_name) VALUES ('legacy-token', 'caller', ?, 'legacy-mac')",
+    ).bind(tokenHash),
+  ]);
+}
+
+function migrations(): D1Migration[] {
+  return (env as Env & { TEST_MIGRATIONS: D1Migration[] }).TEST_MIGRATIONS;
+}
+
+async function applyUpgrade(): Promise<void> {
+  const upgrade = migrations().find(({ name }) => name === "0017_org_identity_verification.sql");
+  expect(upgrade).toBeDefined();
+  await applyD1Migrations(env.DB, [upgrade!]);
+}
+
+async function legacyRefresh(timestamp: string): Promise<void> {
+  await env.DB.prepare(
+    "UPDATE callers SET org_verified_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+  )
+    .bind(timestamp, "caller")
+    .run();
+}
+
+function health(): Promise<Response> {
+  return callWorker(`/v1/pools/${POOL}/health`, {
+    headers: { authorization: `Bearer ${CALLER_TOKEN}` },
+  });
+}
+
+function browserSession(session: string): Promise<Response> {
+  return callWorker("https://octopool.openclaw.ai/v1/me", {
+    headers: { cookie: `octopool_session=${session}` },
+  });
+}

--- a/test/e2e/string-rewrites.test.ts
+++ b/test/e2e/string-rewrites.test.ts
@@ -111,7 +111,7 @@ describe("canonical relay egress protection", () => {
   it("guards the membership refresh without changing credential ownership", async () => {
     await seedPool();
     await env.DB.prepare(
-      "UPDATE callers SET org_verified_at = '2000-01-01', github_login = 'cobalt-mint'",
+      "UPDATE callers SET org_identity_verified_at = '2000-01-01', github_login = 'cobalt-mint'",
     ).run();
     await put([{ pattern: "cobalt-mint", replacement: "public" }]);
     const upstream = vi.fn<typeof fetch>(async () => jsonResponse({}, 404));

--- a/test/e2e/web-session.test.ts
+++ b/test/e2e/web-session.test.ts
@@ -13,6 +13,57 @@ import {
 const APP = "https://octopool.openclaw.ai";
 
 describe("Worker end-to-end web sessions", () => {
+  it("rejects OAuth membership for a substituted account without creating a session", async () => {
+    const upstream = vi.fn<typeof fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      const path = new URL(request.url).pathname;
+      if (path === "/login/oauth/access_token")
+        return jsonResponse({ access_token: "oauth-user-token" });
+      if (path === "/user") return jsonResponse({ id: 101, login: "old-name" });
+      if (path === "/graphql") return orgMembershipResponse(true, 202);
+      return jsonResponse({}, 500);
+    });
+    vi.stubGlobal("fetch", upstream);
+    const start = await callWorker(`${APP}/login/github`);
+    const state = new URL(start.headers.get("location")!).searchParams.get("state")!;
+    const callback = await callWorker(
+      `${APP}/login/github/callback?code=oauth-code&state=${encodeURIComponent(state)}`,
+      { headers: { cookie: `octopool_oauth_state=${encodeURIComponent(state)}` } },
+    );
+    expect(callback.status).toBe(403);
+    expect(await callback.text()).toContain("github_identity_mismatch");
+    expect(cookieValue(callback, "octopool_session")).toBeUndefined();
+    expect(await env.DB.prepare("SELECT count(*) AS count FROM callers").first()).toEqual({
+      count: 0,
+    });
+    expect(await env.DB.prepare("SELECT count(*) AS count FROM web_sessions").first()).toEqual({
+      count: 0,
+    });
+    expect(upstream).toHaveBeenCalledTimes(3);
+  });
+
+  it("binds stale browser sessions to the stored immutable account", async () => {
+    await seedPool();
+    const session = await seedWebSession();
+    await env.DB.prepare(
+      "UPDATE callers SET github_user_id = 101, github_login = 'old-name', org_identity_verified_at = '2020-01-01' WHERE id = 'caller'",
+    ).run();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => orgMembershipResponse(true, 202)),
+    );
+    const response = await callWorker(`${APP}/v1/me`, {
+      headers: { cookie: `octopool_session=${session}` },
+    });
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({ error: { code: "github_identity_mismatch" } });
+    expect(
+      await env.DB.prepare(
+        "SELECT org_identity_verified_at FROM callers WHERE id = 'caller'",
+      ).first(),
+    ).toEqual({ org_identity_verified_at: "2020-01-01" });
+  });
+
   it("returns a typed browser error when the GitHub OAuth exchange fails", async () => {
     let exchangeHadSignal = false;
     const upstream = vi.fn<typeof fetch>(async (input, init) => {
@@ -54,7 +105,7 @@ describe("Worker end-to-end web sessions", () => {
         return jsonResponse({ id: 501, login: "web-user", name: "Web User" });
       }
       if (url.pathname === "/graphql" && bearer(request) === "test-org-token") {
-        return orgMembershipResponse(true);
+        return orgMembershipResponse(true, 501);
       }
       return jsonResponse({ message: "unexpected OAuth request" }, 500);
     });
@@ -113,6 +164,12 @@ describe("Worker end-to-end web sessions", () => {
     const dashboard = await callWorker(`${APP}/dashboard`, { headers: { cookie } });
     expect(dashboard.status).toBe(200);
     expect(dashboard.headers.get("content-type")).toContain("text/html");
+    expect(upstream).toHaveBeenCalledTimes(3);
+    expect(
+      await env.DB.prepare(
+        "SELECT org_verified_at, org_identity_verified_at FROM callers WHERE github_user_id = 501",
+      ).first(),
+    ).toEqual({ org_verified_at: null, org_identity_verified_at: expect.any(String) });
 
     const logout = await callWorker(`${APP}/logout`, { headers: { cookie } });
     expect(logout.status).toBe(302);
@@ -147,7 +204,7 @@ describe("Worker end-to-end web sessions", () => {
         return jsonResponse({ id: 502, login: "web-user-2" });
       }
       if (url.pathname === "/graphql" && bearer(request) === "test-org-token") {
-        return orgMembershipResponse(true);
+        return orgMembershipResponse(true, 502);
       }
       return jsonResponse({ message: "unexpected OAuth request" }, 500);
     });
@@ -170,14 +227,14 @@ describe("Worker end-to-end web sessions", () => {
     await seedPool();
     const session = await seedWebSession();
     await env.DB.prepare(
-      "UPDATE callers SET org_verified_at = datetime('now', '-2 days') WHERE id = 'caller'",
+      "UPDATE callers SET org_identity_verified_at = datetime('now', '-2 days') WHERE id = 'caller'",
     ).run();
     let isMember = true;
     const upstream = vi.fn<typeof fetch>(async (input, init) => {
       const request = new Request(input, init);
       const url = new URL(request.url);
       if (url.pathname === "/graphql" && bearer(request) === "test-org-token") {
-        return orgMembershipResponse(isMember);
+        return orgMembershipResponse(isMember, 42);
       }
       return jsonResponse({ message: "unexpected membership request" }, 500);
     });
@@ -188,12 +245,12 @@ describe("Worker end-to-end web sessions", () => {
     expect(refreshed.status).toBe(200);
     expect(upstream).toHaveBeenCalledTimes(1);
     const verified = await env.DB.prepare(
-      "SELECT org_verified_at FROM callers WHERE id = 'caller'",
-    ).first<{ org_verified_at: string }>();
-    expect(Date.now() - Date.parse(verified!.org_verified_at)).toBeLessThan(60_000);
+      "SELECT org_identity_verified_at FROM callers WHERE id = 'caller'",
+    ).first<{ org_identity_verified_at: string }>();
+    expect(Date.now() - Date.parse(verified!.org_identity_verified_at)).toBeLessThan(60_000);
 
     await env.DB.prepare(
-      "UPDATE callers SET org_verified_at = datetime('now', '-2 days') WHERE id = 'caller'",
+      "UPDATE callers SET org_identity_verified_at = datetime('now', '-2 days') WHERE id = 'caller'",
     ).run();
     isMember = false;
     const revoked = await callWorker(`${APP}/v1/me`, { headers: { cookie } });

--- a/test/github-auth.test.ts
+++ b/test/github-auth.test.ts
@@ -78,6 +78,7 @@ describe("GitHub identity credentials", () => {
       verifyGitHubOrgMember(
         { ...env, OCTOPOOL_GITHUB_ORG_TOKEN: "org-token" } as unknown as Env,
         "octo",
+        42,
       ),
     ).resolves.toEqual(expect.any(String));
 
@@ -96,7 +97,7 @@ describe("GitHub identity credentials", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(verifyGitHubOrgMemberWithToken(env(), "org-token", "octo")).resolves.toEqual(
+    await expect(verifyGitHubOrgMemberWithToken(env(), "org-token", "octo", 42)).resolves.toEqual(
       expect.any(String),
     );
     expect(fetchMock).toHaveBeenCalledWith("https://api.github.com/graphql", expect.any(Object));
@@ -113,7 +114,7 @@ describe("GitHub identity credentials", () => {
       .mockResolvedValueOnce(orgMembershipResponse(["openclaw"]));
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(verifyGitHubOrgMemberWithToken(env(), "org-token", "octo")).resolves.toEqual(
+    await expect(verifyGitHubOrgMemberWithToken(env(), "org-token", "octo", 42)).resolves.toEqual(
       expect.any(String),
     );
     const secondRequest = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body)) as {
@@ -128,7 +129,9 @@ describe("GitHub identity credentials", () => {
       vi.fn(async () => orgMembershipResponse(["other"])),
     );
 
-    await expect(verifyGitHubOrgMemberWithToken(env(), "org-token", "octo")).rejects.toMatchObject({
+    await expect(
+      verifyGitHubOrgMemberWithToken(env(), "org-token", "octo", 42),
+    ).rejects.toMatchObject({
       status: 403,
       code: "org_member_denied",
     });
@@ -141,14 +144,185 @@ describe("GitHub identity credentials", () => {
     );
 
     await expect(
-      verifyGitHubOrgMemberWithToken(env(), "invalid-token", "octo"),
+      verifyGitHubOrgMemberWithToken(env(), "invalid-token", "octo", 42),
     ).rejects.toMatchObject({ status: 502, code: "org_verification_failed" });
+  });
+
+  it("requires an enrolled ID even when a runtime caller omits it", async () => {
+    const upstream = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", upstream);
+    await expect(
+      verifyGitHubOrgMemberWithToken(env(), "org-token", "octo", undefined as unknown as number),
+    ).rejects.toMatchObject({ status: 403, code: "github_identity_required" });
+    expect(upstream).not.toHaveBeenCalled();
+  });
+
+  it("preserves missing-verifier and egress-policy errors", async () => {
+    const upstream = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", upstream);
+    await expect(verifyGitHubOrgMember(env(), "octo", 42)).rejects.toMatchObject({
+      status: 503,
+      code: "org_verification_unavailable",
+    });
+    const guarded = withGitHubEgress(env(), [{ pattern: "octo", replacement: "public" }]);
+    await expect(
+      verifyGitHubOrgMemberWithToken(env(), "org-token", "octo", 42, guarded.githubEgress),
+    ).rejects.toMatchObject({ status: 403, code: "string_rewrite_denied" });
+    expect(upstream).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, null, "42", 0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1])(
+    "rejects a malformed GraphQL account ID %s",
+    async (databaseId) => {
+      const body = await orgMembershipResponse(["openclaw"]).json<MembershipPayload>();
+      body.data.user.databaseId = databaseId;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => Response.json(body)),
+      );
+      await expect(
+        verifyGitHubOrgMemberWithToken(env(), "org-token", "octo", 42),
+      ).rejects.toMatchObject({ status: 502, code: "org_verification_failed" });
+    },
+  );
+
+  it.each([null, [], "org", {}, { login: null }, { login: 1 }, { login: "" }, { login: " " }])(
+    "rejects malformed organization nodes %j even alongside a valid member",
+    async (node) => {
+      const body = await orgMembershipResponse(["openclaw"]).json<MembershipPayload>();
+      body.data.user.organizations.nodes.push(node);
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => Response.json(body)),
+      );
+      await expect(
+        verifyGitHubOrgMemberWithToken(env(), "org-token", "octo", 42),
+      ).rejects.toMatchObject({ status: 502, code: "org_verification_failed" });
+    },
+  );
+
+  it.each([null, [], "bad", {}, { data: null }, { data: { user: [] } }, { errors: "bad" }])(
+    "rejects malformed GraphQL envelopes %j",
+    async (body) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => Response.json(body)),
+      );
+      await expect(
+        verifyGitHubOrgMemberWithToken(env(), "org-token", "octo", 42),
+      ).rejects.toMatchObject({ status: 502, code: "org_verification_failed" });
+    },
+  );
+
+  it("rejects cursor cycles and malformed pagination before accepting membership", async () => {
+    const upstream = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(orgMembershipResponse(["other"], true, "first"))
+      .mockResolvedValueOnce(orgMembershipResponse(["other"], true, "second"))
+      .mockResolvedValueOnce(orgMembershipResponse(["openclaw"], true, "first"));
+    vi.stubGlobal("fetch", upstream);
+    await expect(
+      verifyGitHubOrgMemberWithToken(env(), "org-token", "octo", 42),
+    ).rejects.toMatchObject({ status: 502, code: "org_verification_failed" });
+    expect(upstream).toHaveBeenCalledTimes(3);
+  });
+
+  it.each([
+    ["missing continuation", true, null],
+    ["blank continuation", true, ""],
+    ["invalid hasNextPage", "yes", "next"],
+  ])("rejects %s pagination", async (_label, hasNextPage, endCursor) => {
+    const body = await orgMembershipResponse(["openclaw"]).json<MembershipPayload>();
+    body.data.user.organizations.pageInfo = { hasNextPage, endCursor };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json(body)),
+    );
+    await expect(
+      verifyGitHubOrgMemberWithToken(env(), "org-token", "octo", 42),
+    ).rejects.toMatchObject({ status: 502, code: "org_verification_failed" });
+  });
+
+  it("caps membership bodies and maps failed body reads to the upstream error contract", async () => {
+    let cancelled = false;
+    const oversized = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array(33));
+        },
+        cancel() {
+          cancelled = true;
+        },
+      }),
+    );
+    const failed = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.error(new Error("synthetic-private-upstream"));
+        },
+      }),
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValueOnce(oversized).mockResolvedValueOnce(failed),
+    );
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      await expect(
+        verifyGitHubOrgMemberWithToken(
+          { ...env(), MAX_RESPONSE_BYTES: "32" } as unknown as Env,
+          "org-token",
+          "octo",
+          42,
+        ),
+      ).rejects.toMatchObject({
+        status: 502,
+        code: "org_verification_failed",
+        message: "GitHub membership response was invalid",
+      });
+    }
+    expect(cancelled).toBe(true);
+  });
+
+  it("returns rate-limit metadata with an upstream failure and blocks credential redirects", async () => {
+    const upstream = vi.fn<typeof fetch>(
+      async () =>
+        new Response(null, {
+          status: 429,
+          headers: {
+            "x-ratelimit-resource": "graphql",
+            "x-ratelimit-remaining": "0",
+            "retry-after": "60",
+          },
+        }),
+    );
+    vi.stubGlobal("fetch", upstream);
+    await expect(
+      verifyGitHubOrgMemberWithToken(env(), "org-token", "octo", 42),
+    ).rejects.toMatchObject({
+      status: 502,
+      code: "org_verification_failed",
+      details: {
+        github_rate_limit_resource: "graphql",
+        github_rate_limit_remaining: "0",
+        github_retry_after: "60",
+      },
+    });
+    expect(upstream.mock.calls[0]?.[1]?.redirect).toBe("manual");
   });
 });
 
 function env(): Env {
   return { ALLOWED_GITHUB_ORG: "openclaw", REQUEST_TIMEOUT_MS: "1234" } as unknown as Env;
 }
+
+type MembershipPayload = {
+  data: {
+    user: {
+      databaseId: unknown;
+      organizations: { nodes: unknown[]; pageInfo: unknown };
+    };
+  };
+};
 
 function orgMembershipResponse(
   organizations: string[],
@@ -158,6 +332,7 @@ function orgMembershipResponse(
   return Response.json({
     data: {
       user: {
+        databaseId: 42,
         organizations: {
           nodes: organizations.map((login) => ({ login })),
           pageInfo: { endCursor, hasNextPage },

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -95,6 +95,7 @@ describe("client-filtered stats", () => {
     id: "caller-id",
     name: "Caller",
     github_login: "caller",
+    github_user_id: 42,
     org_login: "openclaw",
     org_verified_at: null,
     caller_token_id: "caller-token-id",


### PR DESCRIPTION
## Summary

Org membership was checked by mutable GitHub login, which could accept membership from a replacement account. Bind every fetched GraphQL membership page to the expected immutable GitHub account ID across bearer and browser refresh, CLI/OAuth login, and admin provisioning. Reject identity substitution without refreshing proof; preserve nonmember, verifier-unavailable, and egress-protection errors while normalizing malformed/upstream failures.

Store identity-bound verification in a new nullable `org_identity_verified_at` column. The additive migration retains existing data and supports schema-first rolling deployment: legacy timestamp writes cannot authorize new Workers. SQL aliases preserve the public `Caller.org_verified_at` field. Legacy rows without an immutable ID require fresh enrollment without inheriting old grants or roles; verified renames stay on the same account. Membership checks add no REST requests.

## Tests

- `GOTOOLCHAIN=go1.26.7 pnpm check`
- `GOTOOLCHAIN=go1.26.7 pnpm exec vitest run --config vitest.e2e.config.ts test/e2e/control-plane.test.ts test/e2e/org-membership-upgrade.test.ts test/e2e/web-session.test.ts`
- Real-D1 regressions cover replacement-account authorization and legacy writes during rolling upgrades; fixtures use synthetic local data.
