### PR TITLE
fix: make caller enrollment and client rotation atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Make active caller enrollment and named-client token rotation atomic across CLI, admin, and browser login, preserving existing access and history while refusing ambiguous upgrades.
 - Bind org membership checks to the enrolled GitHub account on every page, isolate verification timestamps across rolling upgrades, and preserve safe legacy re-login and typed upstream errors.
 - Validate protected `gh repo clone` repository inputs according to native argument ownership, preserving destination paths and Git flags while retaining visible-argument filtering and GitHub.com-only source checks.
 - Keep issue timelines and issue-event reads anonymous-only, retiring cached private cross-references and preserving safe conditional and native fallback behavior.

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -31,6 +31,16 @@ In practice callers usually run `octopool login`, which creates or refreshes thi
 for the default login pool automatically. Use this admin command for manual backfills,
 nonstandard pools, or one-time token issuance.
 
+Admin provisioning uses the same atomic active-ID/org enrollment as CLI and browser
+login. It adds only the requested pool grant and rotates the named `admin` client under
+the shared 16-client cap; it does not promote dashboard roles. Existing active singleton
+roles and grants remain attached to their caller ID. A disabled row stays disabled; a
+fresh enrollment starts with role `none` and does not inherit its authority.
+
+Before upgrading, follow the [atomic enrollment migration gate](operations.md#atomic-enrollment-upgrade).
+Ambiguous active duplicates require an explicit operator ownership decision. There is no
+automatic survivor selection, grant union, role promotion, or token/session transfer.
+
 ## Register an identity
 
 Creates or updates a pooled GitHub identity and its repo scopes. The secret material is

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -66,13 +66,15 @@ Flow:
    are never a fallback for this GitHub.com-only exchange.
 3. The Worker resolves the GitHub user (`GET /user`) and verifies that user is a member
    of `ALLOWED_GITHUB_ORG` using the supplied token.
-4. The caller row and requested default-pool grant are created or refreshed by immutable
-   GitHub **user id**, org, active status, and pool.
+4. One active caller is created or refreshed by immutable GitHub **user id** and org
+   (case-insensitive). CLI, admin, and browser enrollment share this storage owner;
+   the authorized pool grant is added in the same transaction.
 5. A new caller token (`op_…`) is generated and hashed. It replaces only the token for
    the same caller and client name; sessions for the caller's other machines remain valid.
    Callers retain at most 16 named sessions, with least-recently-updated sessions retired
    as new client names are added.
-   The caller row is refreshed with the current login, user id, and verification time.
+   Caller enrollment, the grant, token rotation, and pruning commit atomically. The caller
+   keeps its random ID and receives the current login and identity-bound verification time.
 6. The plaintext token is returned once, for the CLI to store locally.
 
 The CLI follows login and authenticated JSON request redirects only within the
@@ -86,6 +88,24 @@ discovery keeps its existing redirect behavior.
 Clients are 1-80 hostname-safe characters. New CLI versions send the local hostname and
 can override it with `--client`; older clients use `legacy`. Audit rows retain the matched
 caller-token id so stats can separate machines without storing caller token values.
+
+Concurrent logins for one client converge on one caller and one stored token. The last
+committed rotation wins, regardless of response delivery order; an overlapping successful
+response can already carry a superseded token. Login clears the issuing isolate's caller
+cache after commit. Other warm isolates may accept a rotated or disabled token for up to
+30 seconds; rotation does not promise instantaneous global revocation.
+
+Existing singleton caller IDs, grants, dashboard roles, browser sessions, and the token
+row ID for a rotated client are preserved. A new enrollment starts with dashboard role
+`none` and only the pool authorized by its entry point. Disabling a row revokes that row's
+credentials, subject to the cache window; it is not an account-level ban. A later verified
+login may create a new active row, without inheriting the disabled row's grants or role.
+Null-ID history is never claimed by username, and neither disabled rows nor their
+credentials are reactivated.
+
+Migration `0018_active_caller_enrollment.sql` must precede this Worker upgrade. It rejects
+ambiguous active duplicates without merging privileges or deleting history. Enrollment
+fails closed if the index is missing. See the [upgrade gate](operations.md#atomic-enrollment-upgrade).
 
 ### Pool restriction
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -42,9 +42,9 @@ Edit `wrangler.jsonc`:
   OAuth callback when browser sign-in starts on a different host.
 - `routes[]` — the custom domain you want octopool served on.
 
-If you only need one host, ignore `wrangler.public-proxy.jsonc`. OpenClaw uses it only
-because `octopool.dev` lives in a different Cloudflare account from the authoritative
-`octopool.openclaw.ai` data plane.
+If you only need one host, ignore `wrangler.public-proxy.jsonc`. OpenClaw uses it to
+forward `octopool.dev` to the authoritative `octopool.openclaw.ai` data plane. Both
+Workers run in the OpenClaw Services Cloudflare account.
 
 ### 2. Create the data plane
 
@@ -206,8 +206,68 @@ D1 schema lives in `migrations/`:
   seeds explicit empty rules at revision 1.
 - `0017_org_identity_verification.sql` — add a separate nullable identity-bound proof timestamp without backfill or changes to old data;
   apply before the [rolling Worker upgrade](auth.md#immutable-membership-upgrade). Old timestamp writes cannot authorize new Workers.
+- `0018_active_caller_enrollment.sql` — unique active immutable GitHub ID plus case-insensitive org;
+  refuses ambiguous duplicates without changing caller history. Apply before the updated enrollment Worker.
 
 Apply with `wrangler d1 migrations apply DB` (add `--remote` for production).
+
+## Atomic enrollment upgrade
+
+Before applying `0018_active_caller_enrollment.sql`, run this aggregate-only, read-only
+preflight on the intended database. Rerun it at deployment: an earlier clean observation
+is not a lock. Do not include caller names, IDs, hashes, or credentials in public proof.
+
+```sql
+WITH enrollment_groups AS (
+  SELECT github_user_id, org_login COLLATE NOCASE AS org,
+         COUNT(*) AS n, SUM(status = 'active') AS active_n
+  FROM callers
+  WHERE github_user_id IS NOT NULL
+  GROUP BY github_user_id, org_login COLLATE NOCASE
+)
+SELECT
+  (SELECT COUNT(*) FROM enrollment_groups WHERE active_n > 1)
+    AS blocking_active_duplicate_groups,
+  (SELECT COALESCE(SUM(active_n - 1), 0) FROM enrollment_groups WHERE active_n > 1)
+    AS excess_active_rows,
+  (SELECT COUNT(*) FROM enrollment_groups WHERE n > 1 AND active_n <= 1)
+    AS nonblocking_historical_groups,
+  (SELECT COUNT(*) FROM callers WHERE github_user_id IS NULL) AS null_id_rows,
+  (SELECT COUNT(*) FROM callers WHERE github_user_id IS NULL AND status = 'active')
+    AS active_null_id_rows,
+  (SELECT COUNT(*) FROM callers WHERE github_user_id IS NOT NULL AND
+    (typeof(github_user_id) <> 'integer' OR github_user_id <= 0
+     OR github_user_id > 9007199254740991)) AS invalid_nonnull_id_rows;
+```
+
+A nonzero active-duplicate or malformed-ID count blocks deployment for operator review.
+Historical/NULL counts are inventory, not evidence of ownership or permission to merge.
+The index covers only active nonnull immutable IDs and uses `COLLATE NOCASE` for orgs;
+malformed-ID review is a preflight gate, not a new schema constraint.
+
+Apply schema first, including `0017_org_identity_verification.sql`, then verify the
+migration record and the actual `idx_callers_active_github_org` definition before deploying
+the Worker. Index creation is the authoritative uniqueness gate and fails unchanged if a
+new duplicate appeared after preflight. Never automatically choose an oldest/newest row,
+union grants, promote roles, or move tokens, sessions, or audit history. An operator must
+explicitly decide which ambiguous rows to retire in place before retrying. Retired rows
+must not be re-enabled as a recovery shortcut; that can revive attached credentials.
+
+Existing singletons, disabled history, and NULL-ID records survive unchanged. Migration
+0012's named `legacy` tokens are preserved without replaying that migration or adding a
+bootstrap-hash authentication fallback. Same-client rotation retains token row IDs and
+audit links. Ordinary cap pruning keeps the audit event, caller ID, and recorded client
+name while the deleted token's audit FK becomes NULL. Browser sessions remain attached
+to their original caller. Historical noncanonical client names (for example `host.local`
+versus `host`) need a separate reviewed inventory/retirement decision; this migration does
+not normalize or silently combine stored client keys.
+
+During rollout, old code against the new index can reject a competing initial login;
+new code without the index fails enrollment closed. Coordinate an enrollment quiet window
+if transient errors matter. Keep the index on a Worker rollback. A failed migration leaves
+the old enrollment race unresolved and must block rollout, not trigger a fallback. The
+normal 30-second cross-isolate auth-cache window still applies after rotation or row
+revocation. The deployment operator owns production preflight and deployment.
 
 ## Activating string protection
 

--- a/migrations/0018_active_caller_enrollment.sql
+++ b/migrations/0018_active_caller_enrollment.sql
@@ -1,0 +1,4 @@
+-- Ambiguous active enrollments must fail this upgrade; never choose or merge owners.
+CREATE UNIQUE INDEX idx_callers_active_github_org
+ON callers (github_user_id, org_login COLLATE NOCASE)
+WHERE status = 'active' AND github_user_id IS NOT NULL;

--- a/sql/queries/d1.sql
+++ b/sql/queries/d1.sql
@@ -299,50 +299,53 @@ LEFT JOIN identities ON identities.pool_id = pools.id
 WHERE pools.id = ?1
 GROUP BY pools.id;
 
--- name: LoginExistingCaller :one
-SELECT callers.id
-FROM callers
-JOIN caller_pools ON caller_pools.caller_id = callers.id
-WHERE callers.github_user_id = ?1
-  AND callers.org_login = ?2
-  AND callers.status = 'active'
-  AND caller_pools.pool_id = ?3
-LIMIT 1;
-
--- name: FindActiveCallerByGitHubUser :one
-SELECT id
-FROM callers
-WHERE github_user_id = ?1
-  AND org_login = ?2
-  AND status = 'active'
-LIMIT 1;
-
--- name: InsertCaller :exec
+-- name: UpsertCallerEnrollment :one
 INSERT INTO callers (id, name, token_hash, github_login, github_user_id, org_login, org_identity_verified_at, status)
-VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'active');
+VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'active')
+ON CONFLICT(github_user_id, org_login COLLATE NOCASE)
+WHERE status = 'active' AND github_user_id IS NOT NULL
+DO UPDATE SET
+  name = excluded.name,
+  github_login = excluded.github_login,
+  org_identity_verified_at = excluded.org_identity_verified_at,
+  updated_at = CURRENT_TIMESTAMP
+RETURNING id, name, github_login, org_login;
 
 -- name: UpsertCallerToken :exec
 INSERT INTO caller_tokens (id, caller_id, token_hash, client_name, updated_at)
-VALUES (?1, ?2, ?3, ?4, strftime('%Y-%m-%d %H:%M:%f', 'now'))
+VALUES (?1, (
+  SELECT enrolled.id FROM callers AS enrolled
+  WHERE enrolled.github_user_id = ?2 AND enrolled.org_login = ?3 COLLATE NOCASE AND enrolled.status = 'active'
+), ?4, ?5, strftime('%Y-%m-%d %H:%M:%f', 'now'))
 ON CONFLICT(caller_id, client_name) DO UPDATE SET
   token_hash = excluded.token_hash,
   updated_at = excluded.updated_at;
 
 -- name: PruneCallerTokens :exec
 DELETE FROM caller_tokens
-WHERE caller_tokens.caller_id = ?1
-  AND caller_tokens.client_name <> ?2
-  AND caller_tokens.id NOT IN (
-    SELECT kept.id
-    FROM caller_tokens AS kept
-    WHERE kept.caller_id = ?3 AND kept.client_name <> ?4
-    ORDER BY julianday(kept.updated_at) DESC, kept.rowid DESC
-    LIMIT 15
-  );
+WHERE caller_tokens.caller_id = (
+  SELECT enrolled.id FROM callers AS enrolled
+  WHERE enrolled.github_user_id = ?1 AND enrolled.org_login = ?2 COLLATE NOCASE AND enrolled.status = 'active'
+)
+AND caller_tokens.client_name <> ?3
+AND caller_tokens.id NOT IN (
+  SELECT kept.id FROM caller_tokens AS kept
+  WHERE kept.caller_id = (
+    SELECT enrolled.id FROM callers AS enrolled
+    WHERE enrolled.github_user_id = ?1 AND enrolled.org_login = ?2 COLLATE NOCASE AND enrolled.status = 'active'
+  )
+  AND kept.client_name <> ?3
+  ORDER BY julianday(kept.updated_at) DESC, kept.rowid DESC
+  LIMIT 15
+);
 
 -- name: InsertCallerPool :exec
-INSERT OR IGNORE INTO caller_pools (caller_id, pool_id)
-VALUES (?1, ?2);
+INSERT INTO caller_pools (caller_id, pool_id)
+VALUES ((
+  SELECT enrolled.id FROM callers AS enrolled
+  WHERE enrolled.github_user_id = ?1 AND enrolled.org_login = ?2 COLLATE NOCASE AND enrolled.status = 'active'
+), ?3)
+ON CONFLICT(caller_id, pool_id) DO NOTHING;
 
 -- name: GetIdentityPoolKind :one
 SELECT pool_id, kind
@@ -368,15 +371,6 @@ WHERE identity_id = ?1;
 INSERT INTO identity_scopes (identity_id, owner, repo, permission, allow_private)
 VALUES (?1, ?2, ?3, 'read', ?4);
 
--- name: UpdateCallerWebLogin :exec
-UPDATE callers
-SET name = ?1,
-    github_login = ?2,
-    github_user_id = ?3,
-    org_identity_verified_at = ?4,
-    updated_at = CURRENT_TIMESTAMP
-WHERE id = ?5;
-
 -- name: InsertWebSession :exec
 INSERT INTO web_sessions (session_hash, caller_id, expires_at)
 VALUES (?1, ?2, ?3);
@@ -400,7 +394,7 @@ JOIN callers ON callers.id = web_sessions.caller_id
 WHERE web_sessions.session_hash = ?1
   AND web_sessions.expires_at > CURRENT_TIMESTAMP
   AND callers.status = 'active'
-  AND callers.org_login = ?2;
+  AND callers.org_login = ?2 COLLATE NOCASE;
 
 -- name: GetCallerPoolGrant :one
 SELECT 1

--- a/src/callers.ts
+++ b/src/callers.ts
@@ -1,6 +1,7 @@
 import { hashToken, newToken } from "./auth";
 import { ensurePool } from "./db";
 import { queries } from "./generated/sql";
+import { HttpError } from "./http";
 
 type GitHubLoginUser = {
   id: number;
@@ -44,122 +45,46 @@ async function ensureCaller(
   identityVerifiedAt: string,
   client?: { token: string; clientName: string },
 ): Promise<LoginCaller> {
+  if (!Number.isSafeInteger(user.id) || user.id <= 0) {
+    throw new HttpError(502, "github_user_invalid", "GitHub user response was incomplete");
+  }
   await ensurePool(env, pool);
-  const name = user.name ?? user.login;
-  const existing = await findLoginCaller(env, pool, user.id);
-  if (existing === null) {
-    return insertCaller(env, pool, user, name, identityVerifiedAt, client);
-  }
-
-  const statements = [
-    env.DB.prepare(queries.updateCallerWebLogin).bind(
-      name,
-      user.login,
-      user.id,
-      identityVerifiedAt,
-      existing.id,
-    ),
-    env.DB.prepare(queries.insertCallerPool).bind(existing.id, pool),
-    ...(client === undefined
-      ? []
-      : [
-          env.DB.prepare(queries.upsertCallerToken).bind(
-            `caller_token_${crypto.randomUUID()}`,
-            existing.id,
-            await hashToken(client.token),
-            client.clientName,
-          ),
-          env.DB.prepare(queries.pruneCallerTokens).bind(
-            existing.id,
-            client.clientName,
-            existing.id,
-            client.clientName,
-          ),
-        ]),
-  ];
-  await env.DB.batch(statements);
-  return loginCaller(
-    existing.id,
-    name,
-    user.login,
-    env.ALLOWED_GITHUB_ORG,
-    pool,
-    client?.clientName,
-  );
-}
-
-async function findLoginCaller(
-  env: Env,
-  pool: string,
-  githubUserId: number,
-): Promise<{ id: string } | null> {
-  const alreadyGranted = await env.DB.prepare(queries.loginExistingCaller)
-    .bind(githubUserId, env.ALLOWED_GITHUB_ORG, pool)
-    .first<{ id: string }>();
-  if (alreadyGranted !== null) {
-    return alreadyGranted;
-  }
-  return env.DB.prepare(queries.findActiveCallerByGitHubUser)
-    .bind(githubUserId, env.ALLOWED_GITHUB_ORG)
-    .first<{ id: string }>();
-}
-
-async function insertCaller(
-  env: Env,
-  pool: string,
-  user: GitHubLoginUser,
-  name: string,
-  identityVerifiedAt: string,
-  client?: { token: string; clientName: string },
-): Promise<LoginCaller> {
-  const callerId = `caller_${crypto.randomUUID()}`;
   const tokenHash = await hashToken(client?.token ?? newToken("op"));
+  const org = env.ALLOWED_GITHUB_ORG;
   const statements = [
-    env.DB.prepare(queries.insertCaller).bind(
-      callerId,
-      name,
+    env.DB.prepare(queries.upsertCallerEnrollment).bind(
+      `caller_${crypto.randomUUID()}`,
+      user.name ?? user.login,
       tokenHash,
       user.login,
       user.id,
-      env.ALLOWED_GITHUB_ORG,
+      org,
       identityVerifiedAt,
     ),
-    env.DB.prepare(queries.insertCallerPool).bind(callerId, pool),
+    env.DB.prepare(queries.insertCallerPool).bind(user.id, org, pool),
     ...(client === undefined
       ? []
       : [
           env.DB.prepare(queries.upsertCallerToken).bind(
             `caller_token_${crypto.randomUUID()}`,
-            callerId,
+            user.id,
+            org,
             tokenHash,
             client.clientName,
           ),
-          env.DB.prepare(queries.pruneCallerTokens).bind(
-            callerId,
-            client.clientName,
-            callerId,
-            client.clientName,
-          ),
+          env.DB.prepare(queries.pruneCallerTokens).bind(user.id, org, client.clientName),
         ]),
   ];
-  await env.DB.batch(statements);
-  return loginCaller(callerId, name, user.login, env.ALLOWED_GITHUB_ORG, pool, client?.clientName);
-}
-
-function loginCaller(
-  id: string,
-  name: string,
-  githubLogin: string,
-  orgLogin: string,
-  pool: string,
-  clientName?: string,
-): LoginCaller {
+  // Identity subselects resolve every dependent write inside this transaction.
+  // The candidate UUID is never authoritative after an enrollment conflict.
+  const [enrollment] = await env.DB.batch<Omit<LoginCaller, "pool" | "client_name">>(statements);
+  const caller = enrollment?.results[0];
+  if (caller === undefined) {
+    throw new Error("Enrollment returned no caller");
+  }
   return {
-    id,
-    name,
-    github_login: githubLogin,
-    org_login: orgLogin,
+    ...caller,
     pool,
-    ...(clientName === undefined ? {} : { client_name: clientName }),
+    ...(client === undefined ? {} : { client_name: client.clientName }),
   };
 }

--- a/src/generated/sql.ts
+++ b/src/generated/sql.ts
@@ -90,30 +90,25 @@ export const queries = {
     "SELECT\n  COUNT(*) AS total_entries,\n  SUM(CASE WHEN expires_at > CURRENT_TIMESTAMP THEN 1 ELSE 0 END) AS fresh_entries,\n  MAX(checked_at) AS newest_checked_at\nFROM github_public_repos",
   poolHealth:
     "SELECT\n  COUNT(identities.id) AS identities_total,\n  SUM(CASE WHEN identities.status = 'active' THEN 1 ELSE 0 END) AS identities_healthy\nFROM pools\nLEFT JOIN identities ON identities.pool_id = pools.id\nWHERE pools.id = ?1\nGROUP BY pools.id",
-  loginExistingCaller:
-    "SELECT callers.id\nFROM callers\nJOIN caller_pools ON caller_pools.caller_id = callers.id\nWHERE callers.github_user_id = ?1\n  AND callers.org_login = ?2\n  AND callers.status = 'active'\n  AND caller_pools.pool_id = ?3\nLIMIT 1",
-  findActiveCallerByGitHubUser:
-    "SELECT id\nFROM callers\nWHERE github_user_id = ?1\n  AND org_login = ?2\n  AND status = 'active'\nLIMIT 1",
-  insertCaller:
-    "INSERT INTO callers (id, name, token_hash, github_login, github_user_id, org_login, org_identity_verified_at, status)\nVALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'active')",
+  upsertCallerEnrollment:
+    "INSERT INTO callers (id, name, token_hash, github_login, github_user_id, org_login, org_identity_verified_at, status)\nVALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'active')\nON CONFLICT(github_user_id, org_login COLLATE NOCASE)\nWHERE status = 'active' AND github_user_id IS NOT NULL\nDO UPDATE SET\n  name = excluded.name,\n  github_login = excluded.github_login,\n  org_identity_verified_at = excluded.org_identity_verified_at,\n  updated_at = CURRENT_TIMESTAMP\nRETURNING id, name, github_login, org_login",
   upsertCallerToken:
-    "INSERT INTO caller_tokens (id, caller_id, token_hash, client_name, updated_at)\nVALUES (?1, ?2, ?3, ?4, strftime('%Y-%m-%d %H:%M:%f', 'now'))\nON CONFLICT(caller_id, client_name) DO UPDATE SET\n  token_hash = excluded.token_hash,\n  updated_at = excluded.updated_at",
+    "INSERT INTO caller_tokens (id, caller_id, token_hash, client_name, updated_at)\nVALUES (?1, (\n  SELECT enrolled.id FROM callers AS enrolled\n  WHERE enrolled.github_user_id = ?2 AND enrolled.org_login = ?3 COLLATE NOCASE AND enrolled.status = 'active'\n), ?4, ?5, strftime('%Y-%m-%d %H:%M:%f', 'now'))\nON CONFLICT(caller_id, client_name) DO UPDATE SET\n  token_hash = excluded.token_hash,\n  updated_at = excluded.updated_at",
   pruneCallerTokens:
-    "DELETE FROM caller_tokens\nWHERE caller_tokens.caller_id = ?1\n  AND caller_tokens.client_name <> ?2\n  AND caller_tokens.id NOT IN (\n    SELECT kept.id\n    FROM caller_tokens AS kept\n    WHERE kept.caller_id = ?3 AND kept.client_name <> ?4\n    ORDER BY julianday(kept.updated_at) DESC, kept.rowid DESC\n    LIMIT 15\n  )",
-  insertCallerPool: "INSERT OR IGNORE INTO caller_pools (caller_id, pool_id)\nVALUES (?1, ?2)",
+    "DELETE FROM caller_tokens\nWHERE caller_tokens.caller_id = (\n  SELECT enrolled.id FROM callers AS enrolled\n  WHERE enrolled.github_user_id = ?1 AND enrolled.org_login = ?2 COLLATE NOCASE AND enrolled.status = 'active'\n)\nAND caller_tokens.client_name <> ?3\nAND caller_tokens.id NOT IN (\n  SELECT kept.id FROM caller_tokens AS kept\n  WHERE kept.caller_id = (\n    SELECT enrolled.id FROM callers AS enrolled\n    WHERE enrolled.github_user_id = ?1 AND enrolled.org_login = ?2 COLLATE NOCASE AND enrolled.status = 'active'\n  )\n  AND kept.client_name <> ?3\n  ORDER BY julianday(kept.updated_at) DESC, kept.rowid DESC\n  LIMIT 15\n)",
+  insertCallerPool:
+    "INSERT INTO caller_pools (caller_id, pool_id)\nVALUES ((\n  SELECT enrolled.id FROM callers AS enrolled\n  WHERE enrolled.github_user_id = ?1 AND enrolled.org_login = ?2 COLLATE NOCASE AND enrolled.status = 'active'\n), ?3)\nON CONFLICT(caller_id, pool_id) DO NOTHING",
   getIdentityPoolKind: "SELECT pool_id, kind\nFROM identities\nWHERE id = ?1",
   upsertIdentity:
     "INSERT INTO identities (id, pool_id, kind, login, secret_ref, installation_id, status, weight)\nVALUES (?1, ?2, ?3, ?4, ?5, ?6, 'active', ?7)\nON CONFLICT(id) DO UPDATE SET\n  login = excluded.login,\n  secret_ref = excluded.secret_ref,\n  installation_id = excluded.installation_id,\n  status = 'active',\n  weight = excluded.weight,\n  updated_at = CURRENT_TIMESTAMP",
   deleteIdentityScopes: "DELETE FROM identity_scopes\nWHERE identity_id = ?1",
   insertIdentityScope:
     "INSERT INTO identity_scopes (identity_id, owner, repo, permission, allow_private)\nVALUES (?1, ?2, ?3, 'read', ?4)",
-  updateCallerWebLogin:
-    "UPDATE callers\nSET name = ?1,\n    github_login = ?2,\n    github_user_id = ?3,\n    org_identity_verified_at = ?4,\n    updated_at = CURRENT_TIMESTAMP\nWHERE id = ?5",
   insertWebSession:
     "INSERT INTO web_sessions (session_hash, caller_id, expires_at)\nVALUES (?1, ?2, ?3)",
   deleteWebSession: "DELETE FROM web_sessions\nWHERE session_hash = ?1",
   getWebSession:
-    "SELECT\n  callers.id,\n  callers.name,\n  callers.github_login,\n  callers.github_user_id,\n  callers.org_login,\n  callers.org_identity_verified_at AS org_verified_at,\n  callers.dashboard_role,\n  web_sessions.expires_at\nFROM web_sessions\nJOIN callers ON callers.id = web_sessions.caller_id\nWHERE web_sessions.session_hash = ?1\n  AND web_sessions.expires_at > CURRENT_TIMESTAMP\n  AND callers.status = 'active'\n  AND callers.org_login = ?2",
+    "SELECT\n  callers.id,\n  callers.name,\n  callers.github_login,\n  callers.github_user_id,\n  callers.org_login,\n  callers.org_identity_verified_at AS org_verified_at,\n  callers.dashboard_role,\n  web_sessions.expires_at\nFROM web_sessions\nJOIN callers ON callers.id = web_sessions.caller_id\nWHERE web_sessions.session_hash = ?1\n  AND web_sessions.expires_at > CURRENT_TIMESTAMP\n  AND callers.status = 'active'\n  AND callers.org_login = ?2 COLLATE NOCASE",
   getCallerPoolGrant:
     "SELECT 1\nFROM caller_pools\nWHERE caller_id = ?1\n  AND pool_id = ?2\nLIMIT 1",
   touchWebSession:

--- a/test/callers.test.ts
+++ b/test/callers.test.ts
@@ -1,127 +1,101 @@
 import { describe, expect, it, vi } from "vitest";
 import { ensureCliCaller, ensureWebCaller } from "../src/callers";
 
-describe("caller grants", () => {
-  it("auto-enrolls verified org members for CLI login", async () => {
-    const { env, statements } = mockEnv({
-      activeCaller: null,
-    });
+const VERIFIED_AT = "2026-08-31T00:00:00.000Z";
+const storedCaller = {
+  id: "canonical-caller",
+  name: "Alice",
+  github_login: "alice",
+  org_login: "openclaw",
+};
 
-    const caller = await ensureCliCaller(
-      env,
-      "maintainers",
-      { id: 123, login: "alice", name: "Alice" },
-      "2026-06-03T12:00:00.000Z",
-      "op_plain",
-      "alice-macbook",
-    );
-
-    expect(caller).toMatchObject({
-      name: "Alice",
-      github_login: "alice",
-      org_login: "openclaw",
-      pool: "maintainers",
-      client_name: "alice-macbook",
-    });
-    expect(caller.id).toMatch(/^caller_/);
-    expect(statements.some((statement) => statement.query.includes("INSERT INTO callers"))).toBe(
-      true,
-    );
-    expect(
-      statements.some((statement) =>
-        statement.query.includes("INSERT OR IGNORE INTO caller_pools"),
-      ),
-    ).toBe(true);
-    expect(
-      statements.some((statement) => statement.query.includes("INSERT INTO caller_tokens")),
-    ).toBe(true);
-    expect(env.DB.batch).toHaveBeenCalledWith(expect.arrayContaining([expect.any(Object)]));
+describe("caller enrollment boundary", () => {
+  it.each([
+    0,
+    -1,
+    1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.MAX_SAFE_INTEGER + 1,
+    null,
+    undefined,
+    "123",
+  ])("rejects invalid new immutable ID %s before any storage call", async (id) => {
+    const { env, prepare, batch } = boundaryEnv();
+    await expect(
+      ensureWebCaller(env, "maintainers", { id: id as number, login: "alice" }, VERIFIED_AT),
+    ).rejects.toMatchObject({ status: 502 });
+    expect(prepare).not.toHaveBeenCalled();
+    expect(batch).not.toHaveBeenCalled();
   });
 
-  it("reuses an existing caller and grants the login pool", async () => {
-    const { env, statements } = mockEnv({
-      grantedCaller: null,
-      activeCaller: { id: "caller_existing" },
-    });
+  it.each(["CLI", "browser"])(
+    "returns the canonical %s caller only after the full batch resolves",
+    async (surface) => {
+      const { env, batch } = boundaryEnv();
+      let complete!: (value: Awaited<ReturnType<typeof batch>>) => void;
+      batch.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            complete = resolve;
+          }),
+      );
+      let returned = false;
+      const pending = enroll(env, surface).then((value) => {
+        returned = true;
+        return value;
+      });
+      try {
+        await vi.waitFor(() => expect(batch).toHaveBeenCalledOnce());
+        expect(returned).toBe(false);
+      } finally {
+        complete([{ results: [storedCaller] }]);
+      }
+      expect(await pending).toEqual({
+        ...storedCaller,
+        pool: "maintainers",
+        ...(surface === "CLI" ? { client_name: "laptop" } : {}),
+      });
+    },
+  );
 
-    const caller = await ensureWebCaller(
-      env,
-      "maintainers",
-      { id: 123, login: "alice" },
-      "2026-06-03T12:00:00.000Z",
-    );
+  it.each(["CLI", "browser"])(
+    "does not return a candidate caller on %s batch failure",
+    async (surface) => {
+      const { env, batch } = boundaryEnv();
+      batch.mockRejectedValueOnce(new Error("synthetic batch failure"));
+      await expect(enroll(env, surface)).rejects.toThrow("synthetic batch failure");
+    },
+  );
 
-    expect(caller.id).toBe("caller_existing");
-    expect(statements.some((statement) => statement.query.includes("UPDATE callers"))).toBe(true);
-    expect(
-      statements.some((statement) =>
-        statement.query.includes("INSERT OR IGNORE INTO caller_pools"),
-      ),
-    ).toBe(true);
-    expect(statements.some((statement) => statement.query.includes("INSERT INTO callers"))).toBe(
-      false,
-    );
-  });
-
-  it("prefers an existing caller already granted to the login pool", async () => {
-    const { env, statements } = mockEnv({
-      grantedCaller: { id: "caller_granted" },
-      activeCaller: { id: "caller_ungranted" },
-    });
-
-    const caller = await ensureWebCaller(
-      env,
-      "maintainers",
-      { id: 123, login: "alice" },
-      "2026-06-03T12:00:00.000Z",
-    );
-
-    expect(caller.id).toBe("caller_granted");
-    expect(
-      statements.filter(
-        (statement) =>
-          statement.query.includes("FROM callers") &&
-          statement.query.includes("WHERE callers.github_user_id"),
-      ),
-    ).toHaveLength(1);
+  it("rejects an empty batch result instead of returning its candidate UUID", async () => {
+    const { env, batch } = boundaryEnv();
+    batch.mockResolvedValueOnce([{ results: [] }]);
+    await expect(enroll(env, "browser")).rejects.toThrow("Enrollment returned no caller");
   });
 });
 
-function mockEnv({
-  grantedCaller,
-  activeCaller,
-}: {
-  grantedCaller?: { id: string } | null;
-  activeCaller: { id: string } | null;
-}) {
-  const statements: Array<{ query: string; args: unknown[] }> = [];
-  const prepare = vi.fn((query: string) => ({
-    bind: vi.fn((...args: unknown[]) => {
-      const bound = {
-        query,
-        args,
-        first: vi.fn(async () => {
-          if (query.includes("JOIN caller_pools")) {
-            return grantedCaller ?? null;
-          }
-          if (query.includes("FROM callers") && query.includes("WHERE github_user_id")) {
-            return activeCaller;
-          }
-          return null;
-        }),
-        run: vi.fn(async () => ({ success: true })),
-      };
-      statements.push(bound);
-      return bound;
-    }),
+function enroll(env: Env, surface: string) {
+  const user = { id: Number.MAX_SAFE_INTEGER, login: "alice", name: "Alice" };
+  return surface === "CLI"
+    ? ensureCliCaller(env, "maintainers", user, VERIFIED_AT, "synthetic-token", "laptop")
+    : ensureWebCaller(env, "maintainers", user, VERIFIED_AT);
+}
+
+// Only input/result timing is mocked here. SQL and atomicity are covered by
+// the real Workerd/D1 enrollment, migration and HTTP regressions.
+function boundaryEnv() {
+  const prepare = vi.fn(() => ({
+    bind: vi.fn(() => ({ run: vi.fn(async () => ({ success: true })) })),
   }));
-  const batch = vi.fn(async () => []);
+  const batch = vi.fn(async () => [{ results: [storedCaller] }]);
   return {
     env: {
       ALLOWED_GITHUB_ORG: "openclaw",
       DEFAULT_ALLOWED_OWNERS: "openclaw",
       DB: { prepare, batch },
-    } as unknown as Env & { DB: { batch: ReturnType<typeof vi.fn> } },
-    statements,
+    } as unknown as Env,
+    prepare,
+    batch,
   };
 }

--- a/test/e2e/caller-enrollment-migration.test.ts
+++ b/test/e2e/caller-enrollment-migration.test.ts
@@ -1,0 +1,262 @@
+import type { D1Migration } from "@cloudflare/vitest-pool-workers";
+import { applyD1Migrations } from "cloudflare:test";
+import { env } from "cloudflare:workers";
+import { describe, expect, it } from "vitest";
+import { hashToken } from "../../src/auth";
+import { captureD1Baseline, restoreD1Baseline } from "./d1-baseline";
+import { loginClient, mockEnrollmentAccount, type Enrollment } from "./enrollment-support";
+import { callWorker, POOL } from "./harness";
+
+const UPGRADE = "0018_active_caller_enrollment.sql";
+const LEGACY_PROOF = "2099-01-01T00:00:00.000Z";
+const migrations = () => (env as Env & { TEST_MIGRATIONS: D1Migration[] }).TEST_MIGRATIONS;
+
+describe("active caller enrollment migration", () => {
+  it("preserves actual 0012 legacy tokens, singleton roles, grants, sessions and audit links", async () => {
+    await oldSchema();
+    const before = await history();
+    await upgrade();
+    expect(await history()).toEqual(before);
+    expect((await env.DB.prepare("PRAGMA foreign_key_check").all()).results).toEqual([]);
+    const index = await env.DB.prepare(
+      "SELECT sql FROM sqlite_schema WHERE name = 'idx_callers_active_github_org'",
+    ).first<{ sql: string }>();
+    expect(index!.sql).toContain("org_login COLLATE NOCASE");
+    expect(index!.sql).toContain("status = 'active' AND github_user_id IS NOT NULL");
+
+    mockEnrollmentAccount(101, "renamed-user");
+    const response = await loginClient("legacy");
+    expect(response.status).toBe(201);
+    const issued = await response.json<Enrollment>();
+    expect(issued.caller).toMatchObject({
+      id: "singleton",
+      github_login: "renamed-user",
+      org_login: "OpenClaw",
+    });
+    expect(
+      await env.DB.prepare("SELECT id FROM caller_tokens WHERE caller_id = 'singleton'").first(),
+    ).toEqual({ id: "legacy_singleton" });
+    expect(
+      await env.DB.prepare(
+        "SELECT dashboard_role, org_verified_at, org_identity_verified_at FROM callers WHERE id = 'singleton'",
+      ).first(),
+    ).toEqual({
+      dashboard_role: "admin",
+      org_verified_at: LEGACY_PROOF,
+      org_identity_verified_at: expect.any(String),
+    });
+    expect(
+      (
+        await env.DB.prepare(
+          "SELECT pool_id FROM caller_pools WHERE caller_id = 'singleton' ORDER BY pool_id",
+        ).all()
+      ).results,
+    ).toEqual([{ pool_id: POOL }, { pool_id: "restricted" }]);
+    expect(await health("token-singleton", "restricted")).toBe(401);
+    expect(await health(issued.token, "restricted")).toBe(200);
+    const me = await browser("session-singleton");
+    expect(me.status).toBe(200);
+    expect(await me.json()).toMatchObject({ caller: { id: "singleton", dashboard_role: "admin" } });
+    const after = await history();
+    expect(after[2]).toEqual(before[2]); // audit token IDs survive rotation
+    expect(after[3]!.results.map((row) => [row.session_hash, row.caller_id])).toEqual(
+      before[3]!.results.map((row) => [row.session_hash, row.caller_id]),
+    );
+    expect((await env.DB.prepare("PRAGMA foreign_key_check").all()).results).toEqual([]);
+  });
+
+  it.each([
+    ["same org, equal privileges", "OpenClaw", "admin", "restricted"],
+    ["case variant, equal privileges", "OPENCLAW", "admin", "restricted"],
+    ["same org, conflicting privileges", "OpenClaw", "none", POOL],
+    ["case variant, conflicting privileges", "openclaw", "none", POOL],
+  ])(
+    "refuses ambiguous %s without changing history or migration bookkeeping",
+    async (_case, org, role, pool) => {
+      await oldSchema();
+      await duplicate(org!, role!, pool!);
+      const before = await captureD1Baseline(env.DB);
+      await expect(upgrade()).rejects.toThrow(/UNIQUE constraint failed/);
+      expect(await captureD1Baseline(env.DB)).toEqual(before);
+      expect(
+        await env.DB.prepare("SELECT name FROM d1_migrations WHERE name = ?").bind(UPGRADE).first(),
+      ).toBeNull();
+      expect(
+        await env.DB.prepare(
+          "SELECT name FROM sqlite_schema WHERE name = 'idx_callers_active_github_org'",
+        ).first(),
+      ).toBeNull();
+      expect((await env.DB.prepare("PRAGMA foreign_key_check").all()).results).toEqual([]);
+    },
+  );
+
+  it("permits upgrade only after an explicit synthetic retirement, preserving the retired history", async () => {
+    await oldSchema();
+    await duplicate("OPENCLAW", "none", POOL);
+    await expect(upgrade()).rejects.toThrow(/UNIQUE constraint failed/);
+    // Test-owned operator decision, deliberately separate from the migration.
+    await env.DB.prepare("UPDATE callers SET status = 'disabled' WHERE id = 'duplicate'").run();
+    const retired = await history();
+    await upgrade();
+    expect(await history()).toEqual(retired);
+    mockEnrollmentAccount(101);
+    const response = await loginClient("legacy");
+    expect(response.status).toBe(201);
+    expect((await response.json<Enrollment>()).caller.id).toBe("singleton");
+    expect(await health("token-duplicate")).toBe(401);
+    expect((await browser("session-duplicate")).status).toBe(401);
+    expect(
+      await env.DB.prepare(
+        "SELECT status, dashboard_role FROM callers WHERE id = 'duplicate'",
+      ).first(),
+    ).toEqual({ status: "disabled", dashboard_role: "none" });
+    expect(
+      await env.DB.prepare(
+        "SELECT caller_token_id FROM audit_events WHERE request_id = 'audit-duplicate'",
+      ).first(),
+    ).toEqual({ caller_token_id: "duplicate-token" });
+  });
+
+  it("leaves disabled, null-ID and other-org histories unclaimed by fresh enrollments", async () => {
+    await oldSchema();
+    await upgrade();
+    const before = await history();
+    for (const id of [202, 303, 404]) {
+      mockEnrollmentAccount(id, "same-name");
+      const response = await loginClient("legacy");
+      expect(response.status).toBe(201);
+      const issued = await response.json<Enrollment>();
+      expect(issued.caller.id).toMatch(/^caller_/);
+      expect(
+        await env.DB.prepare("SELECT dashboard_role FROM callers WHERE id = ?")
+          .bind(issued.caller.id)
+          .first(),
+      ).toEqual({ dashboard_role: "none" });
+      expect(
+        (
+          await env.DB.prepare("SELECT pool_id FROM caller_pools WHERE caller_id = ?")
+            .bind(issued.caller.id)
+            .all()
+        ).results,
+      ).toEqual([{ pool_id: POOL }]);
+      expect(await health(issued.token)).toBe(200);
+      expect(await health(issued.token, "restricted")).toBe(401);
+    }
+    expect(await health("token-disabled-only", "restricted")).toBe(401);
+    expect(await health("token-null-a", "restricted")).toBe(403);
+    expect((await browser("session-disabled-only")).status).toBe(401);
+    const after = await history();
+    // Every preexisting row and credential stays attached to its original owner.
+    for (let index = 0; index < before.length; index++) {
+      expect(after[index]!.results).toEqual(expect.arrayContaining(before[index]!.results));
+    }
+    await expect(
+      env.DB.prepare("UPDATE callers SET github_user_id = 101 WHERE id = 'null-a'").run(),
+    ).rejects.toThrow(/UNIQUE constraint failed/);
+    await expect(
+      env.DB.prepare("UPDATE callers SET status = 'active' WHERE id = 'disabled-same'").run(),
+    ).rejects.toThrow(/UNIQUE constraint failed/);
+    expect((await env.DB.prepare("PRAGMA foreign_key_check").all()).results).toEqual([]);
+  });
+});
+
+async function oldSchema(): Promise<void> {
+  await restoreD1Baseline(env.DB, ["PRAGMA defer_foreign_keys=TRUE;"]);
+  await applyD1Migrations(
+    env.DB,
+    migrations().filter(({ name }) => name < "0012_"),
+  );
+  await env.DB.batch(
+    [POOL, "restricted"].map((pool) =>
+      env.DB.prepare("INSERT INTO pools (id, name, policy_json) VALUES (?, ?, '{}')").bind(
+        pool,
+        pool,
+      ),
+    ),
+  );
+  for (const [id, uid, status, org] of [
+    ["singleton", 101, "active", "OpenClaw"],
+    ["disabled-same", 101, "disabled", "openclaw"],
+    ["disabled-only", 202, "disabled", "OPENCLAW"],
+    ["null-a", null, "active", "openclaw"],
+    ["null-b", null, "active", "OpenClaw"],
+    ["other-org", 404, "active", "other-org"],
+  ] as const) {
+    await env.DB.batch([
+      env.DB.prepare(
+        "INSERT INTO callers (id, name, token_hash, github_login, github_user_id, org_login, org_verified_at, status, dashboard_role) VALUES (?, 'Historical', ?, 'same-name', ?, ?, ?, ?, 'admin')",
+      ).bind(id, await hashToken(`token-${id}`), uid, org, LEGACY_PROOF, status),
+      env.DB.prepare("INSERT INTO caller_pools (caller_id, pool_id) VALUES (?, 'restricted')").bind(
+        id,
+      ),
+      env.DB.prepare(
+        "INSERT INTO web_sessions (session_hash, caller_id, expires_at) VALUES (?, ?, '2099-01-01')",
+      ).bind(await hashToken(`session-${id}`), id),
+      env.DB.prepare(
+        "INSERT INTO audit_events (request_id, caller_id, pool_id, route_key, route_kind, status, duration_ms) VALUES (?, ?, 'restricted', 'synthetic', 'repo_view', 200, 1)",
+      ).bind(`audit-${id}`, id),
+    ]);
+  }
+  await applyD1Migrations(
+    env.DB,
+    migrations().filter(({ name }) => name >= "0012_" && name < "0018_"),
+  );
+  expect(
+    (await env.DB.prepare("SELECT id, client_name FROM caller_tokens ORDER BY id").all()).results,
+  ).toEqual(
+    ["disabled-only", "disabled-same", "null-a", "null-b", "other-org", "singleton"].map((id) => ({
+      id: `legacy_${id}`,
+      client_name: "legacy",
+    })),
+  );
+}
+
+async function duplicate(org: string, role: string, pool: string): Promise<void> {
+  await env.DB.batch([
+    env.DB.prepare(
+      "INSERT INTO callers (id, name, token_hash, github_login, github_user_id, org_login, status, dashboard_role) VALUES ('duplicate', 'Duplicate', ?, 'same-name', 101, ?, 'active', ?)",
+    ).bind(await hashToken("token-duplicate"), org, role),
+    env.DB.prepare("INSERT INTO caller_pools (caller_id, pool_id) VALUES ('duplicate', ?)").bind(
+      pool,
+    ),
+    env.DB.prepare(
+      "INSERT INTO caller_tokens (id, caller_id, token_hash, client_name) VALUES ('duplicate-token', 'duplicate', ?, 'legacy')",
+    ).bind(await hashToken("token-duplicate")),
+    env.DB.prepare(
+      "INSERT INTO web_sessions (session_hash, caller_id, expires_at) VALUES (?, 'duplicate', '2099-01-01')",
+    ).bind(await hashToken("session-duplicate")),
+    env.DB.prepare(
+      "INSERT INTO audit_events (request_id, caller_id, pool_id, route_key, route_kind, status, duration_ms, caller_token_id, client_name) VALUES ('audit-duplicate', 'duplicate', ?, 'synthetic', 'repo_view', 200, 1, 'duplicate-token', 'legacy')",
+    ).bind(pool),
+  ]);
+}
+
+async function upgrade(): Promise<void> {
+  const migration = migrations().find(({ name }) => name === UPGRADE);
+  expect(migration).toBeDefined();
+  await applyD1Migrations(env.DB, [migration!]);
+}
+
+async function history() {
+  const results = await env.DB.batch<Record<string, unknown>>(
+    [
+      "SELECT * FROM callers ORDER BY id",
+      "SELECT * FROM caller_tokens ORDER BY id",
+      "SELECT * FROM audit_events ORDER BY request_id",
+      "SELECT * FROM web_sessions ORDER BY session_hash",
+      "SELECT * FROM caller_pools ORDER BY caller_id, pool_id",
+    ].map((sql) => env.DB.prepare(sql)),
+  );
+  return results.map(({ results }) => ({ results }));
+}
+
+async function health(token: string, pool = POOL): Promise<number> {
+  return (
+    await callWorker(`/v1/pools/${pool}/health`, { headers: { authorization: `Bearer ${token}` } })
+  ).status;
+}
+function browser(session: string): Promise<Response> {
+  return callWorker("https://octopool.openclaw.ai/v1/me", {
+    headers: { cookie: `octopool_session=${session}` },
+  });
+}

--- a/test/e2e/control-plane.test.ts
+++ b/test/e2e/control-plane.test.ts
@@ -1,7 +1,15 @@
 import { env } from "cloudflare:workers";
 import { describe, expect, it, vi } from "vitest";
+import { hashToken } from "../../src/auth";
+import { captureD1Baseline } from "./d1-baseline";
 import { insertAudit } from "../../src/db";
 import { poolHealth } from "../../src/health";
+import {
+  concurrentEnrollments,
+  loginClient,
+  mockEnrollmentAccount,
+  type Enrollment,
+} from "./enrollment-support";
 import {
   bearer,
   callWorker,
@@ -17,6 +25,219 @@ import {
 } from "./harness";
 
 describe("Worker end-to-end control plane", () => {
+  it("atomically enrolls concurrent first logins and revokes both originals on a third rotation", async () => {
+    mockEnrollmentAccount();
+    const responses = await concurrentEnrollments([
+      () => loginClient("same-client"),
+      () => loginClient("same-client"),
+    ]);
+    expect(responses.map((response) => response.status)).toEqual([201, 201]);
+    const originals = await Promise.all(responses.map((response) => response.json<Enrollment>()));
+    const before = await env.DB.prepare(
+      "SELECT count(*) AS n FROM callers WHERE github_user_id = 101 AND status = 'active'",
+    ).first();
+    const originalAuth = await Promise.all(originals.map(({ token }) => tokenHealth(token)));
+    const third = await loginClient("same-client");
+    expect(third.status).toBe(201);
+    const replacement = await third.json<Enrollment>();
+    const afterAuth = await Promise.all(originals.map(({ token }) => tokenHealth(token)));
+    expect.soft(new Set(originals.map(({ caller }) => caller.id)).size).toBe(1);
+    expect.soft(before).toEqual({ n: 1 });
+    expect.soft(originalAuth.sort()).toEqual([200, 401]);
+    expect.soft(afterAuth).toEqual([401, 401]);
+    expect.soft(replacement.caller.id).toBe(originals[0]!.caller.id);
+    expect(await tokenHealth(replacement.token)).toBe(200);
+    expect
+      .soft(await env.DB.prepare("SELECT count(*) AS n FROM caller_tokens").first())
+      .toEqual({ n: 1 });
+    expect
+      .soft(await env.DB.prepare("SELECT count(*) AS n FROM caller_pools").first())
+      .toEqual({ n: 1 });
+  });
+
+  it("converges concurrent distinct clients and admin grants without promoting roles", async () => {
+    mockEnrollmentAccount();
+    const responses = await concurrentEnrollments([
+      () => loginClient("laptop"),
+      () => loginClient("studio"),
+      () => adminEnrollment("restricted"),
+      () => adminEnrollment("restricted"),
+    ]);
+    expect(responses.map(({ status }) => status)).toEqual([201, 201, 201, 201]);
+    const issued = await Promise.all(responses.map((response) => response.json<Enrollment>()));
+    expect(new Set(issued.map(({ caller }) => caller.id)).size).toBe(1);
+    const id = issued[0]!.caller.id;
+    expect(
+      await env.DB.prepare("SELECT dashboard_role FROM callers WHERE id = ?").bind(id).first(),
+    ).toEqual({ dashboard_role: "none" });
+    expect(
+      (
+        await env.DB.prepare(
+          "SELECT pool_id FROM caller_pools WHERE caller_id = ? ORDER BY pool_id",
+        )
+          .bind(id)
+          .all()
+      ).results,
+    ).toEqual([{ pool_id: POOL }, { pool_id: "restricted" }]);
+    expect(
+      (
+        await env.DB.prepare(
+          "SELECT client_name FROM caller_tokens WHERE caller_id = ? ORDER BY client_name",
+        )
+          .bind(id)
+          .all()
+      ).results,
+    ).toEqual([{ client_name: "admin" }, { client_name: "laptop" }, { client_name: "studio" }]);
+    expect(await tokenHealth(issued[0]!.token)).toBe(200);
+    expect(await tokenHealth(issued[1]!.token)).toBe(200);
+    const adminAuth = await Promise.all(
+      issued.slice(2).map(({ token }) => tokenHealth(token, "restricted")),
+    );
+    expect(adminAuth.sort()).toEqual([200, 401]);
+    const rotated = await (await adminEnrollment("restricted")).json<Enrollment>();
+    for (const { token } of issued.slice(2))
+      expect(await tokenHealth(token, "restricted")).toBe(401);
+    expect(await tokenHealth(rotated.token, "restricted")).toBe(200);
+  });
+
+  it("serializes additions at the 16-client cap with stable ties and preserved audit attribution", async () => {
+    await seedPool();
+    await seedClientCap();
+    mockEnrollmentAccount(42);
+    await seedAudit("pruned", "caller", "repo_view", "miss", 200, {
+      callerTokenId: "old-0",
+      clientName: "old-0",
+    });
+    await seedAudit("rotated", "caller", "repo_view", "miss", 200);
+    const responses = await concurrentEnrollments([
+      () => loginClient("new-a"),
+      () => loginClient("new-b"),
+    ]);
+    expect(responses.map(({ status }) => status)).toEqual([201, 201]);
+    const issued = await Promise.all(responses.map((response) => response.json<Enrollment>()));
+    for (const entry of issued) {
+      expect(entry.caller.id).toBe("caller");
+      expect(await tokenHealth(entry.token)).toBe(200);
+    }
+    const names = (
+      await env.DB.prepare("SELECT client_name FROM caller_tokens ORDER BY client_name").all<{
+        client_name: string;
+      }>()
+    ).results.map(({ client_name }) => client_name);
+    expect(names).toHaveLength(16);
+    expect(names).not.toContain("old-0");
+    expect(names).not.toContain("old-1");
+    expect(names).toEqual(expect.arrayContaining(["old-2", "test-mac", "new-a", "new-b"]));
+    const rotated = await (await loginClient("test-mac")).json<Enrollment>();
+    expect(await tokenHealth(rotated.token)).toBe(200);
+    expect(await tokenHealth(CALLER_TOKEN)).toBe(401);
+    expect(
+      await env.DB.prepare("SELECT id FROM caller_tokens WHERE client_name = 'test-mac'").first(),
+    ).toEqual({ id: "caller-client-token" });
+    expect(
+      (
+        await env.DB.prepare(
+          "SELECT request_id, caller_id, caller_token_id, client_name FROM audit_events ORDER BY request_id",
+        ).all()
+      ).results,
+    ).toEqual([
+      { request_id: "pruned", caller_id: "caller", caller_token_id: null, client_name: "old-0" },
+      {
+        request_id: "rotated",
+        caller_id: "caller",
+        caller_token_id: "caller-client-token",
+        client_name: "test-mac",
+      },
+    ]);
+    expect((await env.DB.prepare("PRAGMA foreign_key_check").all()).results).toEqual([]);
+  });
+
+  it.each(["first insert", "rotation", "pruning"])(
+    "rolls back enrollment and dependent writes after a later %s failure",
+    async (failure) => {
+      await seedPool();
+      mockEnrollmentAccount(failure === "first insert" ? 101 : 42, "changed-profile");
+      if (failure === "pruning") await seedClientCap();
+      await env.DB.prepare(
+        "INSERT INTO pools (id, name, policy_json) VALUES ('restricted', 'restricted', '{}')",
+      ).run();
+      const event =
+        failure === "first insert" ? "INSERT" : failure === "rotation" ? "UPDATE" : "DELETE";
+      await env.DB.prepare(
+        `CREATE TRIGGER enrollment_abort AFTER ${event} ON caller_tokens BEGIN SELECT RAISE(ABORT, 'synthetic-later-write'); END`,
+      ).run();
+      const before = await captureD1Baseline(env.DB);
+      const response =
+        failure === "rotation"
+          ? await loginClient("test-mac")
+          : await adminEnrollment("restricted", "changed-profile");
+      expect(response.status).toBe(500);
+      const body = await response.text();
+      expect(JSON.parse(body)).toMatchObject({ error: { code: "internal_error" } });
+      expect(JSON.parse(body)).not.toHaveProperty("token");
+      expect(body).not.toContain("synthetic-later-write");
+      expect(await captureD1Baseline(env.DB)).toEqual(before);
+      expect(await tokenHealth(CALLER_TOKEN)).toBe(200);
+    },
+  );
+
+  it.each(["CLI", "admin"])(
+    "fails %s enrollment closed without the required index",
+    async (surface) => {
+      await seedPool();
+      mockEnrollmentAccount(42);
+      await env.DB.prepare("DROP INDEX idx_callers_active_github_org").run();
+      const before = await captureD1Baseline(env.DB);
+      const response =
+        surface === "CLI" ? await loginClient("test-mac") : await adminEnrollment(POOL);
+      expect(response.status).toBe(500);
+      const body = await response.json();
+      expect(body).toMatchObject({ error: { code: "internal_error" } });
+      expect(body).not.toHaveProperty("token");
+      expect(await captureD1Baseline(env.DB)).toEqual(before);
+    },
+  );
+
+  it.each(["rotation", "disable"])(
+    "respects the 30-second warm-isolate cache after external %s",
+    async (change) => {
+      await seedPool();
+      const start = Date.now();
+      const clock = vi.spyOn(Date, "now").mockReturnValue(start);
+      const warmHealth = () =>
+        callWarmWorker(`/v1/pools/${POOL}/health`, {
+          headers: { authorization: `Bearer ${CALLER_TOKEN}` },
+        });
+      expect(await tokenHealth(CALLER_TOKEN)).toBe(200);
+      if (change === "rotation") {
+        await env.DB.prepare(
+          "UPDATE caller_tokens SET token_hash = ? WHERE id = 'caller-client-token'",
+        )
+          .bind(await hashToken("external-replacement"))
+          .run();
+      } else {
+        await env.DB.prepare("UPDATE callers SET status = 'disabled' WHERE id = 'caller'").run();
+      }
+      clock.mockReturnValue(start + 29_999);
+      expect((await warmHealth()).status).toBe(200);
+      clock.mockReturnValue(start + 30_000);
+      expect((await warmHealth()).status).toBe(401);
+    },
+  );
+
+  it("invalidates the issuing isolate's cached token only after successful login", async () => {
+    await seedPool();
+    mockEnrollmentAccount(42);
+    const warmHealth = (token: string) =>
+      callWarmWorker(`/v1/pools/${POOL}/health`, { headers: { authorization: `Bearer ${token}` } });
+    expect((await warmHealth(CALLER_TOKEN)).status).toBe(200);
+    const response = await loginClient("test-mac");
+    expect(response.status).toBe(201);
+    const { token } = await response.json<Enrollment>();
+    expect((await warmHealth(CALLER_TOKEN)).status).toBe(401);
+    expect((await warmHealth(token)).status).toBe(200);
+  });
+
   it("rejects membership from a replacement account without refreshing the enrolled caller", async () => {
     await seedPool();
     const stale = "2020-01-01T00:00:00.000Z";
@@ -677,6 +898,12 @@ describe("Worker end-to-end control plane", () => {
   });
 });
 
+async function tokenHealth(token: string, pool = POOL): Promise<number> {
+  return (
+    await callWorker(`/v1/pools/${pool}/health`, { headers: { authorization: `Bearer ${token}` } })
+  ).status;
+}
+
 const STALE = "2020-01-01T00:00:00.000Z";
 
 function membershipPage(userId: number, logins: string[], cursor: string | null = null): Response {
@@ -738,4 +965,28 @@ function cacheEntry(cacheKey: string, staleOffset: string): D1PreparedStatement 
     ) VALUES (?, ?, 'GET', '/fixture', '{}', '{}', 'fixture', 'repo_view', 200, '{}', '{}',
       'json', datetime('now', ?), datetime('now', ?))`,
   ).bind(cacheKey, POOL, staleOffset, staleOffset);
+}
+
+function adminEnrollment(pool: string, login = "enrollment-user"): Promise<Response> {
+  return callWarmWorker("/v1/admin/callers", {
+    method: "POST",
+    headers: { authorization: "Bearer test-admin-token", "content-type": "application/json" },
+    body: JSON.stringify({ pool, github_login: login }),
+  });
+}
+
+async function seedClientCap(): Promise<void> {
+  // Equal instants in both supported formats exercise julianday + rowid ties.
+  await env.DB.batch(
+    Array.from({ length: 15 }, (_, index) =>
+      env.DB.prepare(
+        "INSERT INTO caller_tokens (id, caller_id, token_hash, client_name, updated_at) VALUES (?, 'caller', ?, ?, ?)",
+      ).bind(
+        `old-${index}`,
+        `synthetic-hash-${index}`,
+        `old-${index}`,
+        index % 2 ? "2020-01-01T00:00:00.000Z" : "2020-01-01 00:00:00",
+      ),
+    ),
+  );
 }

--- a/test/e2e/enrollment-support.ts
+++ b/test/e2e/enrollment-support.ts
@@ -1,0 +1,60 @@
+import { env } from "cloudflare:workers";
+import { vi } from "vitest";
+import { callWarmWorker, jsonResponse, orgMembershipResponse } from "./harness";
+import { ownedWork } from "./owned-work";
+
+export type Enrollment = {
+  caller: {
+    id: string;
+    name: string;
+    github_login: string;
+    org_login: string;
+    client_name: string;
+  };
+  token: string;
+};
+
+export function mockEnrollmentAccount(id = 101, login = "enrollment-user"): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn<typeof fetch>(async (input, init) => {
+      const path = new URL(new Request(input, init).url).pathname;
+      if (path === "/graphql") return orgMembershipResponse(true, id);
+      if (path === "/user" || path === `/users/${login}`) return jsonResponse({ id, login });
+      if (path === "/login/oauth/access_token")
+        return jsonResponse({ access_token: "synthetic-oauth" });
+      throw new Error(`Unexpected synthetic GitHub request: ${path}`);
+    }),
+  );
+}
+
+export function loginClient(clientName: string): Promise<Response> {
+  return callWarmWorker("/v1/login/github-cli", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ github_token: "synthetic-github", client_name: clientName }),
+  });
+}
+
+// Only scheduling is intercepted. Every prepared statement and result belongs
+// to real D1, including the old implementation's pre-batch lookup misses.
+export async function concurrentEnrollments(
+  requests: (() => Promise<Response>)[],
+): Promise<Response[]> {
+  const batch = env.DB.batch.bind(env.DB);
+  const gate = ownedWork.gate();
+  let arrived = 0;
+  const spy = vi.spyOn(env.DB, "batch").mockImplementation(async (statements) => {
+    if (++arrived === requests.length) gate.release();
+    await gate.promise;
+    return batch(statements);
+  });
+  const pending = requests.map((request) => request());
+  try {
+    return await Promise.all(pending);
+  } finally {
+    gate.release();
+    await Promise.allSettled(pending);
+    spy.mockRestore();
+  }
+}

--- a/test/e2e/org-membership-upgrade.test.ts
+++ b/test/e2e/org-membership-upgrade.test.ts
@@ -272,7 +272,11 @@ function migrations(): D1Migration[] {
 async function applyUpgrade(): Promise<void> {
   const upgrade = migrations().find(({ name }) => name === "0017_org_identity_verification.sql");
   expect(upgrade).toBeDefined();
-  await applyD1Migrations(env.DB, [upgrade!]);
+  // Current enrollment also requires later additive migrations.
+  await applyD1Migrations(
+    env.DB,
+    migrations().filter(({ name }) => name >= upgrade!.name),
+  );
 }
 
 async function legacyRefresh(timestamp: string): Promise<void> {

--- a/test/e2e/web-session.test.ts
+++ b/test/e2e/web-session.test.ts
@@ -1,5 +1,13 @@
 import { env } from "cloudflare:workers";
 import { describe, expect, it, vi } from "vitest";
+import { hashToken } from "../../src/auth";
+import { captureD1Baseline } from "./d1-baseline";
+import {
+  concurrentEnrollments,
+  loginClient,
+  mockEnrollmentAccount,
+  type Enrollment,
+} from "./enrollment-support";
 import {
   bearer,
   callWorker,
@@ -13,6 +21,151 @@ import {
 const APP = "https://octopool.openclaw.ai";
 
 describe("Worker end-to-end web sessions", () => {
+  it.each(["new", "singleton", "disabled"])(
+    "shares atomic browser/CLI enrollment for a %s identity without transferring authority",
+    async (state) => {
+      let oldSession: string | undefined;
+      if (state !== "new") {
+        await seedPool();
+        oldSession = await seedWebSession();
+        await env.DB.batch([
+          env.DB.prepare(
+            "INSERT INTO pools (id, name, policy_json) VALUES ('restricted', 'restricted', '{}')",
+          ),
+          env.DB.prepare(
+            "INSERT INTO caller_pools (caller_id, pool_id) VALUES ('caller', 'restricted')",
+          ),
+          env.DB.prepare(
+            "UPDATE callers SET org_login = 'OpenClaw', status = ? WHERE id = 'caller'",
+          ).bind(state === "disabled" ? "disabled" : "active"),
+        ]);
+      }
+      mockEnrollmentAccount(42);
+      const callback = await prepareCallback();
+      const [webResponse, cliResponse] = await concurrentEnrollments([
+        callback,
+        () => loginClient("test-mac"),
+      ]);
+      expect(webResponse!.status).toBe(302);
+      expect(cliResponse!.status).toBe(201);
+      const cli = await cliResponse!.json<Enrollment>();
+      const session = cookieValue(webResponse!, "octopool_session")!;
+      const sessionCaller = await callWorker(`${APP}/v1/me`, {
+        headers: { cookie: `octopool_session=${session}` },
+      });
+      expect(sessionCaller.status).toBe(state === "singleton" ? 200 : 403);
+      expect(
+        await env.DB.prepare("SELECT caller_id FROM web_sessions WHERE session_hash = ?")
+          .bind(await hashToken(session))
+          .first(),
+      ).toEqual({ caller_id: cli.caller.id });
+      expect(
+        await env.DB.prepare("SELECT dashboard_role FROM callers WHERE id = ?")
+          .bind(cli.caller.id)
+          .first(),
+      ).toEqual({ dashboard_role: state === "singleton" ? "admin" : "none" });
+      expect(
+        (
+          await env.DB.prepare(
+            "SELECT id FROM callers WHERE status = 'active' AND github_user_id = 42",
+          ).all()
+        ).results,
+      ).toEqual([{ id: cli.caller.id }]);
+      expect(
+        (
+          await env.DB.prepare("SELECT client_name FROM caller_tokens WHERE caller_id = ?")
+            .bind(cli.caller.id)
+            .all()
+        ).results,
+      ).toEqual([{ client_name: "test-mac" }]);
+      const grants = (
+        await env.DB.prepare(
+          "SELECT pool_id FROM caller_pools WHERE caller_id = ? ORDER BY pool_id",
+        )
+          .bind(cli.caller.id)
+          .all()
+      ).results;
+      expect(grants).toEqual(
+        state === "singleton"
+          ? [{ pool_id: POOL }, { pool_id: "restricted" }]
+          : [{ pool_id: POOL }],
+      );
+      const dashboard = await callWorker(`${APP}/v1/dashboard`, {
+        headers: { cookie: `octopool_session=${session}` },
+      });
+      expect(dashboard.status).toBe(state === "singleton" ? 200 : 403);
+      expect(
+        (
+          await callWorker(`/v1/pools/${POOL}/health`, {
+            headers: { authorization: `Bearer ${cli.token}` },
+          })
+        ).status,
+      ).toBe(200);
+      if (oldSession !== undefined) {
+        expect(cli.caller.id === "caller").toBe(state === "singleton");
+        const oldCookie = await callWorker(`${APP}/v1/me`, {
+          headers: { cookie: `octopool_session=${oldSession}` },
+        });
+        expect(oldCookie.status).toBe(state === "singleton" ? 200 : 401);
+        expect(
+          (
+            await callWorker(`/v1/pools/${POOL}/health`, {
+              headers: { authorization: "Bearer caller-token" },
+            })
+          ).status,
+        ).toBe(401);
+        expect(
+          await env.DB.prepare(
+            "SELECT dashboard_role, status FROM callers WHERE id = 'caller'",
+          ).first(),
+        ).toEqual({
+          dashboard_role: "admin",
+          status: state === "disabled" ? "disabled" : "active",
+        });
+        expect(
+          await env.DB.prepare(
+            "SELECT caller_id FROM caller_tokens WHERE id = 'caller-client-token'",
+          ).first(),
+        ).toEqual({ caller_id: "caller" });
+        expect(
+          (
+            await env.DB.prepare(
+              "SELECT caller_id FROM web_sessions WHERE caller_id = 'caller'",
+            ).all()
+          ).results,
+        ).toHaveLength(state === "singleton" ? 2 : 1);
+      }
+      expect((await env.DB.prepare("PRAGMA foreign_key_check").all()).results).toEqual([]);
+    },
+  );
+
+  it("rolls back browser enrollment when its grant write fails without issuing a cookie", async () => {
+    await seedPool();
+    mockEnrollmentAccount(101);
+    const callback = await prepareCallback();
+    await env.DB.prepare(
+      "CREATE TRIGGER browser_grant_abort AFTER INSERT ON caller_pools BEGIN SELECT RAISE(ABORT, 'synthetic-grant-failure'); END",
+    ).run();
+    const before = await captureD1Baseline(env.DB);
+    const response = await callback();
+    expect(response.status).toBe(500);
+    expect(cookieValue(response, "octopool_session")).toBeUndefined();
+    expect(await captureD1Baseline(env.DB)).toEqual(before);
+  });
+
+  it("fails browser enrollment closed when the active identity index is missing", async () => {
+    await seedPool();
+    mockEnrollmentAccount(42);
+    const callback = await prepareCallback();
+    await env.DB.prepare("DROP INDEX idx_callers_active_github_org").run();
+    const before = await captureD1Baseline(env.DB);
+    const response = await callback();
+    expect(response.status).toBe(500);
+    expect(cookieValue(response, "octopool_session")).toBeUndefined();
+    expect(await response.text()).toContain("internal_error");
+    expect(await captureD1Baseline(env.DB)).toEqual(before);
+  });
+
   it("rejects OAuth membership for a substituted account without creating a session", async () => {
     const upstream = vi.fn<typeof fetch>(async (input, init) => {
       const request = new Request(input, init);
@@ -264,4 +417,16 @@ function cookieValue(response: Response, name: string): string | undefined {
   const header = response.headers.get("set-cookie") ?? "";
   const match = new RegExp(`(?:^|,\\s*)${name}=([^;]*)`).exec(header);
   return match === null ? undefined : decodeURIComponent(match[1] ?? "");
+}
+
+async function prepareCallback(): Promise<() => Promise<Response>> {
+  const start = await callWorker(`${APP}/login/github`);
+  const state = new URL(start.headers.get("location")!).searchParams.get("state")!;
+  return () =>
+    callWorker(
+      `${APP}/login/github/callback?code=synthetic-code&state=${encodeURIComponent(state)}`,
+      {
+        headers: { cookie: `octopool_oauth_state=${encodeURIComponent(state)}` },
+      },
+    );
 }


### PR DESCRIPTION
## Summary

Concurrent initial logins could create multiple active callers for the same GitHub identity, leaving an older token valid after another rotation. Enforce one active immutable GitHub ID/org enrollment with a case-insensitive org unique index and one D1 transaction shared by CLI, admin, and browser login. Grant, token, and pruning writes resolve the canonical caller inside that transaction; the caller is returned only after commit.

Preserve existing random caller IDs, roles and grants, browser sessions, rotated token row IDs, audit attribution, and the separate identity-bound membership proof timestamp from #94. Concurrent rotations for one client leave one current stored token; response arrival order does not identify the winner. The 16-client cap, documented 30-second cross-isolate auth-cache window, and per-row disable semantics remain unchanged.

Migration 0018 refuses ambiguous active duplicates unchanged; it never selects a survivor or merges privileges. Historical client-name aliases are not repaired. Document the schema-first deployment gate and correct the operations account description. This PR does not execute a production migration or Worker deployment.

## Tests

All execution evidence uses synthetic data.

- Regression reproduced before the repair: two callers and two initially valid tokens, with one old token still valid after a third rotation.
- Focused Worker proof: `pnpm exec vitest run --config vitest.e2e.config.ts test/e2e/control-plane.test.ts test/e2e/caller-enrollment-migration.test.ts test/e2e/web-session.test.ts test/e2e/org-membership-upgrade.test.ts` — 66 passed.
- Full `GOTOOLCHAIN=go1.26.7 pnpm check` — 625 unit tests and 363 Worker tests passed, plus SQL compile/generation, formatting, lint, TypeScript, Go tests, and vet.
- The operations account-description correction also passed formatting.
