### PR TITLE
fix: keep quota and cooldown feedback monotonic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Keep persisted identity quota and cooldown feedback monotonic across delayed responses, reject invalid numeric observations, and atomically preserve rate/cooldown state on storage failure.
 - Keep `--jq` expressions literal, preserve native `gh` output bytes with native jq 1.7+ on Windows, and recognize `octopool.exe` when resolving the shim target without requiring Unix execute bits.
 - Reject malformed stored pool policies before cache reuse or pooled GitHub access with a typed configuration-unavailable error, preserving valid partial-policy defaults.
 - Reject extra or malformed repository qualifiers and negated scope in issue, code, and commit searches before relay dispatch or cache reuse, preserving typed local fallback for unsupported queries.

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -342,6 +342,12 @@ that excludes failed misses and deliberate local fallback responses.
 Successful `304` refreshes use the existing `hit` status so current stats and CLI parsers count
 the saved request, with `fallback_reason = cache_revalidated` as the distinct audit marker.
 
+Identity availability feedback is separate from cache-source eligibility. Overlapping
+identity responses merge quota and cooldown observations conservatively in the pool
+coordinator, including conditional requests that bypass cache storage. A delayed success
+cannot reopen a known exhausted window or shorten a live cooldown. Fresh cache reuse
+still checks active route eligibility and public proof; see [identity feedback](identities.md#health-feedback-cooldowns).
+
 ## Public-repo guard
 
 The shared cache and pooled identities are **public-repository only**. Before any repo

--- a/docs/identities.md
+++ b/docs/identities.md
@@ -49,7 +49,8 @@ Identity selection runs in a Durable Object partitioned per pool (`pool:<pool_id
 keeps four SQLite tables in DO storage:
 
 - `leases` — sticky route→identity binding, 10s TTL.
-- `rate_states` — last seen `remaining`/`reset_at` per identity and resource bucket.
+- `rate_states` — newest reset window and lowest observed remaining budget within that
+  window, per identity and resource bucket.
 - `cooldowns` — per identity, scoped to `*`, `resource:<r>`, or a route key.
 - `cache_fills` — renewable, token-fenced ownership for concurrent identical cache misses;
   completion wakes followers with the confirmed publication outcome.
@@ -61,23 +62,60 @@ keeps four SQLite tables in DO storage:
 2. Otherwise score each non-cooling candidate by `remaining + weight` (unknown rate
    assumes a fresh 5000 budget; an exhausted-but-unreset identity is skipped) and take
    the best (`reason: highest_remaining`).
-3. If every candidate is cooling down, the Worker returns `503 identities_cooling_down`.
+3. If every candidate is cooling down or quota-exhausted, selection reports
+   `identities_cooling_down`; the relay uses its existing stale-cache or typed
+   `424 fallback_local` response.
 
 The winning route gets a fresh 10s lease so concurrent callers stick to the same identity
 briefly instead of stampeding.
 
 ## Health feedback (cooldowns)
 
-After each GitHub call, `recordResult` updates `rate_states` from the response's
-`x-ratelimit-*` headers and, on a `401`/`403`/`429`, writes a cooldown:
+After an identity-backed GitHub resource call, `recordResult` merges complete, valid
+`x-ratelimit-remaining`/`x-ratelimit-reset` observations into `rate_states`. A greater
+reset timestamp starts a new window; an equal reset keeps the minimum remaining count;
+an older reset cannot change the row. Same-window limit metadata remains the first
+accepted value, so differing limits are not order-independent. A newer window updates
+the limit, using the existing 5000 default when it is absent.
 
-- `401` → global `*` cooldown (Retry-After, else 120s).
-- a `Retry-After` on any error → global `*` cooldown for that duration.
-- `403` with budget remaining (secondary/abuse limit) → global `*` cooldown, 120s.
-- `429` → `resource:<resource>` cooldown, 120s.
-- otherwise → route-key cooldown, 120s.
+Numeric headers must be whole-decimal nonnegative safe integers. Reset must be positive
+and remain safe when converted from seconds to milliseconds. Invalid supplied quota
+fields or an incomplete remaining/reset pair leave known rate state untouched, including
+exhaustion. RPC inputs are also validated. A newer complete positive observation or
+wall-clock time equal to the reset restores quota eligibility; a sticky lease cannot
+bypass live exhaustion. This is conservative feedback, not quota reservation: requests
+already in flight can still consume the same last unit, and same-window quota increases
+remain suppressed until reset.
 
-Cooling-down identities are skipped by selection until their cooldown expires.
+Only `401`/`403`/`429` write cooldowns, independently of quota validation:
+
+- `401` → global `*` cooldown (usable Retry-After, otherwise 120s).
+- `403` or `429` with usable Retry-After → global `*` cooldown for that duration.
+- `403` without usable Retry-After → route-key cooldown, 120s, including permission/SSO
+  failures. A complete zero-budget observation also excludes that resource until reset.
+- `429` without usable Retry-After → `resource:<resource>` cooldown, 120s.
+
+Retry-After supports integer seconds only, with a one-second minimum. HTTP dates,
+malformed numbers, and durations whose absolute deadline is unsafe use the defaults
+above; there is no additional duration cap. Other statuses, including `404`/`422` and
+`5xx`, can update valid quota observations but do not create cooldowns. A `403` with zero
+remaining and no usable reset creates only the route cooldown: it does not establish
+resource-wide exhaustion or invent a reset.
+
+Each cooldown key retains its greatest expiry and the status/reason attached to that
+deadline. Equal or shorter updates do nothing. Route, resource and global keys remain
+independent; a success or newer rate window does not clear a live cooldown. Selection
+and snapshots ignore expired rows at exact deadline equality, without deleting them.
+Rate and cooldown writes for one result use a synchronous storage transaction, so a
+failed second write cannot leave a partially accepted observation.
+
+The trusted route determines the identity's `core`/`search` bucket; the response resource
+header cannot override it. Anonymous API snapshots and App token-exchange responses do
+not update identity budgets. State survives Durable Object eviction. Replaying the same
+absolute SQL observation is idempotent; replaying the relative-duration `recordResult`
+RPC can extend a cooldown. Feedback errors do not initiate retries or compensating state
+deletion. No schema migration or state reset is required; previously overwritten
+observations cannot be reconstructed by this repair.
 
 ## Registration
 

--- a/sql/queries/coordinator.sql
+++ b/sql/queries/coordinator.sql
@@ -57,9 +57,16 @@ ON CONFLICT(route_key) DO UPDATE SET
 INSERT INTO rate_states (identity_id, resource, limit_count, remaining, reset_at)
 VALUES (?1, ?2, ?3, ?4, ?5)
 ON CONFLICT(identity_id, resource) DO UPDATE SET
-  limit_count = excluded.limit_count,
-  remaining = excluded.remaining,
-  reset_at = excluded.reset_at;
+  limit_count = CASE
+    WHEN excluded.reset_at > rate_states.reset_at THEN excluded.limit_count
+    ELSE rate_states.limit_count
+  END,
+  remaining = CASE
+    WHEN excluded.reset_at > rate_states.reset_at THEN excluded.remaining
+    ELSE MIN(rate_states.remaining, excluded.remaining)
+  END,
+  reset_at = excluded.reset_at
+WHERE excluded.reset_at >= rate_states.reset_at;
 
 -- name: UpsertCooldown :exec
 INSERT INTO cooldowns (identity_id, route_key, status, reason, expires_at)
@@ -67,7 +74,8 @@ VALUES (?1, ?2, ?3, ?4, ?5)
 ON CONFLICT(identity_id, route_key) DO UPDATE SET
   status = excluded.status,
   reason = excluded.reason,
-  expires_at = excluded.expires_at;
+  expires_at = excluded.expires_at
+WHERE excluded.expires_at > cooldowns.expires_at;
 
 -- name: CoordinatorRates :many
 SELECT identity_id, resource, limit_count, remaining, reset_at

--- a/src/generated/sql.ts
+++ b/src/generated/sql.ts
@@ -17,9 +17,9 @@ export const queries = {
   upsertLease:
     "INSERT INTO leases (route_key, identity_id, expires_at)\nVALUES (?1, ?2, ?3)\nON CONFLICT(route_key) DO UPDATE SET\n  identity_id = excluded.identity_id,\n  expires_at = excluded.expires_at",
   upsertRateState:
-    "INSERT INTO rate_states (identity_id, resource, limit_count, remaining, reset_at)\nVALUES (?1, ?2, ?3, ?4, ?5)\nON CONFLICT(identity_id, resource) DO UPDATE SET\n  limit_count = excluded.limit_count,\n  remaining = excluded.remaining,\n  reset_at = excluded.reset_at",
+    "INSERT INTO rate_states (identity_id, resource, limit_count, remaining, reset_at)\nVALUES (?1, ?2, ?3, ?4, ?5)\nON CONFLICT(identity_id, resource) DO UPDATE SET\n  limit_count = CASE\n    WHEN excluded.reset_at > rate_states.reset_at THEN excluded.limit_count\n    ELSE rate_states.limit_count\n  END,\n  remaining = CASE\n    WHEN excluded.reset_at > rate_states.reset_at THEN excluded.remaining\n    ELSE MIN(rate_states.remaining, excluded.remaining)\n  END,\n  reset_at = excluded.reset_at\nWHERE excluded.reset_at >= rate_states.reset_at",
   upsertCooldown:
-    "INSERT INTO cooldowns (identity_id, route_key, status, reason, expires_at)\nVALUES (?1, ?2, ?3, ?4, ?5)\nON CONFLICT(identity_id, route_key) DO UPDATE SET\n  status = excluded.status,\n  reason = excluded.reason,\n  expires_at = excluded.expires_at",
+    "INSERT INTO cooldowns (identity_id, route_key, status, reason, expires_at)\nVALUES (?1, ?2, ?3, ?4, ?5)\nON CONFLICT(identity_id, route_key) DO UPDATE SET\n  status = excluded.status,\n  reason = excluded.reason,\n  expires_at = excluded.expires_at\nWHERE excluded.expires_at > cooldowns.expires_at",
   coordinatorRates:
     "SELECT identity_id, resource, limit_count, remaining, reset_at\nFROM rate_states\nWHERE reset_at > ?\nORDER BY identity_id, resource",
   coordinatorCooldowns:

--- a/src/github-rate.ts
+++ b/src/github-rate.ts
@@ -17,19 +17,33 @@ export function rateFromHeaders(headers: Record<string, string>): GitHubRate {
   if (remaining !== undefined) {
     out.remaining = remaining;
   }
-  if (resetAt !== undefined) {
+  // An invalid supplied limit must not become an apparently complete observation
+  // with default metadata at the coordinator. Keep valid remaining for fallback.
+  if (
+    isRateSeconds(resetAt) &&
+    resetAt > 0 &&
+    (headers["x-ratelimit-limit"] === undefined || limit !== undefined)
+  ) {
     out.resetAt = resetAt;
   }
-  if (retryAfter !== undefined) {
+  if (isRateSeconds(retryAfter)) {
     out.retryAfter = retryAfter;
   }
   return out;
 }
 
 function parseHeaderInt(value: string | undefined): number | undefined {
-  if (value === undefined) {
+  if (value === undefined || value === "" || /[^0-9]/.test(value)) {
     return undefined;
   }
-  const parsed = Number.parseInt(value, 10);
-  return Number.isFinite(parsed) ? parsed : undefined;
+  const parsed = Number(value);
+  return isRateInteger(parsed) ? parsed : undefined;
+}
+
+export function isRateInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+export function isRateSeconds(value: unknown): value is number {
+  return isRateInteger(value) && Number.isSafeInteger(value * 1000);
 }

--- a/src/pool-coordinator.ts
+++ b/src/pool-coordinator.ts
@@ -1,6 +1,7 @@
 import { DurableObject } from "cloudflare:workers";
 import type { CacheFillAcquisition, CacheFillOutcome } from "./cache-fill";
 import { queries } from "./generated/sql";
+import { isRateInteger, isRateSeconds } from "./github-rate";
 import type { CoordinatorSnapshot, RecordResult, SelectionRequest, SelectionResult } from "./types";
 
 type LeaseRow = {
@@ -162,27 +163,37 @@ export class PoolCoordinator extends DurableObject<Env> {
   }
 
   recordResult(result: RecordResult): void {
-    if (result.rate?.remaining !== undefined && result.rate.resetAt !== undefined) {
-      this.ctx.storage.sql.exec(
-        queries.upsertRateState,
-        result.identityId,
-        result.resource,
-        result.rate.limit ?? 5000,
-        result.rate.remaining,
-        result.rate.resetAt * 1000,
-      );
-    }
-    if (result.status === 401 || result.status === 403 || result.status === 429) {
-      const cooldown = classifyCooldown(result);
-      this.ctx.storage.sql.exec(
-        queries.upsertCooldown,
-        result.identityId,
-        cooldown.key,
-        result.status,
-        "github_error",
-        Date.now() + cooldown.ttlMs,
-      );
-    }
+    // A failed cooldown statement must not leave half of this observation committed.
+    this.ctx.storage.transactionSync(() => {
+      const rate = result.rate;
+      if (
+        isRateInteger(rate?.remaining) &&
+        isRateSeconds(rate?.resetAt) &&
+        rate.resetAt > 0 &&
+        (rate.limit === undefined || isRateInteger(rate.limit))
+      ) {
+        this.ctx.storage.sql.exec(
+          queries.upsertRateState,
+          result.identityId,
+          result.resource,
+          rate.limit ?? 5000,
+          rate.remaining,
+          rate.resetAt * 1000,
+        );
+      }
+      if (result.status === 401 || result.status === 403 || result.status === 429) {
+        const now = Date.now();
+        const cooldown = classifyCooldown(result, now);
+        this.ctx.storage.sql.exec(
+          queries.upsertCooldown,
+          result.identityId,
+          cooldown.key,
+          result.status,
+          "github_error",
+          now + cooldown.ttlMs,
+        );
+      }
+    });
   }
 
   snapshot(): CoordinatorSnapshot {
@@ -292,17 +303,16 @@ export class PoolCoordinator extends DurableObject<Env> {
   }
 }
 
-function classifyCooldown(result: RecordResult): { key: string; ttlMs: number } {
+function classifyCooldown(result: RecordResult, now: number): { key: string; ttlMs: number } {
+  const retryAfter = result.rate?.retryAfter;
+  const duration = isRateSeconds(retryAfter) ? Math.max(retryAfter, 1) * 1000 : undefined;
   const retryAfterMs =
-    result.rate?.retryAfter !== undefined ? Math.max(result.rate.retryAfter, 1) * 1000 : undefined;
+    duration !== undefined && Number.isSafeInteger(now + duration) ? duration : undefined;
   if (result.status === 401) {
     return { key: "*", ttlMs: retryAfterMs ?? 120_000 };
   }
   if (retryAfterMs !== undefined) {
     return { key: "*", ttlMs: retryAfterMs };
-  }
-  if (result.status === 403 && result.rate?.remaining !== undefined && result.rate.remaining > 0) {
-    return { key: result.routeKey, ttlMs: 120_000 };
   }
   if (result.status === 429) {
     return { key: `resource:${result.resource}`, ttlMs: 120_000 };

--- a/test/e2e/pool-feedback.test.ts
+++ b/test/e2e/pool-feedback.test.ts
@@ -1,0 +1,417 @@
+import { env } from "cloudflare:workers";
+import { evictDurableObject, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it, vi } from "vitest";
+import { queries } from "../../src/generated/sql";
+import { rateFromHeaders } from "../../src/github-rate";
+import { poolCoordinatorStub } from "../../src/pool-coordinator";
+import type { RecordResult } from "../../src/types";
+
+const NOW = 1_800_000_000_000;
+const R1 = NOW / 1000 + 60;
+const R2 = R1 + 60;
+const request = (routeKey = "A", resource = "core", id = "a") => ({
+  routeKey,
+  resource,
+  candidates: [{ id, weight: 100 }],
+});
+const feedback = (
+  rate?: RecordResult["rate"],
+  status = 200,
+  routeKey = "A",
+  resource = "core",
+): RecordResult => ({
+  identityId: "a",
+  routeKey,
+  resource,
+  status,
+  ...(rate === undefined ? {} : { rate }),
+});
+const coordinator = () => poolCoordinatorStub(env, "feedback");
+
+async function rows() {
+  return runInDurableObject(coordinator(), (_instance, state) => ({
+    rates: state.storage.sql
+      .exec("SELECT * FROM rate_states ORDER BY identity_id, resource")
+      .toArray(),
+    cooldowns: state.storage.sql.exec("SELECT * FROM cooldowns ORDER BY route_key").toArray(),
+  }));
+}
+
+describe("persisted quota feedback", () => {
+  it.each([
+    {
+      name: "same-window zero then positive",
+      samples: [
+        [R1, 0, 6000],
+        [R1, 9, 5000],
+      ],
+      reset: R1,
+      remaining: 0,
+      limit: 6000,
+    },
+    {
+      name: "same-window positive then zero",
+      samples: [
+        [R1, 9, 5000],
+        [R1, 0, 6000],
+      ],
+      reset: R1,
+      remaining: 0,
+      limit: 5000,
+    },
+    {
+      name: "same-window minimum",
+      samples: [
+        [R1, 30, 6000],
+        [R1, 7, 5000],
+        [R1, 20, 9000],
+      ],
+      reset: R1,
+      remaining: 7,
+      limit: 6000,
+    },
+    {
+      name: "older future window",
+      samples: [
+        [R2, 0, 6000],
+        [R1, 4999, 5000],
+      ],
+      reset: R2,
+      remaining: 0,
+      limit: 6000,
+    },
+    {
+      name: "older expired window",
+      samples: [
+        [R2, 0, 6000],
+        [NOW / 1000, 4999, 5000],
+      ],
+      reset: R2,
+      remaining: 0,
+      limit: 6000,
+    },
+    {
+      name: "newer positive recovery",
+      samples: [
+        [R1, 0, 6000],
+        [R2, 4999, 5000],
+      ],
+      reset: R2,
+      remaining: 4999,
+      limit: 5000,
+    },
+    {
+      name: "newer depletion then delayed success",
+      samples: [
+        [R1, 4999, 5000],
+        [R2, 0, 6000],
+        [R1, 4900, 5000],
+      ],
+      reset: R2,
+      remaining: 0,
+      limit: 6000,
+    },
+  ])("$name", async ({ samples, reset, remaining, limit }) => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+    const stub = coordinator();
+    expect((await stub.selectIdentity(request())).kind).toBe("selected");
+    for (const [resetAt, count, limitCount] of samples) {
+      await stub.recordResult(
+        feedback({ resetAt: resetAt!, remaining: count!, limit: limitCount! }),
+      );
+    }
+    expect((await rows()).rates).toEqual([
+      { identity_id: "a", resource: "core", limit_count: limit, remaining, reset_at: reset * 1000 },
+    ]);
+    for (const route of ["A", "fresh"]) {
+      expect((await stub.selectIdentity(request(route))).kind).toBe(
+        remaining === 0 ? "unavailable" : "selected",
+      );
+    }
+  });
+
+  it("recovers at exact reset while a sticky lease is still live, without deleting the row", async () => {
+    const clock = vi.spyOn(Date, "now").mockReturnValue(NOW);
+    const stub = coordinator();
+    await stub.selectIdentity(request());
+    await stub.recordResult(feedback({ remaining: 0, resetAt: NOW / 1000 + 1 }));
+    for (const [offset, kind] of [
+      [999, "unavailable"],
+      [1000, "selected"],
+      [1001, "selected"],
+    ] as const) {
+      clock.mockReturnValue(NOW + offset);
+      expect((await stub.selectIdentity(request())).kind).toBe(kind);
+      expect((await stub.snapshot()).rates).toHaveLength(offset < 1000 ? 1 : 0);
+    }
+    expect((await stub.selectIdentity(request())).reason).toBe("sticky");
+    expect((await rows()).rates).toHaveLength(1);
+  });
+
+  it("keeps identity and resource budgets independent", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+    const stub = coordinator();
+    await stub.recordResult(feedback({ remaining: 0, resetAt: R2 }));
+    expect((await stub.selectIdentity(request())).kind).toBe("unavailable");
+    expect((await stub.selectIdentity(request("search", "search"))).kind).toBe("selected");
+    expect((await stub.selectIdentity(request("other", "core", "b"))).kind).toBe("selected");
+  });
+
+  it("ignores missing and malformed header observations, retaining independent cooldown feedback", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+    const stub = coordinator();
+    await stub.recordResult(feedback({ remaining: 0, resetAt: R1 }));
+    const before = (await rows()).rates;
+    const valid = {
+      "x-ratelimit-limit": "6000",
+      "x-ratelimit-remaining": "9",
+      "x-ratelimit-reset": String(R2),
+    };
+    const partials = [{}, { "x-ratelimit-remaining": "9" }, { "x-ratelimit-reset": String(R2) }];
+    for (const headers of partials) {
+      await stub.recordResult(feedback(rateFromHeaders(headers)));
+      expect((await rows()).rates).toEqual(before);
+    }
+    for (const key of Object.keys(valid)) {
+      for (const bad of ["", "9junk", "1e3", "1.5", "-1", "NaN", "Infinity", "9007199254740992"]) {
+        await stub.recordResult(
+          feedback(rateFromHeaders({ ...valid, [key]: bad }), 429, "bad", "core"),
+        );
+        expect((await rows()).rates, `${key}=${bad}`).toEqual(before);
+      }
+    }
+    for (const reset of ["0", "9007199254741"]) {
+      await stub.recordResult(feedback(rateFromHeaders({ ...valid, "x-ratelimit-reset": reset })));
+      expect((await rows()).rates).toEqual(before);
+    }
+    expect((await rows()).cooldowns).toEqual([
+      {
+        identity_id: "a",
+        route_key: "resource:core",
+        status: 429,
+        reason: "github_error",
+        expires_at: NOW + 120_000,
+      },
+    ]);
+    expect((await stub.selectIdentity(request())).kind).toBe("unavailable");
+  });
+
+  it("validates numeric RPC authority without coercion or unsafe reset arithmetic", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+    const stub = coordinator();
+    await stub.recordResult(feedback({ remaining: 0, resetAt: R1 }));
+    const before = (await rows()).rates;
+    for (const key of ["remaining", "resetAt", "limit"] as const) {
+      for (const bad of [-1, 1.5, NaN, Infinity, Number.MAX_SAFE_INTEGER + 1, "9", null]) {
+        const rate = { remaining: 9, resetAt: R2, limit: 6000, [key]: bad } as RecordResult["rate"];
+        await stub.recordResult(feedback(rate));
+        expect((await rows()).rates, `${key}=${String(bad)}`).toEqual(before);
+      }
+    }
+    for (const resetAt of [0, Math.floor(Number.MAX_SAFE_INTEGER / 1000) + 1]) {
+      await stub.recordResult(feedback({ remaining: 9, resetAt }));
+      expect((await rows()).rates).toEqual(before);
+    }
+    await stub.recordResult(
+      feedback({ remaining: Number.MAX_SAFE_INTEGER, resetAt: R2, limit: 0 }),
+    );
+    expect((await rows()).rates).toEqual([
+      {
+        identity_id: "a",
+        resource: "core",
+        limit_count: 0,
+        remaining: Number.MAX_SAFE_INTEGER,
+        reset_at: R2 * 1000,
+      },
+    ]);
+  });
+});
+
+describe("persisted cooldown feedback", () => {
+  it.each([
+    { seconds: 9_005_399_254_740, key: "*", deadline: 9_007_199_254_740_000 },
+    { seconds: 9_005_399_254_741, key: "resource:core", deadline: NOW + 120_000 },
+  ])(
+    "checks the absolute deadline after safe duration conversion: $seconds",
+    async ({ seconds, key, deadline }) => {
+      vi.spyOn(Date, "now").mockReturnValue(NOW);
+      await coordinator().recordResult(
+        feedback(rateFromHeaders({ "retry-after": String(seconds) }), 429),
+      );
+      expect((await rows()).cooldowns[0]).toMatchObject({ route_key: key, expires_at: deadline });
+    },
+  );
+
+  it.each([false, true])(
+    "retains the longer global deadline and its metadata, reverse=%s",
+    async (reverse) => {
+      vi.spyOn(Date, "now").mockReturnValue(NOW);
+      const stub = coordinator();
+      const samples = [feedback({ retryAfter: 3600 }, 429), feedback(undefined, 401)];
+      for (const sample of reverse ? samples.reverse() : samples) await stub.recordResult(sample);
+      await stub.recordResult(feedback({ remaining: 10, resetAt: R2 }));
+      expect((await rows()).cooldowns).toEqual([
+        {
+          identity_id: "a",
+          route_key: "*",
+          status: 429,
+          reason: "github_error",
+          expires_at: NOW + 3_600_000,
+        },
+      ]);
+      for (const [route, resource] of [
+        ["A", "core"],
+        ["B", "search"],
+      ] as const) {
+        expect((await stub.selectIdentity(request(route, resource))).kind).toBe("unavailable");
+      }
+      expect((await stub.selectIdentity(request("B", "core", "b"))).kind).toBe("selected");
+    },
+  );
+
+  it("replays absolute SQL observations without changing state or equal-deadline metadata", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+    await runInDurableObject(coordinator(), (_instance, state) => {
+      const sql = state.storage.sql;
+      sql.exec(queries.upsertRateState, "a", "core", 6000, 0, R2 * 1000);
+      sql.exec(queries.upsertCooldown, "a", "*", 429, "long", NOW + 3_600_000);
+      for (let replay = 0; replay < 2; replay++) {
+        sql.exec(queries.upsertRateState, "a", "core", 6000, 0, R2 * 1000);
+        sql.exec(queries.upsertCooldown, "a", "*", 429, "long", NOW + 3_600_000);
+      }
+      sql.exec(queries.upsertCooldown, "a", "*", 401, "equal", NOW + 3_600_000);
+      sql.exec(queries.upsertCooldown, "a", "*", 403, "short", NOW + 120_000);
+    });
+    expect((await rows()).cooldowns).toEqual([
+      {
+        identity_id: "a",
+        route_key: "*",
+        status: 429,
+        reason: "long",
+        expires_at: NOW + 3_600_000,
+      },
+    ]);
+    expect((await rows()).rates[0]).toMatchObject({ remaining: 0, reset_at: R2 * 1000 });
+    expect((await coordinator().selectIdentity(request())).kind).toBe("unavailable");
+  });
+
+  it("recovers at exact cooldown expiry and accepts a subsequent failure", async () => {
+    const clock = vi.spyOn(Date, "now").mockReturnValue(NOW);
+    const stub = coordinator();
+    await stub.selectIdentity(request());
+    await stub.recordResult(feedback({ retryAfter: 1 }, 401));
+    for (const [offset, kind] of [
+      [999, "unavailable"],
+      [1000, "selected"],
+      [1001, "selected"],
+    ] as const) {
+      clock.mockReturnValue(NOW + offset);
+      expect((await stub.selectIdentity(request())).kind).toBe(kind);
+      expect((await stub.snapshot()).cooldowns).toHaveLength(offset < 1000 ? 1 : 0);
+    }
+    await stub.recordResult(feedback(undefined, 401));
+    expect((await rows()).cooldowns[0]).toMatchObject({ expires_at: NOW + 121_001 });
+    expect((await stub.selectIdentity(request())).kind).toBe("unavailable");
+  });
+
+  it("keeps route, resource and global keys independent", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+    const stub = coordinator();
+    await stub.recordResult(feedback({ remaining: 9 }, 403));
+    expect((await stub.selectIdentity(request())).kind).toBe("unavailable");
+    expect((await stub.selectIdentity(request("B"))).kind).toBe("selected");
+    await stub.recordResult(feedback(undefined, 429, "B", "search"));
+    expect((await stub.selectIdentity(request("C", "search"))).kind).toBe("unavailable");
+    expect((await stub.selectIdentity(request("B"))).kind).toBe("selected");
+    await stub.recordResult(feedback(undefined, 401));
+    expect((await stub.selectIdentity(request("B"))).kind).toBe("unavailable");
+    expect((await rows()).cooldowns.map((row) => row.route_key)).toEqual([
+      "*",
+      "A",
+      "resource:search",
+    ]);
+    expect((await rows()).rates).toEqual([]);
+  });
+
+  it.each([
+    { status: 403, rate: { remaining: 0 }, key: "A" },
+    { status: 403, rate: {}, key: "A" },
+    { status: 403, rate: { remaining: 0, resetAt: R2 }, key: "A" },
+    { status: 403, rate: { remaining: 9, resetAt: R2 }, key: "A" },
+    { status: 429, rate: {}, key: "resource:core" },
+    { status: 401, rate: {}, key: "*" },
+    { status: 404, rate: { remaining: 9, resetAt: R2 }, key: undefined },
+    { status: 422, rate: { remaining: 9, resetAt: R2 }, key: undefined },
+    { status: 503, rate: { remaining: 9, resetAt: R2, retryAfter: 60 }, key: undefined },
+    { status: 304, rate: { remaining: 0, resetAt: R2 }, key: undefined },
+  ])("preserves status/scope policy: $status $rate", async ({ status, rate, key }) => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+    const stub = coordinator();
+    await stub.recordResult(feedback(rate, status));
+    expect((await rows()).cooldowns.map((row) => row.route_key)).toEqual(key ? [key] : []);
+    const exhausted = rate.remaining === 0 && rate.resetAt !== undefined;
+    expect((await stub.selectIdentity(request("B"))).kind).toBe(
+      exhausted || key === "*" || key === "resource:core" ? "unavailable" : "selected",
+    );
+    expect((await rows()).rates).toHaveLength(rate.resetAt === undefined ? 0 : 1);
+  });
+
+  it.each([0, 86_400_000, -1, 1.5, NaN, Infinity, Number.MAX_SAFE_INTEGER, "60", null])(
+    "handles Retry-After safely without a product cap: %s",
+    async (value) => {
+      vi.spyOn(Date, "now").mockReturnValue(NOW);
+      const stub = coordinator();
+      await stub.recordResult(feedback({ retryAfter: value } as RecordResult["rate"], 429));
+      const accepted = value === 0 || value === 86_400_000;
+      expect((await rows()).cooldowns).toEqual([
+        {
+          identity_id: "a",
+          route_key: accepted ? "*" : "resource:core",
+          status: 429,
+          reason: "github_error",
+          expires_at: NOW + (value === 0 ? 1000 : value === 86_400_000 ? 86_400_000_000 : 120_000),
+        },
+      ]);
+    },
+  );
+});
+
+describe("feedback storage lifetime and failure", () => {
+  it("preserves committed state through real DO eviction and stale feedback", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+    let stub = coordinator();
+    await stub.recordResult(feedback({ remaining: 0, resetAt: R2, retryAfter: 3600 }, 429));
+    const before = await rows();
+    await evictDurableObject(stub);
+    stub = coordinator();
+    await stub.recordResult(feedback({ remaining: 4999, resetAt: R1 }, 401));
+    expect(await rows()).toEqual(before);
+    expect((await stub.selectIdentity(request())).kind).toBe("unavailable");
+  });
+
+  it("rolls back the rate write when the subsequent cooldown SQL write fails", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+    const stub = coordinator();
+    await stub.recordResult(feedback({ remaining: 0, resetAt: R1 }));
+    const before = await rows();
+    await runInDurableObject(stub, (_instance, state) => {
+      state.storage.sql.exec(
+        "CREATE TRIGGER reject_cooldown BEFORE INSERT ON cooldowns BEGIN SELECT RAISE(ABORT, 'feedback fault'); END",
+      );
+    });
+    try {
+      await runInDurableObject(stub, (instance) => {
+        expect(() =>
+          instance.recordResult(feedback({ remaining: 4999, resetAt: R2 }, 401)),
+        ).toThrow("feedback fault");
+      });
+      const after = await rows();
+      expect(after).toEqual(before);
+      expect((await stub.selectIdentity(request())).kind).toBe("unavailable");
+    } finally {
+      await runInDurableObject(stub, (_instance, state) =>
+        state.storage.sql.exec("DROP TRIGGER reject_cooldown").toArray(),
+      );
+    }
+  });
+});

--- a/test/e2e/relay-feedback.test.ts
+++ b/test/e2e/relay-feedback.test.ts
@@ -1,0 +1,259 @@
+import { env } from "cloudflare:workers";
+import { describe, expect, it, vi } from "vitest";
+import worker from "../../src/index";
+import { poolCoordinatorStub } from "../../src/pool-coordinator";
+import type { RecordResult } from "../../src/types";
+import {
+  bearer,
+  CALLER_TOKEN,
+  jsonResponse,
+  POOL,
+  relay,
+  runWithContext,
+  seedPool,
+} from "./harness";
+import { ownedWork } from "./owned-work";
+
+const PATH = "/repos/openclaw/octopool";
+const conditional = { headers: { "if-none-match": '"feedback"' } };
+const headers = (remaining: number, reset: number) => ({
+  "x-ratelimit-limit": "5000",
+  "x-ratelimit-remaining": String(remaining),
+  "x-ratelimit-reset": String(reset),
+  // The trusted route still owns the core bucket.
+  "x-ratelimit-resource": "search",
+});
+
+describe("Worker feedback ownership", () => {
+  it.each([
+    { window: "same", status: 200 },
+    { window: "older future", status: 304 },
+    { window: "older expired", status: 200 },
+  ])(
+    "does not reopen exhaustion after overlapping $window $status feedback",
+    async ({ window, status }) => {
+      await seedPool();
+      const reset = Math.floor(Date.now() / 1000) + 3600;
+      const delayedReset =
+        window === "same" ? reset : window === "older future" ? reset - 60 : reset - 3601;
+      const started = ownedWork.gate();
+      const delayed = ownedWork.gate();
+      let calls = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>(async (input, init) => {
+          const request = new Request(input, init);
+          if (bearer(request) === "test-org-token") return jsonResponse({ private: false });
+          expect(bearer(request)).toBe("test-primary-token");
+          expect(request.headers.get("if-none-match")).toBe('"feedback"');
+          calls++;
+          if (calls === 1) {
+            started.release();
+            await delayed.promise;
+            return status === 304
+              ? new Response(null, { status: 304, headers: headers(4999, delayedReset) })
+              : jsonResponse({ id: "delayed" }, 200, headers(4999, delayedReset));
+          }
+          return jsonResponse({ id: "exhausted" }, 200, headers(0, reset));
+        }),
+      );
+      const pending = relay(PATH, undefined, conditional);
+      try {
+        await started.promise;
+        const exhausted = await relay(PATH, undefined, conditional);
+        expect(exhausted.status).toBe(200);
+        expect(await exhausted.json()).toMatchObject({
+          body: { id: "exhausted" },
+          identity: { id: "primary" },
+          relay: { cache: "bypass" },
+        });
+        const stub = poolCoordinatorStub(env, POOL);
+        expect((await stub.snapshot()).rates).toEqual([
+          {
+            identity_id: "primary",
+            resource: "core",
+            limit_count: 5000,
+            remaining: 0,
+            reset_at: reset * 1000,
+          },
+        ]);
+        delayed.release();
+        expect(await (await pending).json()).toMatchObject({ status, identity: { id: "primary" } });
+        const next = await relay(PATH, undefined, conditional);
+        expect(next.status).toBe(424);
+        expect(await next.json()).toMatchObject({
+          error: { code: "fallback_local", details: { reason: "identities_cooling_down" } },
+        });
+        expect(calls).toBe(2);
+        expect((await stub.snapshot()).rates[0]).toMatchObject({
+          resource: "core",
+          remaining: 0,
+          reset_at: reset * 1000,
+        });
+        expect(
+          (
+            await stub.selectIdentity({
+              routeKey: "other",
+              resource: "search",
+              candidates: [{ id: "primary", weight: 200 }],
+            })
+          ).kind,
+        ).toBe("selected");
+      } finally {
+        delayed.release();
+        await Promise.allSettled([pending]);
+      }
+    },
+  );
+
+  it.each(["before", "after"])(
+    "does not compensate or retry when feedback acknowledgement fails %s forwarding",
+    async (phase) => {
+      await seedPool({ secondary: true });
+      const stub = poolCoordinatorStub(env, POOL);
+      const reset = Math.floor(Date.now() / 1000) + 3600;
+      await stub.recordResult({
+        identityId: "primary",
+        routeKey: "unrelated",
+        resource: "core",
+        status: 200,
+        rate: { remaining: 6000, resetAt: reset },
+      });
+      let writes = 0;
+      let calls = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>(async (input, init) => {
+          const request = new Request(input, init);
+          if (bearer(request) === "test-org-token") return jsonResponse({ private: false });
+          expect(bearer(request)).toBe("test-primary-token");
+          calls++;
+          return jsonResponse({ message: "limited" }, 429, {
+            ...headers(0, reset),
+            "retry-after": "3600",
+          });
+        }),
+      );
+      const namespace = new Proxy(env.POOL_COORDINATOR, {
+        get(target, key) {
+          if (key === "get")
+            return () =>
+              new Proxy(stub, {
+                get(real, method) {
+                  if (method === "recordResult")
+                    return async (result: RecordResult) => {
+                      writes++;
+                      if (phase === "after") await real.recordResult(result);
+                      throw new Error("synthetic acknowledgement lost");
+                    };
+                  const value = Reflect.get(real, method, real);
+                  return typeof value === "function"
+                    ? (...args: unknown[]) => Reflect.apply(value, real, args)
+                    : value;
+                },
+              });
+          const value = Reflect.get(target, key, target);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+      const response = await runWithContext((ctx) =>
+        worker.fetch(
+          new Request("https://octopool.dev/v1/github/request", {
+            method: "POST",
+            headers: {
+              authorization: `Bearer ${CALLER_TOKEN}`,
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({ pool: POOL, method: "GET", path: PATH, ...conditional }),
+          }),
+          { ...env, POOL_COORDINATOR: namespace },
+          ctx,
+        ),
+      );
+      expect(response.status).toBe(500);
+      expect(writes).toBe(1);
+      expect(calls).toBe(1);
+      const snapshot = await stub.snapshot();
+      expect(snapshot.rates).toEqual([
+        {
+          identity_id: "primary",
+          resource: "core",
+          limit_count: 5000,
+          remaining: phase === "after" ? 0 : 6000,
+          reset_at: reset * 1000,
+        },
+      ]);
+      expect(snapshot.cooldowns).toHaveLength(phase === "after" ? 1 : 0);
+      if (phase === "after") {
+        expect(snapshot.cooldowns[0]).toMatchObject({ route_key: "*", status: 429 });
+        expect(
+          (
+            await stub.selectIdentity({
+              routeKey: "fresh",
+              resource: "core",
+              candidates: [{ id: "primary", weight: 200 }],
+            })
+          ).kind,
+        ).toBe("unavailable");
+      }
+    },
+  );
+
+  it("keeps anonymous API feedback outside identity budgets", async () => {
+    await seedPool();
+    const reset = Math.floor(Date.now() / 1000) + 3600;
+    const upstream = vi.fn<typeof fetch>(async (input, init) => {
+      expect(bearer(input, init)).toBeUndefined();
+      return jsonResponse({ private: false }, 200, headers(0, reset));
+    });
+    vi.stubGlobal("fetch", upstream);
+    expect((await relay(PATH)).status).toBe(200);
+    expect(upstream).toHaveBeenCalledOnce();
+    expect((await poolCoordinatorStub(env, POOL).snapshot()).rates).toEqual([]);
+    expect(await env.DB.prepare("SELECT remaining FROM github_public_api_rates").first()).toEqual({
+      remaining: 0,
+    });
+  });
+
+  it.each([201, 429])(
+    "does not attribute App token-exchange %s rates to installation quota",
+    async (status) => {
+      await seedPool();
+      await env.DB.prepare(
+        "UPDATE identities SET kind = 'github_app', secret_ref = 'TEST_APP_KEY', installation_id = ? WHERE id = 'primary'",
+      )
+        .bind(987_000 + status)
+        .run();
+      const reset = Math.floor(Date.now() / 1000) + 3600;
+      let exchanges = 0;
+      let resourceCalls = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>(async (input, init) => {
+          const request = new Request(input, init);
+          if (bearer(request) === "test-org-token") return jsonResponse({ private: false });
+          if (request.method === "POST") {
+            exchanges++;
+            return jsonResponse(
+              {
+                token: "synthetic-installation",
+                expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+              },
+              status,
+              { ...headers(0, reset), "retry-after": "3600" },
+            );
+          }
+          expect(bearer(request)).toBe("synthetic-installation");
+          resourceCalls++;
+          return jsonResponse({ private: false });
+        }),
+      );
+      expect((await relay(PATH, undefined, conditional)).status).toBe(status === 201 ? 200 : 502);
+      expect(exchanges).toBe(1);
+      expect(resourceCalls).toBe(status === 201 ? 1 : 0);
+      const snapshot = await poolCoordinatorStub(env, POOL).snapshot();
+      expect(snapshot.rates).toEqual([]);
+      expect(snapshot.cooldowns).toEqual([]);
+    },
+  );
+});

--- a/test/github-rate.test.ts
+++ b/test/github-rate.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { rateFromHeaders } from "../src/github-rate";
+
+describe("GitHub numeric header authority", () => {
+  it("accepts whole decimal integers and optional limit metadata", () => {
+    expect(
+      rateFromHeaders({
+        "x-ratelimit-remaining": "0009",
+        "x-ratelimit-reset": "1800000000",
+        "retry-after": "0",
+      }),
+    ).toEqual({ remaining: 9, resetAt: 1800000000, retryAfter: 0 });
+    expect(
+      rateFromHeaders({
+        "x-ratelimit-limit": "9007199254740991",
+        "x-ratelimit-remaining": "0",
+        "x-ratelimit-reset": "9007199254740",
+      }),
+    ).toEqual({ limit: Number.MAX_SAFE_INTEGER, remaining: 0, resetAt: 9007199254740 });
+  });
+
+  it.each([
+    "",
+    "12junk",
+    "1e3",
+    "1.5",
+    "-1",
+    "+1",
+    " 1",
+    "1 ",
+    "1\n",
+    "NaN",
+    "Infinity",
+    "9007199254740992",
+    "Wed, 21 Oct 2015 07:28:00 GMT",
+  ])("rejects unusable integer Retry-After: %s", (value) => {
+    expect(rateFromHeaders({ "retry-after": value })).toEqual({});
+  });
+
+  it("rejects unsafe seconds-to-milliseconds conversions independently of valid quota", () => {
+    expect(
+      rateFromHeaders({
+        "x-ratelimit-remaining": "9",
+        "x-ratelimit-reset": "9007199254741",
+        "retry-after": "9007199254741",
+      }),
+    ).toEqual({ remaining: 9 });
+  });
+});


### PR DESCRIPTION
## Summary

Delayed GitHub responses could overwrite newer quota exhaustion or shorten an active cooldown. Merge feedback in the coordinator's persisted SQL state: the newest reset window wins, remaining only decreases within that window, and each cooldown key retains its longest absolute deadline with the associated status and reason. Validate complete numeric observations and safe timestamp arithmetic; wrap rate/cooldown writes in a synchronous storage transaction so a failed cooldown write cannot leave a newer quota update committed.

Preserve new-window and exact-expiry recovery, permission/SSO 403 route scope, resource/global cooldown distinctions, existing fallback and cache-source rules, and the limits of observations without a reset. This remains conservative feedback without quota reservation; replaying relative-duration RPC feedback can extend cooldown deadlines. Update the identity/cache documentation and changelog. No schema or dependency changes.

## Tests

- Fresh postcommit native DO/Worker focused suite: 47 tests passed, including overlapping responses, eviction, exact-expiry recovery, malformed numeric authority, and a real SQL-trigger failure proving atomic rollback.
- Fresh full `pnpm check` with Go 1.26.7: generation, format, lint, 790 unit tests, 568 Worker tests, build/types, Go suite, and vet passed. Generated files, manifests, and lockfiles remained unchanged.
- Supplied pre-fix native regression proof: 12 intended failures and two passing controls, with 31 unselected tests and no unhandled errors. Earlier exploratory fixture/teardown failures are excluded from this proof.

The tests use synthetic upstream responses and native local storage/runtime behavior; no live upstream or deployment behavior was proved.
