### PR TITLE
fix: route around unavailable identity credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Include eligible wildcard PATs for explicitly allowed owners and fail over selected local credential errors with bounded shared cooldowns, preserving cache authorization, valid credential continuations, and hard aggregate egress denials.
 - Keep persisted identity quota and cooldown feedback monotonic across delayed responses, reject invalid numeric observations, and atomically preserve rate/cooldown state on storage failure.
 - Keep `--jq` expressions literal, preserve native `gh` output bytes with native jq 1.7+ on Windows, and recognize `octopool.exe` when resolving the shim target without requiring Unix execute bits.
 - Reject malformed stored pool policies before cache reuse or pooled GitHub access with a typed configuration-unavailable error, preserving valid partial-policy defaults.

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -110,6 +110,26 @@ Notes:
   (`409 identity_conflict`).
 - Identity selection between equal candidates is biased by `weight` (default 100).
 
+A wildcard PAT is eligible after public proof even when the requested owner is explicitly
+allowed by the pool. Registration and `GET /v1/pools/:pool/health` describe stored rows:
+`identities_healthy` counts active identities, not verified credential readiness or current
+coordinator availability. Neither operation eagerly validates every Worker binding.
+
+The relay checks the selected credential at use time. Classified local configuration
+failures can select another eligible identity after recording a shared 120-second
+cooldown; exhaustion returns the first generic credential error without secret binding
+names. Each observation can extend the cooldown, and a revision with healthy secrets may
+be suppressed by observations from a revision with missing secrets. A repaired binding
+does not clear that shared state immediately. A valid cached App token can avoid reading
+the private key, but App ID and installation prerequisites still apply, and refresh needs
+the key. See [identity routing](identities.md) for the aggregate and anonymous-fallback limits.
+
+Deploy callers and coordinators with compatible credential-feedback methods. A new caller
+reaching an old coordinator without `recordCredentialFailure` treats the missing method
+as infrastructure failure: no alternate dispatch, fabricated success acknowledgment, or
+compensating storage clear. This method-availability interval lasts for the version overlap;
+the 120-second credential cooldown does not bound it.
+
 ## Pools
 
 Pools are created implicitly the first time they are referenced (caller provisioning,

--- a/docs/identities.md
+++ b/docs/identities.md
@@ -31,12 +31,19 @@ The private key must be `BEGIN PRIVATE KEY` (PKCS#8) PEM — `BEGIN RSA PRIVATE 
 PKCS#8. For v1 the `octopool-cache` App is installed on selected repositories only
 (`openclaw/openclaw`); no private-repo installations.
 
+A valid cached installation token can serve without the private key until refresh is
+needed. A valid installation ID and configured App ID are still required before cache
+lookup. Token-exchange HTTP failures, transport errors, and unexpected crypto failures
+are not classified as local credential configuration failures or retried with another
+identity.
+
 ## Scopes
 
 Each identity has one or more `identity_scopes` rows (`owner`, optional `repo`,
 `allow_private`). When a request targets `owner/repo`, only identities scoped to that
 owner (with a matching `repo` or an owner-wide `NULL` repo) are candidates. A PAT scoped
-to `*` can serve any repository after public proof; scoped PATs and GitHub Apps remain
+to `*` with an owner-wide `NULL` repo can serve any public repository after public proof,
+including owners explicitly listed in `allowed_owners`; scoped PATs and GitHub Apps remain
 limited to their configured owner/repository. Routes with no owner (e.g. `/rate_limit`)
 consider all active identities in the pool.
 
@@ -69,6 +76,22 @@ keeps four SQLite tables in DO storage:
 The winning route gets a fresh 10s lease so concurrent callers stick to the same identity
 briefly instead of stampeding.
 
+Credential readiness is checked only for the selected identity, separately from scope
+eligibility. A missing, blank, or invalid local credential configuration records a
+shared cooldown and lets selection try another eligible identity. Failed IDs remain
+excluded across this request's revalidation and full-fetch phases; a usable credential
+can still serve an existing revalidation-to-full-fetch or canonical-to-exact continuation.
+If all selected credentials fail locally, the relay returns the first typed `503` with
+a generic message, without binding names or secret contents. Local credential failures
+do not permit stale serving. An already-established anonymous local fallback remains
+available when opportunistic pooling cannot help.
+
+Fresh cache eligibility does not depend on live credentials or cooldowns: the relay
+checks current identity scope and public proof before reuse, and checks again for fresh
+publications between attempts. Normal identity metadata may remain cached for 30 seconds;
+cache-source authorization uses a fresh eligibility read. There is no eager scan of all
+credential bindings.
+
 ## Health feedback (cooldowns)
 
 After an identity-backed GitHub resource call, `recordResult` merges complete, valid
@@ -87,7 +110,7 @@ bypass live exhaustion. This is conservative feedback, not quota reservation: re
 already in flight can still consume the same last unit, and same-window quota increases
 remain suppressed until reset.
 
-Only `401`/`403`/`429` write cooldowns, independently of quota validation:
+For GitHub resource responses, only `401`/`403`/`429` write cooldowns, independently of quota validation:
 
 - `401` → global `*` cooldown (usable Retry-After, otherwise 120s).
 - `403` or `429` with usable Retry-After → global `*` cooldown for that duration.
@@ -109,6 +132,19 @@ and snapshots ignore expired rows at exact deadline equality, without deleting t
 Rate and cooldown writes for one result use a synchronous storage transaction, so a
 failed second write cannot leave a partially accepted observation.
 
+Selected local configuration failures use the separate `recordCredentialFailure` RPC:
+an allowlisted credential reason, status `503`, and a global `*` cooldown ending 120
+seconds after each observation. This write preserves any longer existing deadline and
+does not invent a GitHub response or rate observation. Repeated observations may extend
+the deadline. A revision with working secrets can therefore be suppressed by another
+revision's missing configuration until the shared cooldown expires; repairing a binding
+does not immediately clear health state.
+
+Later-page App refresh has a narrower contract: if credentials become unavailable after
+an aggregate starts, the relay refuses the incomplete result without switching identities,
+publishing partial pages, or recording a new local credential cooldown. String-protection
+denials remain hard failures, including during token refresh.
+
 The trusted route determines the identity's `core`/`search` bucket; the response resource
 header cannot override it. Anonymous API snapshots and App token-exchange responses do
 not update identity budgets. State survives Durable Object eviction. Replaying the same
@@ -116,6 +152,12 @@ absolute SQL observation is idempotent; replaying the relative-duration `recordR
 RPC can extend a cooldown. Feedback errors do not initiate retries or compensating state
 deletion. No schema migration or state reset is required; previously overwritten
 observations cannot be reconstructed by this repair.
+
+Credential feedback infrastructure failures stop the attempt without alternate dispatch,
+replay, or compensating state deletion. During mixed-version deployment, a new caller
+reaching an old coordinator without `recordCredentialFailure` also fails this way; the
+method-availability interval depends on version overlap and is **not bounded by 120
+seconds**. See [administration](admin.md) for health interpretation.
 
 ## Registration
 

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -349,6 +349,22 @@ request queue backed up, the relay returns `424 fallback_local` with reason
 
 Every repo route additionally passes a public-visibility check before a pooled identity
 or cache entry is used — see [Cache & public-repo guard](cache.md).
+An eligible wildcard PAT also covers explicitly allowed owners. Missing local bindings
+do not widen scopes or bypass policy, native-only, private-repository, or token-free
+release/event boundaries. Credentials are resolved only after identity selection; a
+classified local configuration failure records shared health and tries another eligible
+identity. If every selected credential fails locally, the first generic typed `503` is
+returned without binding names or secret contents, rather than serving stale bytes.
+The existing clean anonymous local fallback is preserved when opportunistic pooling
+cannot help; string-protection denials and credential-feedback infrastructure failures
+still propagate. See [identities](identities.md) for per-observation cooldowns, cached App
+token prerequisites, and mixed-version method availability.
+
+An aggregate already in progress does not restart or splice pages from another identity
+if a later App refresh lacks credentials. It refuses the incomplete result without partial
+publication or new local credential health; page-fetch and refresh string-protection
+denials remain hard `403` failures.
+
 The complete list of relay paths eligible for anonymous API or public web/raw/Git
 transport is in [Token-Free GitHub Endpoints](token-free.md).
 

--- a/sql/queries/d1.sql
+++ b/sql/queries/d1.sql
@@ -49,10 +49,16 @@ FROM identities
 JOIN identity_scopes ON identity_scopes.identity_id = identities.id
 WHERE identities.pool_id = ?1
   AND identities.status = 'active'
-  AND lower(identity_scopes.owner) = lower(?2)
   AND (
-    lower(identity_scopes.repo) = lower(?3)
-    OR identity_scopes.repo IS NULL
+    (
+      lower(identity_scopes.owner) = lower(?2)
+      AND (lower(identity_scopes.repo) = lower(?3) OR identity_scopes.repo IS NULL)
+    )
+    OR (
+      identities.kind = 'pat'
+      AND identity_scopes.owner = '*'
+      AND identity_scopes.repo IS NULL
+    )
   );
 
 -- name: ListActivePublicIdentitiesForPool :many

--- a/src/generated/sql.ts
+++ b/src/generated/sql.ts
@@ -49,7 +49,7 @@ export const queries = {
   listActiveIdentitiesForPool:
     "SELECT id, kind, login, secret_ref, installation_id, weight\nFROM identities\nWHERE pool_id = ?1\n  AND status = 'active'",
   listActiveIdentitiesForRoute:
-    "SELECT DISTINCT identities.id, identities.kind, identities.login, identities.secret_ref, identities.installation_id, identities.weight\nFROM identities\nJOIN identity_scopes ON identity_scopes.identity_id = identities.id\nWHERE identities.pool_id = ?1\n  AND identities.status = 'active'\n  AND lower(identity_scopes.owner) = lower(?2)\n  AND (\n    lower(identity_scopes.repo) = lower(?3)\n    OR identity_scopes.repo IS NULL\n  )",
+    "SELECT DISTINCT identities.id, identities.kind, identities.login, identities.secret_ref, identities.installation_id, identities.weight\nFROM identities\nJOIN identity_scopes ON identity_scopes.identity_id = identities.id\nWHERE identities.pool_id = ?1\n  AND identities.status = 'active'\n  AND (\n    (\n      lower(identity_scopes.owner) = lower(?2)\n      AND (lower(identity_scopes.repo) = lower(?3) OR identity_scopes.repo IS NULL)\n    )\n    OR (\n      identities.kind = 'pat'\n      AND identity_scopes.owner = '*'\n      AND identity_scopes.repo IS NULL\n    )\n  )",
   listActivePublicIdentitiesForPool:
     "SELECT DISTINCT identities.id, identities.kind, identities.login, identities.secret_ref, identities.installation_id, identities.weight\nFROM identities\nJOIN identity_scopes ON identity_scopes.identity_id = identities.id\nWHERE identities.pool_id = ?1\n  AND identities.status = 'active'\n  AND identities.kind = 'pat'\n  AND identity_scopes.owner = '*'\n  AND identity_scopes.repo IS NULL",
   insertAudit:

--- a/src/github-auth.ts
+++ b/src/github-auth.ts
@@ -6,6 +6,25 @@ import type { Identity } from "./types";
 
 const installationTokenCache = new Map<string, { token: string; expiresAt: number }>();
 
+const credentialFailureMessages = {
+  identity_secret_missing: "Identity credential is not configured",
+  github_app_installation_missing: "GitHub App installation id is missing or invalid",
+  github_app_id_missing: "GitHub App ID is not configured",
+  github_app_key_format: "GitHub App private key must be valid PKCS#8",
+} as const;
+
+export type CredentialFailureReason = keyof typeof credentialFailureMessages;
+
+export function isCredentialFailureReason(value: unknown): value is CredentialFailureReason {
+  return typeof value === "string" && Object.hasOwn(credentialFailureMessages, value);
+}
+
+export class IdentityCredentialError extends HttpError {
+  constructor(readonly reason: CredentialFailureReason) {
+    super(503, reason, credentialFailureMessages[reason]);
+  }
+}
+
 export async function githubToken(env: GitHubEgressEnv, identity: Identity): Promise<string> {
   switch (identity.kind) {
     case "pat":
@@ -19,12 +38,8 @@ async function githubAppInstallationToken(
   env: GitHubEgressEnv,
   identity: Identity,
 ): Promise<string> {
-  if (identity.installation_id === null) {
-    throw new HttpError(
-      503,
-      "github_app_installation_missing",
-      "GitHub App installation id is missing",
-    );
+  if (!Number.isSafeInteger(identity.installation_id) || identity.installation_id! <= 0) {
+    throw new IdentityCredentialError("github_app_installation_missing");
   }
   const appId = githubAppID(env);
   const cacheKey = `${appId}:${identity.installation_id}:${identity.secret_ref}`;
@@ -66,9 +81,9 @@ async function githubAppInstallationToken(
 }
 
 function githubAppID(env: Env): string {
-  const value = (env as unknown as Record<string, string | undefined>).OCTOPOOL_GITHUB_APP_ID;
-  if (value === undefined || value.trim() === "") {
-    throw new HttpError(503, "github_app_id_missing", "GitHub App ID is not configured");
+  const value = (env as unknown as Record<string, unknown>).OCTOPOOL_GITHUB_APP_ID;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new IdentityCredentialError("github_app_id_missing");
   }
   return value.trim();
 }
@@ -93,37 +108,39 @@ async function githubAppJWT(appId: string, privateKeyPEM: string): Promise<strin
 
 async function importPrivateKey(privateKeyPEM: string): Promise<CryptoKey> {
   if (privateKeyPEM.includes("BEGIN RSA PRIVATE KEY")) {
-    throw new HttpError(
-      503,
-      "github_app_key_format",
-      "GitHub App private key must be stored as PKCS#8 BEGIN PRIVATE KEY",
-    );
+    throw new IdentityCredentialError("github_app_key_format");
   }
   const base64 = privateKeyPEM
     .replace(/-----BEGIN PRIVATE KEY-----/g, "")
     .replace(/-----END PRIVATE KEY-----/g, "")
     .replace(/\s+/g, "");
   if (base64 === "") {
-    throw new HttpError(503, "github_app_key_format", "GitHub App private key is empty");
+    throw new IdentityCredentialError("github_app_key_format");
   }
-  const der = base64ToBytes(base64);
-  return crypto.subtle.importKey(
-    "pkcs8",
-    der,
-    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
+  try {
+    const der = base64ToBytes(base64);
+    return await crypto.subtle.importKey(
+      "pkcs8",
+      der,
+      { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+      false,
+      ["sign"],
+    );
+  } catch (error) {
+    if (
+      error instanceof DOMException &&
+      (error.name === "InvalidCharacterError" || error.name === "DataError")
+    ) {
+      throw new IdentityCredentialError("github_app_key_format");
+    }
+    throw error;
+  }
 }
 
 function githubSecret(env: Env, secretRef: string): string {
-  const value = (env as unknown as Record<string, string | undefined>)[secretRef];
-  if (value === undefined || value.trim() === "") {
-    throw new HttpError(
-      503,
-      "identity_secret_missing",
-      `Identity secret ${secretRef} is not configured`,
-    );
+  const value = (env as unknown as Record<string, unknown>)[secretRef];
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new IdentityCredentialError("identity_secret_missing");
   }
   return value;
 }

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,12 +1,11 @@
 import { bytesToBase64 } from "./encoding";
 import type { GitHubEgressEnv } from "./github-egress";
-import { githubToken } from "./github-auth";
 import { requestTimeoutMs, responseCapBytes } from "./github-limits";
 import { appendRelayQuery } from "./github-path";
 import { githubResponseHeaders } from "./github-response";
 import { HttpError } from "./http";
 import { readBodyCapped } from "./response-body";
-import type { GitHubRelayResponse, Identity, RelayRequest, RouteInfo } from "./types";
+import type { GitHubRelayResponse, RelayRequest, RouteInfo } from "./types";
 
 export type GitHubLogProbe =
   | { kind: "exists"; status: number; headers: Record<string, string> }
@@ -15,11 +14,10 @@ export type GitHubLogProbe =
 
 export async function callGitHub(
   env: GitHubEgressEnv,
-  identity: Identity,
+  token: string,
   request: RelayRequest,
   route: RouteInfo,
 ): Promise<GitHubRelayResponse> {
-  const token = await githubToken(env, identity);
   return callGitHubAPI(env, request, route, token);
 }
 
@@ -33,10 +31,9 @@ export async function callPublicGitHub(
 
 export async function probeGitHubLog(
   env: GitHubEgressEnv,
-  identity: Identity,
+  token: string,
   request: RelayRequest,
 ): Promise<GitHubLogProbe> {
-  const token = await githubToken(env, identity);
   const response = await env.githubEgress.fetch(githubUrl(request), {
     method: "GET",
     headers: githubHeaders(token, request.headers),

--- a/src/pool-coordinator.ts
+++ b/src/pool-coordinator.ts
@@ -1,6 +1,7 @@
 import { DurableObject } from "cloudflare:workers";
 import type { CacheFillAcquisition, CacheFillOutcome } from "./cache-fill";
 import { queries } from "./generated/sql";
+import { isCredentialFailureReason, type CredentialFailureReason } from "./github-auth";
 import { isRateInteger, isRateSeconds } from "./github-rate";
 import type { CoordinatorSnapshot, RecordResult, SelectionRequest, SelectionResult } from "./types";
 
@@ -194,6 +195,24 @@ export class PoolCoordinator extends DurableObject<Env> {
         );
       }
     });
+  }
+
+  recordCredentialFailure(result: { identityId: string; reason: CredentialFailureReason }): void {
+    if (
+      typeof result?.identityId !== "string" ||
+      result.identityId === "" ||
+      !isCredentialFailureReason(result.reason)
+    ) {
+      throw new Error("Invalid credential failure observation");
+    }
+    this.ctx.storage.sql.exec(
+      queries.upsertCooldown,
+      result.identityId,
+      "*",
+      503,
+      result.reason,
+      Date.now() + 120_000,
+    );
   }
 
   snapshot(): CoordinatorSnapshot {

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -18,6 +18,7 @@ import { coalesceGitHubCacheMiss } from "./cache-coalesce";
 import type { CacheFillOutcome, OwnedCacheFill } from "./cache-fill";
 import { insertAudit, loadIdentities, loadPoolPolicy } from "./db";
 import { callGitHub, callPublicGitHub, probeGitHubLog } from "./github";
+import { githubToken, IdentityCredentialError } from "./github-auth";
 import { supportsAnonymousGitHubAPI } from "./github-public-api";
 import { rateFromHeaders, type GitHubRate } from "./github-rate";
 import { callAnonymousGitHubAPI, callGitHubWeb } from "./github-web";
@@ -101,6 +102,8 @@ type ActiveRelay = RelayBase & {
   sharedCacheKey: string | undefined;
   cacheKey: string | undefined;
   attemptedIdentityCacheKeys: { cacheKey: string; identity: Pick<Identity, "id" | "kind"> }[];
+  failedIdentityIds: Set<string>;
+  firstCredentialError: IdentityCredentialError | undefined;
   cacheFill: OwnedCacheFill | undefined;
   cacheStatus: "miss" | "bypass";
   cacheable: boolean;
@@ -122,6 +125,16 @@ type RevalidationCandidate = {
   cached: CachedGitHubResponse;
   headers: Record<string, string>;
 };
+
+// Acquisition and feedback failures must cross opportunistic cache/probe catches.
+class IdentityOperationError extends Error {
+  constructor(
+    readonly failure: unknown,
+    readonly feedback = false,
+  ) {
+    super("Identity operation failed");
+  }
+}
 
 export async function relayGitHub(
   request: Request,
@@ -196,7 +209,11 @@ async function relayGitHubRequest(
     active = await prepareRelay(base, policy);
     return await executeRelay(active);
   } catch (error) {
-    return await handleRelayError(base, active, error);
+    return await handleRelayError(
+      base,
+      active,
+      error instanceof IdentityOperationError ? error.failure : error,
+    );
   } finally {
     await active?.cacheFill?.fail();
   }
@@ -238,6 +255,8 @@ async function prepareRelay(
     sharedCacheKey: cacheKey,
     cacheKey,
     attemptedIdentityCacheKeys: [],
+    failedIdentityIds: new Set(),
+    firstCredentialError: undefined,
     cacheFill: undefined,
     cacheStatus: cacheKey === undefined ? "bypass" : "miss",
     cacheable: cacheKey !== undefined,
@@ -398,6 +417,8 @@ async function revalidateStaleRelayCache(state: ActiveRelay): Promise<Response |
     return await attemptStaleRelayCacheRevalidation(state);
   } catch (error) {
     rethrowStringRewriteDenial(error);
+    if (error instanceof IdentityOperationError || error instanceof IdentityCredentialError)
+      throw error;
     return restoreSharedCacheFill(state);
   }
 }
@@ -458,7 +479,9 @@ async function attemptStaleRelayCacheRevalidation(
     selection = await selectIdentity(state.coordinator, {
       routeKey: state.route.routeKey,
       resource: state.route.resource,
-      candidates: identities.map((identity) => ({ id: identity.id, weight: identity.weight })),
+      candidates: identities
+        .filter((identity) => !state.failedIdentityIds.has(identity.id))
+        .map((identity) => ({ id: identity.id, weight: identity.weight })),
     });
   } catch {
     return undefined;
@@ -483,7 +506,9 @@ async function attemptStaleRelayCacheRevalidation(
   if (state.cacheFill === undefined) {
     return restoreSharedCacheFill(state);
   }
-  const github = await callRevalidationAPI(state, candidates[0]!, false, identity);
+  const token = await acquireIdentityToken(state, identity);
+  if (token === undefined) return restoreSharedCacheFill(state);
+  const github = await callRevalidationAPI(state, candidates[0]!, false, identity, token);
   if (github === undefined) {
     return restoreSharedCacheFill(state);
   }
@@ -517,6 +542,7 @@ async function callRevalidationAPI(
   candidate: RevalidationCandidate,
   tokenFree: boolean,
   identity?: Identity,
+  token?: string,
 ): Promise<GitHubRelayResponse | undefined> {
   const request: RelayRequest = {
     ...state.cacheRequest,
@@ -529,11 +555,11 @@ async function callRevalidationAPI(
         ? undefined
         : completeRunJobsSuperset(response, state.runJobsSuperset, anonymousRunJobsPage(state));
     }
-    if (identity !== undefined) {
+    if (identity !== undefined && token !== undefined) {
       state.paginatedIdentityRateRecorded = false;
       const response = sanitizeGitHubResponse(
         state.route,
-        await callGitHub(state.env, identity, request, state.route),
+        await callGitHub(state.env, token, request, state.route),
       );
       return completeRunJobsSuperset(
         response,
@@ -573,6 +599,12 @@ async function finishRevalidation(
   }
   if (github.status !== 304) {
     if (identity !== undefined) {
+      if (
+        githubResponseLocalFallbackReason(github.status, rateFromHeaders(github.headers)) !==
+        undefined
+      ) {
+        state.failedIdentityIds.add(identity.id);
+      }
       await state.coordinator.recordResult(
         coordinatorResult(state, identity, github.status, rateFromHeaders(github.headers)),
       );
@@ -703,7 +735,8 @@ async function callPublicBackend(state: ActiveRelay): Promise<Response> {
     try {
       return await callIdentityPool(state);
     } catch (error) {
-      rethrowStringRewriteDenial(error);
+      if (error instanceof IdentityOperationError && error.feedback) throw error;
+      rethrowStringRewriteDenial(error instanceof IdentityOperationError ? error.failure : error);
       // The anonymous request already had a clean local fallback. Preserve it
       // if the opportunistic pooled attempt cannot serve the request.
     }
@@ -719,30 +752,31 @@ async function callIdentityPool(state: ActiveRelay): Promise<Response> {
     throw new HttpError(503, "no_identity", "No active identity can serve this route");
   }
   await rememberIdentityCacheKeys(state, identities);
-  const attemptedIdentityIds = new Set<string>();
-  let fallbackReason = "identity_pool_depleted";
-  for (let attempt = 0; attempt < identities.length; attempt++) {
+  // Prior revalidation failures retain the existing cooling outcome. Only an
+  // ordinary resource attempt in this phase replaces it with its own reason.
+  let fallbackReason = "identities_cooling_down";
+  for (let attempt = 0; attempt <= identities.length; attempt++) {
+    const identityCached = await serveFreshIdentityCache(state, identities);
+    if (identityCached !== undefined) return identityCached;
     const candidates = identities
-      .filter((candidate) => !attemptedIdentityIds.has(candidate.id))
+      .filter((candidate) => !state.failedIdentityIds.has(candidate.id))
       .map((candidate) => ({ id: candidate.id, weight: candidate.weight }));
-    if (candidates.length === 0) {
+    if (candidates.length === 0 || attempt === identities.length) {
       break;
     }
-    const identityCached = await serveFreshIdentityCache(state, identities, attemptedIdentityIds);
-    if (identityCached !== undefined) {
-      return identityCached;
-    }
-    const selection = await selectIdentity(state.coordinator, {
+    const selection = await state.coordinator.selectIdentity({
       routeKey: state.route.routeKey,
       resource: state.route.resource,
       candidates,
     });
+    if (selection.kind === "unavailable") {
+      throw (
+        state.firstCredentialError ??
+        new HttpError(503, "identities_cooling_down", "All identity candidates are cooling down")
+      );
+    }
     const identity = findIdentity(identities, selection.identityId);
     state.identity = identity;
-    const terminalLog = await revalidateCachedTerminalLog(state, identity, selection.reason);
-    if (terminalLog !== undefined) {
-      return terminalLog;
-    }
     const identityCacheKey = state.cacheEnabled
       ? await githubCacheKey(state.request.pool, state.cacheRequest, state.route, identity)
       : undefined;
@@ -756,9 +790,13 @@ async function callIdentityPool(state: ActiveRelay): Promise<Response> {
     if (coalesced !== undefined) {
       return serveFreshCachedRelayResponse(state, coalesced, { coalesced: true });
     }
+    const token = await acquireIdentityToken(state, identity);
+    if (token === undefined) continue;
+    const terminalLog = await revalidateCachedTerminalLog(state, identity, selection.reason, token);
+    if (terminalLog !== undefined) return terminalLog;
     const firstPage = sanitizeGitHubResponse(
       state.route,
-      await callGitHub(state.env, identity, state.cacheRequest, state.route),
+      await callGitHub(state.env, token, state.cacheRequest, state.route),
     );
     state.paginatedIdentityRateRecorded = false;
     const github = await completeRunJobsSuperset(
@@ -769,7 +807,7 @@ async function callIdentityPool(state: ActiveRelay): Promise<Response> {
     const rate = rateFromHeaders(github.headers);
     const identityFallback = githubResponseLocalFallbackReason(github.status, rate);
     if (identityFallback !== undefined) {
-      attemptedIdentityIds.add(identity.id);
+      state.failedIdentityIds.add(identity.id);
       fallbackReason = identityFallback;
       await state.coordinator.recordResult(coordinatorResult(state, identity, github.status, rate));
       continue;
@@ -781,6 +819,7 @@ async function callIdentityPool(state: ActiveRelay): Promise<Response> {
       rate,
     });
   }
+  if (state.firstCredentialError !== undefined) throw state.firstCredentialError;
   const stale = await serveStaleRelayCache(state, fallbackReason);
   if (stale !== undefined) {
     return stale;
@@ -788,6 +827,28 @@ async function callIdentityPool(state: ActiveRelay): Promise<Response> {
   throw new HttpError(424, "fallback_local", "Run this request with local GitHub credentials", {
     reason: fallbackReason,
   });
+}
+
+async function acquireIdentityToken(
+  state: ActiveRelay,
+  identity: Identity,
+): Promise<string | undefined> {
+  try {
+    return await githubToken(state.env, identity);
+  } catch (error) {
+    if (!(error instanceof IdentityCredentialError)) throw new IdentityOperationError(error);
+    state.failedIdentityIds.add(identity.id);
+    state.firstCredentialError ??= error;
+    try {
+      await state.coordinator.recordCredentialFailure({
+        identityId: identity.id,
+        reason: error.reason,
+      });
+    } catch (feedbackError) {
+      throw new IdentityOperationError(feedbackError, true);
+    }
+    return undefined;
+  }
 }
 
 async function switchRelayCacheKey(
@@ -959,9 +1020,11 @@ function identityRunJobsPage(
 ): (request: RelayRequest) => Promise<GitHubRelayResponse> {
   return async (request) => {
     await recordFirstPaginatedIdentityRate(state, identity, firstPage);
+    // A partially collected aggregate cannot restart selection or mix identities.
+    const token = await githubToken(state.env, identity);
     const page = sanitizeGitHubResponse(
       state.route,
-      await callGitHub(state.env, identity, request, state.route),
+      await callGitHub(state.env, token, request, state.route),
     );
     await state.coordinator.recordResult(
       coordinatorResult(state, identity, page.status, rateFromHeaders(page.headers)),
@@ -1255,6 +1318,7 @@ async function revalidateCachedTerminalLog(
   state: ActiveRelay,
   identity: Identity,
   leaseReason: SelectionLeaseReason,
+  token: string,
 ): Promise<Response | undefined> {
   const cached = state.terminalLogCached;
   const key = state.terminalLogCacheKey;
@@ -1263,7 +1327,7 @@ async function revalidateCachedTerminalLog(
   }
   state.terminalLogCached = undefined;
   try {
-    const probe = await probeGitHubLog(state.env, identity, state.request);
+    const probe = await probeGitHubLog(state.env, token, state.request);
     if (probe.kind === "exists") {
       await publishTerminalLogCache(state.env, key, cached);
       state.ctx.waitUntil(
@@ -1393,15 +1457,11 @@ function staleFallbackReasonFromError(error: unknown): string | undefined {
 async function serveFreshIdentityCache(
   state: ActiveRelay,
   identities: Identity[],
-  attemptedIdentityIds: Set<string>,
 ): Promise<Response | undefined> {
   if (!state.cacheEnabled) {
     return undefined;
   }
   for (const identity of identities) {
-    if (attemptedIdentityIds.has(identity.id)) {
-      continue;
-    }
     const cacheKey = await githubCacheKey(
       state.request.pool,
       state.cacheRequest,

--- a/src/run-jobs-superset.ts
+++ b/src/run-jobs-superset.ts
@@ -1,6 +1,7 @@
 import { PUBLIC_SHAPES } from "./github-public-shapes";
 import { boundedPageSize, firstPageQuery, validScalarQuery } from "./github-public-utils";
 import { isRecord } from "./object";
+import { rethrowStringRewriteDenial } from "./github-egress";
 import type { GitHubRelayResponse, RelayRequest, RouteInfo } from "./types";
 
 const MAX_PAGE_SIZE = 100;
@@ -104,7 +105,8 @@ export async function completeRunJobsSuperset(
         ...view.cacheRequest,
         query: { ...view.cacheRequest.query, page: String(page) },
       });
-    } catch {
+    } catch (error) {
+      rethrowStringRewriteDenial(error);
       return response;
     }
     if (

--- a/test/e2e/identity-credentials.test.ts
+++ b/test/e2e/identity-credentials.test.ts
@@ -1,0 +1,331 @@
+import { env } from "cloudflare:workers";
+import { evictDurableObject, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it, vi } from "vitest";
+import { poolCoordinatorStub } from "../../src/pool-coordinator";
+import type { CredentialFailureReason } from "../../src/github-auth";
+import { HttpError } from "../../src/http";
+import { bearer, githubUpstream, jsonResponse, POOL, seedPool } from "./harness";
+import { appIdentity, requestWithEnv } from "./identity-routing-support";
+
+const coordinator = () => poolCoordinatorStub(env, POOL);
+const localCases: [string, "pat" | "app", Record<string, unknown>, string][] = [
+  ["missing PAT", "pat", { TEST_PAT_PRIMARY: undefined }, "identity_secret_missing"],
+  ["blank PAT", "pat", { TEST_PAT_PRIMARY: " \n " }, "identity_secret_missing"],
+  ["wrong-type PAT", "pat", { TEST_PAT_PRIMARY: {} }, "identity_secret_missing"],
+  ["missing App ID", "app", { OCTOPOOL_GITHUB_APP_ID: undefined }, "github_app_id_missing"],
+  ["blank App ID", "app", { OCTOPOOL_GITHUB_APP_ID: " " }, "github_app_id_missing"],
+  ["wrong-type App ID", "app", { OCTOPOOL_GITHUB_APP_ID: 777 }, "github_app_id_missing"],
+  ["missing key", "app", { TEST_APP_KEY: undefined }, "identity_secret_missing"],
+  ["blank key", "app", { TEST_APP_KEY: " " }, "identity_secret_missing"],
+  ["wrong-type key", "app", { TEST_APP_KEY: {} }, "identity_secret_missing"],
+  [
+    "PKCS1",
+    "app",
+    { TEST_APP_KEY: "-----BEGIN RSA PRIVATE KEY-----\nsynthetic\n-----END RSA PRIVATE KEY-----" },
+    "github_app_key_format",
+  ],
+  [
+    "empty PEM",
+    "app",
+    { TEST_APP_KEY: "-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----" },
+    "github_app_key_format",
+  ],
+  [
+    "base64",
+    "app",
+    { TEST_APP_KEY: "-----BEGIN PRIVATE KEY-----\n%%%\n-----END PRIVATE KEY-----" },
+    "github_app_key_format",
+  ],
+  [
+    "DER",
+    "app",
+    { TEST_APP_KEY: "-----BEGIN PRIVATE KEY-----\nYmFk\n-----END PRIVATE KEY-----" },
+    "github_app_key_format",
+  ],
+];
+
+describe("selected identity credential failures", () => {
+  it.each(localCases)(
+    "tries only the selected %s then serves and audits the healthy PAT",
+    async (_label, kind, overrides, reason) => {
+      await seedPool({ secondary: true });
+      if (kind === "app") await appIdentity();
+      const logs = vi.spyOn(console, "error").mockImplementation(() => {});
+      const upstream = githubUpstream({ primary: jsonResponse({ private: false, id: 17 }) });
+      vi.stubGlobal("fetch", upstream);
+      const before = Date.now();
+      const response = await requestWithEnv(overrides);
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        identity: { id: "secondary" },
+        body: { id: 17 },
+      });
+      expect(upstream.mock.calls.map(([input, init]) => bearer(input, init))).toEqual([
+        "test-org-token",
+        "test-secondary-token",
+      ]);
+      const snapshot = await coordinator().snapshot();
+      expect(snapshot.rates).toEqual([]);
+      expect(snapshot.cooldowns).toEqual([
+        expect.objectContaining({ identity_id: "primary", route_key: "*", status: 503, reason }),
+      ]);
+      expect(snapshot.cooldowns[0]!.expires_at).toBeGreaterThanOrEqual(before + 120_000);
+      expect(snapshot.cooldowns[0]!.expires_at).toBeLessThanOrEqual(Date.now() + 120_000);
+      expect(
+        await env.DB.prepare("SELECT identity_id, status, error_code FROM audit_events").all(),
+      ).toMatchObject({ results: [{ identity_id: "secondary", status: 200, error_code: null }] });
+      expect(logs).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([null, 0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1])(
+    "rejects installation %s before exchange",
+    async (installation) => {
+      await seedPool({ secondary: true });
+      await appIdentity(installation);
+      const upstream = githubUpstream({ primary: jsonResponse({ private: false }) });
+      vi.stubGlobal("fetch", upstream);
+      expect(await (await requestWithEnv()).json()).toMatchObject({
+        identity: { id: "secondary" },
+      });
+      expect(upstream).toHaveBeenCalledTimes(2);
+      expect((await coordinator().snapshot()).cooldowns[0]?.reason).toBe(
+        "github_app_installation_missing",
+      );
+    },
+  );
+
+  it("visits every broken ID once, returns the first generic error, and later reports cooling", async () => {
+    await seedPool({ secondary: true });
+    await appIdentity(null);
+    const upstream = githubUpstream({ primary: jsonResponse({ private: false }) });
+    vi.stubGlobal("fetch", upstream);
+    const response = await requestWithEnv({ TEST_PAT_SECONDARY: undefined });
+    expect(response.status).toBe(503);
+    const text = await response.text();
+    expect(JSON.parse(text)).toMatchObject({ error: { code: "github_app_installation_missing" } });
+    expect(text).not.toMatch(/TEST_|secret_ref|token|PRIVATE KEY/);
+    const snapshot = await coordinator().snapshot();
+    expect(snapshot.cooldowns).toHaveLength(2);
+    expect(snapshot.rates).toEqual([]);
+    expect(await (await requestWithEnv()).json()).toMatchObject({
+      error: { code: "fallback_local", details: { reason: "identities_cooling_down" } },
+    });
+    expect((await coordinator().snapshot()).cooldowns).toEqual(snapshot.cooldowns);
+    expect(
+      upstream.mock.calls.every(([input, init]) => bearer(input, init) === "test-org-token"),
+    ).toBe(true);
+  });
+
+  it.each([401, 403, 429])(
+    "keeps real HTTP %s feedback after a missing credential and returns the first local error",
+    async (status) => {
+      await seedPool({ secondary: true });
+      vi.stubGlobal(
+        "fetch",
+        githubUpstream({ primary: jsonResponse({ message: "synthetic failure" }, status) }),
+      );
+      const response = await requestWithEnv({ TEST_PAT_PRIMARY: undefined });
+      expect(response.status).toBe(503);
+      expect(await response.json()).toMatchObject({
+        error: {
+          code: "identity_secret_missing",
+          message: "Identity credential is not configured",
+        },
+      });
+      expect((await coordinator().snapshot()).cooldowns).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            identity_id: "primary",
+            status: 503,
+            route_key: "*",
+            reason: "identity_secret_missing",
+          }),
+          expect.objectContaining({ identity_id: "secondary", status, reason: "github_error" }),
+        ]),
+      );
+      expect((await coordinator().snapshot()).rates).toEqual([]);
+    },
+  );
+
+  it("recovers at exactly 120 seconds, persists across eviction and never shortens a longer cooldown", async () => {
+    await seedPool();
+    const now = Date.now();
+    const clock = vi.spyOn(Date, "now").mockReturnValue(now);
+    vi.stubGlobal("fetch", githubUpstream({ primary: jsonResponse({ private: false }) }));
+    expect((await requestWithEnv({ TEST_PAT_PRIMARY: undefined })).status).toBe(503);
+    await evictDurableObject(coordinator());
+    clock.mockReturnValue(now + 119_999);
+    expect(await (await requestWithEnv()).json()).toMatchObject({
+      error: { details: { reason: "identities_cooling_down" } },
+    });
+    clock.mockReturnValue(now + 120_000);
+    expect(await (await requestWithEnv()).json()).toMatchObject({ identity: { id: "primary" } });
+    const rows = await runInDurableObject(coordinator(), (_instance, state) =>
+      state.storage.sql.exec("SELECT * FROM cooldowns").toArray(),
+    );
+    expect(rows).toEqual([
+      {
+        identity_id: "primary",
+        route_key: "*",
+        status: 503,
+        reason: "identity_secret_missing",
+        expires_at: now + 120_000,
+      },
+    ]);
+    await coordinator().recordResult({
+      identityId: "primary",
+      routeKey: "other",
+      resource: "core",
+      status: 401,
+      rate: { retryAfter: 500 },
+    });
+    await coordinator().recordCredentialFailure({
+      identityId: "primary",
+      reason: "github_app_key_format",
+    });
+    expect((await coordinator().snapshot()).cooldowns[0]).toMatchObject({
+      status: 401,
+      reason: "github_error",
+      expires_at: now + 620_000,
+    });
+    clock.mockRestore();
+  });
+
+  it("retains a cached App token without a key, then fails over at refresh", async () => {
+    await seedPool({ secondary: true });
+    await appIdentity(92001);
+    const now = Date.now();
+    const clock = vi.spyOn(Date, "now").mockReturnValue(now);
+    let exchanges = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        if (bearer(input, init) === "test-org-token") return jsonResponse({ private: false });
+        if (new Request(input, init).method === "POST") {
+          exchanges++;
+          return jsonResponse({
+            token: "synthetic-app",
+            expires_at: new Date(now + 3_600_000).toISOString(),
+          });
+        }
+        return jsonResponse({ private: false });
+      }),
+    );
+    expect(await (await requestWithEnv()).json()).toMatchObject({ identity: { id: "primary" } });
+    expect(await (await requestWithEnv({ TEST_APP_KEY: undefined })).json()).toMatchObject({
+      identity: { id: "primary" },
+    });
+    clock.mockReturnValue(now + 3_540_000);
+    expect(await (await requestWithEnv({ TEST_APP_KEY: undefined })).json()).toMatchObject({
+      identity: { id: "secondary" },
+    });
+    expect(exchanges).toBe(1);
+    clock.mockRestore();
+  });
+
+  it.each([
+    ["missing App ID", 98001, undefined, undefined, "github_app_id_missing"],
+    ["blank App ID", 98002, " ", undefined, "github_app_id_missing"],
+    ["wrong-type App ID", 98003, 777, undefined, "github_app_id_missing"],
+    ["missing installation", 98004, undefined, null, "github_app_installation_missing"],
+    ["zero installation", 98005, undefined, 0, "github_app_installation_missing"],
+    ["negative installation", 98006, undefined, -1, "github_app_installation_missing"],
+    ["fractional installation", 98007, undefined, 1.5, "github_app_installation_missing"],
+    [
+      "unsafe installation",
+      98008,
+      undefined,
+      Number.MAX_SAFE_INTEGER + 1,
+      "github_app_installation_missing",
+    ],
+  ] as const)(
+    "checks %s even with a valid cached App token",
+    async (_label, installation, appId, invalidInstallation, reason) => {
+      await seedPool({ secondary: true });
+      await appIdentity(installation);
+      let exchanges = 0;
+      const resources: string[] = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>(async (input, init) => {
+          const request = new Request(input, init);
+          const token = bearer(request);
+          if (token === "test-org-token") return jsonResponse({ private: false });
+          if (request.method === "POST") {
+            exchanges++;
+            expect(new URL(request.url).pathname).toBe(
+              `/app/installations/${installation}/access_tokens`,
+            );
+            return jsonResponse({
+              token: "synthetic-prerequisite-app",
+              expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+            });
+          }
+          resources.push(token!);
+          return jsonResponse({ private: false });
+        }),
+      );
+      expect(await (await requestWithEnv()).json()).toMatchObject({ identity: { id: "primary" } });
+      // A keyless request proves the real mint populated a still-valid token entry.
+      expect(await (await requestWithEnv({ TEST_APP_KEY: undefined })).json()).toMatchObject({
+        identity: { id: "primary" },
+      });
+      if (invalidInstallation !== undefined) await appIdentity(invalidInstallation);
+      const response = await requestWithEnv({
+        TEST_APP_KEY: undefined,
+        OCTOPOOL_GITHUB_APP_ID: appId,
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ identity: { id: "secondary" } });
+      expect(exchanges).toBe(1);
+      expect(resources).toEqual([
+        "synthetic-prerequisite-app",
+        "synthetic-prerequisite-app",
+        "test-secondary-token",
+      ]);
+      expect(await coordinator().snapshot()).toMatchObject({
+        rates: [],
+        cooldowns: [expect.objectContaining({ identity_id: "primary", reason, status: 503 })],
+      });
+    },
+  );
+
+  it.each(["http", "transport", "arbitrary503"])(
+    "does not retry an installation POST on %s failure",
+    async (mode) => {
+      await seedPool({ secondary: true });
+      await appIdentity(93001);
+      let posts = 0;
+      const upstream = vi.fn<typeof fetch>(async (input, init) => {
+        if (bearer(input, init) === "test-org-token") return jsonResponse({ private: false });
+        expect(new Request(input, init).method).toBe("POST");
+        posts++;
+        if (mode === "transport") throw new Error("synthetic transport fault");
+        if (mode === "arbitrary503")
+          throw new HttpError(503, "synthetic_infrastructure", "Synthetic infrastructure failure");
+        return jsonResponse({ message: "synthetic private upstream" }, 503);
+      });
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      vi.stubGlobal("fetch", upstream);
+      const response = await requestWithEnv();
+      expect(response.status).toBe(mode === "http" ? 502 : mode === "transport" ? 500 : 503);
+      expect(posts).toBe(1);
+      expect((await coordinator().snapshot()).cooldowns).toEqual([]);
+      expect((await coordinator().snapshot()).rates).toEqual([]);
+      expect(await response.text()).not.toContain("synthetic private upstream");
+    },
+  );
+
+  it("rejects nonallowlisted credential reasons in the real DO without persistence", async () => {
+    await runInDurableObject(coordinator(), (instance) => {
+      expect(() =>
+        instance.recordCredentialFailure({
+          identityId: "primary",
+          reason: "SYNTHETIC_BINDING" as CredentialFailureReason,
+        }),
+      ).toThrow("Invalid credential failure observation");
+    });
+    expect((await coordinator().snapshot()).cooldowns).toEqual([]);
+  });
+});

--- a/test/e2e/identity-routing-lifecycle.test.ts
+++ b/test/e2e/identity-routing-lifecycle.test.ts
@@ -1,0 +1,708 @@
+import { env } from "cloudflare:workers";
+import { runInDurableObject } from "cloudflare:test";
+import { describe, expect, it, vi } from "vitest";
+import { clearConfigCache } from "../../src/config-cache";
+import { githubCacheKey, readGitHubCache, writeGitHubCache } from "../../src/cache";
+import { loadIdentities } from "../../src/db";
+import { deleteEdgeJSON } from "../../src/edge-cache";
+import { poolCoordinatorStub } from "../../src/pool-coordinator";
+import { classifyRoute, defaultPolicy } from "../../src/policy";
+import { terminalLogCacheKey } from "../../src/terminal-log-cache";
+import { runJobsSupersetView } from "../../src/run-jobs-superset";
+import type { CredentialFailureReason } from "../../src/github-auth";
+import {
+  bearer,
+  CALLER_TOKEN,
+  githubUpstream,
+  jsonResponse,
+  POOL,
+  rateHeaders,
+  seedPool,
+} from "./harness";
+import { appIdentity, PATH, requestWithEnv, requestWithWarmEnv } from "./identity-routing-support";
+import { ownedWork } from "./owned-work";
+
+const DIFF_PATH = "/repos/openclaw/octopool/pulls/42";
+const diffOptions = { headers: { accept: "application/vnd.github.diff" } };
+const coordinator = () => poolCoordinatorStub(env, POOL);
+
+async function expireEntries(): Promise<void> {
+  const rows = await env.DB.prepare("SELECT cache_key FROM github_cache_entries").all<{
+    cache_key: string;
+  }>();
+  for (const row of rows.results) await deleteEdgeJSON("github-v1", row.cache_key);
+  await env.DB.prepare(
+    "UPDATE github_cache_entries SET expires_at = datetime('now', '-1 second')",
+  ).run();
+}
+
+function diffUpstream(serve: (token: string | undefined) => Promise<Response> | Response) {
+  return vi.fn<typeof fetch>(async (input, init) => {
+    const token = bearer(input, init);
+    if (token === "test-org-token") return jsonResponse({ private: false });
+    if (token === undefined) return new Response("unavailable", { status: 503 });
+    return serve(token);
+  });
+}
+function diffResponse() {
+  return new Response("diff --git a/a b/a\n", {
+    headers: { "content-type": "text/plain", etag: '"identity-diff"' },
+  });
+}
+
+function feedbackNamespace(
+  observe: (
+    result: { identityId: string; reason: CredentialFailureReason },
+    forward: () => Promise<void>,
+  ) => Promise<void>,
+) {
+  const stub = coordinator();
+  return new Proxy(env.POOL_COORDINATOR, {
+    get(target, key) {
+      if (key === "get")
+        return () =>
+          new Proxy(stub, {
+            get(real, method) {
+              if (method === "recordCredentialFailure")
+                return (result: { identityId: string; reason: CredentialFailureReason }) =>
+                  observe(result, async () => {
+                    await real.recordCredentialFailure(result);
+                  });
+              const value = Reflect.get(real, method, real);
+              return typeof value === "function"
+                ? (...args: unknown[]) => Reflect.apply(value, real, args)
+                : value;
+            },
+          });
+      const value = Reflect.get(target, key, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
+describe("identity routing lifecycle boundaries", () => {
+  it("keeps the failed ID excluded across pooled revalidation, shared fill restoration and follower completion", async () => {
+    await seedPool({ secondary: true });
+    vi.stubGlobal(
+      "fetch",
+      diffUpstream(() => diffResponse()),
+    );
+    expect((await requestWithEnv({}, DIFF_PATH, diffOptions)).status).toBe(200);
+    await expireEntries();
+    const entered = ownedWork.gate();
+    const release = ownedWork.gate();
+    let feedback = 0;
+    const namespace = feedbackNamespace(async (result, forward) => {
+      expect(result.identityId).toBe("primary");
+      feedback++;
+      await forward();
+    });
+    const upstream = diffUpstream(async (token) => {
+      expect(token).toBe("test-secondary-token");
+      entered.release();
+      await release.promise;
+      return diffResponse();
+    });
+    vi.stubGlobal("fetch", upstream);
+    const overrides = { TEST_PAT_PRIMARY: undefined, POOL_COORDINATOR: namespace };
+    const pending = requestWithEnv(overrides, DIFF_PATH, diffOptions);
+    let follower: Promise<Response> | undefined;
+    try {
+      await Promise.race([
+        entered.promise,
+        pending.then(() => {
+          throw new Error("Relay completed before the gated resource call");
+        }),
+      ]);
+      follower = requestWithEnv(overrides, DIFF_PATH, diffOptions);
+      // Observe registration without resolving Runner-owned gates inside the DO.
+      await Promise.race([
+        vi.waitFor(async () => {
+          const waiting = await runInDurableObject(
+            coordinator(),
+            (instance) =>
+              (instance as unknown as { cacheFillWaiters: Map<string, unknown> }).cacheFillWaiters
+                .size,
+          );
+          expect(waiting).toBe(1);
+        }),
+        follower.then(() => {
+          throw new Error("Follower completed before coordinator waiting");
+        }),
+      ]);
+      release.release();
+      const responses = await Promise.all([pending, follower]);
+      for (const response of responses) {
+        expect(response.status).toBe(200);
+        expect(await response.json()).toMatchObject({
+          identity: { id: "secondary" },
+          body: "diff --git a/a b/a\n",
+        });
+      }
+      expect(feedback).toBe(1);
+      expect(
+        upstream.mock.calls.filter(
+          ([input, init]) => bearer(input, init) === "test-secondary-token",
+        ),
+      ).toHaveLength(1);
+      expect(
+        await runInDurableObject(coordinator(), (_instance, state) =>
+          state.storage.sql.exec("SELECT * FROM cache_fills").toArray(),
+        ),
+      ).toEqual([]);
+    } finally {
+      release.release();
+      await Promise.allSettled(follower === undefined ? [pending] : [pending, follower]);
+    }
+  });
+
+  it.each([
+    ["before", "revalidation"],
+    ["after", "revalidation"],
+    ["before", "ordinary"],
+    ["after", "ordinary"],
+    ["before", "public"],
+    ["after", "public"],
+  ])(
+    "treats credential feedback failure %s in %s as infrastructure without retry or clearing state",
+    async (phase, boundary) => {
+      await seedPool({ secondary: true });
+      if (boundary === "revalidation") {
+        vi.stubGlobal(
+          "fetch",
+          diffUpstream(() => diffResponse()),
+        );
+        expect((await requestWithEnv({}, DIFF_PATH, diffOptions)).status).toBe(200);
+        await expireEntries();
+      }
+      let writes = 0;
+      const namespace = feedbackNamespace(async (_result, forward) => {
+        writes++;
+        if (phase === "after") await forward();
+        throw new Error("Synthetic feedback acknowledgement failed");
+      });
+      const logs = vi.spyOn(console, "error").mockImplementation(() => {});
+      const upstream = vi.fn<typeof fetch>(async (input, init) => {
+        if (bearer(input, init) === "test-org-token") return jsonResponse({ private: false });
+        return jsonResponse({ message: "anonymous quota exhausted" }, 429);
+      });
+      vi.stubGlobal("fetch", upstream);
+      const response = await requestWithEnv(
+        { TEST_PAT_PRIMARY: undefined, POOL_COORDINATOR: namespace },
+        boundary === "public" ? "/users/octocat" : DIFF_PATH,
+        boundary === "public" ? {} : diffOptions,
+      );
+      expect(response.status).toBe(500);
+      expect(await response.json()).toMatchObject({ error: { code: "internal_error" } });
+      expect(writes).toBe(1);
+      expect(
+        upstream.mock.calls.every(
+          ([input, init]) => bearer(input, init) !== "test-secondary-token",
+        ),
+      ).toBe(true);
+      expect((await coordinator().snapshot()).cooldowns).toHaveLength(phase === "after" ? 1 : 0);
+      expect((await coordinator().snapshot()).rates).toEqual([]);
+      expect(JSON.stringify(logs.mock.calls)).not.toContain("TEST_PAT_PRIMARY");
+      expect(
+        await runInDurableObject(coordinator(), (_instance, state) =>
+          state.storage.sql.exec("SELECT * FROM cache_fills").toArray(),
+        ),
+      ).toEqual([]);
+    },
+  );
+
+  it.each([
+    ["revalidation", "http", 98101],
+    ["revalidation", "transport", 98102],
+    ["revalidation", "crypto", 98103],
+    ["revalidation", "denial", 98104],
+    ["public", "http", 98105],
+    ["public", "transport", 98106],
+    ["public", "crypto", 98107],
+    ["public", "denial", 98108],
+    ["public", "local", 98109],
+  ] as const)(
+    "preserves %s acquisition ownership for %s failure",
+    async (boundary, failure, installation) => {
+      await seedPool({ secondary: true });
+      if (boundary === "revalidation") {
+        vi.stubGlobal(
+          "fetch",
+          diffUpstream(() => diffResponse()),
+        );
+        expect((await requestWithEnv({}, DIFF_PATH, diffOptions)).status).toBe(200);
+        await expireEntries();
+      }
+      await appIdentity(installation);
+      if (failure === "denial")
+        await env.DB.prepare("UPDATE string_rewrite_policy SET rules_json = ?")
+          .bind(JSON.stringify([{ pattern: "access_tokens", replacement: "blocked" }]))
+          .run();
+      const cryptoFailure =
+        failure === "crypto"
+          ? vi
+              .spyOn(crypto.subtle, "importKey")
+              .mockRejectedValue(
+                new DOMException("Synthetic crypto operation failure", "OperationError"),
+              )
+          : undefined;
+      let posts = 0;
+      const resourceTokens: string[] = [];
+      const upstream = vi.fn<typeof fetch>(async (input, init) => {
+        const request = new Request(input, init);
+        const token = bearer(request);
+        if (token === "test-org-token") return jsonResponse({ private: false });
+        if (request.method === "POST") {
+          posts++;
+          if (failure === "transport") throw new Error("Synthetic exchange transport failure");
+          return jsonResponse({ message: "synthetic exchange failure" }, 503);
+        }
+        if (token !== undefined) resourceTokens.push(token);
+        return jsonResponse({ message: "anonymous quota exhausted" }, 429);
+      });
+      vi.stubGlobal("fetch", upstream);
+      const response = await requestWithEnv(
+        failure === "local" ? { TEST_APP_KEY: undefined, TEST_PAT_SECONDARY: undefined } : {},
+        boundary === "public" ? "/users/octocat" : DIFF_PATH,
+        boundary === "public" ? {} : diffOptions,
+      );
+      const code =
+        failure === "denial"
+          ? "string_rewrite_denied"
+          : boundary === "public"
+            ? "fallback_local"
+            : failure === "http"
+              ? "github_app_token_failed"
+              : "internal_error";
+      expect(response.status).toBe(
+        failure === "denial" ? 403 : boundary === "public" ? 424 : failure === "http" ? 502 : 500,
+      );
+      expect(await response.json()).toMatchObject({
+        error: {
+          code,
+          ...(boundary === "public" && failure !== "denial"
+            ? { details: { reason: "github_rate_limited" } }
+            : {}),
+        },
+      });
+      expect(posts).toBe(failure === "http" || failure === "transport" ? 1 : 0);
+      if (cryptoFailure !== undefined) expect(cryptoFailure).toHaveBeenCalledOnce();
+      expect(resourceTokens).toEqual([]);
+      const health = await coordinator().snapshot();
+      expect(health.rates).toEqual([]);
+      expect(health.cooldowns).toHaveLength(failure === "local" ? 2 : 0);
+      expect(
+        await runInDurableObject(coordinator(), (_instance, state) =>
+          state.storage.sql.exec("SELECT * FROM cache_fills").toArray(),
+        ),
+      ).toEqual([]);
+    },
+  );
+
+  it("treats credential feedback failure missing-method inside a native request as infrastructure", async () => {
+    await seedPool({ secondary: true });
+    vi.stubGlobal(
+      "fetch",
+      diffUpstream(() => diffResponse()),
+    );
+    expect((await requestWithEnv({}, DIFF_PATH, diffOptions)).status).toBe(200);
+    await expireEntries();
+    await runInDurableObject(coordinator(), (_instance, state) =>
+      state.storage.put("protocol-marker", true),
+    );
+    clearConfigCache();
+    const upstream = diffUpstream(() => {
+      throw new Error("No resource request may follow failed feedback");
+    });
+    vi.stubGlobal("fetch", upstream);
+    const response = await ownedWork.track(
+      (env as Env & { IDENTITY_PROTOCOL: Fetcher }).IDENTITY_PROTOCOL.fetch(
+        "https://octopool.dev/v1/github/request",
+        {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${CALLER_TOKEN}`,
+            "content-type": "application/json",
+            "x-test-identity-protocol": "missing-method",
+          },
+          body: JSON.stringify({ pool: POOL, method: "GET", path: DIFF_PATH, ...diffOptions }),
+        },
+      ),
+    );
+    const body = await ownedWork.track(response.text());
+    expect(response.bodyUsed).toBe(true);
+    expect(response.status).toBe(500);
+    expect(JSON.parse(body)).toMatchObject({ error: { code: "internal_error" } });
+    expect(response.headers.get("x-test-feedback-calls")).toBe("1");
+    expect(Number(response.headers.get("x-test-background-registered"))).toBeGreaterThan(0);
+    expect(response.headers.get("x-test-background-settled")).toBe(
+      response.headers.get("x-test-background-registered"),
+    );
+    expect(
+      upstream.mock.calls.every(([input, init]) => bearer(input, init) !== "test-secondary-token"),
+    ).toBe(true);
+    expect(await coordinator().snapshot()).toMatchObject({ cooldowns: [], rates: [] });
+    expect(
+      await runInDurableObject(coordinator(), (_instance, state) =>
+        state.storage.get("protocol-marker"),
+      ),
+    ).toBe(true);
+    expect(
+      await runInDurableObject(coordinator(), (_instance, state) =>
+        state.storage.sql.exec("SELECT * FROM cache_fills").toArray(),
+      ),
+    ).toEqual([]);
+    expect(
+      await env.DB.prepare(
+        "SELECT status, error_code FROM audit_events ORDER BY rowid DESC LIMIT 1",
+      ).first(),
+    ).toEqual({ status: 500, error_code: "internal_error" });
+  });
+
+  it("completes the real reset and control following native missing-method feedback", async () => {
+    expect(
+      await runInDurableObject(coordinator(), (_instance, state) =>
+        state.storage.get("protocol-marker"),
+      ),
+    ).toBeUndefined();
+    expect(await coordinator().snapshot()).toMatchObject({ cooldowns: [], rates: [], leases: [] });
+    expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM audit_events").first()).toEqual({
+      count: 0,
+    });
+    await seedPool();
+    vi.stubGlobal(
+      "fetch",
+      diffUpstream(() => diffResponse()),
+    );
+    expect((await requestWithEnv({}, DIFF_PATH, diffOptions)).status).toBe(200);
+  });
+
+  it("serves eligible fresh cache with no credential and live cooldown but rejects revoked scope", async () => {
+    await seedPool();
+    const upstream = diffUpstream(() => diffResponse());
+    vi.stubGlobal("fetch", upstream);
+    expect((await requestWithEnv({}, DIFF_PATH, diffOptions)).status).toBe(200);
+    const before = upstream.mock.calls.map(([input, init]) => ({
+      url: new Request(input, init).url,
+      token: bearer(input, init),
+    }));
+    await coordinator().recordCredentialFailure({
+      identityId: "primary",
+      reason: "identity_secret_missing",
+    });
+    expect(
+      await (
+        await requestWithWarmEnv({ TEST_PAT_PRIMARY: undefined }, DIFF_PATH, diffOptions)
+      ).json(),
+    ).toMatchObject({ relay: { cache: "hit" }, identity: { id: "primary" } });
+    const following = upstream.mock.calls
+      .slice(before.length)
+      .map(([input, init]) => ({ url: new Request(input, init).url, token: bearer(input, init) }));
+    expect(before).toEqual([
+      { url: "https://github.com/openclaw/octopool/pull/42.diff", token: undefined },
+      { url: "https://api.github.com/repos/openclaw/octopool", token: "test-org-token" },
+      {
+        url: "https://api.github.com/repos/openclaw/octopool/pulls/42",
+        token: "test-primary-token",
+      },
+    ]);
+    // Existing revalidation/public-proof and web phases precede the identity cache scan.
+    expect(following).toEqual([
+      { url: "https://api.github.com/repos/openclaw/octopool", token: "test-org-token" },
+      { url: "https://github.com/openclaw/octopool/pull/42.diff", token: undefined },
+      { url: "https://api.github.com/repos/openclaw/octopool", token: "test-org-token" },
+    ]);
+    await env.DB.prepare("DELETE FROM identity_scopes WHERE identity_id = 'primary'").run();
+    const route = classifyRoute(
+      { pool: POOL, method: "GET", path: DIFF_PATH },
+      defaultPolicy("openclaw"),
+    );
+    expect(await loadIdentities(env, POOL, route)).toHaveLength(1);
+    expect(await (await requestWithWarmEnv({}, DIFF_PATH, diffOptions)).json()).toMatchObject({
+      error: { details: { reason: "no_identity" } },
+    });
+  });
+
+  it("counts multiple broken IDs once across revalidation and fill and retains the first local error", async () => {
+    await seedPool({ secondary: true });
+    vi.stubGlobal(
+      "fetch",
+      diffUpstream(() => diffResponse()),
+    );
+    expect((await requestWithEnv({}, DIFF_PATH, diffOptions)).status).toBe(200);
+    await expireEntries();
+    await env.DB.prepare(
+      "UPDATE identities SET kind = 'github_app', installation_id = NULL WHERE id = 'secondary'",
+    ).run();
+    const calls: string[] = [];
+    const namespace = feedbackNamespace(async (result, forward) => {
+      calls.push(result.identityId);
+      await forward();
+    });
+    vi.stubGlobal(
+      "fetch",
+      diffUpstream(() => {
+        throw new Error("Broken credentials cannot dispatch");
+      }),
+    );
+    const response = await requestWithEnv(
+      { TEST_PAT_PRIMARY: undefined, POOL_COORDINATOR: namespace },
+      DIFF_PATH,
+      diffOptions,
+    );
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({ error: { code: "identity_secret_missing" } });
+    expect(calls).toEqual(["primary", "secondary"]);
+    expect((await coordinator().snapshot()).cooldowns).toHaveLength(2);
+    expect((await coordinator().snapshot()).rates).toEqual([]);
+    expect(
+      await runInDurableObject(coordinator(), (_instance, state) =>
+        state.storage.sql.exec("SELECT * FROM cache_fills").toArray(),
+      ),
+    ).toEqual([]);
+  });
+
+  it("rescans a late shared publication after the last local failure feedback without filtering its cache", async () => {
+    await seedPool();
+    const request = { pool: POOL, method: "GET" as const, path: DIFF_PATH, ...diffOptions };
+    const route = classifyRoute(request, defaultPolicy("openclaw"));
+    const identity = (await loadIdentities(env, POOL, route, { fresh: true }))[0]!;
+    const key = await githubCacheKey(POOL, request, route, identity);
+    let writes = 0;
+    const namespace = feedbackNamespace(async (_result, forward) => {
+      writes++;
+      await forward();
+      expect(
+        await writeGitHubCache(
+          env,
+          key,
+          request,
+          route,
+          { status: 200, headers: {}, body: "late shared diff", body_encoding: "text" },
+          identity,
+        ),
+      ).toBe("shared");
+    });
+    vi.stubGlobal(
+      "fetch",
+      diffUpstream(() => {
+        throw new Error("No usable resource credential");
+      }),
+    );
+    const response = await requestWithEnv(
+      { TEST_PAT_PRIMARY: undefined, POOL_COORDINATOR: namespace },
+      DIFF_PATH,
+      diffOptions,
+    );
+    expect(await response.json()).toMatchObject({
+      body: "late shared diff",
+      identity: { id: "primary" },
+      relay: { cache: "hit" },
+    });
+    expect(writes).toBe(1);
+    expect((await coordinator().snapshot()).cooldowns[0]).toMatchObject({
+      identity_id: "primary",
+      status: 503,
+    });
+    expect(
+      await env.DB.prepare("SELECT identity_id FROM github_cache_entries WHERE cache_key = ?")
+        .bind(key)
+        .first(),
+    ).toEqual({ identity_id: "primary" });
+  });
+
+  it("keeps metadata cached for exactly 30 seconds independently of live credential availability", async () => {
+    await seedPool();
+    clearConfigCache();
+    const route = classifyRoute(
+      { pool: POOL, method: "GET", path: PATH },
+      defaultPolicy("openclaw"),
+    );
+    const now = Date.now();
+    const clock = vi.spyOn(Date, "now").mockReturnValue(now);
+    const missingEnv = { ...env, TEST_PAT_PRIMARY: undefined } as Env;
+    expect(await loadIdentities(missingEnv, POOL, route)).toHaveLength(1);
+    await env.DB.prepare("UPDATE identities SET status = 'disabled'").run();
+    clock.mockReturnValue(now + 29_999);
+    expect(await loadIdentities(missingEnv, POOL, route)).toHaveLength(1);
+    expect(await loadIdentities(missingEnv, POOL, route, { fresh: true })).toEqual([]);
+    clock.mockReturnValue(now + 30_000);
+    expect(await loadIdentities(missingEnv, POOL, route)).toEqual([]);
+    clock.mockRestore();
+  });
+
+  it.each([302, 404, 503])(
+    "retains terminal-log probe state across a missing credential for probe %s",
+    async (probeStatus) => {
+      await seedPool({ secondary: true });
+      const path = "/repos/openclaw/octopool/actions/jobs/42/logs";
+      const key = terminalLogCacheKey({ pool: POOL, method: "GET", path });
+      const createdAt = new Date(Date.now() - 3_700_000).toISOString();
+      await env.ACTIONS_LOGS.put(key, "old synthetic log", {
+        httpMetadata: { contentType: "text/plain" },
+        customMetadata: { "created-at": createdAt, "body-encoding": "text" },
+      });
+      let probes = 0;
+      const upstream = vi.fn<typeof fetch>(async (input, init) => {
+        const token = bearer(input, init);
+        if (token === "test-org-token") return jsonResponse({ private: false });
+        if (token === undefined) return jsonResponse({ id: 42, status: "completed" });
+        expect(token).toBe("test-secondary-token");
+        probes++;
+        if (probes > 1)
+          return new Response("refetched synthetic log", {
+            headers: { "content-type": "text/plain", ...rateHeaders({ remaining: 198 }) },
+          });
+        if (probeStatus === 302)
+          return new Response(null, {
+            status: 302,
+            headers: {
+              location: "https://productionresultssa0.blob.core.windows.net/actions/log.txt",
+              ...rateHeaders({ remaining: 199 }),
+            },
+          });
+        return jsonResponse({ message: "deleted" }, probeStatus, rateHeaders({ remaining: 199 }));
+      });
+      vi.stubGlobal("fetch", upstream);
+      const response = await requestWithEnv({ TEST_PAT_PRIMARY: undefined }, path, {});
+      const body = await response.json<{ identity?: unknown }>();
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject(
+        probeStatus === 404
+          ? { status: 404, identity: { id: "secondary" }, body: { message: "deleted" } }
+          : {
+              status: 200,
+              body: probeStatus === 302 ? "old synthetic log" : "refetched synthetic log",
+            },
+      );
+      if (probeStatus === 302) expect(body.identity).toBeUndefined();
+      else expect(body.identity).toMatchObject({ id: "secondary" });
+      const stored = await env.ACTIONS_LOGS.get(key);
+      if (probeStatus === 404) expect(stored).toBeNull();
+      else {
+        expect(await stored!.text()).toBe(
+          probeStatus === 302 ? "old synthetic log" : "refetched synthetic log",
+        );
+        expect(stored!.customMetadata?.["created-at"]).not.toBe(createdAt);
+      }
+      const dispatched = upstream.mock.calls.filter(
+        ([input, init]) =>
+          bearer(input, init) !== undefined && bearer(input, init) !== "test-org-token",
+      );
+      expect(
+        dispatched.map(([input, init]) => ({
+          token: bearer(input, init),
+          url: new Request(input, init).url,
+          redirect: init?.redirect,
+        })),
+      ).toEqual(
+        Array.from({ length: probeStatus === 503 ? 2 : 1 }, () => ({
+          token: "test-secondary-token",
+          url: `https://api.github.com${path}`,
+          redirect: "manual",
+        })),
+      );
+      expect(
+        await env.DB.prepare(
+          "SELECT identity_id, status FROM audit_events ORDER BY rowid DESC LIMIT 1",
+        ).first(),
+      ).toEqual({
+        identity_id: probeStatus === 302 ? null : "secondary",
+        status: probeStatus === 404 ? 404 : 200,
+      });
+      expect((await coordinator().snapshot()).rates).toEqual([
+        expect.objectContaining({
+          identity_id: "secondary",
+          remaining: probeStatus === 503 ? 198 : 199,
+        }),
+      ]);
+      expect((await coordinator().snapshot()).cooldowns[0]?.reason).toBe("identity_secret_missing");
+    },
+  );
+
+  it("never splices or publishes aggregate pages when a cached App token needs a missing key mid-aggregate", async () => {
+    await seedPool({ secondary: true });
+    await appIdentity(95001);
+    const now = Date.now();
+    const clock = vi.spyOn(Date, "now").mockReturnValue(now);
+    let posts = 0;
+    let pages = 0;
+    const upstream = vi.fn<typeof fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      const token = bearer(request);
+      if (token === "test-org-token") return jsonResponse({ private: false });
+      if (token === undefined) return jsonResponse({ message: "unavailable" }, 503);
+      if (request.method === "POST") {
+        posts++;
+        return jsonResponse({
+          token: "synthetic-aggregate-app",
+          expires_at: new Date(now + 61_000).toISOString(),
+        });
+      }
+      expect(token).toBe("synthetic-aggregate-app");
+      if (new URL(request.url).pathname === PATH) return jsonResponse({ private: false });
+      pages++;
+      clock.mockReturnValue(now + 1_000);
+      return jsonResponse({
+        total_count: 101,
+        jobs: Array.from({ length: 100 }, (_, id) => ({ id, status: "completed" })),
+      });
+    });
+    vi.stubGlobal("fetch", upstream);
+    expect((await requestWithEnv()).status).toBe(200);
+    const response = await requestWithEnv(
+      { TEST_APP_KEY: undefined },
+      "/repos/openclaw/octopool/actions/runs/42/attempts/2/jobs",
+      { headers: { "x-octopool-public-shape": "actions-jobs-v1" } },
+    );
+    expect(await response.json()).toMatchObject({
+      error: { code: "fallback_local", details: { reason: "pagination_exhausted" } },
+    });
+    expect(posts).toBe(1);
+    expect(pages).toBe(1);
+    expect(
+      upstream.mock.calls.filter(([input, init]) => bearer(input, init) === "test-secondary-token"),
+    ).toEqual([]);
+    expect(await coordinator().snapshot()).toMatchObject({ cooldowns: [], rates: [] });
+    expect(
+      await env.DB.prepare(
+        "SELECT COUNT(*) AS count FROM github_cache_entries WHERE route_kind = 'run_jobs'",
+      ).first(),
+    ).toEqual({ count: 0 });
+    const request = {
+      pool: POOL,
+      method: "GET" as const,
+      path: "/repos/openclaw/octopool/actions/runs/42/attempts/2/jobs",
+      headers: { "x-octopool-public-shape": "actions-jobs-v1" },
+    };
+    const route = classifyRoute(request, defaultPolicy("openclaw"));
+    const cacheRequest = runJobsSupersetView(request, route)!.cacheRequest;
+    const identities = await loadIdentities(env, POOL, route, { fresh: true });
+    for (const identity of [undefined, ...identities]) {
+      expect(
+        await readGitHubCache(env, await githubCacheKey(POOL, cacheRequest, route, identity)),
+      ).toBeUndefined();
+    }
+    expect(
+      await runInDurableObject(coordinator(), (_instance, state) =>
+        state.storage.sql.exec("SELECT * FROM cache_fills").toArray(),
+      ),
+    ).toEqual([]);
+    clock.mockRestore();
+  });
+
+  it("keeps installation exchange egress denial hard with a healthy alternate", async () => {
+    await seedPool({ secondary: true });
+    await appIdentity(96001);
+    await env.DB.prepare("UPDATE string_rewrite_policy SET rules_json = ?")
+      .bind(JSON.stringify([{ pattern: "access_tokens", replacement: "blocked" }]))
+      .run();
+    const upstream = githubUpstream({ primary: jsonResponse({ private: false }) });
+    vi.stubGlobal("fetch", upstream);
+    const response = await requestWithEnv();
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({ error: { code: "string_rewrite_denied" } });
+    expect(upstream).toHaveBeenCalledOnce();
+    expect((await coordinator().snapshot()).cooldowns).toEqual([]);
+  });
+});

--- a/test/e2e/identity-routing-native-main.ts
+++ b/test/e2e/identity-routing-native-main.ts
@@ -1,0 +1,78 @@
+import { createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import worker from "../../src/index";
+
+export { PoolCoordinator } from "../../src/pool-coordinator";
+
+// This protocol negative needs a native request lifetime around the real relay.
+// The ordinary test setup still owns storage reset and graceful DO eviction.
+export default {
+  ...worker,
+  async fetch(request: Request, env: Env, native: ExecutionContext): Promise<Response> {
+    if (request.headers.get("x-test-identity-protocol") !== "missing-method") {
+      return worker.fetch(request, env, native);
+    }
+    let calls = 0;
+    const namespace = new Proxy(env.POOL_COORDINATOR, {
+      get(target, key) {
+        if (key === "get")
+          return (...args: Parameters<typeof target.get>) => {
+            const stub = target.get(...args);
+            return new Proxy(stub, {
+              get(real, method) {
+                if (method === "recordCredentialFailure")
+                  return async () => {
+                    calls++;
+                    await (
+                      real as unknown as { absentCredentialFailure(): Promise<void> }
+                    ).absentCredentialFailure();
+                  };
+                const value = Reflect.get(real, method, real);
+                return typeof value === "function"
+                  ? (...values: unknown[]) => Reflect.apply(value, real, values)
+                  : value;
+              },
+            });
+          };
+        const value = Reflect.get(target, key, target);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+    const ctx = createExecutionContext();
+    const waitUntil = ctx.waitUntil.bind(ctx);
+    let registered = 0;
+    let settled = 0;
+    ctx.waitUntil = (promise) => {
+      registered++;
+      const observed = promise.finally(() => {
+        settled++;
+      });
+      native.waitUntil(observed);
+      waitUntil(observed);
+    };
+    let response!: Response;
+    const errors: unknown[] = [];
+    try {
+      response = await worker.fetch(
+        request,
+        { ...env, TEST_PAT_PRIMARY: undefined, POOL_COORDINATOR: namespace } as Env,
+        ctx,
+      );
+    } catch (error) {
+      errors.push(error);
+    } finally {
+      try {
+        await waitOnExecutionContext(ctx);
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (errors.length === 1) throw errors[0];
+    if (errors.length) throw new AggregateError(errors, "Native protocol request drain failed");
+    const body = await response.text();
+    const headers = new Headers(response.headers);
+    headers.set("x-test-feedback-calls", String(calls));
+    headers.set("x-test-background-registered", String(registered));
+    headers.set("x-test-background-settled", String(settled));
+    return new Response(body, { status: response.status, headers });
+  },
+};

--- a/test/e2e/identity-routing-phases.test.ts
+++ b/test/e2e/identity-routing-phases.test.ts
@@ -1,0 +1,436 @@
+import { env } from "cloudflare:workers";
+import { runInDurableObject } from "cloudflare:test";
+import { describe, expect, it, vi } from "vitest";
+import { githubCacheKey, readEdgeGitHubCache, writeGitHubCache } from "../../src/cache";
+import { loadIdentities } from "../../src/db";
+import { deleteEdgeJSON } from "../../src/edge-cache";
+import { poolCoordinatorStub } from "../../src/pool-coordinator";
+import { classifyRoute, defaultPolicy } from "../../src/policy";
+import { bearer, jsonResponse, POOL, seedPool } from "./harness";
+import { appIdentity, PATH, requestWithEnv } from "./identity-routing-support";
+import { ownedWork } from "./owned-work";
+
+const DIFF = "/repos/openclaw/octopool/pulls/42";
+const diffOptions = { headers: { accept: "application/vnd.github.diff" } };
+const diffBody = "diff --git a/a b/a\n";
+const coordinator = () => poolCoordinatorStub(env, POOL);
+const diffResponse = () => new Response(diffBody, { headers: { etag: '"phase-diff"' } });
+
+function upstreamWith(resource: (request: Request) => Response | Promise<Response>) {
+  return vi.fn<typeof fetch>(async (input, init) => {
+    const request = new Request(input, init);
+    if (bearer(request) === "test-org-token") return jsonResponse({ private: false });
+    if (bearer(request) === undefined) return new Response("unavailable", { status: 503 });
+    return resource(request);
+  });
+}
+async function warmExpiredDiff() {
+  vi.stubGlobal(
+    "fetch",
+    upstreamWith(() => diffResponse()),
+  );
+  expect((await requestWithEnv({}, DIFF, diffOptions)).status).toBe(200);
+  const rows = await env.DB.prepare("SELECT cache_key FROM github_cache_entries").all<{
+    cache_key: string;
+  }>();
+  for (const row of rows.results) await deleteEdgeJSON("github-v1", row.cache_key);
+  await env.DB.prepare(
+    "UPDATE github_cache_entries SET expires_at = datetime('now', '-1 second')",
+  ).run();
+}
+async function expectNoFills() {
+  expect(
+    await runInDurableObject(coordinator(), (_instance, state) =>
+      state.storage.sql.exec("SELECT * FROM cache_fills").toArray(),
+    ),
+  ).toEqual([]);
+}
+
+describe("identity selection phase ownership", () => {
+  it("F1 reuses the healthy PAT after pooled diff 412 revalidation with max-age zero", async () => {
+    await seedPool();
+    await warmExpiredDiff();
+    const calls: (string | null)[] = [];
+    vi.stubGlobal(
+      "fetch",
+      upstreamWith((request) => {
+        expect(bearer(request)).toBe("test-primary-token");
+        calls.push(request.headers.get("if-none-match"));
+        return calls.length === 1 ? new Response("precondition", { status: 412 }) : diffResponse();
+      }),
+    );
+    const response = await requestWithEnv({}, DIFF, {
+      headers: { ...diffOptions.headers, "cache-control": "max-age=0" },
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      identity: { id: "primary" },
+      body: diffBody,
+      relay: { cache: "miss" },
+    });
+    expect(calls).toEqual(['"phase-diff"', null]);
+    expect((await coordinator().snapshot()).cooldowns).toEqual([]);
+    expect(
+      await env.DB.prepare(
+        "SELECT COUNT(*) AS count FROM github_cache_entries WHERE expires_at > datetime('now')",
+      ).first(),
+    ).toEqual({ count: 1 });
+    await expectNoFills();
+  });
+
+  it("F1 reuses the successful canonical run-list PAT for the exact filtered continuation", async () => {
+    await seedPool();
+    const queries: Record<string, string>[] = [];
+    vi.stubGlobal(
+      "fetch",
+      upstreamWith((request) => {
+        expect(bearer(request)).toBe("test-primary-token");
+        const query = Object.fromEntries(new URL(request.url).searchParams);
+        queries.push(query);
+        return jsonResponse({
+          total_count: 25,
+          workflow_runs:
+            query.branch === undefined
+              ? Array.from({ length: 25 }, (_, id) => ({
+                  id,
+                  head_branch: "main",
+                  status: "completed",
+                  conclusion: "success",
+                }))
+              : [
+                  { id: 101, head_branch: "target", status: "completed", conclusion: "success" },
+                  { id: 102, head_branch: "target", status: "completed", conclusion: "success" },
+                ],
+        });
+      }),
+    );
+    const response = await requestWithEnv({}, "/repos/openclaw/octopool/actions/runs", {
+      query: { branch: "target", limit: "2" },
+      headers: { "x-octopool-public-shape": "actions-summary-v1" },
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      identity: { id: "primary" },
+      body: { workflow_runs: [{ id: 101 }, { id: 102 }] },
+    });
+    expect(queries).toEqual([
+      { page: "1", per_page: "25" },
+      { branch: "target", per_page: "2" },
+    ]);
+    expect(
+      await env.DB.prepare(
+        "SELECT identity_id, query_json FROM github_cache_entries ORDER BY query_json",
+      ).all(),
+    ).toMatchObject({
+      results: [
+        { identity_id: "primary", query_json: '{"branch":"target","per_page":"2"}' },
+        { identity_id: "primary", query_json: '{"page":"1","per_page":"25"}' },
+      ],
+    });
+    expect((await coordinator().snapshot()).cooldowns).toEqual([]);
+    await expectNoFills();
+  });
+
+  it("F2 serves late eligible same-colo edge-only B while A fails and B is cooling", async () => {
+    await seedPool({ secondary: true });
+    await coordinator().recordCredentialFailure({
+      identityId: "secondary",
+      reason: "identity_secret_missing",
+    });
+    const request = { pool: POOL, method: "GET" as const, path: DIFF, ...diffOptions };
+    const route = classifyRoute(request, defaultPolicy("openclaw"));
+    const identity = (await loadIdentities(env, POOL, route, { fresh: true })).find(
+      (item) => item.id === "secondary",
+    )!;
+    expect(identity.id).toBe("secondary");
+    const key = await githubCacheKey(POOL, request, route, identity);
+    const entered = ownedWork.gate();
+    const release = ownedWork.gate();
+    const upstream = upstreamWith(async (request) => {
+      expect(bearer(request)).toBe("test-primary-token");
+      entered.release();
+      await release.promise;
+      return new Response("unauthorized", { status: 401 });
+    });
+    vi.stubGlobal("fetch", upstream);
+    const pending = requestWithEnv({ TEST_PAT_SECONDARY: undefined }, DIFF, diffOptions);
+    try {
+      await Promise.race([
+        entered.promise,
+        pending.then(() => {
+          throw new Error("Relay finished before A dispatch");
+        }),
+      ]);
+      const body = diffBody + "x".repeat(270_000);
+      expect(
+        await writeGitHubCache(
+          env,
+          key,
+          request,
+          route,
+          { status: 200, headers: {}, body, body_encoding: "text" },
+          identity,
+        ),
+      ).toBe("edge_only");
+      expect(await readEdgeGitHubCache(key)).toMatchObject({ body, identity: { id: "secondary" } });
+      expect(
+        await env.DB.prepare("SELECT COUNT(*) AS count FROM github_cache_entries").first(),
+      ).toEqual({ count: 0 });
+      release.release();
+      const response = await pending;
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        identity: { id: "secondary" },
+        body,
+        relay: { cache: "hit" },
+      });
+      expect(
+        upstream.mock.calls.filter(([input, init]) => bearer(input, init) === "test-primary-token"),
+      ).toHaveLength(1);
+      expect((await coordinator().snapshot()).cooldowns).toHaveLength(2);
+      await expectNoFills();
+    } finally {
+      release.release();
+      await pending;
+    }
+  });
+
+  it.each(["401", "403", "zero403", "429", "config", "412"])(
+    "F3 revalidation %s preserves exhaustion with allowed and disallowed stale",
+    async (kind) => {
+      await seedPool();
+      await warmExpiredDiff();
+      const calls: (string | null)[] = [];
+      const status = kind === "zero403" ? 403 : Number(kind);
+      vi.stubGlobal(
+        "fetch",
+        upstreamWith((request) => {
+          calls.push(request.headers.get("if-none-match"));
+          if (kind === "412" && calls.length === 2) return diffResponse();
+          return new Response("failure", {
+            status,
+            headers:
+              kind === "zero403"
+                ? {
+                    "x-ratelimit-remaining": "0",
+                    "x-ratelimit-reset": String(Math.floor(Date.now() / 1000) + 3600),
+                  }
+                : {},
+          });
+        }),
+      );
+      const overrides = kind === "config" ? { TEST_PAT_PRIMARY: undefined } : {};
+      const response = await requestWithEnv(overrides, DIFF, diffOptions);
+      if (kind === "config") {
+        expect(response.status).toBe(503);
+        expect(await response.json()).toMatchObject({ error: { code: "identity_secret_missing" } });
+        expect(calls).toEqual([]);
+      } else if (kind === "412") {
+        expect(response.status).toBe(200);
+        expect(await response.json()).toMatchObject({ body: diffBody, relay: { cache: "miss" } });
+        expect(calls).toEqual(['"phase-diff"', null]);
+      } else {
+        expect(response.status).toBe(200);
+        expect(await response.json()).toMatchObject({
+          body: diffBody,
+          relay: { cache: "stale", stale_reason: "identities_cooling_down" },
+        });
+        expect(calls).toEqual(['"phase-diff"']);
+      }
+      // Live cooldowns forbid dispatch; max-age zero must also forbid stale.
+      if (kind !== "412") {
+        const live = await requestWithEnv(overrides, DIFF, {
+          headers: { ...diffOptions.headers, "cache-control": "max-age=0" },
+        });
+        expect(live.status).toBe(424);
+        expect(await live.json()).toMatchObject({
+          error: { details: { reason: "identities_cooling_down" } },
+        });
+        expect(calls).toHaveLength(kind === "config" ? 0 : 1);
+      }
+      await expectNoFills();
+    },
+  );
+
+  it.each(["401", "403", "zero403", "429", "config", "412"])(
+    "refuses stale for first revalidation %s with max-age zero",
+    async (kind) => {
+      await seedPool();
+      await warmExpiredDiff();
+      const calls: (string | null)[] = [];
+      vi.stubGlobal(
+        "fetch",
+        upstreamWith((request) => {
+          calls.push(request.headers.get("if-none-match"));
+          if (kind === "412" && calls.length === 2) return diffResponse();
+          return new Response("failure", {
+            status: kind === "zero403" ? 403 : Number(kind),
+            headers: kind === "zero403" ? { "x-ratelimit-remaining": "0" } : {},
+          });
+        }),
+      );
+      const response = await requestWithEnv(
+        kind === "config" ? { TEST_PAT_PRIMARY: undefined } : {},
+        DIFF,
+        { headers: { ...diffOptions.headers, "cache-control": "max-age=0" } },
+      );
+      expect(response.status).toBe(kind === "config" ? 503 : kind === "412" ? 200 : 424);
+      expect(await response.json()).toMatchObject(
+        kind === "config"
+          ? { error: { code: "identity_secret_missing" } }
+          : kind === "412"
+            ? { relay: { cache: "miss" } }
+            : { error: { details: { reason: "identities_cooling_down" } } },
+      );
+      expect(calls).toHaveLength(kind === "config" ? 0 : kind === "412" ? 2 : 1);
+    },
+  );
+
+  it.each([401, 403, 429])(
+    "retains ordinary final %s stale eligibility independently of revalidation",
+    async (status) => {
+      await seedPool();
+      await warmExpiredDiff();
+      // No validator: this is an ordinary attempt, not conditional revalidation.
+      await env.DB.prepare("UPDATE github_cache_entries SET response_headers_json = '{}'").run();
+      const calls: string[] = [];
+      vi.stubGlobal(
+        "fetch",
+        upstreamWith((request) => {
+          expect(request.headers.get("if-none-match")).toBeNull();
+          calls.push(bearer(request)!);
+          return new Response("failure", { status });
+        }),
+      );
+      const response = await requestWithEnv({}, DIFF, diffOptions);
+      expect(response.status).toBe(status === 429 ? 200 : 424);
+      expect(await response.json()).toMatchObject(
+        status === 429
+          ? { relay: { cache: "stale", stale_reason: "github_rate_limited" } }
+          : {
+              error: {
+                details: {
+                  reason:
+                    status === 401 ? "github_identity_unauthorized" : "github_identity_forbidden",
+                },
+              },
+            },
+      );
+      expect(calls).toEqual(["test-primary-token"]);
+    },
+  );
+
+  it.each([401, 403, 429])(
+    "uses one healthy alternative after revalidation %s instead of retrying the rejected PAT",
+    async (status) => {
+      await seedPool({ secondary: true });
+      await warmExpiredDiff();
+      const calls: string[] = [];
+      vi.stubGlobal(
+        "fetch",
+        upstreamWith((request) => {
+          const token = bearer(request)!;
+          calls.push(token);
+          return token === "test-primary-token"
+            ? new Response("failure", { status })
+            : diffResponse();
+        }),
+      );
+      const response = await requestWithEnv({}, DIFF, {
+        headers: { ...diffOptions.headers, "cache-control": "max-age=0" },
+      });
+      expect(await response.json()).toMatchObject({
+        identity: { id: "secondary" },
+        body: diffBody,
+      });
+      expect(calls).toEqual(["test-primary-token", "test-secondary-token"]);
+    },
+  );
+
+  it("reuses the eligible revalidating PAT after rejecting a 304 for a revoked cache source", async () => {
+    await seedPool({ secondary: true });
+    await warmExpiredDiff();
+    await coordinator().recordResult({
+      identityId: "primary",
+      routeKey: "other",
+      resource: "core",
+      status: 401,
+      rate: {},
+    });
+    const calls: (string | null)[] = [];
+    vi.stubGlobal(
+      "fetch",
+      upstreamWith(async (request) => {
+        expect(bearer(request)).toBe("test-secondary-token");
+        calls.push(request.headers.get("if-none-match"));
+        if (calls.length === 1)
+          await env.DB.prepare(
+            "UPDATE identities SET status = 'disabled' WHERE id = 'primary'",
+          ).run();
+        return calls.length === 1 ? new Response(null, { status: 304 }) : diffResponse();
+      }),
+    );
+    const response = await requestWithEnv({}, DIFF, {
+      headers: { ...diffOptions.headers, "cache-control": "max-age=0" },
+    });
+    expect(await response.json()).toMatchObject({ identity: { id: "secondary" }, body: diffBody });
+    expect(calls).toEqual(['"phase-diff"', null]);
+  });
+
+  it.each(["page-two", "refresh"])(
+    "keeps the inherited aggregate %s egress denial hard",
+    async (mode) => {
+      await seedPool({ secondary: true });
+      await appIdentity(mode === "refresh" ? 97001 : 97002);
+      const now = Date.now();
+      const clock = vi.spyOn(Date, "now").mockReturnValue(now);
+      let posts = 0;
+      let pages = 0;
+      vi.stubGlobal(
+        "fetch",
+        upstreamWith((request) => {
+          if (request.method === "POST") {
+            posts++;
+            return jsonResponse({
+              token: "synthetic-hard-denial-app",
+              expires_at: new Date(now + 61_000).toISOString(),
+            });
+          }
+          expect(bearer(request)).toBe("synthetic-hard-denial-app");
+          if (new URL(request.url).pathname === PATH) return jsonResponse({ private: false });
+          pages++;
+          if (mode === "refresh") clock.mockReturnValue(now + 1_000);
+          return jsonResponse({
+            total_count: 101,
+            jobs: Array.from({ length: 100 }, (_, id) => ({ id, status: "completed" })),
+          });
+        }),
+      );
+      expect((await requestWithEnv()).status).toBe(200);
+      await env.DB.prepare("UPDATE string_rewrite_policy SET rules_json = ?")
+        .bind(
+          JSON.stringify([
+            { pattern: mode === "refresh" ? "access_tokens" : "page=2", replacement: "blocked" },
+          ]),
+        )
+        .run();
+      const response = await requestWithEnv(
+        {},
+        "/repos/openclaw/octopool/actions/runs/42/attempts/2/jobs",
+        { headers: { "x-octopool-public-shape": "actions-jobs-v1" } },
+      );
+      expect(response.status).toBe(403);
+      expect(await response.json()).toMatchObject({ error: { code: "string_rewrite_denied" } });
+      expect(posts).toBe(1);
+      expect(pages).toBe(1);
+      expect((await coordinator().snapshot()).cooldowns).toEqual([]);
+      expect(
+        await env.DB.prepare(
+          "SELECT COUNT(*) AS count FROM github_cache_entries WHERE route_kind = 'run_jobs'",
+        ).first(),
+      ).toEqual({ count: 0 });
+      await expectNoFills();
+      clock.mockRestore();
+    },
+  );
+});

--- a/test/e2e/identity-routing-support.ts
+++ b/test/e2e/identity-routing-support.ts
@@ -1,0 +1,43 @@
+import { env } from "cloudflare:workers";
+import { clearConfigCache } from "../../src/config-cache";
+import worker from "../../src/index";
+import type { RelayRequest } from "../../src/types";
+import { CALLER_TOKEN, POOL, runWithContext } from "./harness";
+
+export const PATH = "/repos/openclaw/octopool";
+export const conditional = { headers: { "if-none-match": '"identity-routing"' } };
+
+export function requestWithEnv(
+  overrides: Record<string, unknown> = {},
+  path = PATH,
+  options: Pick<RelayRequest, "headers" | "query"> = conditional,
+): Promise<Response> {
+  clearConfigCache();
+  return requestWithWarmEnv(overrides, path, options);
+}
+
+export function requestWithWarmEnv(
+  overrides: Record<string, unknown> = {},
+  path = PATH,
+  options: Pick<RelayRequest, "headers" | "query"> = conditional,
+): Promise<Response> {
+  return runWithContext((ctx) =>
+    worker.fetch(
+      new Request("https://octopool.dev/v1/github/request", {
+        method: "POST",
+        headers: { authorization: `Bearer ${CALLER_TOKEN}`, "content-type": "application/json" },
+        body: JSON.stringify({ pool: POOL, method: "GET", path, ...options }),
+      }),
+      { ...env, ...overrides } as Env,
+      ctx,
+    ),
+  );
+}
+
+export async function appIdentity(installation: number | null = 91001): Promise<void> {
+  await env.DB.prepare(
+    "UPDATE identities SET kind = 'github_app', secret_ref = 'TEST_APP_KEY', installation_id = ? WHERE id = 'primary'",
+  )
+    .bind(installation)
+    .run();
+}

--- a/test/e2e/identity-routing.test.ts
+++ b/test/e2e/identity-routing.test.ts
@@ -1,0 +1,323 @@
+import { env } from "cloudflare:workers";
+import { describe, expect, it, vi } from "vitest";
+import { loadIdentities } from "../../src/db";
+import { classifyRoute, defaultPolicy } from "../../src/policy";
+import { poolCoordinatorStub } from "../../src/pool-coordinator";
+import { bearer, githubUpstream, jsonResponse, POOL, relay, seedPool } from "./harness";
+import { issueEventCases } from "../fixtures/issue-event-visibility";
+import { releaseMarkdown } from "../fixtures/release-summary";
+import { requestWithEnv } from "./identity-routing-support";
+
+const PATH = "/repos/openclaw/octopool";
+const conditional = { headers: { "if-none-match": '"identity-routing"' } };
+
+describe("eligible and usable identity routing", () => {
+  it("serves an allowlisted public repo with only a wildcard PAT", async () => {
+    await seedPool();
+    await env.DB.prepare(
+      "UPDATE identity_scopes SET owner = '*' WHERE identity_id = 'primary'",
+    ).run();
+    const route = classifyRoute(
+      { pool: POOL, method: "GET", path: PATH },
+      defaultPolicy("openclaw"),
+    );
+    const ids = (await loadIdentities(env, POOL, route, { fresh: true })).map((id) => id.id);
+    const upstream = githubUpstream({ primary: jsonResponse({ private: false }) });
+    vi.stubGlobal("fetch", upstream);
+    const response = await relay(PATH, undefined, conditional);
+    const body = await response.json();
+    expect({ ids, status: response.status, body }).toMatchObject({
+      ids: ["primary"],
+      status: 200,
+      body: { identity: { id: "primary" } },
+    });
+    expect(upstream).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips a preferred missing credential for a healthy PAT", async () => {
+    await seedPool({ secondary: true });
+    await env.DB.prepare(
+      "UPDATE identities SET secret_ref = 'SYNTHETIC_MISSING_BINDING' WHERE id = 'primary'",
+    ).run();
+    const upstream = githubUpstream({ primary: jsonResponse({ private: false }) });
+    vi.stubGlobal("fetch", upstream);
+    const response = await relay(PATH, undefined, conditional);
+    const body = await response.json();
+    expect({ status: response.status, body }).toMatchObject({
+      status: 200,
+      body: { identity: { id: "secondary" } },
+    });
+    expect(upstream).toHaveBeenCalledTimes(2);
+    const health = await poolCoordinatorStub(env, POOL).snapshot();
+    expect(health.rates).toEqual([]);
+    expect(health.cooldowns).toEqual([
+      expect.objectContaining({
+        identity_id: "primary",
+        route_key: "*",
+        status: 503,
+        reason: "identity_secret_missing",
+      }),
+    ]);
+  });
+
+  it("does not eagerly check an unselected missing binding", async () => {
+    await seedPool({ secondary: true });
+    vi.stubGlobal("fetch", githubUpstream({ primary: jsonResponse({ private: false }) }));
+    expect(await (await requestWithEnv({ TEST_PAT_SECONDARY: undefined })).json()).toMatchObject({
+      identity: { id: "primary" },
+    });
+    expect((await poolCoordinatorStub(env, POOL).snapshot()).cooldowns).toEqual([]);
+  });
+
+  it.each([404, 422, 503, 401, 403, 429])(
+    "preserves ordinary resource %s selection and feedback",
+    async (status) => {
+      await seedPool({ secondary: true });
+      const tokens: string[] = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>(async (input, init) => {
+          const token = bearer(input, init);
+          if (token === "test-org-token") return jsonResponse({ private: false });
+          tokens.push(token!);
+          return token === "test-primary-token"
+            ? jsonResponse({ message: "resource failure" }, status)
+            : jsonResponse({ private: false });
+        }),
+      );
+      const response = await requestWithEnv();
+      const failover = [401, 403, 429].includes(status);
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        status: failover ? 200 : status,
+        identity: { id: failover ? "secondary" : "primary" },
+      });
+      expect(tokens).toEqual(
+        failover ? ["test-primary-token", "test-secondary-token"] : ["test-primary-token"],
+      );
+      const snapshot = await poolCoordinatorStub(env, POOL).snapshot();
+      expect(snapshot.rates).toEqual([]);
+      expect(snapshot.cooldowns).toEqual(
+        failover
+          ? [expect.objectContaining({ identity_id: "primary", status, reason: "github_error" })]
+          : [],
+      );
+    },
+  );
+
+  it.each(["private", "owner-policy", "logs-policy", "stored-policy", "native"])(
+    "retains the %s boundary with a missing wildcard PAT and healthy alternate",
+    async (boundary) => {
+      await seedPool({ secondary: true });
+      await env.DB.prepare("UPDATE identity_scopes SET owner = '*'").run();
+      if (boundary === "owner-policy" || boundary === "logs-policy")
+        await env.DB.prepare("UPDATE pools SET policy_json = ?")
+          .bind(
+            JSON.stringify({ allowed_owners: [], allow_public_repos: false, allow_logs: false }),
+          )
+          .run();
+      if (boundary === "stored-policy")
+        await env.DB.prepare("UPDATE pools SET policy_json = '[]'").run();
+      const upstream = vi.fn<typeof fetch>(async () =>
+        jsonResponse({ private: boundary === "private" }),
+      );
+      vi.stubGlobal("fetch", upstream);
+      const path =
+        boundary === "native"
+          ? `${PATH}/rules/branches/main`
+          : boundary === "logs-policy"
+            ? `${PATH}/actions/jobs/42/logs`
+            : PATH;
+      const response = await requestWithEnv({ TEST_PAT_PRIMARY: undefined }, path);
+      expect(response.status).toBe(boundary === "stored-policy" ? 503 : 424);
+      const reason =
+        boundary === "private"
+          ? "repo_not_public"
+          : boundary === "native"
+            ? "local_credentials_required"
+            : boundary === "logs-policy"
+              ? "logs_denied"
+              : "owner_denied";
+      expect(await response.json()).toMatchObject({
+        error:
+          boundary === "stored-policy"
+            ? { code: "pool_policy_unavailable" }
+            : { code: "fallback_local", details: { reason } },
+      });
+      expect(upstream.mock.calls.map(([input, init]) => bearer(input, init))).toEqual(
+        boundary === "private" ? ["test-org-token"] : [],
+      );
+      expect(await poolCoordinatorStub(env, POOL).snapshot()).toMatchObject({
+        cooldowns: [],
+        rates: [],
+      });
+      expect(
+        await env.DB.prepare("SELECT COUNT(*) AS count FROM github_cache_entries").first(),
+      ).toEqual({ count: 0 });
+    },
+  );
+
+  it("does not widen alternate eligibility after selected local failure", async () => {
+    await seedPool({ secondary: true });
+    await env.DB.prepare(
+      "UPDATE identity_scopes SET repo = 'different-repo' WHERE identity_id = 'secondary'",
+    ).run();
+    const upstream = githubUpstream({ primary: jsonResponse({ private: false }) });
+    vi.stubGlobal("fetch", upstream);
+    const response = await requestWithEnv({ TEST_PAT_PRIMARY: undefined });
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({ error: { code: "identity_secret_missing" } });
+    expect(upstream.mock.calls.map(([input, init]) => bearer(input, init))).toEqual([
+      "test-org-token",
+    ]);
+    expect((await poolCoordinatorStub(env, POOL).snapshot()).cooldowns).toEqual([
+      expect.objectContaining({ identity_id: "primary" }),
+    ]);
+  });
+});
+
+describe.each([
+  {
+    kind: "release",
+    path: `${PATH}/releases/tags/v0.8.0`,
+    publicBody: { tag_name: "v0.8.0", draft: false, body: releaseMarkdown },
+    headers: { "x-octopool-public-shape": "release-summary-v1" },
+  },
+  ...issueEventCases.map((fixture) => ({ ...fixture, headers: {} })),
+])("$kind token-free credential boundary", ({ kind, path, publicBody, headers }) => {
+  it.each([200, 429, 503])(
+    "keeps upstream %s anonymous with a missing PAT and healthy alternate",
+    async (status) => {
+      await seedPool({ secondary: true });
+      const calls: Request[] = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>(async (input, init) => {
+          const request = new Request(input, init);
+          calls.push(request);
+          if (new URL(request.url).pathname === PATH) return jsonResponse({ private: false });
+          return jsonResponse(
+            status === 200 ? publicBody : { message: "anonymous unavailable" },
+            status,
+          );
+        }),
+      );
+      const response = await requestWithEnv({ TEST_PAT_PRIMARY: undefined }, path, { headers });
+      expect(response.status).toBe(status === 200 ? 200 : 424);
+      const body = await response.json<{ identity?: unknown; body?: unknown }>();
+      expect(body.identity).toBeUndefined();
+      if (status === 200) expect(body.body).toEqual(publicBody);
+      else expect(body).toMatchObject({ error: { code: "fallback_local" } });
+      const resources = calls.filter((request) => new URL(request.url).pathname === path);
+      expect(resources).toHaveLength(1);
+      expect(resources[0]!.headers.has("authorization")).toBe(false);
+      expect(
+        calls.every(
+          (request) =>
+            bearer(request) === undefined ||
+            (kind === "release" &&
+              bearer(request) === "test-org-token" &&
+              new URL(request.url).pathname === PATH),
+        ),
+      ).toBe(true);
+      expect(await poolCoordinatorStub(env, POOL).snapshot()).toMatchObject({
+        cooldowns: [],
+        rates: [],
+      });
+      expect(
+        (await env.DB.prepare("SELECT identity_id FROM github_cache_entries").all()).results.every(
+          (row) => row.identity_id === null,
+        ),
+      ).toBe(true);
+    },
+  );
+});
+
+describe("real D1 eligibility boundaries", () => {
+  it("preserves pool, active, exact/case, NULL, App, publicOnly, ownerless and DISTINCT semantics", async () => {
+    await seedPool();
+    await env.DB.prepare(
+      "INSERT INTO pools (id, name, policy_json) VALUES ('other', 'other', '{}')",
+    ).run();
+    const fixtures: [string, string, string, string, string | null, string][] = [
+      ["exact", POOL, "pat", "OPENCLAW", "OCTOPOOL", "active"],
+      ["app", POOL, "github_app", "OpenClaw", null, "active"],
+      ["app-exact", POOL, "github_app", "openclaw", "octopool", "active"],
+      ["wrong-repo", POOL, "github_app", "openclaw", "another", "active"],
+      ["wildcard-app", POOL, "github_app", "*", null, "active"],
+      ["wildcard-repo", POOL, "pat", "*", "octopool", "active"],
+      ["broad", POOL, "pat", "*", null, "active"],
+      ["disabled", POOL, "pat", "*", null, "disabled"],
+      ["elsewhere", "other", "pat", "*", null, "active"],
+      ["wrong-owner", POOL, "pat", "another", null, "active"],
+    ];
+    for (const [id, pool, kind, owner, repo, status] of fixtures) {
+      await env.DB.batch([
+        env.DB.prepare(
+          "INSERT INTO identities (id, pool_id, kind, login, secret_ref, status) VALUES (?, ?, ?, ?, 'ABSENT', ?)",
+        ).bind(id, pool, kind, id, status),
+        env.DB.prepare(
+          "INSERT INTO identity_scopes (identity_id, owner, repo) VALUES (?, ?, ?)",
+        ).bind(id, owner, repo),
+      ]);
+    }
+    await env.DB.batch([
+      env.DB.prepare(
+        "INSERT INTO identity_scopes (identity_id, owner, repo) VALUES ('broad', 'OpenClaw', 'Octopool')",
+      ),
+      env.DB.prepare(
+        "INSERT INTO identity_scopes (identity_id, owner, repo) VALUES ('broad', 'openclaw', NULL)",
+      ),
+      env.DB.prepare(
+        "INSERT INTO identity_scopes (identity_id, owner, repo) VALUES ('broad', '*', NULL)",
+      ),
+      env.DB.prepare(
+        "INSERT INTO identities (id, pool_id, kind, login, secret_ref, status) VALUES ('unscoped', ?, 'pat', 'unscoped', 'ABSENT', 'active')",
+      ).bind(POOL),
+    ]);
+    const policy = defaultPolicy("openclaw");
+    const ids = async (path: string) =>
+      (
+        await loadIdentities(
+          env,
+          POOL,
+          classifyRoute({ pool: POOL, method: "GET", path }, policy),
+          { fresh: true },
+        )
+      )
+        .map((id) => id.id)
+        .sort();
+    expect(await ids(PATH)).toEqual(["app", "app-exact", "broad", "exact", "primary"]);
+    expect(await ids("/repos/another/public")).toEqual(["broad"]);
+    expect(await ids("/rate_limit")).toEqual([
+      "app",
+      "app-exact",
+      "broad",
+      "exact",
+      "primary",
+      "unscoped",
+      "wildcard-app",
+      "wildcard-repo",
+      "wrong-owner",
+      "wrong-repo",
+    ]);
+    const { queries } = await import("../../src/generated/sql");
+    const plan = await env.DB.prepare(`EXPLAIN QUERY PLAN ${queries.listActiveIdentitiesForRoute}`)
+      .bind(POOL, "openclaw", "octopool")
+      .all<{ detail: string }>();
+    expect(plan.results.map((row) => row.detail).join("\n")).toContain(
+      "idx_identities_pool_status",
+    );
+  });
+
+  it("uses the wildcard PAT outside the allowlist after public proof", async () => {
+    await seedPool();
+    await env.DB.prepare("UPDATE identity_scopes SET owner = '*'").run();
+    const upstream = githubUpstream({ primary: jsonResponse({ private: false }) });
+    vi.stubGlobal("fetch", upstream);
+    expect(
+      await (await relay("/repos/another/public", undefined, conditional)).json(),
+    ).toMatchObject({ identity: { id: "primary" } });
+    expect(upstream).toHaveBeenCalledTimes(2);
+  });
+});

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -12,9 +12,10 @@ const TEST_APP_KEY = generateKeyPairSync("rsa", {
 export default defineConfig({
   plugins: [
     cloudflareTest(async () => ({
-      main: "./src/index.ts",
+      main: "./test/e2e/identity-routing-native-main.ts",
       wrangler: { configPath: "./wrangler.jsonc" },
       miniflare: {
+        serviceBindings: { IDENTITY_PROTOCOL: { name: "octopool" } },
         bindings: {
           TEST_MIGRATIONS: await readD1Migrations(path.resolve("migrations")),
           TEST_PAT_PRIMARY: "test-primary-token",


### PR DESCRIPTION
## Summary

Owner-restricted identity selection excluded wildcard PATs, and a selected identity with unavailable local PAT or App configuration aborted the request before an eligible alternate could be tried. Include wildcard PATs while preserving pool, active, owner, and App eligibility restrictions; classify local credential failures in the authentication layer with sanitized errors.

Record acknowledged local credential failures through a narrow coordinator operation that applies a monotonic 120-second shared cooldown without fabricating a GitHub response or rate-limit feedback. Relay failover tracks only failed identities across request phases, preserves healthy credential continuations and authoritative fresh-cache checks, and retains hard string-protection denials in bounded aggregate requests.

Document shared-secret skew, mixed-version operation availability, and incomplete aggregate limits. The native missing-operation regression proves the local Worker protocol boundary and following reset; it does not establish production mixed-deployment compatibility.

## Tests

- Fresh post-commit focused identity routing, credentials, lifecycle, and phase suites: 119/119 passed.
- Fresh post-commit canonical `pnpm check`: generation guards, formatting, lint, 790 unit tests, 687 Worker tests, TypeScript build, Go tests, and Go vet passed with Go 1.26.7.
- Generated files and all reviewed file bytes remained unchanged; ordinary pnpm 11.21.0 and source typecheck passed afterward.
- Original credential/eligibility failures and valid phase/aggregate negative evidence were established before landing; the completed preservation proof and independent P2 review were accepted before this commit.
