### PR TITLE
fix: enforce single-repository search grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Reject extra or malformed repository qualifiers and negated scope in issue, code, and commit searches before relay dispatch or cache reuse, preserving typed local fallback for unsupported queries.
 - Make active caller enrollment and named-client token rotation atomic across CLI, admin, and browser login, preserving existing access and history while refusing ambiguous upgrades.
 - Bind org membership checks to the enrolled GitHub account on every page, isolate verification timestamps across rolling upgrades, and preserve safe legacy re-login and typed upstream errors.
 - Validate protected `gh repo clone` repository inputs according to native argument ownership, preserving destination paths and Git flags while retaining visible-argument filtering and GitHub.com-only source checks.

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -320,8 +320,14 @@ the Worker remains GET-only and does not relay those neighboring routes.
   reason `logs_denied`.
 - `allow_search` — search routes require it (default `false`). Issue, code, and commit searches
   require exactly one `repo:owner/name` qualifier plus plain terms and optional
-  `type:issue|pr` / `state:open|closed`; repository search accepts plain terms only. Invalid
-  queries return `424 fallback_local` with reason `search_denied`.
+  `type:issue|pr` / `state:open|closed`. Every token must match this grammar: additional,
+  quoted, bare, or malformed repo qualifiers, `OR`/`NOT`, and negated terms are rejected
+  before upstream dispatch or cache reuse. Qualifier names and filter values are lowercase;
+  owner/repository casing and whitespace between tokens are accepted without rewriting the
+  query sent upstream. Repository search keeps its separate plain-term grammar. Invalid
+  queries return `424 fallback_local` with reason `search_denied`. The supported token-free
+  issue-search shape can run with `allow_search: false`, subject to the same grammar and
+  owner/public-repository gates, and never falls through to pooled credentials.
 
 When a Cloudflare backend (D1 or the pool Durable Object) rejects work because its
 request queue backed up, the relay returns `424 fallback_local` with reason

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -202,24 +202,37 @@ function repoFromSearchQuery(query: Record<string, string | string[]> | undefine
     throw new HttpError(403, "search_denied", "Search routes require a repo-scoped q query");
   }
   const tokens = q.trim().split(/\s+/).filter(Boolean);
-  const matches = tokens
-    .map((token) => /^repo:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/.exec(token))
-    .filter((match): match is RegExpExecArray => match !== null);
-  if (matches.length !== 1 || matches[0]?.[1] === undefined || matches[0]?.[2] === undefined) {
-    throw new HttpError(403, "search_denied", "Search routes require exactly one repo qualifier");
-  }
+  let scope: { owner: string; repo: string } | undefined;
   for (const token of tokens) {
-    if (token.startsWith("repo:")) {
+    const match = /^repo:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/.exec(token);
+    if (match !== null) {
+      if (scope !== undefined || match[1] === undefined || match[2] === undefined) {
+        throw new HttpError(
+          403,
+          "search_denied",
+          "Search routes require exactly one repo qualifier",
+        );
+      }
+      scope = { owner: match[1], repo: match[2] };
       continue;
     }
     if (/^type:(issue|pr)$/.test(token) || /^state:(open|closed)$/.test(token)) {
       continue;
     }
-    if (!/^[A-Za-z0-9_.-]+$/.test(token) || token.toUpperCase() === "OR") {
+    const upper = token.toUpperCase();
+    if (
+      token.startsWith("-") ||
+      !/^[A-Za-z0-9_.-]+$/.test(token) ||
+      upper === "OR" ||
+      upper === "NOT"
+    ) {
       throw new HttpError(403, "search_denied", "Search routes only allow plain repo-scoped terms");
     }
   }
-  return { owner: matches[0][1], repo: matches[0][2] };
+  if (scope === undefined) {
+    throw new HttpError(403, "search_denied", "Search routes require exactly one repo qualifier");
+  }
+  return scope;
 }
 
 function searchRepoForRule(

--- a/test/e2e/restricted-search.test.ts
+++ b/test/e2e/restricted-search.test.ts
@@ -1,0 +1,191 @@
+import { env } from "cloudflare:workers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { githubCacheKey, writeGitHubCache } from "../../src/cache";
+import { deleteEdgeJSON } from "../../src/edge-cache";
+import { classifyRoute, defaultPolicy, validateRelayRequest } from "../../src/policy";
+import { recordPublicGitHubRepo } from "../../src/public-repos";
+import {
+  deniedRepoSearchQueries,
+  repoSearchPaths,
+  validRepoSearchQueries,
+} from "../fixtures/restricted-search";
+import { bearer, jsonResponse, rateHeaders, relay, seedPool } from "./harness";
+
+const searchBody = { total_count: 1, incomplete_results: false, items: [{ id: 7 }] };
+
+function mockSearchUpstream() {
+  const upstream = vi.fn<typeof fetch>(async (input, init) => {
+    const request = new Request(input, init);
+    const url = new URL(request.url);
+    if (url.hostname === "api.github.com" && url.pathname.startsWith("/search/")) {
+      return jsonResponse(searchBody, 200, rateHeaders({ remaining: 4_999 }));
+    }
+    if (url.hostname === "api.github.com" && url.pathname.startsWith("/repos/")) {
+      return jsonResponse({ private: false });
+    }
+    if (url.hostname === "github.com") {
+      return new Response('<meta name="octolytics-dimension-repository_public" content="true" />');
+    }
+    throw new Error(`Unexpected synthetic upstream: ${request.url}`);
+  });
+  vi.stubGlobal("fetch", upstream);
+  return upstream;
+}
+
+async function cacheRows() {
+  return (await env.DB.prepare("SELECT * FROM github_cache_entries ORDER BY cache_key").all())
+    .results;
+}
+
+async function expectSearchDenied(response: Response) {
+  expect.soft(response.status).toBe(424);
+  expect.soft(await response.json()).toMatchObject({
+    error: { code: "fallback_local", details: { reason: "search_denied" } },
+  });
+}
+
+describe.each(repoSearchPaths)("Worker restricted search boundary for %s", (path) => {
+  beforeEach(seedPool);
+
+  it.each(deniedRepoSearchQueries)("denies q=%j before dispatch or cache writes", async (q) => {
+    const upstream = mockSearchUpstream();
+    const edgePut = vi.spyOn(caches.default, "put");
+    await expectSearchDenied(await relay(path, undefined, { query: { q } }));
+    // relay() drains waitUntil, so these include eventual fetches and publications.
+    expect.soft(upstream).not.toHaveBeenCalled();
+    expect.soft(await cacheRows()).toEqual([]);
+    expect.soft(edgePut).not.toHaveBeenCalled();
+    expect(
+      await env.DB.prepare(
+        "SELECT route_kind, status, error_code, fallback_reason, identity_id, cache_status FROM audit_events",
+      ).first(),
+    ).toEqual({
+      route_kind: "denied",
+      status: 424,
+      error_code: "fallback_local",
+      fallback_reason: "search_denied",
+      identity_id: null,
+      cache_status: "unknown",
+    });
+  });
+
+  it.each(validRepoSearchQueries)("dispatches valid q=%j unchanged", async (q) => {
+    const upstream = mockSearchUpstream();
+    const response = await relay(path, undefined, { query: { q } });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ status: 200, body: searchBody });
+    const requests = upstream.mock.calls.map(([input, init]) => new Request(input, init));
+    const resourceCalls = requests.filter((request) => new URL(request.url).pathname === path);
+    expect(resourceCalls).toHaveLength(1);
+    expect(new URL(resourceCalls[0]!.url).searchParams.get("q")).toBe(q);
+    expect(bearer(resourceCalls[0]!)).toBe(
+      path === "/search/code" ? "test-primary-token" : undefined,
+    );
+    expect(await cacheRows()).toHaveLength(1);
+  });
+
+  it.each(["edge", "shared"])(
+    "rejects legacy malformed queries before %s cache reuse",
+    async (layer) => {
+      const validRequest = validateRelayRequest({
+        pool: "maintainers",
+        method: "GET",
+        path,
+        query: { q: "repo:openclaw/octopool needle" },
+      });
+      const route = classifyRoute(validRequest, {
+        ...defaultPolicy("openclaw"),
+        allow_search: true,
+      });
+      await recordPublicGitHubRepo(env, route);
+      const queries = [
+        'repo:openclaw/octopool repo:"other/private" needle',
+        "NOT repo:openclaw/octopool needle",
+      ];
+      for (const q of queries) {
+        // Reproduce the old trusted route attached to an unchecked full query.
+        const request = { ...validRequest, query: { q } };
+        const key = await githubCacheKey(request.pool, request, route);
+        await writeGitHubCache(env, key, request, route, {
+          status: 200,
+          headers: {},
+          body: searchBody,
+          body_encoding: "json",
+        });
+        if (layer === "shared") await deleteEdgeJSON("github-v1", key);
+      }
+      const before = await cacheRows();
+      expect(before).toHaveLength(2);
+      const upstream = mockSearchUpstream();
+      const edgePut = vi.spyOn(caches.default, "put");
+      for (const q of queries)
+        await expectSearchDenied(await relay(path, undefined, { query: { q } }));
+      expect(upstream).not.toHaveBeenCalled();
+      expect(await cacheRows()).toEqual(before);
+      expect(edgePut).not.toHaveBeenCalled();
+    },
+  );
+
+  it("retains search policy denial and authenticates before grammar denial", async () => {
+    await env.DB.prepare(
+      "UPDATE pools SET policy_json = json_set(policy_json, '$.allow_search', json('false'))",
+    ).run();
+    const upstream = mockSearchUpstream();
+    await expectSearchDenied(
+      await relay(path, undefined, { query: { q: "repo:openclaw/octopool needle" } }),
+    );
+    const response = await relay(path, "invalid-caller-token", {
+      query: { q: 'repo:openclaw/octopool repo:"other/private" needle' },
+    });
+    expect(response.status).toBe(401);
+    expect(upstream).not.toHaveBeenCalled();
+    expect(await cacheRows()).toEqual([]);
+  });
+});
+
+describe("Worker restricted search shape and protection boundaries", () => {
+  beforeEach(seedPool);
+
+  it.each([true, false])(
+    "does not let the issue shape bypass grammar with allow_search=%s",
+    async (allowSearch) => {
+      await env.DB.prepare(
+        "UPDATE pools SET policy_json = json_set(policy_json, '$.allow_search', json(?))",
+      )
+        .bind(JSON.stringify(allowSearch))
+        .run();
+      const upstream = mockSearchUpstream();
+      for (const q of [
+        'repo:openclaw/octopool repo:"other/private" type:issue needle',
+        "NOT repo:openclaw/octopool type:issue needle",
+      ]) {
+        await expectSearchDenied(
+          await relay("/search/issues", undefined, {
+            query: { q },
+            headers: { "x-octopool-public-shape": "issue-search-v1" },
+          }),
+        );
+      }
+      expect(upstream).not.toHaveBeenCalled();
+      expect(await cacheRows()).toEqual([]);
+    },
+  );
+
+  it.each([
+    ["needle", 'repo:openclaw/octopool repo:"other/private" needle'],
+    ["^https://api\\.github\\.com/search/code", "repo:openclaw/octopool needle"],
+  ])("preserves protected input and canonical egress denial %#", async (pattern, q) => {
+    await env.DB.prepare("UPDATE string_rewrite_policy SET rules_json = ?")
+      .bind(JSON.stringify([{ pattern, replacement: "public" }]))
+      .run();
+    const upstream = mockSearchUpstream();
+    const response = await relay("/search/code", undefined, { query: { q } });
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({ error: { code: "string_rewrite_denied" } });
+    const resourceCalls = upstream.mock.calls.filter(([input, init]) =>
+      new URL(new Request(input, init).url).pathname.startsWith("/search/"),
+    );
+    expect(resourceCalls).toHaveLength(0);
+    expect(await cacheRows()).toEqual([]);
+  });
+});

--- a/test/fixtures/restricted-search.ts
+++ b/test/fixtures/restricted-search.ts
@@ -1,0 +1,41 @@
+export const repoSearchPaths = ["/search/issues", "/search/code", "/search/commits"];
+
+export const deniedRepoSearchQueries = [
+  "repo:openclaw/octopool repo:other/project needle",
+  "repo:openclaw/octopool repo:openclaw/octopool needle",
+  'repo:openclaw/octopool repo:"other/private" needle',
+  'repo:"other/private" repo:openclaw/octopool needle',
+  "repo:openclaw/octopool repo:other needle",
+  "repo:openclaw/octopool repo: needle",
+  "repo:openclaw/octopool repo:other/ needle",
+  "repo:openclaw/octopool repo:/private needle",
+  "repo:openclaw/octopool repo:other/private/extra needle",
+  "repo:openclaw/octopool repo:other/private,third/project needle",
+  "repo:openclaw/octopool,other/private needle",
+  'repo:"openclaw/octopool" needle',
+  "needle",
+  "",
+  "repo:openclaw/octopool needle OR other",
+  "repo:openclaw/octopool needle or other",
+  "repo:openclaw/octopool OR repo:other/project needle",
+  "NOT repo:openclaw/octopool needle",
+  "needle NOT repo:openclaw/octopool",
+  "not repo:openclaw/octopool needle",
+  "repo:openclaw/octopool NOT needle",
+  "-repo:openclaw/octopool needle",
+  "repo:openclaw/octopool -repo:other/private needle",
+  "repo:openclaw/octopool -needle",
+  "(repo:openclaw/octopool) needle",
+  "repo:openclaw/octopool org:other needle",
+  "REPO:openclaw/octopool needle",
+  "repo:openclaw/octopool TYPE:issue needle",
+  "repo:openclaw/octopool state:OPEN needle",
+];
+
+export const validRepoSearchQueries = [
+  "repo:openclaw/octopool",
+  "repo:openclaw/octopool needle cache-hit v1.2 under_score",
+  "needle repo:openclaw/octopool type:issue state:open",
+  "type:pr state:closed repo:openclaw/octopool needle",
+  " \tneedle\nrepo:OpenClaw/OctoPool  type:issue\tstate:open \r\n",
+];

--- a/test/policy.test.ts
+++ b/test/policy.test.ts
@@ -1,5 +1,57 @@
 import { describe, expect, it } from "vitest";
 import { classifyRoute, defaultPolicy, validateRelayRequest } from "../src/policy";
+import {
+  deniedRepoSearchQueries,
+  repoSearchPaths,
+  validRepoSearchQueries,
+} from "./fixtures/restricted-search";
+
+describe.each(repoSearchPaths)("restricted search grammar for %s", (path) => {
+  const policy = { ...defaultPolicy("openclaw"), allow_search: true };
+  const requestFor = (q: string | string[] | undefined) =>
+    validateRelayRequest({ pool: "maintainers", method: "GET", path, query: { q } });
+
+  it.each(deniedRepoSearchQueries)("denies unsupported q=%j", (q) => {
+    expect(() => classifyRoute(requestFor(q), policy)).toThrow(
+      expect.objectContaining({ status: 403, code: "search_denied" }),
+    );
+  });
+
+  it("requires a single string q", () => {
+    for (const query of [undefined, {}, { q: ["repo:openclaw/octopool", "needle"] }]) {
+      const request = validateRelayRequest({ pool: "maintainers", method: "GET", path, query });
+      expect(() => classifyRoute(request, policy)).toThrow(
+        expect.objectContaining({ status: 403, code: "search_denied" }),
+      );
+    }
+  });
+
+  it.each(validRepoSearchQueries)("preserves valid q=%j", (q) => {
+    const request = requestFor(q);
+    expect(classifyRoute(request, policy)).toMatchObject({
+      owner: "openclaw",
+      repo: q.includes("OctoPool") ? "OctoPool" : "octopool",
+      publicOnly: false,
+      resource: "search",
+    });
+    expect(request.query?.q).toBe(q);
+    expect(() => classifyRoute(request, { ...policy, allow_search: false })).toThrow(
+      expect.objectContaining({ status: 403, code: "search_denied" }),
+    );
+  });
+
+  it("retains owner and public-only policy routing", () => {
+    const request = requestFor("repo:Other/Project needle");
+    expect(classifyRoute(request, policy)).toMatchObject({
+      owner: "other",
+      repo: "Project",
+      publicOnly: true,
+    });
+    expect(() => classifyRoute(request, { ...policy, allow_public_repos: false })).toThrow(
+      expect.objectContaining({ status: 403, code: "owner_denied" }),
+    );
+  });
+});
 
 describe("route policy", () => {
   const policy = defaultPolicy("openclaw");


### PR DESCRIPTION
## Summary

Fixes a relay grammar violation where extra malformed repository qualifiers or unsupported negation in issue, code, and commit searches could reach dispatch or cache reuse. Validate every token at one parser owner and require exactly one complete `repo:owner/name` qualifier.

Preserve valid query bytes, owner/public-only gates, the token-free issue-search exception, and protected-input/egress checks. Rejected queries retain typed `424 fallback_local` / `search_denied` and caller-owned native fallback. No cache generation bump is needed because invalid queries fail before cache state exists. This does not claim that every malformed form broadens live GitHub results.

## Tests

Fresh post-commit verification on this PR head:

- `pnpm exec vitest run --config vitest.e2e.config.ts test/e2e/restricted-search.test.ts`: 115 passed.
- `GOTOOLCHAIN=go1.26.7 pnpm check`: passed generation checks, formatting, lint, 733 unit tests, 478 Worker tests, build/types, Go tests, and vet; no generated drift.

All search execution was synthetic. An earlier full run encountered Worker deadline/isolation failures; unchanged capped/default comparisons and subsequent full checks passed. The intermittent overrun cause remains unknown. No concurrency, deadline, test configuration, or guard change was made.
