### PR TITLE
fix: isolate auth tests and repair Windows CLI behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   release-asset-windows:
-    name: Windows release asset helpers
+    name: Windows Go suite and release asset helpers
     runs-on: windows-latest
     timeout-minutes: 10
     steps:
@@ -29,6 +29,10 @@ jobs:
           cache: false
       - name: Test native Windows staging and filesystem protection
         run: go test -v ./cmd/octopool -run '^TestReleaseAssets(Windows.*|Filename(Validation|SourceDirectories)|StagingFilesystemSyntax|LimitsAndIdentity|BoundedCopyFailures|SnapshotWriteCloseAndCancellationCleanup|ExactBasenameAndTextBudget)$' -count=1
+      - name: Test full native Windows Go suite
+        run: go test ./... -count=1
+      - name: Vet native Windows Go code
+        run: go vet ./...
 
   check:
     name: Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
           cache: false
       - name: Test native Windows staging and filesystem protection
         run: go test -v ./cmd/octopool -run '^TestReleaseAssets(Windows.*|Filename(Validation|SourceDirectories)|StagingFilesystemSyntax|LimitsAndIdentity|BoundedCopyFailures|SnapshotWriteCloseAndCancellationCleanup|ExactBasenameAndTextBudget)$' -count=1
+      - name: Verify native Windows jq output support
+        run: |
+          jq --version
+          jq --binary --null-input empty
       - name: Test full native Windows Go suite
         run: go test ./... -count=1
       - name: Vet native Windows Go code
@@ -63,6 +67,9 @@ jobs:
 
       - name: Install
         run: pnpm install --frozen-lockfile
+
+      - name: Verify jq test dependency
+        run: jq --version
 
       - name: Check Go module tidiness
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Keep `--jq` expressions literal, preserve native `gh` output bytes with native jq 1.7+ on Windows, and recognize `octopool.exe` when resolving the shim target without requiring Unix execute bits.
 - Reject malformed stored pool policies before cache reuse or pooled GitHub access with a typed configuration-unavailable error, preserving valid partial-policy defaults.
 - Reject extra or malformed repository qualifiers and negated scope in issue, code, and commit searches before relay dispatch or cache reuse, preserving typed local fallback for unsupported queries.
 - Make active caller enrollment and named-client token rotation atomic across CLI, admin, and browser login, preserving existing access and history while refusing ambiguous upgrades.

--- a/cmd/octopool/cli_config_test.go
+++ b/cmd/octopool/cli_config_test.go
@@ -95,7 +95,7 @@ func TestCallerRequestFlagsAuthSnapshot(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			isolateHTTPTestConfig(t)
+			isolateTestConfig(t)
 			for _, name := range []string{"OCTOPOOL_URL", "OCTOPOOL_POOL", "OCTOPOOL_TOKEN", "OCTOPOOL_TEST_CALLER_TOKEN"} {
 				t.Setenv(name, tt.env[name])
 			}

--- a/cmd/octopool/cli_e2e_test.go
+++ b/cmd/octopool/cli_e2e_test.go
@@ -253,8 +253,10 @@ type cliResult struct {
 func buildCLIBinary(t *testing.T) string {
 	t.Helper()
 	bin := filepath.Join(t.TempDir(), executableName("octopool"))
-	cmd := exec.Command("go", "build", "-o", bin, ".")
+	tool, env := testCompiler(t)
+	cmd := exec.CommandContext(t.Context(), tool, "build", "-o", bin, ".")
 	cmd.Dir = "."
+	cmd.Env = env
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("go build: %v\n%s", err, out)
 	}
@@ -266,10 +268,8 @@ func runCLI(t *testing.T, bin string, serverURL string, extra map[string]string,
 	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, bin, args...)
-	home := t.TempDir()
-	env := append(os.Environ(),
-		"HOME="+home,
-		"XDG_CONFIG_HOME="+filepath.Join(home, ".config"),
+	env := append(os.Environ(), testConfigEnv(t.TempDir())...)
+	env = append(env,
 		"OCTOPOOL_STRING_REWRITE_FILE=",
 		"OCTOPOOL_TOKEN=test-token",
 		"OCTOPOOL_POOL=maintainers",

--- a/cmd/octopool/command_install_shim.go
+++ b/cmd/octopool/command_install_shim.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -167,14 +168,18 @@ func stableOctopoolPath() (string, error) {
 
 func executableNamedOctopool(path string) bool {
 	info, err := os.Stat(path)
-	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o111 == 0 {
 		return false
 	}
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
 		resolved = path
 	}
-	return strings.EqualFold(filepath.Base(resolved), "octopool")
+	base := filepath.Base(resolved)
+	return strings.EqualFold(base, "octopool") || (runtime.GOOS == "windows" && strings.EqualFold(base, "octopool.exe"))
 }
 
 func writableStartupPath(path string) (string, error) {

--- a/cmd/octopool/command_install_shim_test.go
+++ b/cmd/octopool/command_install_shim_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -15,11 +16,15 @@ func TestUpdateShimBlockAppendsAndReplaces(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := string(first)
+	wantShimDir := "octopool_shim_dir='/home/alice/.local/share/octopool/bin'"
+	if runtime.GOOS == "windows" {
+		wantShimDir = `octopool_shim_dir='\home\alice\.local\share\octopool\bin'`
+	}
 	for _, want := range []string{
 		"export EXISTING=1",
 		shimBlockStart,
 		"export OCTOPOOL_GH_PATH='/opt/bin/gh'",
-		"octopool_shim_dir='/home/alice/.local/share/octopool/bin'",
+		wantShimDir,
 		`export PATH="$octopool_path_next"`,
 		shimBlockEnd,
 	} {
@@ -38,6 +43,7 @@ func TestUpdateShimBlockAppendsAndReplaces(t *testing.T) {
 }
 
 func TestUpdateShimBlockKeepsPathIdempotentInZsh(t *testing.T) {
+	isolateTestConfig(t)
 	zsh, err := exec.LookPath("zsh")
 	if err != nil {
 		t.Skip("zsh is required to exercise .zshenv PATH behavior")
@@ -134,6 +140,7 @@ func TestApplyShimInstallPlanIsIdempotent(t *testing.T) {
 }
 
 func TestVerifyShimInstallChecksLoginShell(t *testing.T) {
+	isolateTestConfig(t)
 	zsh, err := exec.LookPath("zsh")
 	if err != nil {
 		t.Skip("zsh is required to verify shell startup behavior")

--- a/cmd/octopool/command_install_shim_test.go
+++ b/cmd/octopool/command_install_shim_test.go
@@ -236,3 +236,62 @@ func TestExecutableNamedOctopool(t *testing.T) {
 		t.Fatal("expected differently named executable to be rejected")
 	}
 }
+
+func TestExecutableNamedOctopoolControls(t *testing.T) {
+	windows := runtime.GOOS == "windows"
+	for _, tt := range []struct {
+		name string
+		mode os.FileMode
+		want bool
+	}{
+		{"octopool", 0o755, true},
+		{"OcToPoOl", 0o755, true},
+		{"octopool.exe", 0o755, windows},
+		{"OcToPoOl.ExE", 0o755, windows},
+		{"octopool", 0o644, windows},
+		{"octopool.exe", 0o644, windows},
+		{"octopool.cmd", 0o755, false},
+		{"octopool.bat", 0o755, false},
+		{"octopool.com", 0o755, false},
+		{"octopool.exe.bak", 0o755, false},
+		{"octopool.exe.exe", 0o755, false},
+		{"octopool-gh", 0o755, false},
+		{"other.exe", 0o755, false},
+	} {
+		t.Run(tt.name+"/"+tt.mode.String(), func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), tt.name)
+			if err := os.WriteFile(path, []byte("binary"), tt.mode); err != nil {
+				t.Fatal(err)
+			}
+			// An octopool-named link must not hide a differently named target.
+			link := filepath.Join(t.TempDir(), executableName("octopool"))
+			if err := os.Symlink(path, link); err != nil {
+				t.Fatal(err)
+			}
+			for _, candidate := range []string{path, link} {
+				if got := executableNamedOctopool(candidate); got != tt.want {
+					t.Errorf("executableNamedOctopool(%q) = %v, want %v", candidate, got, tt.want)
+				}
+			}
+		})
+	}
+	for _, kind := range []string{"directory", "absent"} {
+		t.Run(kind, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), executableName("octopool"))
+			if kind == "directory" {
+				if err := os.Mkdir(path, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			link := filepath.Join(t.TempDir(), executableName("octopool"))
+			if err := os.Symlink(path, link); err != nil {
+				t.Fatal(err)
+			}
+			for _, candidate := range []string{path, link} {
+				if executableNamedOctopool(candidate) {
+					t.Errorf("expected %s to be rejected: %s", kind, candidate)
+				}
+			}
+		})
+	}
+}

--- a/cmd/octopool/gh_fallback.go
+++ b/cmd/octopool/gh_fallback.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -76,7 +77,13 @@ func execRealGHAfterLocalFallback(
 func runJQ(ctx context.Context, stdout io.Writer, input []byte, expr string) error {
 	child, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(child, "jq", "-r", expr)
+	args := []string{"-r"}
+	if runtime.GOOS == "windows" {
+		// Native jq otherwise expands every LF, including raw string payloads.
+		args = append(args, "--binary")
+	}
+	// A filter that resembles a jq option is still a filter.
+	cmd := exec.CommandContext(child, "jq", append(args, "--", expr)...)
 	cmd.Stdin = bytes.NewReader(input)
 	cmd.Stdout = stdout
 	cmd.Stderr = io.Discard

--- a/cmd/octopool/gh_fallback_test.go
+++ b/cmd/octopool/gh_fallback_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os/exec"
+	"testing"
+)
+
+func TestRunJQPreservesOutputBytes(t *testing.T) {
+	isolateTestConfig(t)
+	if !jqAvailable() {
+		t.Skip("jq is required")
+	}
+	for _, tt := range []struct {
+		name, input, expr, want string
+	}{
+		{"LF", `"left\nright"`, ".", "left\nright\n"},
+		{"CRLF", `"left\r\nright"`, ".", "left\r\nright\n"},
+		{"CR", `"left\rright"`, ".", "left\rright\n"},
+		{"Unicode", `"caf\u00e9 日本語 🦞"`, ".", "café 日本語 🦞\n"},
+		{"empty string", `""`, ".", "\n"},
+		{"trailing LF", `"tail\n"`, ".", "tail\n\n"},
+		{"trailing CRLF", `"tail\r\n"`, ".", "tail\r\n\n"},
+		{"trailing CR", `"tail\r"`, ".", "tail\r\n"},
+		{"multiple results", `["a\n", "b\r\n", "c\r", "雪", "", true, 42]`, ".[]", "a\n\nb\r\n\nc\r\n雪\n\ntrue\n42\n"},
+		{"input stream", "\"a\\r\\nb\"\n\"雪\"\n", ".", "a\r\nb\n雪\n"},
+		{"no results", `[]`, ".[]", ""},
+		{"negative filter", `42`, "-.", "-42\n"},
+		{"double-negative filter", `[1,2,3]`, "--length", "3\n"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			if err := runJQ(t.Context(), &out, []byte(tt.input), tt.expr); err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(out.Bytes(), []byte(tt.want)) {
+				t.Fatalf("output = %q, want %q", out.Bytes(), tt.want)
+			}
+		})
+	}
+}
+
+func TestRunJQErrorsAndCancellation(t *testing.T) {
+	isolateTestConfig(t)
+	if !jqAvailable() {
+		t.Skip("jq is required")
+	}
+	for _, tt := range []struct{ name, input, expr string }{
+		{"invalid expression", `null`, ".["},
+		{"help is a filter, not an option", `null`, "--help"},
+		{"version is a filter, not an option", `null`, "--version"},
+		{"invalid input", `{"unfinished":`, "."},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			err := runJQ(t.Context(), &out, []byte(tt.input), tt.expr)
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) || out.Len() != 0 {
+				t.Fatalf("error = %v, output = %q; want jq failure without output", err, out.Bytes())
+			}
+		})
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	var out bytes.Buffer
+	if err := runJQ(ctx, &out, []byte(`"unused"`), "."); !errors.Is(err, context.Canceled) || out.Len() != 0 {
+		t.Fatalf("canceled run: error = %v, output = %q", err, out.Bytes())
+	}
+}

--- a/cmd/octopool/gh_local_user_test.go
+++ b/cmd/octopool/gh_local_user_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestWriteLocalUserLogin(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", "")
+	isolateTestConfig(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		if request.URL.Path != "/v1/pools/maintainers/health" || request.Header.Get("authorization") != "Bearer op_token" {
 			t.Fatalf("unexpected health request: %s auth=%q", request.URL.Path, request.Header.Get("authorization"))
@@ -32,8 +31,7 @@ func TestWriteLocalUserLogin(t *testing.T) {
 }
 
 func TestWriteLocalUserLoginRejectsOverridesAndBroaderShapes(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", "")
+	isolateTestConfig(t)
 	if err := saveAuth(authFile{
 		URL: "https://octopool.dev", Pool: "maintainers", Token: "op_token", Login: "alice", CreatedAt: time.Now(),
 	}); err != nil {

--- a/cmd/octopool/gh_path_test.go
+++ b/cmd/octopool/gh_path_test.go
@@ -188,25 +188,10 @@ func buildGHPathFixture(t *testing.T, module, command string) string {
 		t.Fatal(err)
 	}
 	binary := filepath.Join(dir, "fixture.exe")
-	goTool := executableName("go")
-	// -trimpath can leave GOROOT empty; use PATH only in that case.
-	if root := runtime.GOROOT(); root != "" {
-		goTool = filepath.Join(root, "bin", goTool)
-	}
-	goPath, err := exec.LookPath(goTool)
-	if err != nil {
-		t.Fatalf("locate Go compiler for fixture (%q): %v", goTool, err)
-	}
+	goPath, env := testCompiler(t)
 	cmd := exec.CommandContext(t.Context(), goPath, "build", "-buildvcs=false", "-o", binary, "./cmd/"+command)
 	cmd.Dir = dir
-	// Ignore caller Go configuration, including workspace, flags and experiments.
-	for _, entry := range os.Environ() {
-		key, _, _ := strings.Cut(entry, "=")
-		if !strings.HasPrefix(key, "GO") && !strings.HasPrefix(key, "CGO_") {
-			cmd.Env = append(cmd.Env, entry)
-		}
-	}
-	cmd.Env = append(cmd.Env, "GOENV=off", "GO111MODULE=on", "GOWORK=off", "GOTOOLCHAIN=local", "GOPROXY=off", "GOSUMDB=off", "CGO_ENABLED=0")
+	cmd.Env = env
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("build Go fixture: %v\n%s", err, out)
 	}
@@ -264,7 +249,7 @@ func TestResolveGHPathAcceptsExplicitRelativePath(t *testing.T) {
 
 func TestResolveGHPathAcceptsExplicitCommandName(t *testing.T) {
 	dir := t.TempDir()
-	realGH := filepath.Join(dir, "custom-gh")
+	realGH := filepath.Join(dir, executableName("custom-gh"))
 	if err := os.WriteFile(realGH, []byte("#!/bin/sh\necho gh version\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -289,8 +274,16 @@ func TestResolveGHPathSkipsInvalidCandidates(t *testing.T) {
 	if err := os.Mkdir(realDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(nonExecutableDir, "gh"), []byte("#!/bin/sh\n"), 0o644); err != nil {
-		t.Fatal(err)
+	invalid := filepath.Join(nonExecutableDir, "gh")
+	if runtime.GOOS == "windows" {
+		// Windows has no Unix executable bits; a directory is unusable on both.
+		if err := os.Mkdir(invalid, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		if err := os.WriteFile(invalid, []byte("#!/bin/sh\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
 	}
 	realGH := filepath.Join(realDir, "gh")
 	if err := os.WriteFile(realGH, []byte("#!/bin/sh\necho gh version\n"), 0o755); err != nil {

--- a/cmd/octopool/gh_relay_client_test.go
+++ b/cmd/octopool/gh_relay_client_test.go
@@ -249,7 +249,7 @@ func TestShouldRunRealGH(t *testing.T) {
 }
 
 func TestNewGHRelayClientMissingLoginUsesFallbackSentinel(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	isolateTestConfig(t)
 	t.Setenv("OCTOPOOL_TOKEN", "")
 	_, err := newGHRelayClient()
 	if !errors.Is(err, errOctopoolNotLoggedIn) {
@@ -295,8 +295,7 @@ func newRelayTestClient(
 	respond func(call int64) (status int, body string),
 ) (ghRelayClient, *atomic.Int64) {
 	t.Helper()
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	isolateTestConfig(t)
 	t.Setenv("OCTOPOOL_STRING_REWRITE_FILE", "")
 	calls := &atomic.Int64{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/octopool/gh_test_helpers_test.go
+++ b/cmd/octopool/gh_test_helpers_test.go
@@ -15,8 +15,7 @@ type relayTestResponse struct {
 
 func relayTestServer(t *testing.T, responseBody func(map[string]any) any) {
 	t.Helper()
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	isolateTestConfig(t)
 	t.Setenv("OCTOPOOL_STRING_REWRITE_FILE", "")
 	t.Setenv("OCTOPOOL_TOKEN", "test-token")
 	t.Setenv("OCTOPOOL_POOL", "maintainers")

--- a/cmd/octopool/gh_top_search_test.go
+++ b/cmd/octopool/gh_top_search_test.go
@@ -163,7 +163,7 @@ func TestRunGHSearchFallsBackForUnimplementedSort(t *testing.T) {
 }
 
 func TestRunGHSearchFallsBackForQualifiedQuery(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	isolateTestConfig(t)
 	var out bytes.Buffer
 	result := handleGHSearch(t.Context(), []string{
 		"issues",
@@ -178,7 +178,7 @@ func TestRunGHSearchFallsBackForQualifiedQuery(t *testing.T) {
 }
 
 func TestRunGHSearchFallsBackForUnsupportedTerm(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	isolateTestConfig(t)
 	var out bytes.Buffer
 	result := handleGHSearch(t.Context(), []string{
 		"issues",

--- a/cmd/octopool/go_test_helpers_test.go
+++ b/cmd/octopool/go_test_helpers_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func testGoTool(t *testing.T) string {
+	t.Helper()
+	tool := executableName("go")
+	// -trimpath can leave GOROOT empty; use PATH only in that case.
+	if root := runtime.GOROOT(); root != "" {
+		tool = filepath.Join(root, "bin", tool)
+	}
+	path, err := exec.LookPath(tool)
+	if err != nil {
+		t.Fatalf("locate Go compiler (%q): %v", tool, err)
+	}
+	return path
+}
+
+func testCompiler(t *testing.T) (string, []string) {
+	t.Helper()
+	tool := testGoTool(t)
+	root := t.TempDir()
+	telemetry := filepath.Join(root, "telemetry")
+	if err := os.Mkdir(telemetry, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Go's own telemetry override prevents user-config reads and background
+	// telemetry children racing TempDir cleanup, including during go env.
+	if err := os.WriteFile(filepath.Join(telemetry, "mode"), []byte("off\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var env []string
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		key = strings.ToUpper(key)
+		if !strings.HasPrefix(key, "GO") && !strings.HasPrefix(key, "CGO_") {
+			env = append(env, entry)
+		}
+	}
+	env = append(env, "GOENV=off", "GO111MODULE=on", "GOWORK=off", "GOTOOLCHAIN=local", "GOPROXY=off", "GOSUMDB=off", "CGO_ENABLED=0", "TEST_TELEMETRY_DIR="+telemetry)
+	query := exec.CommandContext(t.Context(), tool, "env", "-json", "GOCACHE", "GOMODCACHE")
+	query.Env = append([]string{}, env...)
+	// Resolve defaults before replacing HOME. GOPATH only participates in this
+	// query; only the two reusable cache paths cross the compiler boundary.
+	for _, key := range []string{"GOCACHE", "GOMODCACHE", "GOPATH"} {
+		if value, ok := os.LookupEnv(key); ok {
+			query.Env = append(query.Env, key+"="+value)
+		}
+	}
+	out, err := query.Output()
+	if err != nil {
+		t.Fatalf("resolve Go compiler caches: %v", err)
+	}
+	var caches map[string]string
+	if err := json.Unmarshal(out, &caches); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"GOCACHE", "GOMODCACHE"} {
+		if !filepath.IsAbs(caches[key]) {
+			t.Fatalf("Go returned a non-absolute %s: %q", key, caches[key])
+		}
+		env = append(env, key+"="+caches[key])
+	}
+	return tool, append(env, testConfigEnv(root)...)
+}
+
+func TestCompilerCacheAndConfigBoundary(t *testing.T) {
+	for _, explicit := range []bool{false, true} {
+		name := "default caches"
+		if explicit {
+			name = "explicit caches"
+		}
+		t.Run(name, func(t *testing.T) {
+			inherited := seedInheritedConfig(t)
+			sentinels := configSnapshot(t, inherited)
+			for _, key := range []string{"GOCACHE", "GOMODCACHE", "GOPATH"} {
+				t.Setenv(key, "")
+				if err := os.Unsetenv(key); err != nil {
+					t.Fatal(err)
+				}
+			}
+			for _, key := range []string{"XDG_CACHE_HOME", "LocalAppData", "LOCALAPPDATA"} {
+				t.Setenv(key, filepath.Join(inherited, "cache"))
+			}
+			if explicit {
+				t.Setenv("GOCACHE", filepath.Join(t.TempDir(), "build-cache"))
+				t.Setenv("GOMODCACHE", filepath.Join(t.TempDir(), "module-cache"))
+			}
+			telemetry := t.TempDir()
+			if err := os.WriteFile(filepath.Join(telemetry, "mode"), []byte("off\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			// Ask Go independently under the original synthetic home, before
+			// poisoning flags or applying the compiler helper's isolation.
+			baseline := exec.CommandContext(t.Context(), testGoTool(t), "env", "-json", "GOCACHE", "GOMODCACHE")
+			baseline.Env = append(os.Environ(), "GOENV=off", "GOWORK=off", "GOFLAGS=", "GOEXPERIMENT=", "GOTOOLCHAIN=local", "TEST_TELEMETRY_DIR="+telemetry)
+			out, err := baseline.Output()
+			if err != nil {
+				t.Fatal(err)
+			}
+			var want map[string]string
+			if err := json.Unmarshal(out, &want); err != nil {
+				t.Fatal(err)
+			}
+			for _, key := range []string{"GOFLAGS", "GOEXPERIMENT", "GOWORK", "GOTOOLCHAIN"} {
+				t.Setenv(key, "invalid-inherited-setting")
+			}
+			source := filepath.Join(t.TempDir(), "probe.go")
+			if err := os.WriteFile(source, []byte(`package main
+import ("fmt"; "os"; "runtime")
+func main() {
+    dir, err := os.UserConfigDir()
+    if err != nil { panic(err) }
+    fmt.Printf("%s\n%s\n%s\n%s\n", os.Getenv("GOCACHE"), os.Getenv("GOMODCACHE"), dir, runtime.Version())
+}
+`), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			var previousConfig, previousExport string
+			for build := range 2 {
+				tool, env := testCompiler(t)
+				binary := filepath.Join(t.TempDir(), executableName("probe"))
+				cmd := exec.CommandContext(t.Context(), tool, "build", "-o", binary, source)
+				cmd.Env = env
+				if out, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("offline probe build: %v\n%s", err, out)
+				}
+				probe := exec.CommandContext(t.Context(), binary)
+				probe.Env = env
+				out, err := probe.Output()
+				if err != nil {
+					t.Fatal(err)
+				}
+				got := strings.Split(strings.TrimSpace(string(out)), "\n")
+				if len(got) != 4 || got[0] != want["GOCACHE"] || got[1] != want["GOMODCACHE"] || got[3] != runtime.Version() {
+					t.Fatalf("compiled probe environment/toolchain: %q; want caches %v and %s", out, want, runtime.Version())
+				}
+				if relative, err := filepath.Rel(inherited, got[2]); err != nil || filepath.IsLocal(relative) || got[2] == previousConfig {
+					t.Fatalf("compiler config was not independently isolated: %q", got[2])
+				}
+				previousConfig = got[2]
+				// Inspect a real compiler export artifact, not just returned env values.
+				export := exec.CommandContext(t.Context(), tool, "list", "-export", "-f", "{{.Export}}", "fmt")
+				export.Env = env
+				out, err = export.Output()
+				if err != nil {
+					t.Fatal(err)
+				}
+				artifact := strings.TrimSpace(string(out))
+				if relative, err := filepath.Rel(want["GOCACHE"], artifact); err != nil || !filepath.IsLocal(relative) {
+					t.Fatalf("export artifact escaped the selected cache: %q", artifact)
+				}
+				if _, err := os.Stat(artifact); err != nil {
+					t.Fatal(err)
+				}
+				if build > 0 && artifact != previousExport {
+					t.Fatalf("compiler did not reuse the export artifact: %q != %q", artifact, previousExport)
+				}
+				previousExport = artifact
+				t.Logf("build %d: caches=%v, config=%s, export=%s, toolchain=%s", build, want, got[2], artifact, got[3])
+			}
+			for path, before := range sentinels {
+				if filepath.Base(path) != "auth.json" {
+					continue
+				}
+				if data, err := os.ReadFile(path); err != nil || string(data) != before {
+					t.Errorf("compiler changed inherited auth sentinel: %s (%v)", path, err)
+				}
+			}
+		})
+	}
+}

--- a/cmd/octopool/http_client_test.go
+++ b/cmd/octopool/http_client_test.go
@@ -8,21 +8,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 )
-
-func isolateHTTPTestConfig(t *testing.T) {
-	t.Helper()
-	root := t.TempDir()
-	for _, name := range []string{"HOME", "XDG_CONFIG_HOME", "AppData", "APPDATA", "USERPROFILE", "GH_CONFIG_DIR"} {
-		t.Setenv(name, filepath.Join(root, name))
-	}
-}
 
 func useHTTPTestTransport(t *testing.T, transport http.RoundTripper) {
 	t.Helper()
@@ -68,7 +59,7 @@ func TestAuthenticatedJSONRedirects(t *testing.T) {
 		for _, code := range []int{301, 302, 303, 307, 308} {
 			for _, destination := range []string{"direct", "same-origin", "cross-port", "cross-host", "downgrade", "same-origin-then-cross-port"} {
 				t.Run(method+"/"+strconv.Itoa(code)+"/"+destination, func(t *testing.T) {
-					isolateHTTPTestConfig(t)
+					isolateTestConfig(t)
 					token := "synthetic-caller-token"
 					if method == http.MethodPost {
 						token = "synthetic-admin-token"
@@ -154,7 +145,7 @@ func TestAuthenticatedJSONRedirectEffectiveOrigin(t *testing.T) {
 	for _, scheme := range []string{"http", "https"} {
 		for _, explicitFirst := range []bool{false, true} {
 			t.Run(scheme+"/explicit-first="+strconv.FormatBool(explicitFirst), func(t *testing.T) {
-				isolateHTTPTestConfig(t)
+				isolateTestConfig(t)
 				host, port := "LOCALHOST", "80"
 				if scheme == "https" {
 					host, port = "127.0.0.1", "443"
@@ -201,7 +192,7 @@ func TestAuthenticatedJSONRedirectEffectiveOrigin(t *testing.T) {
 }
 
 func TestAuthenticatedJSONRedirectLimit(t *testing.T) {
-	isolateHTTPTestConfig(t)
+	isolateTestConfig(t)
 	var requests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests.Add(1)
@@ -219,7 +210,7 @@ func TestAuthenticatedJSONMalformedRedirects(t *testing.T) {
 		for _, code := range []int{307, 308} {
 			for _, location := range []string{"token-escape", "token-port", "nonsecret", "same-origin-then-malformed"} {
 				t.Run(method+"/"+strconv.Itoa(code)+"/"+location, func(t *testing.T) {
-					isolateHTTPTestConfig(t)
+					isolateTestConfig(t)
 					token := "synthetic-caller-token"
 					if method == http.MethodPost {
 						token = "synthetic-admin-token"
@@ -280,7 +271,7 @@ func TestAuthenticatedJSONMalformedRedirects(t *testing.T) {
 func TestAuthenticatedJSONIgnoresUnusedLocations(t *testing.T) {
 	for _, code := range []int{200, 300, 304, 307, 308} {
 		t.Run(strconv.Itoa(code), func(t *testing.T) {
-			isolateHTTPTestConfig(t)
+			isolateTestConfig(t)
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if code < 307 {
 					w.Header().Set("Location", "/%zz/nonsecret")
@@ -303,7 +294,7 @@ func TestAuthenticatedJSONIgnoresUnusedLocations(t *testing.T) {
 func TestAuthenticatedJSONRequestErrors(t *testing.T) {
 	for _, failure := range []string{"canceled", "deadline", "connection-refused"} {
 		t.Run(failure, func(t *testing.T) {
-			isolateHTTPTestConfig(t)
+			isolateTestConfig(t)
 			var requests atomic.Int32
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				requests.Add(1)
@@ -353,7 +344,7 @@ func TestAuthenticatedJSONRedirectRequestErrors(t *testing.T) {
 	for _, method := range []string{http.MethodGet, http.MethodPost} {
 		for _, code := range []int{307, 308} {
 			t.Run(method+"/"+strconv.Itoa(code), func(t *testing.T) {
-				isolateHTTPTestConfig(t)
+				isolateTestConfig(t)
 				const token = "synthetic-reflected-credential"
 				var followed atomic.Bool
 				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/octopool/login_redirect_test.go
+++ b/cmd/octopool/login_redirect_test.go
@@ -20,7 +20,7 @@ func TestLoginRedirects(t *testing.T) {
 	for _, code := range []int{307, 308} {
 		for _, destination := range []string{"direct", "same-origin", "cross-port", "cross-host", "downgrade", "same-origin-then-cross-port", "trusted-discovery", "trusted-discovery-same-origin", "insecure-opt-in"} {
 			t.Run(strconv.Itoa(code)+"/"+destination, func(t *testing.T) {
-				isolateHTTPTestConfig(t)
+				isolateTestConfig(t)
 				t.Setenv("GH_TOKEN", githubToken)
 				t.Setenv("GITHUB_TOKEN", "")
 				t.Setenv("OCTOPOOL_POOL", "")
@@ -131,7 +131,7 @@ func writeRedirectTestDiscovery(w http.ResponseWriter, apiBase string) {
 }
 
 func TestLoginDiscoveryHTTPRedirect(t *testing.T) {
-	isolateHTTPTestConfig(t)
+	isolateTestConfig(t)
 	var targetRequests atomic.Int32
 	var discoveryURL string
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -157,7 +157,7 @@ func TestLoginMalformedRedirects(t *testing.T) {
 	const token = "synthetic-github-token"
 	for _, code := range []int{307, 308} {
 		t.Run(strconv.Itoa(code), func(t *testing.T) {
-			isolateHTTPTestConfig(t)
+			isolateTestConfig(t)
 			t.Setenv("GH_TOKEN", token)
 			t.Setenv("GITHUB_TOKEN", "")
 			t.Setenv("OCTOPOOL_POOL", "")

--- a/cmd/octopool/login_test.go
+++ b/cmd/octopool/login_test.go
@@ -133,7 +133,7 @@ func TestFormatLoginFailureQuotesProvisioningCommandArguments(t *testing.T) {
 
 func TestLoginAcceptsPositionalServerAndStoresDiscoveredAuth(t *testing.T) {
 	t.Setenv("GH_TOKEN", "gh_test")
-	isolateHTTPTestConfig(t)
+	isolateTestConfig(t)
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/cmd/octopool/login_token_test.go
+++ b/cmd/octopool/login_token_test.go
@@ -35,7 +35,7 @@ func TestLoginGitHubTokenSelection(t *testing.T) {
 		{name: "empty github.com token rejects Enterprise fallback", storedToken: " \t\n", wantError: "gh auth token returned empty output"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			isolateHTTPTestConfig(t)
+			isolateTestConfig(t)
 			t.Setenv("GH_TOKEN", tt.ghToken)
 			t.Setenv("GITHUB_TOKEN", tt.githubToken)
 			t.Setenv("GH_HOST", "ghe.example.test")

--- a/cmd/octopool/main_test.go
+++ b/cmd/octopool/main_test.go
@@ -21,7 +21,7 @@ func TestVersionCommand(t *testing.T) {
 }
 
 func TestCommandHelp(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	isolateTestConfig(t)
 	authFile, err := authPath()
 	if err != nil {
 		t.Fatal(err)
@@ -102,7 +102,7 @@ func TestValidateAuthURLForRequestNormalizesTrailingSlash(t *testing.T) {
 }
 
 func TestWhoamiPrintsSavedLogin(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	isolateTestConfig(t)
 	if err := saveAuth(authFile{
 		URL:       "https://octopool.example.com",
 		Pool:      "core",
@@ -132,7 +132,7 @@ func TestWhoamiPrintsSavedLogin(t *testing.T) {
 }
 
 func TestWhoamiJSON(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	isolateTestConfig(t)
 	if err := saveAuth(authFile{
 		URL:       "https://octopool.example.com",
 		Pool:      "core",

--- a/cmd/octopool/string_rewrites_policy_test.go
+++ b/cmd/octopool/string_rewrites_policy_test.go
@@ -29,8 +29,7 @@ func TestStringRewritePolicyFailuresNeverRunChild(t *testing.T) {
 		{"unpaired surrogate", 200, strings.Replace(rewriteActiveTestPolicy, "public", `\ud800`, 1)},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			t.Setenv("HOME", t.TempDir())
-			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			isolateTestConfig(t)
 			t.Setenv("OCTOPOOL_STRING_REWRITE_FILE", "")
 			var calls atomic.Int64
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/octopool/string_rewrites_process_test.go
+++ b/cmd/octopool/string_rewrites_process_test.go
@@ -184,8 +184,7 @@ func rewriteTestServer(t *testing.T, policyBody string, relay http.HandlerFunc) 
 	body := &atomic.Value{}
 	body.Store(policyBody)
 	calls := &atomic.Int64{}
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	isolateTestConfig(t)
 	t.Setenv("OCTOPOOL_STRING_REWRITE_FILE", "")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer test-token" {

--- a/cmd/octopool/test_config_test.go
+++ b/cmd/octopool/test_config_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func isolateTestConfig(t *testing.T) {
+	t.Helper()
+	for _, entry := range testConfigEnv(t.TempDir()) {
+		name, value, _ := strings.Cut(entry, "=")
+		t.Setenv(name, value)
+	}
+}
+
+func testConfigEnv(root string) []string {
+	var env []string
+	for _, name := range []string{"HOME", "XDG_CONFIG_HOME", "AppData", "APPDATA", "USERPROFILE", "GH_CONFIG_DIR", "ZDOTDIR", "XDG_DATA_HOME"} {
+		// Windows environment keys are case insensitive; both spellings must agree.
+		env = append(env, name+"="+filepath.Join(root, strings.ToLower(name)))
+	}
+	return env
+}
+
+// Exercise the existing tests in a child: their own isolation must protect the
+// inherited stores, even when the platform prefers XDG_CONFIG_HOME or AppData.
+func TestAuthTestsPreserveInheritedConfig(t *testing.T) {
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{
+		"TestCommandHelp",
+		"TestWhoamiPrintsSavedLogin",
+		"TestWhoamiJSON",
+		"TestNewGHRelayClientMissingLoginUsesFallbackSentinel",
+		"TestWriteLocalUserLogin",
+		"TestWriteLocalUserLoginRejectsOverridesAndBroaderShapes",
+		"TestLoginAcceptsPositionalServerAndStoresDiscoveredAuth",
+		"TestLoginRedirects",
+		"TestCallerRequestFlagsAuthSnapshot",
+		"TestStringRewriteSavedURLBinding",
+	} {
+		t.Run(name, func(t *testing.T) {
+			inherited := seedInheritedConfig(t)
+			before := configSnapshot(t, inherited)
+			cmd := exec.CommandContext(t.Context(), executable, "-test.run=^"+name+"$", "-test.v", "-test.count=1")
+			cmd.Env = os.Environ()
+			out, err := cmd.CombinedOutput()
+			// Check preservation even if the child fails before completing a write.
+			if after := configSnapshot(t, inherited); !reflect.DeepEqual(after, before) {
+				t.Error("child changed inherited config outside its temporary directory")
+			}
+			if err != nil || !strings.Contains(string(out), "--- PASS: "+name+" (") {
+				t.Fatalf("child test did not pass: %v\n%s", err, out)
+			}
+			if !t.Failed() {
+				t.Log("child passed; inherited config sentinels unchanged")
+			}
+		})
+	}
+}
+
+func TestCLIConfigIsolation(t *testing.T) {
+	bin := buildCLIBinary(t)
+	for _, args := range [][]string{{"whoami", "--json"}, {"login", "http://unsafe.example.test"}} {
+		t.Run(args[0], func(t *testing.T) {
+			inherited := seedInheritedConfig(t)
+			before := configSnapshot(t, inherited)
+			result := runCLI(t, bin, "", nil, args...)
+			if after := configSnapshot(t, inherited); !reflect.DeepEqual(after, before) {
+				t.Error("CLI child changed inherited config")
+			}
+			want := "not logged in"
+			if args[0] == "login" {
+				want = "HTTPS"
+			}
+			if result.err == nil || result.stdout != "" || !strings.Contains(result.stderr, want) {
+				t.Fatalf("expected isolated CLI failure (%s), got err=%v stdout=%q stderr=%q", want, result.err, result.stdout, result.stderr)
+			}
+		})
+	}
+}
+
+func seedInheritedConfig(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	// This fixture deliberately does not use the isolation helper under test.
+	for _, name := range []string{"HOME", "XDG_CONFIG_HOME", "AppData", "APPDATA", "USERPROFILE", "GH_CONFIG_DIR"} {
+		dir := filepath.Join(root, strings.ToLower(name))
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv(name, dir)
+	}
+	for _, name := range []string{"OCTOPOOL_TOKEN", "OCTOPOOL_URL", "OCTOPOOL_POOL", "OCTOPOOL_STRING_REWRITE_FILE", "OCTOPOOL_ALLOW_INSECURE_LOGIN", "GH_TOKEN", "GITHUB_TOKEN"} {
+		t.Setenv(name, "")
+	}
+	// Resolve the real platform path only after every candidate root is synthetic.
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, configDir := range []string{dir, os.Getenv("XDG_CONFIG_HOME"), os.Getenv("AppData"), os.Getenv("GH_CONFIG_DIR")} {
+		auth := filepath.Join(configDir, "octopool", "auth.json")
+		if err := os.MkdirAll(filepath.Dir(auth), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(auth, []byte(`{"url":"https://sentinel.invalid","pool":"sentinel","token":"synthetic-sentinel","login":"sentinel"}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func configSnapshot(t *testing.T, root string) map[string]string {
+	t.Helper()
+	files := map[string]string{}
+	if err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			files[path] = "directory"
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		files[path] = string(data)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return files
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -49,6 +49,11 @@ block is preserved. `--dry-run` validates the plan and prints its paths without 
 Only zsh is currently supported because it has a startup file that every interactive
 and non-interactive invocation reads.
 
+Executable discovery follows symlinks and accepts regular `octopool` files, requiring
+execute bits on Unix. On Windows it also recognizes `octopool.exe` case-insensitively
+without requiring Unix execute bits. This recognition does not establish support for
+the full zsh installer on native Windows.
+
 ```sh
 octopool install-shim --dry-run
 octopool install-shim
@@ -120,7 +125,11 @@ Use `--json` for scripts.
 ### `octopool gh api <GET path> [--paginate] [--slurp] [--jq <expr>]`
 
 Relays a read-only `gh api` call through Octopool's cache and pool. Prints the GitHub
-response body exactly like `gh api`, optionally piping it through `jq -r <expr>`.
+response body exactly like `gh api`, optionally piping it through `jq -r -- <expr>`.
+The expression is always a filter, never a jq command-line option.
+On Windows, relay-backed `--jq` requires native jq 1.7 or newer and adds `--binary`
+to retain native `gh` LF output terminators and preserve literal string bytes,
+including embedded LF, CRLF, lone CR, and Unicode. Other platforms omit the Windows option.
 GET reads using `--paginate` and `--slurp` stay relay-cached for up to 10 pages.
 When present, GitHub's Link header authoritatively selects the next page; header-less
 web-synthesized and legacy-cached responses fall back to array-length and `total_count`


### PR DESCRIPTION
## Summary

Auth tests that isolated only HOME could still read or overwrite inherited authentication stores through platform-specific configuration paths. Centralize synthetic application-config isolation for auth tests and CLI subprocesses, with child-test sentinels proving inherited stores remain untouched. Keep compiler selection and reusable Go caches separate from application configuration, including real offline-build and compiler-artifact reuse checks.

Broader native Windows coverage exposed runtime bugs in jq output and executable discovery. Preserve native gh output bytes and LF terminators by using native jq 1.7+ binary mode on Windows, including literal embedded LF, CRLF, lone CR, and Unicode. Pass jq expressions after `--` so option-shaped expressions remain literal filters. Recognize regular `octopool.exe` targets and symlinks on Windows without requiring Unix execute bits; Unix checks remain intact. This does not establish full native Windows zsh installer support.

Retain the Windows release-asset helpers while running the complete Go suite and vet. Linux CI explicitly requires jq; Windows CI also verifies binary-mode capability before the full suite. Add literal byte, argument-boundary, and executable-discovery controls, plus CLI documentation and a changelog entry.

## Tests

- Supplied before evidence: inherited-config Linux sentinel failures; the original expanded native Windows run failed five test groups. An overlay of the old jq implementation reproduced three argument-boundary failures. These are regression evidence, not passing Windows proof.
- Fresh post-commit native macOS owner/caller suites passed on Go 1.26.7 and 1.27.0 with `-count=1`, real jq subprocesses, synthetic application config, and no focused-test skips.
- Fresh post-commit canonical `GOTOOLCHAIN=go1.26.7 pnpm check` passed: 775 unit tests, 521 Worker tests, generation/guards, formatting, lint, build/type checks, full Go tests, and vet. Cleanup and ordinary pinned-pnpm dependency verification passed; no generated, manifest, lockfile, or installed-layout drift.
- Exact-head [native Linux Check](https://github.com/openclaw/octopool/actions/runs/33385399826/job/99466774172) and [native Windows Go suite and release-asset helpers](https://github.com/openclaw/octopool/actions/runs/33385399826/job/99466773883) passed at `c22de31ef139c9d26d72df094fa95643a226eb11`. Every step succeeded, including both jq preflights, the complete Windows Go suite, and Windows vet.
- All [CodeQL analyses](https://github.com/openclaw/octopool/actions/runs/33385397292) passed on that same head: actions, Go, and JavaScript/TypeScript. The CodeQL status check also passed. Optional `[code]smith` skipped; a superseded optional dispatch was cancelled and its replacement passed. No required gate was skipped or rerun.
