### PR TITLE
fix: fail closed on malformed stored policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Reject malformed stored pool policies before cache reuse or pooled GitHub access with a typed configuration-unavailable error, preserving valid partial-policy defaults.
 - Reject extra or malformed repository qualifiers and negated scope in issue, code, and commit searches before relay dispatch or cache reuse, preserving typed local fallback for unsupported queries.
 - Make active caller enrollment and named-client token rotation atomic across CLI, admin, and browser login, preserving existing access and history while refusing ambiguous upgrades.
 - Bind org membership checks to the enrolled GitHub account on every page, isolate verification timestamps across rolling upgrades, and preserve safe legacy re-login and typed upstream errors.

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -118,6 +118,15 @@ owners = `DEFAULT_ALLOWED_OWNERS` (`openclaw`), `allow_public_repos: true`,
 `allow_search: false`, `allow_logs: true`.
 There is no pool-creation endpoint; edit `pools.policy_json` in D1 to change a policy.
 
+Stored policies must be JSON objects. `{}` and partial objects retain defaults for missing
+fields. Present `allow_public_repos`, `allow_search`, and `allow_logs` values must be
+booleans; `allowed_owners` must be an array of strings (an empty array is valid). Stored
+owner strings are lowercased. Invalid JSON, roots, or known field types block relay
+serving with `503 pool_policy_unavailable`, without exposing the stored value. Repair the
+row to recover; referencing an existing pool does not replace its policy with defaults.
+An isolate may use a previously valid cached policy for up to 30 seconds after an edit;
+cold/expired lookups reject corruption, and failed parses are not cached.
+
 ## Deployment-wide string protection
 
 String rewrite rules are a **single deployment-wide policy**, independent of pool policy.

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -329,6 +329,19 @@ the Worker remains GET-only and does not relay those neighboring routes.
   issue-search shape can run with `allow_search: false`, subject to the same grammar and
   owner/public-repository gates, and never falls through to pooled credentials.
 
+Stored policy must be a JSON object. Missing fields, including an explicit `{}`, retain
+the defaults above; present boolean fields must be booleans and `allowed_owners` must
+contain only strings. Invalid JSON, roots, or known fields return
+`503 pool_policy_unavailable` with a generic message, before cache access or pooled
+identity selection. Authentication and deployment-wide string protection still run first.
+This configuration error does not authorize native fallback; valid policy denials and
+caller-owned native reads retain their existing `424 fallback_local` behavior.
+
+Valid policies may remain cached in an isolate for 30 seconds after a database edit.
+Cold and expired lookups reject corrupt storage, and failed parses are never cached as
+successful configuration; a corrected value can be read on the next lookup. There is no
+persistent last-known-good policy fallback.
+
 When a Cloudflare backend (D1 or the pool Durable Object) rejects work because its
 request queue backed up, the relay returns `424 fallback_local` with reason
 `relay_overloaded` (other surfaces report `503 relay_overloaded`) instead of an untyped

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -26,29 +26,41 @@ export function defaultPolicy(owners: string): PoolPolicy {
 }
 
 export function parsePolicy(raw: string, fallbackOwners: string): PoolPolicy {
+  let value: unknown;
   try {
-    const value: unknown = JSON.parse(raw);
-    if (!isRecord(value)) {
-      return defaultPolicy(fallbackOwners);
-    }
-    const fallback = defaultPolicy(fallbackOwners);
-    return {
-      allowed_owners: Array.isArray(value.allowed_owners)
-        ? value.allowed_owners
-            .filter((item): item is string => typeof item === "string")
-            .map((item) => item.toLowerCase())
-        : fallback.allowed_owners,
-      allow_public_repos:
-        typeof value.allow_public_repos === "boolean"
-          ? value.allow_public_repos
-          : fallback.allow_public_repos,
-      allow_search:
-        typeof value.allow_search === "boolean" ? value.allow_search : fallback.allow_search,
-      allow_logs: typeof value.allow_logs === "boolean" ? value.allow_logs : fallback.allow_logs,
-    };
+    value = JSON.parse(raw);
   } catch {
-    return defaultPolicy(fallbackOwners);
+    throw poolPolicyUnavailable();
   }
+  if (!isRecord(value)) {
+    throw poolPolicyUnavailable();
+  }
+  // Missing fields (including an explicit {}) retain the stored-policy contract.
+  // Present but invalid restrictions must never become new-pool defaults.
+  const policy = defaultPolicy(fallbackOwners);
+  if (Object.hasOwn(value, "allowed_owners")) {
+    if (
+      !Array.isArray(value.allowed_owners) ||
+      !value.allowed_owners.every((item): item is string => typeof item === "string")
+    ) {
+      throw poolPolicyUnavailable();
+    }
+    policy.allowed_owners = value.allowed_owners.map((item) => item.toLowerCase());
+  }
+  for (const field of ["allow_public_repos", "allow_search", "allow_logs"] as const) {
+    if (Object.hasOwn(value, field)) {
+      const flag = value[field];
+      if (typeof flag !== "boolean") {
+        throw poolPolicyUnavailable();
+      }
+      policy[field] = flag;
+    }
+  }
+  return policy;
+}
+
+function poolPolicyUnavailable(): HttpError {
+  return new HttpError(503, "pool_policy_unavailable", "Pool policy is unavailable");
 }
 
 export function validateRelayRequest(value: unknown): RelayRequest {

--- a/test/config-cache.test.ts
+++ b/test/config-cache.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cachedConfigLookup, clearConfigCache } from "../src/config-cache";
+
+describe("configuration cache", () => {
+  beforeEach(clearConfigCache);
+  afterEach(() => {
+    clearConfigCache();
+    vi.restoreAllMocks();
+  });
+
+  it("retries rejected cold loads immediately and caches only successful values", async () => {
+    const failure = new Error("synthetic unavailable configuration");
+    const load = vi.fn().mockRejectedValueOnce(failure).mockResolvedValue("repaired");
+    await expect(cachedConfigLookup("policy:fixture", load)).rejects.toBe(failure);
+    await expect(cachedConfigLookup("policy:fixture", load)).resolves.toBe("repaired");
+    await expect(cachedConfigLookup("policy:fixture", load)).resolves.toBe("repaired");
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not extend or serve an expired success when a reload fails", async () => {
+    const clock = vi.spyOn(Date, "now").mockReturnValue(0);
+    const load = vi
+      .fn()
+      .mockResolvedValueOnce("valid")
+      .mockRejectedValueOnce(new Error("unavailable"))
+      .mockResolvedValueOnce("repaired");
+    await expect(cachedConfigLookup("policy:fixture", load)).resolves.toBe("valid");
+    clock.mockReturnValue(29_999);
+    await expect(cachedConfigLookup("policy:fixture", load)).resolves.toBe("valid");
+    expect(load).toHaveBeenCalledTimes(1);
+    clock.mockReturnValue(30_000);
+    await expect(cachedConfigLookup("policy:fixture", load)).rejects.toThrow("unavailable");
+    await expect(cachedConfigLookup("policy:fixture", load)).resolves.toBe("repaired");
+    expect(load).toHaveBeenCalledTimes(3);
+  });
+});

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -1,5 +1,68 @@
-import { describe, expect, it, vi } from "vitest";
-import { loadIdentities, pruneOldAuditEvents } from "../src/db";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearConfigCache } from "../src/config-cache";
+import { loadIdentities, loadPoolPolicy, pruneOldAuditEvents } from "../src/db";
+import { restrictivePolicy } from "./fixtures/stored-policy";
+
+describe("stored pool policy loading", () => {
+  beforeEach(clearConfigCache);
+  afterEach(() => {
+    clearConfigCache();
+    vi.restoreAllMocks();
+  });
+
+  function fixture(initial: string | null) {
+    let raw = initial;
+    const first = vi.fn(async () => (raw === null ? null : { policy_json: raw }));
+    const bind = vi.fn(() => ({ first }));
+    const prepare = vi.fn(() => ({ bind }));
+    return {
+      env: { ...env(prepare), DEFAULT_ALLOWED_OWNERS: "openclaw" } satisfies Env,
+      first,
+      set: (next: string) => {
+        raw = next;
+      },
+    };
+  }
+
+  it("keeps a missing pool distinct from an invalid stored policy", async () => {
+    const db = fixture(null);
+    await expect(loadPoolPolicy(db.env, "missing")).resolves.toBeNull();
+  });
+
+  it("does not cache failed parses and reads a repair on the next lookup", async () => {
+    const db = fixture("null");
+    for (let attempt = 0; attempt < 2; attempt++) {
+      await expect(loadPoolPolicy(db.env, "maintainers")).rejects.toMatchObject({
+        status: 503,
+        code: "pool_policy_unavailable",
+      });
+    }
+    db.set(JSON.stringify(restrictivePolicy));
+    await expect(loadPoolPolicy(db.env, "maintainers")).resolves.toEqual(restrictivePolicy);
+    await expect(loadPoolPolicy(db.env, "maintainers")).resolves.toEqual(restrictivePolicy);
+    expect(db.first).toHaveBeenCalledTimes(3);
+  });
+
+  it("expires a valid policy at 30 seconds without reviving it after a parse failure", async () => {
+    const clock = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const db = fixture(JSON.stringify(restrictivePolicy));
+    await expect(loadPoolPolicy(db.env, "maintainers")).resolves.toEqual(restrictivePolicy);
+    db.set("[]");
+    clock.mockReturnValue(30_999);
+    await expect(loadPoolPolicy(db.env, "maintainers")).resolves.toEqual(restrictivePolicy);
+    expect(db.first).toHaveBeenCalledTimes(1);
+    clock.mockReturnValue(31_000);
+    await expect(loadPoolPolicy(db.env, "maintainers")).rejects.toMatchObject({
+      code: "pool_policy_unavailable",
+    });
+    db.set("{}");
+    await expect(loadPoolPolicy(db.env, "maintainers")).resolves.toMatchObject({
+      allow_public_repos: true,
+      allow_logs: true,
+    });
+    expect(db.first).toHaveBeenCalledTimes(3);
+  });
+});
 
 describe("identity loading", () => {
   it("uses explicitly broad public PAT identities for public-only routes", async () => {

--- a/test/e2e/stored-policy.test.ts
+++ b/test/e2e/stored-policy.test.ts
@@ -1,0 +1,269 @@
+import { env } from "cloudflare:workers";
+import { runInDurableObject } from "cloudflare:test";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { githubCacheKey, writeGitHubCache } from "../../src/cache";
+import { ensurePool, loadPoolPolicy } from "../../src/db";
+import { deleteEdgeJSON } from "../../src/edge-cache";
+import { classifyRoute, defaultPolicy } from "../../src/policy";
+import { poolCoordinatorStub } from "../../src/pool-coordinator";
+import { recordPublicGitHubRepo } from "../../src/public-repos";
+import { malformedStoredPolicies, restrictivePolicy } from "../fixtures/stored-policy";
+import {
+  bearer,
+  CALLER_TOKEN,
+  callWarmWorker,
+  callWorker,
+  jsonResponse,
+  POOL,
+  rateHeaders,
+  relay,
+  seedPool,
+} from "./harness";
+
+const CHECK_PATH =
+  "/repos/openclaw/octopool/commits/0123456789abcdef0123456789abcdef01234567/check-runs";
+const LOG_PATH = "/repos/elsewhere/octopool/actions/jobs/42/logs";
+const CACHE_BODY = { total_count: 1, check_runs: [{ id: 7, name: "cached-policy-fixture" }] };
+const LIVE_BODY = { total_count: 1, check_runs: [{ id: 8, name: "pooled-policy-fixture" }] };
+
+async function storePolicy(raw: string): Promise<void> {
+  await env.DB.prepare("UPDATE pools SET policy_json = ? WHERE id = ?").bind(raw, POOL).run();
+}
+
+async function seedCachedChecks(path = CHECK_PATH): Promise<string> {
+  const request = { pool: POOL, method: "GET", path };
+  const route = classifyRoute(request, defaultPolicy("openclaw"));
+  await recordPublicGitHubRepo(env, route);
+  const key = await githubCacheKey(POOL, request, route);
+  expect(
+    await writeGitHubCache(env, key, request, route, {
+      status: 200,
+      headers: {},
+      body: CACHE_BODY,
+      body_encoding: "json",
+    }),
+  ).toBe("shared");
+  return key;
+}
+
+function mockUpstream() {
+  const upstream = vi.fn<typeof fetch>(async (input, init) => {
+    const request = new Request(input, init);
+    if (bearer(request) === "test-org-token") return jsonResponse({ private: false });
+    if (bearer(request) === "test-primary-token") {
+      if (new URL(request.url).pathname.endsWith("/logs")) {
+        return new Response("pooled-log-fixture", { headers: rateHeaders({ remaining: 4_999 }) });
+      }
+      return jsonResponse(LIVE_BODY, 200, rateHeaders({ remaining: 4_999 }));
+    }
+    return jsonResponse({ message: "synthetic public backend unavailable" }, 503);
+  });
+  vi.stubGlobal("fetch", upstream);
+  return upstream;
+}
+
+async function expectUnavailable(response: Response): Promise<void> {
+  expect.soft(response.status).toBe(503);
+  expect.soft(response.headers.get("cache-control")).toBe("no-store");
+  expect.soft(await response.json()).toEqual({
+    error: {
+      code: "pool_policy_unavailable",
+      message: "Pool policy is unavailable",
+      request_id: expect.any(String),
+    },
+  });
+}
+
+async function coordinatorSnapshot() {
+  return runInDurableObject(poolCoordinatorStub(env, POOL), (instance) => instance.snapshot());
+}
+
+function warmRelay(): Promise<Response> {
+  return callWarmWorker("/v1/github/request", {
+    method: "POST",
+    headers: { authorization: `Bearer ${CALLER_TOKEN}`, "content-type": "application/json" },
+    body: JSON.stringify({ pool: POOL, method: "GET", path: CHECK_PATH }),
+  });
+}
+
+describe("Worker stored pool policy", () => {
+  beforeEach(async () => {
+    // The real table fixture has a fresh identity-bound membership timestamp.
+    await seedPool();
+    await storePolicy(JSON.stringify(restrictivePolicy));
+  });
+
+  it.each(malformedStoredPolicies)(
+    "rejects $name before edge/shared cache or pooled dispatch",
+    async ({ raw }) => {
+      const key = await seedCachedChecks();
+      await storePolicy(raw);
+      const upstream = mockUpstream();
+      const edgeMatch = vi.spyOn(caches.default, "match");
+      await expectUnavailable(await relay(CHECK_PATH));
+      await deleteEdgeJSON("github-v1", key);
+      await expectUnavailable(await relay(CHECK_PATH));
+      await expectUnavailable(
+        await relay(CHECK_PATH, CALLER_TOKEN, { headers: { "if-none-match": '"miss"' } }),
+      );
+      expect.soft(upstream).not.toHaveBeenCalled();
+      expect.soft(edgeMatch).not.toHaveBeenCalled();
+      expect.soft(await coordinatorSnapshot()).toEqual({ leases: [], rates: [], cooldowns: [] });
+      expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM audit_events").first()).toEqual({
+        count: 0,
+      });
+    },
+  );
+
+  it("rejects corrupted restrictive policy instead of enabling public-owner cache and pooled logs", async () => {
+    const outsidePath = CHECK_PATH.replace("/openclaw/", "/elsewhere/");
+    await seedCachedChecks(outsidePath);
+    await env.DB.prepare(
+      "INSERT INTO identity_scopes (identity_id, owner, permission, allow_private) VALUES ('primary', '*', 'read', 0)",
+    ).run();
+    const upstream = mockUpstream();
+    for (const [path, reason] of [
+      [outsidePath, "owner_denied"],
+      [LOG_PATH, "logs_denied"],
+    ] as const) {
+      const denied = await relay(path);
+      expect(denied.status).toBe(424);
+      expect(await denied.json()).toMatchObject({
+        error: { code: "fallback_local", details: { reason } },
+      });
+    }
+    expect(upstream).not.toHaveBeenCalled();
+    await storePolicy('{"private-policy-marker":');
+    await expectUnavailable(await relay(outsidePath));
+    await expectUnavailable(
+      await relay(LOG_PATH, CALLER_TOKEN, { headers: { "if-none-match": '"miss"' } }),
+    );
+    expect.soft(upstream).not.toHaveBeenCalled();
+    expect(await coordinatorSnapshot()).toEqual({ leases: [], rates: [], cooldowns: [] });
+  });
+
+  it.each([
+    { name: "complete restrictive", raw: JSON.stringify(restrictivePolicy) },
+    { name: "partial", raw: '{"allow_public_repos":false}' },
+    { name: "empty object", raw: "{}" },
+  ])("serves valid $name policy through cache and pooled paths", async ({ raw }) => {
+    await storePolicy(raw);
+    await seedCachedChecks();
+    const upstream = mockUpstream();
+    const cached = await relay(CHECK_PATH);
+    expect(cached.status).toBe(200);
+    expect(await cached.json()).toMatchObject({ body: CACHE_BODY, relay: { cache: "hit" } });
+    expect(upstream).not.toHaveBeenCalled();
+    const live = await relay(CHECK_PATH, CALLER_TOKEN, { headers: { "if-none-match": '"miss"' } });
+    expect(live.status).toBe(200);
+    expect(await live.json()).toMatchObject({
+      body: LIVE_BODY,
+      identity: { id: "primary" },
+      relay: { cache: "bypass" },
+    });
+    expect((await coordinatorSnapshot()).leases).toHaveLength(1);
+  });
+
+  it("keeps local authentication ahead of stored-policy errors", async () => {
+    await storePolicy("null");
+    const upstream = mockUpstream();
+    const missing = await callWorker("/v1/github/request", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ pool: POOL, method: "GET", path: CHECK_PATH }),
+    });
+    expect(missing.status).toBe(401);
+    expect(await missing.json()).toMatchObject({ error: { code: "missing_auth" } });
+    const invalid = await relay(CHECK_PATH, "invalid-caller");
+    expect(invalid.status).toBe(401);
+    expect(await invalid.json()).toMatchObject({ error: { code: "invalid_auth" } });
+    await env.DB.prepare("DELETE FROM caller_pools").run();
+    const ungranted = await relay(CHECK_PATH);
+    expect(ungranted.status).toBe(401);
+    expect(await ungranted.json()).toMatchObject({ error: { code: "invalid_auth" } });
+    expect(upstream).not.toHaveBeenCalled();
+  });
+
+  it("creates defaults only for a new pool and never overwrites corrupt existing storage", async () => {
+    await ensurePool(env, "new-pool");
+    await expect(loadPoolPolicy(env, "new-pool")).resolves.toEqual(
+      defaultPolicy(env.DEFAULT_ALLOWED_OWNERS),
+    );
+    await storePolicy("null");
+    await ensurePool(env, POOL);
+    const upstream = mockUpstream();
+    await expectUnavailable(await relay(CHECK_PATH));
+    expect(
+      await env.DB.prepare("SELECT policy_json FROM pools WHERE id = ?").bind(POOL).first(),
+    ).toEqual({ policy_json: "null" });
+    expect(upstream).not.toHaveBeenCalled();
+  });
+
+  it("recovers a failed cold lookup immediately after storage is repaired", async () => {
+    await seedCachedChecks();
+    await storePolicy("[]");
+    const upstream = mockUpstream();
+    await expectUnavailable(await relay(CHECK_PATH));
+    await expectUnavailable(await warmRelay());
+    await storePolicy("{}");
+    const repaired = await warmRelay();
+    expect(repaired.status).toBe(200);
+    expect(await repaired.json()).toMatchObject({ body: CACHE_BODY, relay: { cache: "hit" } });
+    expect(upstream).not.toHaveBeenCalled();
+    expect(await coordinatorSnapshot()).toEqual({ leases: [], rates: [], cooldowns: [] });
+  });
+
+  it("preserves caller-owned native fallback for valid policies and reports corrupt policy as unavailable", async () => {
+    const path = "/repos/openclaw/octopool/rules/branches/main";
+    const upstream = mockUpstream();
+    const valid = await relay(path);
+    expect(valid.status).toBe(424);
+    expect(await valid.json()).toMatchObject({
+      error: { code: "fallback_local", details: { reason: "local_credentials_required" } },
+    });
+    await storePolicy("null");
+    await expectUnavailable(await relay(path));
+    expect(upstream).not.toHaveBeenCalled();
+    expect(await coordinatorSnapshot()).toEqual({ leases: [], rates: [], cooldowns: [] });
+  });
+
+  it("retains global string protection before pool failure and native fallback", async () => {
+    await storePolicy("null");
+    const upstream = mockUpstream();
+    await env.DB.prepare("UPDATE string_rewrite_policy SET rules_json = ?")
+      .bind('[{"pattern":"octopool","replacement":"public"}]')
+      .run();
+    const denied = await relay(CHECK_PATH);
+    expect(denied.status).toBe(403);
+    expect(await denied.json()).toMatchObject({ error: { code: "string_rewrite_denied" } });
+    await env.DB.prepare("DELETE FROM string_rewrite_policy").run();
+    const unavailable = await relay("/repos/openclaw/octopool/rules/branches/main");
+    expect(unavailable.status).toBe(503);
+    expect(await unavailable.json()).toMatchObject({
+      error: { code: "string_rewrite_policy_unavailable" },
+    });
+    expect(upstream).not.toHaveBeenCalled();
+  });
+
+  it("retains the 30-second valid-policy window, then rejects corruption and recovers without caching failure", async () => {
+    await seedCachedChecks();
+    const upstream = mockUpstream();
+    const now = Date.now();
+    const clock = vi.spyOn(Date, "now").mockReturnValue(now);
+    expect((await relay(CHECK_PATH)).status).toBe(200);
+    await storePolicy("null");
+    clock.mockReturnValue(now + 29_999);
+    expect((await warmRelay()).status).toBe(200);
+    clock.mockReturnValue(now + 30_000);
+    await expectUnavailable(await warmRelay());
+    await expectUnavailable(await warmRelay());
+    await storePolicy('{"allowed_owners":[],"allow_public_repos":false}');
+    const repaired = await warmRelay();
+    expect(repaired.status).toBe(424);
+    expect(await repaired.json()).toMatchObject({
+      error: { code: "fallback_local", details: { reason: "owner_denied" } },
+    });
+    expect(upstream).not.toHaveBeenCalled();
+    expect(await coordinatorSnapshot()).toEqual({ leases: [], rates: [], cooldowns: [] });
+  });
+});

--- a/test/fixtures/stored-policy.ts
+++ b/test/fixtures/stored-policy.ts
@@ -1,0 +1,36 @@
+export const restrictivePolicy = {
+  allowed_owners: ["openclaw"],
+  allow_public_repos: false,
+  allow_search: false,
+  allow_logs: false,
+};
+
+export const malformedStoredPolicies = [
+  { name: "invalid JSON", raw: '{"private-policy-marker":' },
+  ...[null, [], ["openclaw"], "private-policy-marker", false, 42].map((root) => ({
+    name: `root ${JSON.stringify(root)}`,
+    raw: JSON.stringify(root),
+  })),
+  ...["allow_public_repos", "allow_search", "allow_logs"].flatMap((field) =>
+    ["false", null, 0, [], {}].map((value) => ({
+      name: `${field}=${JSON.stringify(value)}`,
+      raw: JSON.stringify({ ...restrictivePolicy, [field]: value }),
+    })),
+  ),
+  ...[
+    "openclaw",
+    null,
+    false,
+    42,
+    {},
+    [42],
+    ["openclaw", 42],
+    ["openclaw", null],
+    ["openclaw", false],
+    ["openclaw", {}],
+    ["openclaw", []],
+  ].map((allowed_owners) => ({
+    name: `allowed_owners=${JSON.stringify(allowed_owners)}`,
+    raw: JSON.stringify({ ...restrictivePolicy, allowed_owners }),
+  })),
+];

--- a/test/policy.test.ts
+++ b/test/policy.test.ts
@@ -1,10 +1,61 @@
 import { describe, expect, it } from "vitest";
-import { classifyRoute, defaultPolicy, validateRelayRequest } from "../src/policy";
+import { HttpError } from "../src/http";
+import { classifyRoute, defaultPolicy, parsePolicy, validateRelayRequest } from "../src/policy";
+import { malformedStoredPolicies, restrictivePolicy } from "./fixtures/stored-policy";
 import {
   deniedRepoSearchQueries,
   repoSearchPaths,
   validRepoSearchQueries,
 } from "./fixtures/restricted-search";
+
+describe("stored pool policy", () => {
+  it.each(malformedStoredPolicies)("rejects $name with a safe configuration error", ({ raw }) => {
+    expect(() => parsePolicy(raw, "openclaw")).toThrow(
+      new HttpError(503, "pool_policy_unavailable", "Pool policy is unavailable"),
+    );
+    expect(() => parsePolicy(raw, "openclaw")).toThrow(
+      expect.objectContaining({ status: 503, code: "pool_policy_unavailable" }),
+    );
+  });
+
+  it("preserves creation defaults and explicit empty-object storage", () => {
+    const expected = {
+      allowed_owners: ["openclaw", "other"],
+      allow_public_repos: true,
+      allow_search: false,
+      allow_logs: true,
+    };
+    expect(defaultPolicy(" OpenClaw, ,OTHER ")).toEqual(expected);
+    expect(parsePolicy("{}", " OpenClaw, ,OTHER ")).toEqual(expected);
+  });
+
+  it("preserves complete restrictions, missing fields, and historical owner normalization", () => {
+    expect(parsePolicy(JSON.stringify(restrictivePolicy), "other")).toEqual(restrictivePolicy);
+    expect(parsePolicy('{"allow_logs":false}', "openclaw")).toEqual({
+      ...defaultPolicy("openclaw"),
+      allow_logs: false,
+    });
+    expect(
+      parsePolicy('{"allowed_owners":["OpenClaw"," OTHER ","","OpenClaw"]}', "fallback"),
+    ).toEqual({
+      ...defaultPolicy("fallback"),
+      allowed_owners: ["openclaw", " other ", "", "openclaw"],
+    });
+    expect(parsePolicy('{"allowed_owners":[]}', "fallback").allowed_owners).toEqual([]);
+    expect(parsePolicy('{"future_field":{"enabled":true}}', "openclaw")).toEqual(
+      defaultPolicy("openclaw"),
+    );
+  });
+
+  it.each([true, false])("preserves explicit %s for each boolean independently", (flag) => {
+    for (const field of ["allow_public_repos", "allow_search", "allow_logs"]) {
+      expect(parsePolicy(JSON.stringify({ [field]: flag }), "openclaw")).toEqual({
+        ...defaultPolicy("openclaw"),
+        [field]: flag,
+      });
+    }
+  });
+});
 
 describe.each(repoSearchPaths)("restricted search grammar for %s", (path) => {
   const policy = { ...defaultPolicy("openclaw"), allow_search: true };


### PR DESCRIPTION
## Summary

Malformed stored pool policies could silently become permissive defaults, allowing cached reads or pooled GitHub access that the stored restrictions should have blocked. Strict decoding now belongs to the policy parser: invalid JSON, non-object roots, wrong-type explicitly present known fields, and non-string owner-array members return a generic `503 pool_policy_unavailable` before cache access or pooled identity selection.

Creation defaults and valid complete, partial, and `{}` policies retain their established defaults and owner normalization; unknown fields remain ignored. Authentication and deployment-wide string protection still run first. The existing 30-second valid configuration cache window is preserved; failed parses are not cached, so repaired storage can recover on the next lookup. This configuration error does not authorize native fallback.

## Tests

- Fresh post-commit focused Worker/D1/Durable Object proof: `pnpm exec vitest run --config vitest.e2e.config.ts test/e2e/stored-policy.test.ts` — 43 passed.
- Fresh post-commit full gate: `GOTOOLCHAIN=go1.26.7 pnpm check` — 775 unit tests and 521 Worker tests passed, with generation/drift, formatting, lint, TypeScript builds, Go tests, and vet. Ordinary real index; no generated drift.
- Supplied pre-fix synthetic Worker proof: 35 failing regression cases and 5 passing controls after successful initialization, including actual cache and pooled responses under corrupt restrictive storage.
