### PR TITLE
fix: enforce native declared input protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Honor native input declarations and reject malformed nonempty declared JSON before dispatch, preserving explicit UTF-8 text, zero-byte best-effort compatibility, and existing interactive-input limits.
 - Normalize compound client-name aliases consistently across CLI, login and stats, safely rotate historical singletons in place, and refuse ambiguous legacy families without changing credentials; apply the schema write guards before rollout.
 - Include eligible wildcard PATs for explicitly allowed owners and fail over selected local credential errors with bounded shared cooldowns, preserving cache authorization, valid credential continuations, and hard aggregate egress denials.
 - Keep persisted identity quota and cooldown feedback monotonic across delayed responses, reject invalid numeric observations, and atomically preserve rate/cooldown state on storage failure.

--- a/cmd/octopool/string_rewrites_api.go
+++ b/cmd/octopool/string_rewrites_api.go
@@ -76,6 +76,11 @@ func parseRewriteAPI(args []string) (rewriteAPIOptions, error) {
 			key, value, ok := strings.Cut(flag.value, ":")
 			key = strings.ToLower(strings.TrimSpace(key))
 			value = strings.TrimSpace(value)
+			// Content-Type declares native raw-body semantics; it is not a relay
+			// header capability. Final preparation validates every native header.
+			if ok && key == "content-type" {
+				return result, errRewriteUnsupported
+			}
 			if !ok || !safeRelayHeader(key) {
 				return result, errRewriteBlocked
 			}

--- a/cmd/octopool/string_rewrites_declared_input_test.go
+++ b/cmd/octopool/string_rewrites_declared_input_test.go
@@ -1,0 +1,961 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// Filesystem isolation alone does not clear inherited caller or native overrides.
+func declaredInputEnvironment(t *testing.T) {
+	t.Helper()
+	isolateTestConfig(t)
+	for _, key := range []string{"OCTOPOOL_TOKEN", "OCTOPOOL_URL", "OCTOPOOL_POOL", "OCTOPOOL_STRING_REWRITE_FILE", "OCTOPOOL_GH_PATH", "OCTOPOOL_NO_FALLBACK", "GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN", "GH_HOST", "GH_REPO", "OCTOPOOL_TEST_DECLARED_CAPTURE", "OCTOPOOL_TEST_DECLARED_MUTATE", "OCTOPOOL_TEST_DECLARED_EXIT"} {
+		t.Setenv(key, "")
+	}
+}
+
+func buildDeclaredInputChild(t *testing.T) string {
+	t.Helper()
+	tool, env := testCompiler(t)
+	path := filepath.Join(t.TempDir(), executableName("capture-input"))
+	cmd := exec.CommandContext(t.Context(), tool, "build", "-o", path, "./testdata/declared-input-child")
+	cmd.Env = env
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("capture child build: %v\n%s", err, out)
+	}
+	return path
+}
+
+type declaredInputReader struct {
+	io.Reader
+	reads, bytes int
+}
+
+func (r *declaredInputReader) Read(p []byte) (int, error) {
+	r.reads++
+	n, err := r.Reader.Read(p)
+	r.bytes += n
+	return n, err
+}
+
+func TestDeclaredInput(t *testing.T) {
+	// Resolve reusable compiler caches before replacing application config roots.
+	binary := buildCLIBinary(t)
+	child := buildDeclaredInputChild(t)
+	declaredInputEnvironment(t)
+	policyStore, _ := rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	workflow := []string{"workflow", "run", "deploy.yml", "--repo=acme/repo"}
+	api := []string{"api", "graphql", "--input=-"}
+	run := func(t *testing.T, args []string, input io.Reader, blocked bool, top bool) rewriteCapture {
+		t.Helper()
+		capturePath := filepath.Join(t.TempDir(), "capture.json")
+		t.Setenv("OCTOPOOL_GH_PATH", child)
+		t.Setenv("OCTOPOOL_TEST_DECLARED_CAPTURE", capturePath)
+		var stdout, stderr bytes.Buffer
+		var err error
+		if top {
+			err = runGH(t.Context(), args, &stdout, &stderr)
+		} else {
+			// The child gets only platform/config essentials and synthetic fixture controls.
+			env := testConfigEnv(t.TempDir())
+			for _, key := range []string{"SystemRoot", "WINDIR", "TMPDIR", "TMP", "TEMP", "OCTOPOOL_TEST_DECLARED_CAPTURE", "OCTOPOOL_TEST_DECLARED_MUTATE", "OCTOPOOL_TEST_DECLARED_EXIT"} {
+				env = append(env, key+"="+os.Getenv(key))
+			}
+			err = execRealGHWithStdinAndEnv(t.Context(), args, input, &stdout, &stderr, env)
+		}
+		if blocked {
+			if err != errRewriteBlocked || err.Error() != "string rewrite protection blocked unsafe input" || stdout.Len() != 0 || stderr.Len() != 0 {
+				t.Errorf("expected generic denial and no child output; err=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+			}
+			if _, statErr := os.Stat(capturePath); !os.IsNotExist(statErr) {
+				t.Error("denied input reached child")
+			}
+			return rewriteCapture{}
+		}
+		if err != nil {
+			t.Fatalf("prepared child: %v; stderr=%s", err, &stderr)
+		}
+		if stdout.String() != "child stdout\n" || stderr.String() != "child stderr\n" {
+			t.Fatalf("child streams changed: %q %q", &stdout, &stderr)
+		}
+		got := readRewriteCapture(t, capturePath)
+		if got.Env["GH_HOST"] != "github.com" || got.Env["GH_REPO"] != "" {
+			t.Fatal("child host not pinned")
+		}
+		for path := range got.Files {
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				t.Error("snapshot survived child exit")
+			}
+			if runtime.GOOS != "windows" && (got.Modes[path] != 0600 || got.DirectoryModes[path] != 0700) {
+				t.Error("snapshot permissions changed")
+			}
+		}
+		return got
+	}
+
+	for _, flag := range []string{"--json", "--json=1", "--json=t", "--json=T", "--json=true", "--json=TRUE", "--json=True"} {
+		t.Run("true/"+flag, func(t *testing.T) {
+			got := run(t, append(slices.Clone(workflow), flag), strings.NewReader(`{"message":"\u0069nternal-model"}`), false, false)
+			var value map[string]string
+			if err := json.Unmarshal([]byte(got.Stdin), &value); err != nil || value["message"] != "public" {
+				t.Errorf("child did not receive rewritten string-map JSON: %q (%v)", got.Stdin, err)
+			}
+		})
+	}
+	for _, flags := range [][]string{
+		nil, {"--json=0"}, {"--json=f"}, {"--json=F"}, {"--json=false"}, {"--json=FALSE"}, {"--json=False"}, {"--json", "--json=false"}, {"--", "--json"}, {"--ref", "--json"}, {"-r", "--json"}, {"--raw-field", "--json"}, {"--field", "--json"},
+	} {
+		t.Run("unread/"+strings.Join(flags, "_"), func(t *testing.T) {
+			reader := &declaredInputReader{Reader: strings.NewReader("not JSON")}
+			prepared, err := prepareProtectedGH(t.Context(), append(slices.Clone(workflow), flags...), reader)
+			if prepared != nil {
+				defer prepared.cleanup()
+			}
+			if err != nil || reader.reads != 0 {
+				t.Errorf("inactive JSON declaration read stdin: reads=%d err=%v", reader.reads, err)
+			}
+		})
+	}
+	for _, flags := range [][]string{{"--json=0", "--json=T"}, {"--json", "false"}, {"--ref", "--", "--json=T"}, {"--json", "--", "--json=false"}} {
+		t.Run("active/"+strings.Join(flags, "_"), func(t *testing.T) {
+			got := run(t, append(slices.Clone(workflow), flags...), strings.NewReader(`{"message":"internal-model"}`), false, false)
+			if got.Stdin != `{"message":"public"}` {
+				t.Errorf("JSON not prepared: %q", got.Stdin)
+			}
+		})
+	}
+	for _, args := range [][]string{
+		{"-Racme/repo", "workflow", "run", "deploy.yml", "--json=T"},
+		{"workflow", "--repo", "acme/repo", "run", "deploy.yml", "--json=T"},
+		{"--repo=acme/repo", "workflow", "run", "deploy.yml", "--json"},
+	} {
+		t.Run("command ownership/"+strings.Join(args, "_"), func(t *testing.T) {
+			got := run(t, args, strings.NewReader(`{"message":"internal-model"}`), false, false)
+			if got.Stdin != `{"message":"public"}` {
+				t.Errorf("interleaved repository hid declaration: %q", got.Stdin)
+			}
+		})
+	}
+	for _, flag := range []string{"--json=", "--json=yes", "--json=TrUe", "--json= true", "--json=on"} {
+		t.Run("invalid bool/"+flag, func(t *testing.T) {
+			reader := &declaredInputReader{Reader: strings.NewReader(`{}`)}
+			run(t, append(slices.Clone(workflow), flag, "--json=true"), reader, true, false)
+			if reader.reads != 0 {
+				t.Error("invalid occurrence read stdin")
+			}
+		})
+	}
+	bad := []struct{ name, body string }{
+		{"duplicate", `{"message":"\u0069nternal-model","extra":"a","extra":"b"}`},
+		{"decoded duplicate", `{"message":"\u0069nternal-model","ex\u0074ra":"a","extra":"b"}`},
+		{"protected key duplicate", `{"\u0069nternal-model":"a","extra":"a","extra":"b"}`},
+		{"nested duplicate", `{"nested":{"a":"x","a":"y"}}`},
+		{"high surrogate", `{"message":"\u0069nternal-model","extra":"\ud800"}`},
+		{"low surrogate", `{"message":"\u0069nternal-model","extra":"\udc00"}`},
+		{"syntax", `{"message":`}, {"second value", `{} {}`}, {"whitespace", " \n\t"},
+		{"UTF8", "{\"message\":\"\xff\"}"}, {"depth", strings.Repeat("[", 66) + "0" + strings.Repeat("]", 66)},
+		{"key collision", `{"internal-model":"x","public":"y"}`},
+	}
+	for _, surface := range []string{"workflow", "API stdin", "API file"} {
+		for _, test := range bad {
+			t.Run(surface+" rejects/"+test.name, func(t *testing.T) {
+				args := slices.Clone(api)
+				if surface == "workflow" {
+					args = append(slices.Clone(workflow), "--json")
+				}
+				if surface == "API file" {
+					path := filepath.Join(t.TempDir(), "input.json")
+					if err := os.WriteFile(path, []byte(test.body), 0600); err != nil {
+						t.Fatal(err)
+					}
+					args[2] = "--input=" + path
+				}
+				run(t, args, strings.NewReader(test.body), true, surface == "API file")
+			})
+		}
+	}
+	for _, headers := range [][]string{
+		{"--header", "Content-Type: application/json"}, {"-HContent-Type: application/problem+json"}, {"-H=Content-Type: Text/JSON; charset=utf-8"}, {"--header=cOnTeNt-TyPe: APPLICATION/JSON"},
+		{"--header=Accept: text/plain"}, {"--header=Content-Type:", "--header=Content-Type: text/plain"},
+		{"--header=Content-Type: application/json", "--header=Content-Type: APPLICATION/JSON"},
+	} {
+		t.Run("JSON headers/"+strings.Join(headers, "_"), func(t *testing.T) {
+			run(t, append(slices.Clone(api), headers...), strings.NewReader(`{"a":"x","a":"y"}`), true, false)
+		})
+	}
+	for _, headers := range [][]string{
+		{"--header=Content-Type: nonsense"}, {"--header=Content-Type: application/json; broken"},
+		{"--header=Content-Type: text/plain", "--header=Content-Type: application/json"},
+		{"--header=Content-Type: text/plain", "--header=Content-Type:"},
+		{"--header=Authorization: synthetic-denied"}, {"--hostname=enterprise.invalid"},
+	} {
+		t.Run("denial before read/"+strings.Join(headers, "_"), func(t *testing.T) {
+			reader := &declaredInputReader{Reader: strings.NewReader(`{}`)}
+			run(t, append(append(slices.Clone(api), "--verbose"), headers...), reader, true, false)
+			if reader.reads != 0 {
+				t.Error("invalid declaration or credential/host read source")
+			}
+		})
+	}
+	textBody := " {\"a\":\"internal-model\", \"a\":\"\\ud800\"} \n"
+	for _, top := range []bool{false, true} {
+		for _, first := range []bool{false, true} {
+			name := "final"
+			if top {
+				name = "runGH"
+			}
+			if first {
+				name += " header first"
+			} else {
+				name += " verbose first"
+			}
+			t.Run("explicit text/"+name, func(t *testing.T) {
+				path := filepath.Join(t.TempDir(), "input.txt")
+				if err := os.WriteFile(path, []byte(textBody), 0600); err != nil {
+					t.Fatal(err)
+				}
+				flags := []string{"--verbose", "--header=Content-Type: text/plain"}
+				if first {
+					slices.Reverse(flags)
+				}
+				args := append([]string{"api", "graphql", "--input=" + path}, flags...)
+				got := run(t, args, nil, false, top)
+				if !rewriteCaptureHasContent(got, strings.ReplaceAll(textBody, "internal-model", "public")) {
+					t.Errorf("text bytes reformatted: %v", got.Files)
+				}
+			})
+		}
+	}
+	for _, body := range []string{"", `{"message":"\u0069nternal-model","emoji":"\ud83e\udd9e"}`, `null`, `["internal-model",123456789012345678901234567890]`, `true`, `"internal-model"`} {
+		t.Run("valid JSON/"+body, func(t *testing.T) {
+			got := run(t, api, strings.NewReader(body), false, false)
+			want := strings.ReplaceAll(body, "internal-model", "public")
+			if strings.Contains(body, `\u0069`) {
+				want = `{"emoji":"🦞","message":"public"}`
+			}
+			if !rewriteCaptureHasContent(got, want) {
+				t.Errorf("JSON compatibility changed: %v", got.Files)
+			}
+		})
+	}
+	t.Run("post delimiter visible only", func(t *testing.T) {
+		got := run(t, []string{"api", "graphql", "--verbose", "--", "--input=missing-internal-model", "--header=Authorization: internal-model", "--hostname=enterprise.invalid", "-Fvalue=@missing-internal-model"}, nil, false, false)
+		delimiter := slices.Index(got.Args, "--")
+		host := slices.Index(got.Args, "--hostname=github.com")
+		if host < 0 || host > delimiter || len(got.Files) != 0 || !slices.Contains(got.Args, "--input=missing-public") {
+			t.Errorf("delimiter ownership lost: %v", got.Args)
+		}
+	})
+	t.Run("header-looking value is text", func(t *testing.T) {
+		got := run(t, []string{"api", "graphql", "--template", "--header=Authorization: internal-model", "--verbose"}, nil, false, false)
+		if !slices.Contains(got.Args, "--header=Authorization: public") {
+			t.Error("value not rewritten")
+		}
+	})
+	t.Run("snapshot keeps original source", func(t *testing.T) {
+		dir := t.TempDir()
+		source := filepath.Join(dir, "internal-model.json")
+		if err := os.WriteFile(source, []byte(`{"message":"internal-model"}`), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "public.json"), []byte(`{"message":"wrong source"}`), 0600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("OCTOPOOL_TEST_DECLARED_MUTATE", source)
+		got := run(t, []string{"api", "graphql", "--input", source}, nil, false, false)
+		if !rewriteCaptureHasContent(got, `{"message":"public"}`) {
+			t.Error("original capture lost")
+		}
+		if data, err := os.ReadFile(source); err != nil || string(data) != "later source bytes" {
+			t.Fatal("child did not mutate source after preparation")
+		}
+	})
+	t.Run("typed source stays literal text", func(t *testing.T) {
+		got := run(t, []string{"workflow", "run", "deploy.yml", "--repo=acme/repo", "-Fmessage=@-"}, strings.NewReader(textBody), false, false)
+		if !rewriteCaptureHasContent(got, strings.ReplaceAll(textBody, "internal-model", "public")) || got.Stdin != "" {
+			t.Error("typed field lost text bytes or stdin ownership")
+		}
+	})
+	t.Run("raw field stays argument", func(t *testing.T) {
+		got := run(t, []string{"api", "graphql", "-fmessage=@missing-internal-model"}, nil, false, false)
+		if len(got.Files) != 0 || !slices.Contains(got.Args, "-fmessage=@missing-public") {
+			t.Error("raw field became source")
+		}
+	})
+	t.Run("policy introduces JSON declaration", func(t *testing.T) {
+		policyStore.Store(`{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"internal-model","replacement":"public"},{"pattern":"native-json","replacement":"json=1"}]}`)
+		defer policyStore.Store(rewriteActiveTestPolicy)
+		got := run(t, append(slices.Clone(workflow), "--native-json"), strings.NewReader(`{"message":"internal-model"}`), false, false)
+		if got.Stdin != `{"message":"public"}` {
+			t.Error("new declaration not inspected")
+		}
+	})
+	t.Run("text to JSON upgrade validates captured bytes", func(t *testing.T) {
+		policyStore.Store(`{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"text/plain","replacement":"application/json"}]}`)
+		defer policyStore.Store(rewriteActiveTestPolicy)
+		run(t, append(slices.Clone(api), "--verbose", "--header=Content-Type: text/plain"), strings.NewReader(`{"a":"x","a":"y"}`), true, false)
+	})
+	t.Run("JSON to text cannot downgrade", func(t *testing.T) {
+		policyStore.Store(`{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"application/json","replacement":"text/plain"}]}`)
+		defer policyStore.Store(rewriteActiveTestPolicy)
+		run(t, append(slices.Clone(api), "--verbose", "--header=Content-Type: application/json"), strings.NewReader(`{"a":"x","a":"y"}`), true, false)
+	})
+	t.Run("limit plus one", func(t *testing.T) {
+		reader := &declaredInputReader{Reader: strings.NewReader(strings.Repeat(" ", rewriteMaxContent+200))}
+		run(t, append(slices.Clone(workflow), "--json=1"), reader, true, false)
+		if reader.bytes != rewriteMaxContent+1 {
+			t.Errorf("bounded read consumed %d bytes", reader.bytes)
+		}
+	})
+	for _, headers := range [][]string{
+		{"--header", "Content-Type: application/json"},
+		{"-HContent-Type: application/problem+json"},
+		{"-H=Content-Type: Text/JSON; charset=utf-8"},
+		{"--header=Content-Type:", "--header=Content-Type: not a MIME type"},
+		{"--header=Content-Type: application/json; charset=utf-8; version=1", "--header=Content-Type: APPLICATION/JSON; version=1; charset=\"utf-8\""},
+	} {
+		t.Run("valid header JSON/"+strings.Join(headers, "_"), func(t *testing.T) {
+			got := run(t, append(slices.Clone(api), headers...), strings.NewReader(`{"message":"internal-model"}`), false, false)
+			if !rewriteCaptureHasContent(got, `{"message":"public"}`) {
+				t.Error("declared JSON header not dispatched")
+			}
+		})
+	}
+	for _, flags := range [][]string{{"-r--json"}, {"-r=--json"}, {"--ref=--json"}, {"-f--json"}, {"-F=--json"}, {"--help=false", "--json=false"}} {
+		t.Run("attached ownership/"+strings.Join(flags, "_"), func(t *testing.T) {
+			reader := &declaredInputReader{Reader: strings.NewReader("not JSON")}
+			prepared, err := prepareProtectedGH(t.Context(), append(slices.Clone(workflow), flags...), reader)
+			if prepared != nil {
+				defer prepared.cleanup()
+			}
+			if err != nil || reader.reads != 0 {
+				t.Errorf("value became declaration: %v reads=%d", err, reader.reads)
+			}
+		})
+	}
+	for _, flag := range []string{"--raw-field", "--field", "--jq", "--template", "--cache", "--preview", "--method"} {
+		t.Run("API value ownership/"+flag, func(t *testing.T) {
+			reader := &declaredInputReader{Reader: strings.NewReader("not JSON")}
+			prepared, err := prepareProtectedGH(t.Context(), []string{"api", "graphql", "--verbose", flag, "--input=-"}, reader)
+			if prepared != nil {
+				defer prepared.cleanup()
+			}
+			if err != nil || reader.reads != 0 {
+				t.Errorf("value became source: %v reads=%d", err, reader.reads)
+			}
+		})
+	}
+	t.Run("consumed API delimiter is a value", func(t *testing.T) {
+		got := run(t, append(slices.Clone(api), "--template", "--", "-HContent-Type: text/plain"), strings.NewReader(textBody), false, false)
+		if !rewriteCaptureHasContent(got, strings.ReplaceAll(textBody, "internal-model", "public")) {
+			t.Error("value delimiter hid text declaration")
+		}
+	})
+	t.Run("stdin remains idle without input declaration", func(t *testing.T) {
+		reader := &declaredInputReader{Reader: strings.NewReader("not JSON")}
+		prepared, err := prepareProtectedGH(t.Context(), []string{"api", "graphql", "--header=Content-Type: application/json"}, reader)
+		if prepared != nil {
+			defer prepared.cleanup()
+		}
+		if err != nil || reader.reads != 0 {
+			t.Errorf("header alone read stdin: %v reads=%d", err, reader.reads)
+		}
+	})
+	t.Run("unrelated operand does not select workflow", func(t *testing.T) {
+		reader := &declaredInputReader{Reader: strings.NewReader("not JSON")}
+		prepared, err := prepareProtectedGH(t.Context(), []string{"config", "get", "workflow", "run", "--json"}, reader)
+		if prepared != nil {
+			defer prepared.cleanup()
+		}
+		if err != nil || reader.reads != 0 {
+			t.Errorf("operand selected workflow: %v reads=%d", err, reader.reads)
+		}
+	})
+	t.Run("generated repo precedes delimiter", func(t *testing.T) {
+		repo := t.TempDir()
+		for _, args := range [][]string{{"init", "--quiet", repo}, {"-C", repo, "remote", "add", "origin", "https://github.com/acme/repo"}} {
+			cmd := exec.CommandContext(t.Context(), "git", args...)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("synthetic repo: %v %s", err, out)
+			}
+		}
+		t.Chdir(repo)
+		got := run(t, []string{"workflow", "run", "--json", "--", "deploy.yml"}, strings.NewReader(`{"message":"internal-model"}`), false, false)
+		pin, delimiter := slices.Index(got.Args, "--repo=github.com/acme/repo"), slices.Index(got.Args, "--")
+		if pin < 0 || pin > delimiter {
+			t.Errorf("repo pin became positional: %v", got.Args)
+		}
+	})
+	t.Run("explicit text stdin preserves valid JSON formatting", func(t *testing.T) {
+		body := " { \"message\" : \"internal-model\" } \n"
+		got := run(t, append(slices.Clone(api), "--header=Content-Type: text/plain"), strings.NewReader(body), false, false)
+		if !rewriteCaptureHasContent(got, strings.ReplaceAll(body, "internal-model", "public")) {
+			t.Error("explicit text was JSON formatted")
+		}
+	})
+	t.Run("binary declaration is not an escape hatch", func(t *testing.T) {
+		run(t, append(slices.Clone(api), "--header=Content-Type: application/octet-stream"), strings.NewReader("\xff"), true, false)
+	})
+	t.Run("undeclared input retains opportunistic text", func(t *testing.T) {
+		got := run(t, []string{"extension", "synthetic", "--input=-"}, strings.NewReader(textBody), false, false)
+		if !rewriteCaptureHasContent(got, strings.ReplaceAll(textBody, "internal-model", "public")) {
+			t.Error("undeclared text changed")
+		}
+	})
+	t.Run("workflow exact zero bytes", func(t *testing.T) {
+		got := run(t, append(slices.Clone(workflow), "--json=T"), strings.NewReader(""), false, false)
+		if got.Stdin != "" {
+			t.Error("zero-byte workflow input changed")
+		}
+	})
+	t.Run("modeled empty body remains invalid", func(t *testing.T) {
+		run(t, []string{"api", "repos/acme/repo/issues/1/comments", "--method=POST", "--input=-"}, strings.NewReader(""), true, false)
+	})
+	for _, surface := range []string{"regular stdin file", "pipe"} {
+		t.Run(surface, func(t *testing.T) {
+			body := `{"message":"\u0069nternal-model"}`
+			var reader *os.File
+			if surface == "pipe" {
+				var writer *os.File
+				var err error
+				reader, writer, err = os.Pipe()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := io.WriteString(writer, body); err != nil {
+					t.Fatal(err)
+				}
+				if err := writer.Close(); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				path := filepath.Join(t.TempDir(), "stdin.json")
+				if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+					t.Fatal(err)
+				}
+				var err error
+				reader, err = os.Open(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			defer reader.Close()
+			got := run(t, append(slices.Clone(workflow), "--json=T"), reader, false, false)
+			if got.Stdin != `{"message":"public"}` {
+				t.Error("file/pipe input not inspected")
+			}
+		})
+	}
+	t.Run("upgrade captures once and rewrites once", func(t *testing.T) {
+		policyStore.Store(`{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"text/plain","replacement":"application/json"},{"pattern":"internal-model","replacement":"public"}]}`)
+		defer policyStore.Store(rewriteActiveTestPolicy)
+		body := `{"message":"` + strings.Repeat("a", 600000) + `\u0069nternal-model"}`
+		reader := &declaredInputReader{Reader: strings.NewReader(body)}
+		got := run(t, append(slices.Clone(api), "--header=Content-Type: text/plain"), reader, false, false)
+		if reader.bytes != len(body) || !rewriteCaptureHasContent(got, `{"message":"`+strings.Repeat("a", 600000)+`public"}`) {
+			t.Error("capture was reread, charged twice, or not JSON inspected")
+		}
+	})
+	t.Run("rewritten input source is captured", func(t *testing.T) {
+		policyStore.Store(`{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"new-input","replacement":"input"},{"pattern":"internal-model","replacement":"public"}]}`)
+		defer policyStore.Store(rewriteActiveTestPolicy)
+		got := run(t, []string{"api", "graphql", "--verbose", "--new-input=-"}, strings.NewReader(`{"message":"internal-model"}`), false, false)
+		if !rewriteCaptureHasContent(got, `{"message":"public"}`) || got.Stdin != "" {
+			t.Error("new input source escaped preparation")
+		}
+	})
+	for _, headers := range [][]string{
+		{"--header=Content-Type: text/plain", "--header=Authorization: synthetic-denied", "--verbose"},
+		{"--verbose", "--header=Authorization: synthetic-denied", "--header=Content-Type: text/plain"},
+		{"--header=Proxy-Authorization: synthetic-denied", "--header=Content-Type: text/plain"},
+		{"--header=Content-Type: text/plain", "--header=X-GitHub-Token: synthetic-denied"},
+	} {
+		t.Run("credential header order/"+strings.Join(headers, "_"), func(t *testing.T) {
+			reader := &declaredInputReader{Reader: strings.NewReader(textBody)}
+			run(t, append(slices.Clone(api), headers...), reader, true, false)
+			if reader.reads != 0 {
+				t.Error("credential denial read source")
+			}
+		})
+	}
+	for _, test := range []struct{ name, body string }{
+		{"material", `{"message":"{\"pattern\":\"internal-model\",\"replacement\":\"public\"}"}`},
+		{"marshal expansion", `"` + strings.Repeat("<", 180000) + `"`},
+	} {
+		t.Run("final budget and material/"+test.name, func(t *testing.T) { run(t, api, strings.NewReader(test.body), true, false) })
+	}
+	t.Run("aggregate sources and cleanup", func(t *testing.T) {
+		temp := t.TempDir()
+		for _, key := range []string{"TMPDIR", "TMP", "TEMP"} {
+			t.Setenv(key, temp)
+		}
+		path := filepath.Join(t.TempDir(), "large.txt")
+		if err := os.WriteFile(path, []byte(strings.Repeat("a", 600000)), 0600); err != nil {
+			t.Fatal(err)
+		}
+		run(t, []string{"workflow", "run", "deploy.yml", "--repo=acme/repo", "-Fone=@" + path, "-Ftwo=@" + path}, nil, true, false)
+		if files, err := os.ReadDir(temp); err != nil || len(files) != 0 {
+			t.Fatalf("denial left staging: %v (%v)", files, err)
+		}
+	})
+	t.Run("duplicate stdin consumers reject", func(t *testing.T) {
+		run(t, []string{"api", "graphql", "--verbose", "--input=-", "-Fbody=@-"}, strings.NewReader(`{}`), true, false)
+	})
+	t.Run("expansion limit and residual rejection", func(t *testing.T) {
+		policy, _ := json.Marshal(map[string]any{"schema_version": 1, "revision": 1, "updated_at": "2026-08-28T00:00:00Z", "rules": []map[string]string{{"pattern": "internal-model", "replacement": strings.Repeat("p", 1024)}}})
+		policyStore.Store(string(policy))
+		defer policyStore.Store(rewriteActiveTestPolicy)
+		run(t, api, strings.NewReader(`"`+strings.Repeat("internal-model", 1100)+`"`), true, false)
+		policyStore.Store(`{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"internal-model","replacement":"public"},{"pattern":"REMOVE","replacement":""}]}`)
+		run(t, api, strings.NewReader(`{"message":"interREMOVEnal-model"}`), true, false)
+	})
+	for _, failure := range []string{"start", "exit"} {
+		t.Run("cleanup on child "+failure, func(t *testing.T) {
+			temp := t.TempDir()
+			for _, key := range []string{"TMPDIR", "TMP", "TEMP"} {
+				t.Setenv(key, temp)
+			}
+			t.Setenv("OCTOPOOL_GH_PATH", child)
+			capture := filepath.Join(t.TempDir(), "capture.json")
+			t.Setenv("OCTOPOOL_TEST_DECLARED_CAPTURE", capture)
+			t.Setenv("OCTOPOOL_TEST_DECLARED_EXIT", "7")
+			if failure == "start" {
+				broken := filepath.Join(t.TempDir(), executableName("broken-child"))
+				if err := os.WriteFile(broken, []byte("synthetic invalid executable\n"), 0700); err != nil {
+					t.Fatal(err)
+				}
+				t.Setenv("OCTOPOOL_GH_PATH", broken)
+			}
+			var stdout, stderr bytes.Buffer
+			err := execRealGHWithStdin(t.Context(), api, strings.NewReader(`{"message":"internal-model"}`), &stdout, &stderr)
+			if err == nil {
+				t.Fatal("expected child failure")
+			}
+			if failure == "exit" {
+				if err != (exitCodeError{Code: 7}) || stdout.String() != "child stdout\n" || stderr.String() != "child stderr\n" {
+					t.Fatalf("child exit lost: %v %q %q", err, &stdout, &stderr)
+				}
+				got := readRewriteCapture(t, capture)
+				if !rewriteCaptureHasContent(got, `{"message":"public"}`) {
+					t.Error("failed child did not receive snapshot")
+				}
+			} else if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Error("invalid executable ran capture child")
+			}
+			if files, err := os.ReadDir(temp); err != nil || len(files) != 0 {
+				t.Fatalf("child failure left staging: %v (%v)", files, err)
+			}
+		})
+	}
+	t.Run("CLI generic diagnostic", func(t *testing.T) {
+		capture := filepath.Join(t.TempDir(), "capture.json")
+		cmd := exec.CommandContext(t.Context(), binary, "gh", "workflow", "run", "deploy.yml", "--repo=acme/repo", "--json=T")
+		cmd.Env = testConfigEnv(t.TempDir())
+		for _, key := range []string{"SystemRoot", "WINDIR", "TMPDIR", "TMP", "TEMP", "OCTOPOOL_URL", "OCTOPOOL_POOL", "OCTOPOOL_TOKEN"} {
+			cmd.Env = append(cmd.Env, key+"="+os.Getenv(key))
+		}
+		cmd.Env = append(cmd.Env, "OCTOPOOL_GH_PATH="+child, "OCTOPOOL_TEST_DECLARED_CAPTURE="+capture)
+		cmd.Stdin = strings.NewReader(`{"message":"\u0069nternal-model","extra":"a","extra":"b"}`)
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout, cmd.Stderr = &stdout, &stderr
+		err := cmd.Run()
+		if exit, ok := err.(*exec.ExitError); !ok || exit.ExitCode() != 1 || stdout.Len() != 0 || stderr.String() != "error: string rewrite protection blocked unsafe input\n" {
+			t.Fatalf("CLI denial: %v %q %q", err, &stdout, &stderr)
+		}
+		if _, err := os.Stat(capture); !os.IsNotExist(err) {
+			t.Error("CLI denial reached child")
+		}
+	})
+
+}
+
+// These target semantics are independently established by installed native gh:
+// API -i bundles continue into F/H; -s is not an API shorthand; h returns help.
+func TestDeclaredInputBundles(t *testing.T) {
+	child := buildDeclaredInputChild(t)
+	declaredInputEnvironment(t)
+	policyStore, _ := rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	type capture struct {
+		rewriteCapture
+		Include, Silent, Help bool
+		Headers               []string
+		Fields, RawFields     []string
+	}
+	run := func(t *testing.T, args []string, stdin io.Reader, blocked, top bool) capture {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "capture.json")
+		t.Setenv("OCTOPOOL_GH_PATH", child)
+		t.Setenv("OCTOPOOL_TEST_DECLARED_CAPTURE", path)
+		var stdout, stderr bytes.Buffer
+		var err error
+		if top {
+			err = runGH(t.Context(), args, &stdout, &stderr)
+		} else {
+			env := testConfigEnv(t.TempDir())
+			for _, key := range []string{"SystemRoot", "WINDIR", "TMPDIR", "TMP", "TEMP", "OCTOPOOL_TEST_DECLARED_CAPTURE"} {
+				env = append(env, key+"="+os.Getenv(key))
+			}
+			err = execRealGHWithStdinAndEnv(t.Context(), args, stdin, &stdout, &stderr, env)
+		}
+		if blocked {
+			if err != errRewriteBlocked || stdout.Len() != 0 || stderr.Len() != 0 {
+				t.Errorf("expected generic denial with no child output: %v %q %q", err, &stdout, &stderr)
+			}
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				t.Error("denied bundle reached child")
+			}
+			return capture{}
+		}
+		if err != nil {
+			t.Fatalf("prepared child: %v %q", err, &stderr)
+		}
+		var got capture
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatal(err)
+		}
+		if stdout.String() != "child stdout\n" || stderr.String() != "child stderr\n" {
+			t.Error("child streams changed")
+		}
+		return got
+	}
+	for _, spelling := range []string{"-iF", "-iF=", "-iiF", "-iF separate", "-i -F", "-i=false -F", "-ii=false -F"} {
+		for _, sourceKind := range []string{"file", "stdin"} {
+			t.Run("typed source/"+spelling+"/"+sourceKind, func(t *testing.T) {
+				source := "-"
+				original := "internal-model\n"
+				if sourceKind == "file" {
+					source = filepath.Join(t.TempDir(), "original.txt")
+					if err := os.WriteFile(source, []byte(original), 0600); err != nil {
+						t.Fatal(err)
+					}
+				}
+				value := "body=@" + source
+				flags := []string{spelling + value}
+				switch spelling {
+				case "-iF separate":
+					flags = []string{"-iF", value}
+				case "-i -F":
+					flags = []string{"-i", "-F", value}
+				case "-i=false -F":
+					flags = []string{"-i=false", "-F", value}
+				case "-ii=false -F":
+					flags = []string{"-ii=false", "-F", value}
+				}
+				got := run(t, append([]string{"api", "graphql", "--verbose"}, flags...), strings.NewReader(original), false, false)
+				if !rewriteCaptureHasContent(got.rewriteCapture, "public\n") {
+					t.Errorf("target received unfiltered or missing source: %v", got.Files)
+				}
+				if got.Include != !strings.Contains(spelling, "false") {
+					t.Errorf("include option lost: %v", got.Args)
+				}
+				for path := range got.Files {
+					if path == source || path == "-" {
+						t.Error("target retained original source")
+					}
+					if _, err := os.Stat(path); !os.IsNotExist(err) {
+						t.Error("snapshot not cleaned")
+					}
+				}
+				if sourceKind == "file" {
+					if data, err := os.ReadFile(source); err != nil || string(data) != original {
+						t.Error("original file changed")
+					}
+				} else if got.Stdin != "" {
+					t.Error("stdin source was not captured")
+				}
+			})
+		}
+	}
+	for _, header := range []string{"Authorization:synthetic-denied", "Proxy-Authorization:synthetic-denied", "X-GitHub-Token:synthetic-denied"} {
+		for _, separate := range []bool{false, true} {
+			t.Run("credential/"+header+"/"+strconv.FormatBool(separate), func(t *testing.T) {
+				args := []string{"api", "graphql", "--verbose", "--input=-", "-iH" + header}
+				if separate {
+					args = append(args[:len(args)-1], "-iH", header)
+				}
+				reader := &declaredInputReader{Reader: strings.NewReader(`{}`)}
+				run(t, args, reader, true, false)
+				if reader.reads != 0 {
+					t.Error("bundled credential denial read source")
+				}
+			})
+		}
+	}
+	for _, flags := range [][]string{
+		{"-iHContent-Type:text/plain"}, {"-iH=Content-Type:text/plain"}, {"-iH", "Content-Type:text/plain"}, {"-i", "-HContent-Type:text/plain"},
+		{"-iHContent-Type:application/json"}, {"-iHContent-Type:application/problem+json"}, {"-iHContent-Type:text/plain", "-HContent-Type:application/json"},
+	} {
+		t.Run("content type/"+strings.Join(flags, "_"), func(t *testing.T) {
+			body := " {\"a\":\"internal-model\", \"a\":\"second\"} \n"
+			blocked := strings.Contains(strings.Join(flags, " "), "json")
+			got := run(t, append([]string{"api", "graphql", "--verbose", "--input=-"}, flags...), strings.NewReader(body), blocked, false)
+			if !blocked && (!got.Include || !rewriteCaptureHasContent(got.rewriteCapture, strings.ReplaceAll(body, "internal-model", "public"))) {
+				t.Error("bundled text changed content or include semantics")
+			}
+		})
+	}
+	t.Run("bundled source through runGH", func(t *testing.T) {
+		source := filepath.Join(t.TempDir(), "original.txt")
+		if err := os.WriteFile(source, []byte("internal-model"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		got := run(t, []string{"api", "graphql", "-iFbody=@" + source}, nil, false, true)
+		if !got.Include || !rewriteCaptureHasContent(got.rewriteCapture, "public") {
+			t.Error("runGH lost bundle protection")
+		}
+	})
+	for _, flags := range [][]string{{"-i=0"}, {"-i=TRUE"}, {"-ii=false"}, {"-i", "--silent"}, {"-iFbody==--json"}, {"-Fbody=-iHAuthorization:synthetic"}, {"-it", "--", "--input=-"}, {"--", "-iFbody=@missing"}} {
+		t.Run("ownership/"+strings.Join(flags, "_"), func(t *testing.T) {
+			args := append([]string{"api", "graphql", "--verbose"}, flags...)
+			input := strings.NewReader(`{"message":"safe"}`)
+			got := run(t, args, input, false, false)
+			if strings.HasPrefix(flags[0], "-i") && flags[0] != "-i=0" && flags[0] != "-ii=false" && !got.Include {
+				t.Error("leading include disappeared")
+			}
+			if flags[0] == "-i=0" || flags[0] == "-ii=false" {
+				if got.Include {
+					t.Error("Boolean assignment lost")
+				}
+			}
+			if slices.Contains(flags, "--silent") && !got.Silent {
+				t.Error("silent long option lost")
+			}
+			if flags[0] == "-it" && !rewriteCaptureHasContent(got.rewriteCapture, `{"message":"safe"}`) {
+				t.Error("consumed template delimiter hid the input source")
+			}
+			if flags[0] == "--" && len(got.Files) != 0 {
+				t.Error("postdelimiter source opened")
+			}
+		})
+	}
+	for _, flag := range []string{"-i=falseFbody=@-", "-i=", "-i=invalid", "--include=", "--include=invalid"} {
+		t.Run("invalid include assignment/"+flag, func(t *testing.T) {
+			reader := &declaredInputReader{Reader: strings.NewReader(`{}`)}
+			run(t, []string{"api", "graphql", "--verbose", flag, "--input=-"}, reader, true, false)
+			if reader.reads != 0 {
+				t.Error("invalid Boolean occurrence read source")
+			}
+		})
+	}
+	for _, rule := range []struct{ pattern, replacement string }{{"include", "public"}, {"true", "false"}} {
+		for _, flags := range [][]string{{"-i"}, {"-ii"}, {"-i=1"}, {"-iFbody=@-"}, {"-iiFbody=@-"}, {"-iHX-Fixture:safe"}} {
+			t.Run("caller spelling/"+rule.pattern+"/"+strings.Join(flags, "_"), func(t *testing.T) {
+				policyStore.Store(`{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"` + rule.pattern + `","replacement":"` + rule.replacement + `"}]}`)
+				defer policyStore.Store(rewriteActiveTestPolicy)
+				var input io.Reader
+				if strings.Contains(strings.Join(flags, ""), "Fbody=@-") {
+					input = strings.NewReader("safe")
+				}
+				got := run(t, append([]string{"api", "graphql", "--verbose"}, flags...), input, false, false)
+				if !got.Include {
+					t.Error("synthetic flag text changed the caller's include option")
+				}
+				if input != nil && !rewriteCaptureHasContent(got.rewriteCapture, "safe") {
+					t.Error("preserving shorthand lost source protection")
+				}
+			})
+		}
+	}
+	t.Run("literal Boolean matches still rewrite", func(t *testing.T) {
+		policyStore.Store(`{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"true","replacement":"false"}]}`)
+		defer policyStore.Store(rewriteActiveTestPolicy)
+		got := run(t, []string{"api", "graphql", "--verbose", "-i=true"}, nil, false, false)
+		if got.Include {
+			t.Error("caller-provided Boolean value was not rewritten")
+		}
+		got = run(t, []string{"api", "graphql", "--verbose", "-iFbody=@-"}, strings.NewReader("true"), false, false)
+		if !got.Include || !rewriteCaptureHasContent(got.rewriteCapture, "false") {
+			t.Error("implicit Boolean and explicit source text were conflated")
+		}
+	})
+	t.Run("literal bundle text matches still rewrite", func(t *testing.T) {
+		policyStore.Store(`{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"iHX-Fixture:old","replacement":"iHX-Fixture:new"}]}`)
+		defer policyStore.Store(rewriteActiveTestPolicy)
+		got := run(t, []string{"api", "graphql", "--verbose", "-iHX-Fixture:old"}, nil, false, false)
+		if !got.Include || !slices.Contains(got.Headers, "X-Fixture:new") {
+			t.Error("splitting the caller's bundle erased an original policy match")
+		}
+	})
+	t.Run("literal header matches still rewrite", func(t *testing.T) {
+		policyStore.Store(`{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"include","replacement":"public"}]}`)
+		defer policyStore.Store(rewriteActiveTestPolicy)
+		got := run(t, []string{"api", "graphql", "--verbose", "-iHX-Fixture:include"}, nil, false, false)
+		if !got.Include || !slices.Contains(got.Headers, "X-Fixture:public") {
+			t.Error("implicit flag name and caller-provided header text were conflated")
+		}
+	})
+	for _, flag := range []string{"-i-method=GET", "-ii-method=GET", "-i-header=X-Fixture:value", "-i-include=false", "-i-input=-", "-i-"} {
+		t.Run("malformed bundle/"+flag, func(t *testing.T) {
+			reader := &declaredInputReader{Reader: strings.NewReader(`{}`)}
+			run(t, []string{"api", "graphql", "--verbose", "--input=-", flag}, reader, true, false)
+			if reader.reads != 0 {
+				t.Error("invalid shorthand became executable or read a source")
+			}
+		})
+	}
+	t.Run("policy-created malformed bundle", func(t *testing.T) {
+		policyStore.Store(`{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"bundle-invalid","replacement":"-i-method=GET"}]}`)
+		defer policyStore.Store(rewriteActiveTestPolicy)
+		run(t, []string{"api", "graphql", "--verbose", "--input=-", "bundle-invalid"}, strings.NewReader(`{}`), true, false)
+	})
+	t.Run("policy-created bundle", func(t *testing.T) {
+		policyStore.Store(`{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"bundle-input","replacement":"-iFbody=@-"},{"pattern":"internal-model","replacement":"public"}]}`)
+		defer policyStore.Store(rewriteActiveTestPolicy)
+		got := run(t, []string{"api", "graphql", "--verbose", "bundle-input"}, strings.NewReader("internal-model"), false, false)
+		if !got.Include || !rewriteCaptureHasContent(got.rewriteCapture, "public") || got.Stdin != "" {
+			t.Error("new bundle escaped preparation")
+		}
+	})
+	for _, test := range []struct {
+		name  string
+		flags []string
+		help  bool
+	}{
+		{"long", []string{"--help"}, true}, {"long true", []string{"--help=TRUE"}, true}, {"short", []string{"-h"}, true}, {"short suffix", []string{"-hh=false"}, true},
+		{"short cannot be unset", []string{"-h", "--help=false"}, true}, {"short ignores later invalid JSON", []string{"-h", "--json=invalid"}, true},
+		{"final false", []string{"--help", "--help=false"}, false}, {"final true", []string{"--help=false", "--help"}, true},
+		{"value-owned", []string{"--ref", "--help"}, false}, {"short value-owned", []string{"-r-h"}, false}, {"postdelimiter", []string{"--", "--help"}, false}, {"consumed delimiter", []string{"--ref", "--", "--help"}, true},
+	} {
+		t.Run("workflow help/"+test.name, func(t *testing.T) {
+			args := []string{"workflow", "run", "--repo=acme/repo", "--json"}
+			if test.name != "postdelimiter" {
+				args = append(args, "deploy.yml")
+			}
+			args = append(args, test.flags...)
+			reader := &declaredInputReader{Reader: strings.NewReader(`{"message":"internal-model"}`)}
+			prepared, err := prepareProtectedGH(t.Context(), args, reader)
+			if err != nil {
+				t.Fatalf("preparation: %v", err)
+			}
+			prepared.cleanup()
+			if (reader.reads == 0) != test.help {
+				t.Errorf("help stdin ownership: reads=%d help=%v", reader.reads, test.help)
+			}
+			input := filepath.Join(t.TempDir(), "stdin.json")
+			if err := os.WriteFile(input, []byte(`{"message":"internal-model"}`), 0600); err != nil {
+				t.Fatal(err)
+			}
+			file, err := os.Open(input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer file.Close()
+			saved := os.Stdin
+			os.Stdin = file
+			defer func() { os.Stdin = saved }()
+			got := run(t, args, nil, false, true)
+			offset, err := file.Seek(0, io.SeekCurrent)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Help != test.help || (offset == 0) != test.help {
+				t.Errorf("runGH help/control changed stdin: help=%v offset=%d args=%v", got.Help, offset, got.Args)
+			}
+			if !test.help && got.Stdin != `{"message":"public"}` {
+				t.Error("false or value-owned help skipped JSON protection")
+			}
+		})
+	}
+	for _, test := range []struct{ arg, field, raw, header string }{
+		{"-iFbody==--json", "body==--json", "", ""},
+		{"-iFbody=-i-method=GET", "body=-i-method=GET", "", ""},
+		{"-iFbody=-iHAuthorization:synthetic", "body=-iHAuthorization:synthetic", "", ""},
+		{"-iF=body=--help", "body=--help", "", ""},
+		{"-Fbody=-iHAuthorization:synthetic", "body=-iHAuthorization:synthetic", "", ""},
+		{"-ifbody=@missing=--json", "", "body=@missing=--json", ""},
+		{"-iHX-Fixture:-Fbody=@missing=--help", "", "", "X-Fixture:-Fbody=@missing=--help"},
+	} {
+		t.Run("full value/"+test.arg, func(t *testing.T) {
+			got := run(t, []string{"api", "graphql", "--verbose", test.arg}, nil, false, false)
+			if len(got.Files) != 0 {
+				t.Error("literal value became a source")
+			}
+			if test.field != "" && !slices.Contains(got.Fields, test.field) {
+				t.Errorf("field remainder changed: %v", got.Fields)
+			}
+			if test.raw != "" && !slices.Contains(got.RawFields, test.raw) {
+				t.Errorf("raw remainder changed: %v", got.RawFields)
+			}
+			if test.header != "" && !slices.Contains(got.Headers, test.header) {
+				t.Errorf("header remainder changed: %v", got.Headers)
+			}
+		})
+	}
+	t.Run("bundled path frozen before rewriting and delimiter", func(t *testing.T) {
+		dir := t.TempDir()
+		source := filepath.Join(dir, "-internal-model=source.txt")
+		if err := os.WriteFile(source, []byte("internal-model"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "-public=source.txt"), []byte("wrong source"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		got := run(t, []string{"api", "graphql", "--verbose", "-iFbody=@" + source, "--", "-iFother=@missing"}, nil, false, false)
+		if !got.Include || !rewriteCaptureHasContent(got.rewriteCapture, "public") || len(got.Files) != 1 {
+			t.Error("bundle lost original source or delimiter ownership")
+		}
+		if data, err := os.ReadFile(source); err != nil || string(data) != "internal-model" {
+			t.Error("original source changed")
+		}
+		for path := range got.Files {
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				t.Error("sanitized snapshot survived exit")
+			}
+		}
+	})
+	t.Run("bundled header upgrade retains stronger inspection", func(t *testing.T) {
+		policyStore.Store(`{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"text/plain","replacement":"application/json"},{"pattern":"internal-model","replacement":"public"}]}`)
+		defer policyStore.Store(rewriteActiveTestPolicy)
+		args := []string{"api", "graphql", "--verbose", "--input=-", "-iHContent-Type:text/plain"}
+		got := run(t, args, strings.NewReader(`{"message":"\u0069nternal-model"}`), false, false)
+		if !got.Include || !rewriteCaptureHasContent(got.rewriteCapture, `{"message":"public"}`) || !slices.Contains(got.Headers, "Content-Type:application/json") {
+			t.Error("normalization lost upgraded header or original source inspection")
+		}
+		run(t, args, strings.NewReader(`{"a":"one","a":"two"}`), true, false)
+	})
+	t.Run("argument bytes remain bounded before sources", func(t *testing.T) {
+		reader := &declaredInputReader{Reader: strings.NewReader(`{}`)}
+		args := []string{"api", "graphql", "--input=-", "-" + strings.Repeat("i", rewriteMaxContent)}
+		run(t, args, reader, true, false)
+		if reader.reads != 0 {
+			t.Error("oversize argv read stdin")
+		}
+	})
+	for _, flags := range [][]string{{"--help="}, {"--help", "--json=invalid"}} {
+		t.Run("invalid long help parse/"+strings.Join(flags, "_"), func(t *testing.T) {
+			reader := &declaredInputReader{Reader: strings.NewReader(`{}`)}
+			run(t, append([]string{"workflow", "run", "deploy.yml", "--repo=acme/repo", "--json"}, flags...), reader, true, false)
+			if reader.reads != 0 {
+				t.Error("invalid long help invocation read stdin")
+			}
+		})
+	}
+	t.Run("capture target rejects empty include assignment", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "capture.json")
+		cmd := exec.CommandContext(t.Context(), child, "api", "graphql", "-i=")
+		cmd.Env = append(testConfigEnv(t.TempDir()), "OCTOPOOL_TEST_DECLARED_CAPTURE="+path)
+		for _, key := range []string{"SystemRoot", "WINDIR", "TMPDIR", "TMP", "TEMP"} {
+			cmd.Env = append(cmd.Env, key+"="+os.Getenv(key))
+		}
+		if err := cmd.Run(); err == nil {
+			t.Error("explicit empty assignment became bare true")
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Error("invalid target invocation captured inputs")
+		}
+	})
+
+}

--- a/cmd/octopool/string_rewrites_fallback.go
+++ b/cmd/octopool/string_rewrites_fallback.go
@@ -16,13 +16,10 @@ func prepareRewriteBestEffort(policy stringRewritePolicy, args []string, stdin i
 	if len(args) == 0 {
 		return errRewriteBlocked
 	}
-	if args[0] == "api" {
-		if err := validateBestEffortAPI(args); err != nil {
-			return err
-		}
+	declaration, err := describeBestEffortInput(args)
+	if err != nil {
+		return err
 	}
-
-	var err error
 	prepared.args, err = pinBestEffortRepositories(policy, args)
 	if err != nil {
 		return err
@@ -31,8 +28,9 @@ func prepareRewriteBestEffort(policy stringRewritePolicy, args []string, stdin i
 	if err != nil {
 		return err
 	}
+	captures := map[string]*bestEffortCapturedInput{}
 	var stdinConsumed bool
-	prepared.args, stdinConsumed, err = snapshotBestEffortSources(policy, prepared.args, stdin, prepared, false)
+	prepared.args, stdinConsumed, err = snapshotBestEffortSources(policy, prepared.args, stdin, prepared, captures, false)
 	if err != nil {
 		return err
 	}
@@ -40,7 +38,9 @@ func prepareRewriteBestEffort(policy stringRewritePolicy, args []string, stdin i
 	if err != nil {
 		return err
 	}
-	prepared.args, stdinConsumed, err = snapshotBestEffortSources(policy, prepared.args, stdin, prepared, stdinConsumed)
+	// Validate final host/header/repository declarations before reading any new
+	// source, including declarations introduced by a visible argument rewrite.
+	final, err := describeBestEffortInput(prepared.args)
 	if err != nil {
 		return err
 	}
@@ -52,40 +52,47 @@ func prepareRewriteBestEffort(policy stringRewritePolicy, args []string, stdin i
 	if err != nil {
 		return err
 	}
-	prepared.forceGitHubHost = true
-	if args[0] == "api" {
-		if !bestEffortAPIHasHostname(prepared.args) {
-			if err := policy.checkStructural("github.com"); err != nil {
-				return err
-			}
-			prepared.args = append(prepared.args, "--hostname=github.com")
-		}
-		if err := validateBestEffortAPI(prepared.args); err != nil {
-			return err
-		}
-	}
-
-	if stdinConsumed {
-		prepared.stdin = strings.NewReader("")
-		return nil
-	}
-	if stdin == nil || rewriteReaderIsTerminal(stdin) || !bestEffortConsumesStdin(prepared.args) {
-		prepared.stdin = stdin
-		return nil
-	}
-	remaining := rewriteMaxContent - prepared.bestEffortSources
-	if remaining < 0 {
-		return errRewriteBlocked
-	}
-	data, err := boundedRewriteRead(stdin, remaining)
+	prepared.args, stdinConsumed, err = snapshotBestEffortSources(policy, prepared.args, stdin, prepared, captures, stdinConsumed)
 	if err != nil {
 		return err
 	}
-	prepared.bestEffortSources += len(data)
-	if prepared.bestEffortSources > rewriteMaxContent {
-		return errRewriteBlocked
+	prepared.args, err = finishBestEffortSources(policy, prepared.args, prepared, captures)
+	if err != nil {
+		return err
 	}
-	rewritten, err := rewriteBestEffortData(policy, data, prepared)
+	prepared.forceGitHubHost = true
+	if declaration.command == "api" || final.command == "api" {
+		final, err = describeBestEffortInput(prepared.args)
+		if err != nil {
+			return err
+		}
+		hasHost := false
+		for _, token := range final.args {
+			hasHost = hasHost || token.name == "--hostname"
+		}
+		if !hasHost {
+			if err := policy.checkStructural("github.com"); err != nil {
+				return err
+			}
+			prepared.args = insertBestEffortFlag(prepared.args, final, "--hostname=github.com")
+		}
+	}
+	if stdinConsumed {
+		if final.workflowJSON {
+			return errRewriteBlocked
+		}
+		prepared.stdin = strings.NewReader("")
+		return nil
+	}
+	if stdin == nil || rewriteReaderIsTerminal(stdin) || !final.workflowJSON {
+		prepared.stdin = stdin
+		return nil
+	}
+	data, err := readBestEffortSource("-", stdin, prepared)
+	if err != nil {
+		return err
+	}
+	rewritten, err := rewriteBestEffortData(policy, data, prepared, bestEffortDeclaredJSON)
 	if err != nil {
 		return err
 	}
@@ -94,50 +101,24 @@ func prepareRewriteBestEffort(policy stringRewritePolicy, args []string, stdin i
 }
 
 func rewriteBestEffortArguments(policy stringRewritePolicy, args []string, prepared *rewritePreparation) ([]string, error) {
+	declaration, err := describeBestEffortInput(args)
+	if err != nil {
+		return nil, err
+	}
+	args = declaration.argv
 	out := make([]string, 0, len(args))
-	for index := 0; index < len(args); index++ {
-		arg := args[index]
-		if arg == "--repo" || arg == "-R" || arg == "--input" {
-			index++
-			if index >= len(args) {
-				return nil, errRewriteBlocked
-			}
-			out = append(out, arg, args[index])
+	for _, token := range declaration.args {
+		if token.name == "--repo" || token.name == "--input" || (token.name == "--field" && bestEffortFieldIsSource(token.value)) {
+			out = append(out, args[token.start:token.end]...)
 			continue
 		}
-		if strings.HasPrefix(arg, "--repo=") || (strings.HasPrefix(arg, "-R") && len(arg) > 2) || strings.HasPrefix(arg, "--input=") {
-			out = append(out, arg)
-			continue
-		}
-		if arg == "--field" || arg == "-F" {
-			index++
-			if index >= len(args) {
-				return nil, errRewriteBlocked
-			}
-			if bestEffortFieldIsSource(args[index]) {
-				out = append(out, arg, args[index])
-				continue
-			}
-			rewrittenFlag, err := prepared.text(policy, arg)
+		for _, arg := range args[token.start:token.end] {
+			rewritten, err := prepared.text(policy, arg)
 			if err != nil {
 				return nil, err
 			}
-			rewrittenValue, err := prepared.text(policy, args[index])
-			if err != nil {
-				return nil, err
-			}
-			out = append(out, rewrittenFlag, rewrittenValue)
-			continue
+			out = append(out, rewritten)
 		}
-		if field, ok := bestEffortAttachedField(arg); ok && bestEffortFieldIsSource(field) {
-			out = append(out, arg)
-			continue
-		}
-		rewritten, err := prepared.text(policy, arg)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, rewritten)
 	}
 	return out, nil
 }
@@ -147,98 +128,95 @@ func bestEffortFieldIsSource(field string) bool {
 	return ok && strings.HasPrefix(value, "@")
 }
 
-func snapshotBestEffortSources(policy stringRewritePolicy, args []string, stdin io.Reader, prepared *rewritePreparation, stdinConsumed bool) ([]string, bool, error) {
+func snapshotBestEffortSources(policy stringRewritePolicy, args []string, stdin io.Reader, prepared *rewritePreparation, captures map[string]*bestEffortCapturedInput, stdinConsumed bool) ([]string, bool, error) {
+	declaration, err := describeBestEffortInput(args)
+	if err != nil {
+		return nil, false, err
+	}
+	args = declaration.argv
 	out := make([]string, 0, len(args))
-	for index := 0; index < len(args); index++ {
-		arg := args[index]
-		if arg == "--input" {
-			index++
-			if index >= len(args) || (args[index] == "-" && stdinConsumed) {
+	for _, token := range declaration.args {
+		source, key, kind := token.value, "", declaration.inputKind
+		field := token.name == "--field" && bestEffortFieldIsSource(token.value)
+		if token.name != "--input" && !field {
+			out = append(out, args[token.start:token.end]...)
+			continue
+		}
+		if field {
+			key, source, _ = strings.Cut(token.value, "=")
+			source, kind = strings.TrimPrefix(source, "@"), bestEffortText
+			if key == "" {
 				return nil, false, errRewriteBlocked
 			}
-			if prepared.snapshots[args[index]] {
-				out = append(out, "--input="+args[index])
-				continue
+		}
+		capture := captures[source]
+		path := source
+		if capture == nil {
+			if source == "" || (source == "-" && stdinConsumed) {
+				return nil, false, errRewriteBlocked
 			}
-			path, err := snapshotBestEffortInput(policy, args[index], stdin, prepared)
+			data, err := readBestEffortSource(source, stdin, prepared)
 			if err != nil {
 				return nil, false, err
 			}
-			stdinConsumed = stdinConsumed || args[index] == "-"
+			path, err = prepared.snapshot(nil)
+			if err != nil {
+				return nil, false, err
+			}
+			captures[path] = &bestEffortCapturedInput{data: data, kind: kind}
+			stdinConsumed = stdinConsumed || source == "-"
+			if field {
+				key, err = prepared.text(policy, key)
+				if err != nil || key == "" {
+					return nil, false, errRewriteBlocked
+				}
+			}
+		} else if kind == bestEffortDeclaredJSON {
+			capture.kind = bestEffortDeclaredJSON
+		}
+		if field {
+			out = append(out, token.capturedField(key+"=@"+path))
+		} else {
 			out = append(out, "--input="+path)
-			continue
 		}
-		if value, ok := strings.CutPrefix(arg, "--input="); ok {
-			if value == "-" && stdinConsumed {
-				return nil, false, errRewriteBlocked
-			}
-			if prepared.snapshots[value] {
-				out = append(out, arg)
-				continue
-			}
-			path, err := snapshotBestEffortInput(policy, value, stdin, prepared)
-			if err != nil {
-				return nil, false, err
-			}
-			stdinConsumed = stdinConsumed || value == "-"
-			out = append(out, "--input="+path)
-			continue
-		}
-		if arg == "--field" || arg == "-F" {
-			index++
-			if index >= len(args) {
-				return nil, false, errRewriteBlocked
-			}
-			rewritten, handled, consumed, err := snapshotBestEffortField(policy, args[index], stdin, prepared, stdinConsumed)
-			if err != nil {
-				return nil, false, err
-			}
-			if handled {
-				stdinConsumed = stdinConsumed || consumed
-				out = append(out, "--field="+rewritten)
-			} else {
-				out = append(out, arg, args[index])
-			}
-			continue
-		}
-		if value, ok := bestEffortAttachedField(arg); ok {
-			rewritten, handled, consumed, err := snapshotBestEffortField(policy, value, stdin, prepared, stdinConsumed)
-			if err != nil {
-				return nil, false, err
-			}
-			if handled {
-				stdinConsumed = stdinConsumed || consumed
-				out = append(out, "--field="+rewritten)
-				continue
-			}
-		}
-		out = append(out, arg)
 	}
 	return out, stdinConsumed, nil
 }
 
-func snapshotBestEffortInput(policy stringRewritePolicy, source string, stdin io.Reader, prepared *rewritePreparation) (string, error) {
-	data, err := readBestEffortSource(source, stdin, prepared)
+func finishBestEffortSources(policy stringRewritePolicy, args []string, prepared *rewritePreparation, captures map[string]*bestEffortCapturedInput) ([]string, error) {
+	declaration, err := describeBestEffortInput(args)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	rewritten, err := rewriteBestEffortData(policy, data, prepared)
-	if err != nil {
-		return "", err
+	args = declaration.argv
+	out := append([]string(nil), args...)
+	for _, token := range declaration.args {
+		source, key := token.value, ""
+		if token.name == "--field" {
+			key, source, _ = strings.Cut(source, "=")
+			source = strings.TrimPrefix(source, "@")
+		} else if token.name != "--input" {
+			continue
+		}
+		capture := captures[source]
+		if capture == nil {
+			continue
+		}
+		data, err := rewriteBestEffortData(policy, capture.data, prepared, capture.kind)
+		if err != nil {
+			return nil, err
+		}
+		path, err := prepared.snapshot(data)
+		if err != nil {
+			return nil, err
+		}
+		if token.name == "--field" {
+			out[token.start] = token.capturedField(key + "=@" + path)
+		} else {
+			out[token.start] = "--input=" + path
+		}
 	}
-	return prepared.snapshot(rewritten)
-}
-
-func snapshotBestEffortTextInput(policy stringRewritePolicy, source string, stdin io.Reader, prepared *rewritePreparation) (string, error) {
-	data, err := readBestEffortSource(source, stdin, prepared)
-	if err != nil {
-		return "", err
-	}
-	text, err := prepared.text(policy, string(data))
-	if err != nil {
-		return "", err
-	}
-	return prepared.snapshot([]byte(text))
+	return out, nil
 }
 
 func readBestEffortSource(source string, stdin io.Reader, prepared *rewritePreparation) ([]byte, error) {
@@ -257,59 +235,22 @@ func readBestEffortSource(source string, stdin io.Reader, prepared *rewritePrepa
 	return data, nil
 }
 
-func snapshotBestEffortField(policy stringRewritePolicy, field string, stdin io.Reader, prepared *rewritePreparation, stdinConsumed bool) (string, bool, bool, error) {
-	key, value, ok := strings.Cut(field, "=")
-	if !ok || !strings.HasPrefix(value, "@") {
-		return "", false, false, nil
-	}
-	if key == "" {
-		return "", false, false, errRewriteBlocked
-	}
-	source := strings.TrimPrefix(value, "@")
-	if source == "" || (source == "-" && stdinConsumed) {
-		return "", false, false, errRewriteBlocked
-	}
-	rewrittenKey, err := prepared.text(policy, key)
-	if err != nil || rewrittenKey == "" {
-		return "", false, false, errRewriteBlocked
-	}
-	if prepared.snapshots[source] {
-		return rewrittenKey + "=@" + source, true, false, nil
-	}
-	path, err := snapshotBestEffortTextInput(policy, source, stdin, prepared)
-	if err != nil {
-		return "", false, false, err
-	}
-	return rewrittenKey + "=@" + path, true, source == "-", nil
-}
-
-func bestEffortAttachedField(arg string) (string, bool) {
-	if value, ok := strings.CutPrefix(arg, "--field="); ok {
-		return value, true
-	}
-	if value, ok := strings.CutPrefix(arg, "-F"); ok && value != "" {
-		return strings.TrimPrefix(value, "="), true
-	}
-	return "", false
-}
-
-func bestEffortAPIHasHostname(args []string) bool {
-	for _, arg := range args[1:] {
-		if arg == "--hostname" || strings.HasPrefix(arg, "--hostname=") {
-			return true
-		}
-	}
-	return false
-}
-
-func rewriteBestEffortData(policy stringRewritePolicy, data []byte, prepared *rewritePreparation) ([]byte, error) {
+func rewriteBestEffortData(policy stringRewritePolicy, data []byte, prepared *rewritePreparation, kind bestEffortInputKind) ([]byte, error) {
 	if len(data) == 0 {
 		return data, nil
 	}
 	if policy.containsRuleMaterial(string(data)) {
 		return nil, errRewriteBlocked
 	}
-	if value, err := strictRewriteJSON(data, rewriteMaxContent); err == nil {
+	if kind == bestEffortText {
+		text, err := prepared.text(policy, string(data))
+		return []byte(text), err
+	}
+	value, parseErr := strictRewriteJSON(data, rewriteMaxContent)
+	if kind == bestEffortDeclaredJSON && parseErr != nil {
+		return nil, errRewriteBlocked
+	}
+	if parseErr == nil {
 		rewritten, err := rewriteBestEffortJSON(policy, value, prepared)
 		if err != nil {
 			return nil, err
@@ -363,18 +304,6 @@ func rewriteBestEffortJSON(policy stringRewritePolicy, value any, prepared *rewr
 	}
 }
 
-func bestEffortConsumesStdin(args []string) bool {
-	if len(args) < 2 || args[0] != "workflow" || args[1] != "run" {
-		return false
-	}
-	for _, arg := range args[2:] {
-		if arg == "--json" || arg == "--json=true" {
-			return true
-		}
-	}
-	return false
-}
-
 func rewriteReaderIsTerminal(reader io.Reader) bool {
 	file, ok := reader.(*os.File)
 	if !ok {
@@ -385,48 +314,37 @@ func rewriteReaderIsTerminal(reader io.Reader) bool {
 }
 
 func pinBestEffortRepositories(policy stringRewritePolicy, args []string) ([]string, error) {
+	declaration, err := describeBestEffortInput(args)
+	if err != nil {
+		return nil, err
+	}
+	args = declaration.argv
 	out := append([]string(nil), args...)
 	hasRepo := false
-	searchFilter := len(out) >= 2 && out[0] == "search"
-	for index := 0; index < len(out); index++ {
-		arg := out[index]
-		if arg == "--repo" || arg == "-R" {
-			hasRepo = true
-			index++
-			if index >= len(out) {
-				return nil, errRewriteBlocked
-			}
-			repo, err := normalizeBestEffortRepo(policy, out[index])
-			if err != nil {
-				return nil, err
-			}
-			out[index] = bestEffortRepoFlagValue(repo, searchFilter)
+	for _, token := range declaration.args {
+		if token.name != "--repo" {
 			continue
 		}
-		if value, ok := strings.CutPrefix(arg, "--repo="); ok {
-			hasRepo = true
-			repo, err := normalizeBestEffortRepo(policy, value)
-			if err != nil {
-				return nil, err
-			}
-			out[index] = "--repo=" + bestEffortRepoFlagValue(repo, searchFilter)
-			continue
+		hasRepo = true
+		repo, err := normalizeBestEffortRepo(policy, token.value)
+		if err != nil {
+			return nil, err
 		}
-		if value, ok := strings.CutPrefix(arg, "-R"); ok && value != "" {
-			hasRepo = true
-			repo, err := normalizeBestEffortRepo(policy, strings.TrimPrefix(value, "="))
-			if err != nil {
-				return nil, err
-			}
-			out[index] = "--repo=" + bestEffortRepoFlagValue(repo, searchFilter)
+		value := bestEffortRepoFlagValue(repo, declaration.command == "search")
+		if token.end-token.start == 2 {
+			out[token.start+1] = value
+		} else if token.booleanPrefix != "" {
+			out[token.start] = token.booleanPrefix + "R=" + value
+		} else {
+			out[token.start] = "--repo=" + value
 		}
 	}
-	if !hasRepo && bestEffortNeedsRepository(out) {
+	if !hasRepo && bestEffortNeedsRepository([]string{declaration.command}) {
 		repo, err := currentBestEffortRepo(policy)
 		if err != nil {
 			return nil, err
 		}
-		out = append(out, "--repo="+repo)
+		out = insertBestEffortFlag(out, declaration, "--repo="+repo)
 	}
 	return out, nil
 }
@@ -610,68 +528,6 @@ func normalizeBestEffortRepo(policy stringRewritePolicy, value string) (string, 
 		return "", err
 	}
 	return pinned, nil
-}
-
-func validateBestEffortAPI(args []string) error {
-	endpoint := ""
-	for index := 1; index < len(args); index++ {
-		arg := args[index]
-		switch {
-		case arg == "--hostname":
-			index++
-			if index >= len(args) || args[index] != "github.com" {
-				return errRewriteBlocked
-			}
-		case strings.HasPrefix(arg, "--hostname="):
-			if strings.TrimPrefix(arg, "--hostname=") != "github.com" {
-				return errRewriteBlocked
-			}
-		case arg == "--header" || arg == "-H":
-			index++
-			if index >= len(args) || sensitiveBestEffortHeader(args[index]) {
-				return errRewriteBlocked
-			}
-		case strings.HasPrefix(arg, "--header="):
-			if sensitiveBestEffortHeader(strings.TrimPrefix(arg, "--header=")) {
-				return errRewriteBlocked
-			}
-		case strings.HasPrefix(arg, "-H") && len(arg) > 2:
-			if sensitiveBestEffortHeader(strings.TrimPrefix(arg[2:], "=")) {
-				return errRewriteBlocked
-			}
-		case bestEffortAPISeparateValueFlag(arg):
-			index++
-			if index >= len(args) {
-				return errRewriteBlocked
-			}
-		case bestEffortAPIAttachedValueFlag(arg):
-			continue
-		case !strings.HasPrefix(arg, "-") && endpoint == "":
-			endpoint = arg
-		}
-	}
-	if endpoint == "" || strings.Contains(endpoint, "://") || rewriteEndpointPlaceholder.MatchString(endpoint) {
-		return errRewriteBlocked
-	}
-	return nil
-}
-
-func bestEffortAPISeparateValueFlag(arg string) bool {
-	switch arg {
-	case "--method", "-X", "--input", "--field", "-F", "--raw-field", "-f", "--jq", "-q":
-		return true
-	default:
-		return false
-	}
-}
-
-func bestEffortAPIAttachedValueFlag(arg string) bool {
-	for _, prefix := range []string{"--method=", "--input=", "--field=", "--raw-field=", "--jq=", "-X", "-F", "-f", "-q"} {
-		if strings.HasPrefix(arg, prefix) && len(arg) > len(prefix) {
-			return true
-		}
-	}
-	return false
 }
 
 func sensitiveBestEffortHeader(value string) bool {

--- a/cmd/octopool/string_rewrites_native_input.go
+++ b/cmd/octopool/string_rewrites_native_input.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"maps"
+	"mime"
+	"strconv"
+	"strings"
+)
+
+type bestEffortInputKind uint8
+
+const (
+	bestEffortUndeclared bestEffortInputKind = iota
+	bestEffortText
+	bestEffortDeclaredJSON
+)
+
+type bestEffortArg struct {
+	start, end    int
+	name, value   string
+	booleanPrefix string
+}
+
+func (arg bestEffortArg) capturedField(value string) string {
+	if arg.booleanPrefix != "" {
+		return arg.booleanPrefix + "F=" + value
+	}
+	return "--field=" + value
+}
+
+type bestEffortNativeInput struct {
+	command, subcommand string
+	args                []bestEffortArg
+	argv                []string
+	delimiter           int
+	workflowJSON        bool
+	inputKind           bestEffortInputKind
+}
+
+// Parse known native declarations without rewriting caller spelling. Synthetic
+// flag names and defaults must never become visible policy input.
+func describeBestEffortInput(args []string) (bestEffortNativeInput, error) {
+	out := bestEffortNativeInput{delimiter: -1}
+	argumentBytes := 0
+	appendArg := func(arg string) error {
+		argumentBytes += len(arg)
+		if argumentBytes > rewriteMaxContent {
+			return errRewriteBlocked
+		}
+		out.argv = append(out.argv, arg)
+		return nil
+	}
+	commandIndex := -1
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			out.delimiter = len(out.argv)
+			for ; i < len(args); i++ {
+				start := len(out.argv)
+				if err := appendArg(args[i]); err != nil {
+					return out, err
+				}
+				out.args = append(out.args, bestEffortArg{start: start, end: start + 1})
+			}
+			break
+		}
+		parseArg, booleanPrefix := arg, ""
+		// Native API has one Boolean shorthand: i. Each occurrence leaves the
+		// next shorthand active, unless =value assigns the whole remainder.
+		if out.command == "api" && strings.HasPrefix(arg, "-i") {
+			rest, value := arg[1:], "true"
+			for strings.HasPrefix(rest, "i") {
+				rest = rest[1:]
+				if strings.HasPrefix(rest, "=") {
+					value, rest = rest[1:], ""
+				}
+				if _, err := strconv.ParseBool(value); err != nil {
+					return out, errRewriteBlocked
+				}
+			}
+			// An invalid '-' shorthand must not become a long option or delimiter.
+			if strings.HasPrefix(rest, "-") {
+				return out, errRewriteBlocked
+			}
+			if rest == "" {
+				parseArg = "--include=" + value
+			} else {
+				booleanPrefix = arg[:len(arg)-len(rest)]
+				parseArg = "-" + rest
+			}
+		}
+		token := bestEffortArg{start: len(out.argv), booleanPrefix: booleanPrefix}
+		if err := appendArg(arg); err != nil {
+			return out, err
+		}
+		if !strings.HasPrefix(arg, "-") {
+			if out.command == "" {
+				out.command = arg
+				commandIndex = token.start
+			} else if out.subcommand == "" {
+				out.subcommand = arg
+			}
+		} else {
+			name, value, equal := strings.Cut(parseArg, "=")
+			if !strings.HasPrefix(parseArg, "--") && len(parseArg) > 2 {
+				name, value, equal = parseArg[:2], parseArg[2:], true
+				// With no text after '=', pflag treats it as the value itself.
+				if len(value) > 1 && value[0] == '=' {
+					value = value[1:]
+				}
+			}
+			canonical := ""
+			switch name {
+			case "--repo", "-R":
+				canonical = "--repo"
+			case "--input":
+				canonical = "--input"
+			case "--field", "-F":
+				canonical = "--field"
+			}
+			if out.command == "api" {
+				switch name {
+				case "--header", "-H":
+					canonical = "--header"
+				case "--hostname", "--cache":
+					canonical = name
+				case "--method", "-X":
+					canonical = "--method"
+				case "--raw-field", "-f":
+					canonical = "--raw-field"
+				case "--jq", "-q":
+					canonical = "--jq"
+				case "--template", "-t":
+					canonical = "--template"
+				case "--preview", "-p":
+					canonical = "--preview"
+				}
+			}
+			if out.command == "workflow" {
+				switch name {
+				case "--ref", "-r":
+					canonical = "--ref"
+				case "--raw-field", "-f":
+					canonical = "--raw-field"
+				}
+			}
+			if canonical != "" {
+				if !equal {
+					i++
+					if i >= len(args) {
+						return out, errRewriteBlocked
+					}
+					value = args[i]
+					if err := appendArg(value); err != nil {
+						return out, err
+					}
+				}
+				token.name, token.value = canonical, value
+			} else if out.command == "api" && name == "--include" {
+				if !equal {
+					value = "true"
+				}
+				if _, err := strconv.ParseBool(value); err != nil {
+					return out, errRewriteBlocked
+				}
+				token.name, token.value = name, value
+			} else if (out.command == "workflow" || out.command == "") && name == "-h" {
+				token.name = "-h"
+			} else if ((out.command == "workflow" || out.command == "") && name == "--help") || (out.command == "workflow" && name == "--json") {
+				if !equal {
+					value = "true"
+				}
+				token.name, token.value = name, value
+			}
+		}
+		token.end = len(out.argv)
+		out.args = append(out.args, token)
+	}
+	if out.delimiter < 0 {
+		out.delimiter = len(out.argv)
+	}
+	if out.command == "workflow" && out.subcommand == "run" {
+		help := false
+		for _, token := range out.args {
+			// gh's inherited help flag has no h alias. Pflag returns ErrHelp
+			// immediately on h; its suffix and later assignments cannot undo it.
+			if token.name == "-h" {
+				help = true
+				break
+			}
+			if token.name == "--json" || token.name == "--help" {
+				value, err := strconv.ParseBool(token.value)
+				if err != nil {
+					return out, errRewriteBlocked
+				}
+				if token.name == "--json" {
+					out.workflowJSON = value
+				} else {
+					help = value
+				}
+			}
+		}
+		out.workflowJSON = out.workflowJSON && !help
+	}
+	if out.command == "api" {
+		args = out.argv
+		out.inputKind = bestEffortDeclaredJSON
+		endpoint := ""
+		headers := []string{}
+		for _, token := range out.args {
+			switch token.name {
+			case "--hostname":
+				if token.value != "github.com" {
+					return out, errRewriteBlocked
+				}
+			case "--header":
+				if sensitiveBestEffortHeader(token.value) {
+					return out, errRewriteBlocked
+				}
+				name, value, ok := strings.Cut(token.value, ":")
+				if strings.EqualFold(strings.TrimSpace(name), "Content-Type") {
+					if !ok {
+						return out, errRewriteBlocked
+					}
+					headers = append(headers, strings.TrimSpace(value))
+				}
+			case "":
+				value := args[token.start]
+				if token.start == commandIndex {
+					continue
+				}
+				if endpoint == "" && value != "--" && (token.start > out.delimiter || !strings.HasPrefix(value, "-")) {
+					endpoint = value
+				}
+			}
+		}
+		if endpoint == "" || strings.Contains(endpoint, "://") || rewriteEndpointPlaceholder.MatchString(endpoint) {
+			return out, errRewriteBlocked
+		}
+		kind, err := bestEffortContentType(headers)
+		if err != nil {
+			return out, err
+		}
+		out.inputKind = kind
+	}
+	return out, nil
+}
+
+func bestEffortContentType(headers []string) (bestEffortInputKind, error) {
+	// Native Header.Add retains order. Header.Get sees the first value, and an
+	// empty first value causes the transport to replace all values with JSON.
+	if len(headers) == 0 || headers[0] == "" {
+		return bestEffortDeclaredJSON, nil
+	}
+	media, params, err := mime.ParseMediaType(headers[0])
+	if err != nil || !strings.Contains(media, "/") {
+		return 0, errRewriteBlocked
+	}
+	for _, value := range headers[1:] {
+		other, otherParams, err := mime.ParseMediaType(value)
+		if err != nil || media != other || !maps.Equal(params, otherParams) {
+			return 0, errRewriteBlocked
+		}
+	}
+	_, subtype, _ := strings.Cut(media, "/")
+	if subtype == "json" || strings.HasSuffix(subtype, "+json") {
+		return bestEffortDeclaredJSON, nil
+	}
+	return bestEffortText, nil
+}
+
+func insertBestEffortFlag(args []string, declaration bestEffortNativeInput, flag string) []string {
+	out := append([]string(nil), args[:declaration.delimiter]...)
+	out = append(out, flag)
+	return append(out, args[declaration.delimiter:]...)
+}
+
+// Sources are captured before argv rewriting, but rewritten only after both
+// declarations are known. The empty private snapshot is an owned opaque handle;
+// original bytes remain in bounded memory and never reach the child uninspected.
+type bestEffortCapturedInput struct {
+	data []byte
+	kind bestEffortInputKind
+}

--- a/cmd/octopool/testdata/declared-input-child/main.go
+++ b/cmd/octopool/testdata/declared-input-child/main.go
@@ -1,0 +1,159 @@
+// This synthetic child captures prepared inputs without invoking gh or a network.
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	capture := struct {
+		Args           []string
+		Stdin          string
+		Files          map[string]string
+		Modes          map[string]uint32
+		DirectoryModes map[string]uint32
+		Env            map[string]string
+		Include        bool
+		Silent         bool
+		Help           bool
+		Headers        []string
+		Fields         []string
+		RawFields      []string
+	}{Args: os.Args[1:], Files: map[string]string{}, Modes: map[string]uint32{}, DirectoryModes: map[string]uint32{}, Env: map[string]string{"GH_HOST": os.Getenv("GH_HOST"), "GH_REPO": os.Getenv("GH_REPO")}}
+	// Independent synthetic target semantics, checked against native gh loopback
+	// and stdin-offset controls. Do not import the protection descriptor here.
+	var paths []string
+	values := map[string]bool{"repo": true, "ref": true, "field": true, "raw-field": true, "header": true, "method": true, "jq": true, "template": true, "cache": true, "preview": true, "hostname": true, "input": true}
+	short := map[byte]string{'R': "repo", 'r': "ref", 'F': "field", 'f': "raw-field", 'H': "header", 'X': "method", 'q': "jq", 't': "template", 'p': "preview", 'i': "include"}
+	set := func(name, value string) {
+		switch name {
+		case "include", "silent", "help":
+			v, err := strconv.ParseBool(value)
+			if err != nil {
+				panic(err)
+			}
+			switch name {
+			case "include":
+				capture.Include = v
+			case "silent":
+				capture.Silent = v
+			case "help":
+				capture.Help = v
+			}
+		case "input":
+			paths = append(paths, value)
+		case "field":
+			capture.Fields = append(capture.Fields, value)
+			_, source, _ := strings.Cut(value, "=")
+			if strings.HasPrefix(source, "@") {
+				paths = append(paths, source[1:])
+			}
+		case "raw-field":
+			capture.RawFields = append(capture.RawFields, value)
+		case "header":
+			capture.Headers = append(capture.Headers, value)
+		}
+	}
+parse:
+	for i := 0; i < len(capture.Args); i++ {
+		arg := capture.Args[i]
+		if arg == "--" {
+			break
+		}
+		if strings.HasPrefix(arg, "--") {
+			name, value, equal := strings.Cut(arg[2:], "=")
+			if values[name] && !equal {
+				i++
+				if i >= len(capture.Args) {
+					panic("missing fixture value")
+				}
+				value = capture.Args[i]
+			}
+			if (name == "help" || name == "include" || name == "silent") && !equal {
+				value = "true"
+			}
+			set(name, value)
+		} else if strings.HasPrefix(arg, "-") && len(arg) > 1 {
+			for tail := arg[1:]; len(tail) > 0; {
+				letter := tail[0]
+				tail = tail[1:]
+				// Native gh inherits a long help flag without an h alias. Pflag
+				// handles unregistered h by immediately returning ErrHelp.
+				if letter == 'h' {
+					capture.Help = true
+					break parse
+				}
+				name, known := short[letter]
+				if !known {
+					os.Exit(2)
+				}
+				value := "true"
+				if len(tail) > 1 && tail[0] == '=' {
+					value = tail[1:]
+					tail = ""
+				} else if values[name] {
+					if tail != "" {
+						value = tail
+						tail = ""
+					} else {
+						i++
+						if i >= len(capture.Args) {
+							panic("missing fixture value")
+						}
+						value = capture.Args[i]
+					}
+				}
+				set(name, value)
+			}
+		}
+	}
+	if !capture.Help {
+		input, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			panic(err)
+		}
+		capture.Stdin = string(input)
+		if path := os.Getenv("OCTOPOOL_TEST_DECLARED_MUTATE"); path != "" {
+			if err := os.WriteFile(path, []byte("later source bytes"), 0600); err != nil {
+				panic(err)
+			}
+		}
+		for _, path := range paths {
+			if path == "-" {
+				capture.Files[path] = capture.Stdin
+				continue
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				panic(err)
+			}
+			capture.Files[path] = string(data)
+			info, err := os.Stat(path)
+			if err != nil {
+				panic(err)
+			}
+			capture.Modes[path] = uint32(info.Mode().Perm())
+			info, err = os.Stat(filepath.Dir(path))
+			if err != nil {
+				panic(err)
+			}
+			capture.DirectoryModes[path] = uint32(info.Mode().Perm())
+		}
+	}
+	data, err := json.Marshal(capture)
+	if err != nil {
+		panic(err)
+	}
+	if err := os.WriteFile(os.Getenv("OCTOPOOL_TEST_DECLARED_CAPTURE"), data, 0600); err != nil {
+		panic(err)
+	}
+	_, _ = io.WriteString(os.Stdout, "child stdout\n")
+	_, _ = io.WriteString(os.Stderr, "child stderr\n")
+	code, _ := strconv.Atoi(os.Getenv("OCTOPOOL_TEST_DECLARED_EXIT"))
+	os.Exit(code)
+}

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -281,8 +281,14 @@ policy files private and use the dedicated authenticated admin import path.
 
 Modeled CLI submissions retain strict structural snapshots. Unmodeled native `gh` commands
 use bounded best-effort rewriting of visible arguments, declared piped JSON/text, and `--input`
-snapshots so an evolving CLI surface does not halt normal operations. Interactive or deferred
-native content remains outside that guarantee. Server-mediated relay requests remain strict.
+snapshots so an evolving CLI surface does not halt normal operations. Nonempty native workflow
+JSON and API input declared as JSON (including the native default Content-Type) must parse
+strictly; failures never downgrade to text. Explicit non-JSON API input remains bounded UTF-8
+text, and exactly zero-byte best-effort input retains native compatibility. Interactive or
+deferred native content and downstream reinterpretation of mislabeled text remain outside
+that guarantee. Arbitrary input readers remain byte-bounded, not promptly cancellable.
+See [CLI](cli.md#outbound-string-rewrite-protection) for declaration and header-order limits.
+Server-mediated relay requests remain strict.
 
 Each relay request owns a frozen transport context with its checked policy snapshot;
 there is no global mutable policy or stale policy fallback. Canonical outgoing URLs and

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -598,10 +598,11 @@ Commands and flags outside the modeled vocabulary use a bounded best-effort pass
 instead of being denied solely for being new or unfamiliar. Octopool rewrites every visible
 argument, snapshots and filters `--input` files or `--input=-`, snapshots typed
 `-F`/`--field key=@source` text without changing its formatting, and filters stdin when the
-command explicitly declares it (currently `workflow run --json`). Valid JSON request stdin/files are decoded recursively so string keys and values are rewritten
-without corrupting JSON; other valid UTF-8 is rewritten as text. This keeps workflow
-dispatches (`gh workflow run` field or `--json` forms), job-log reads, unmodeled uploads, and newly
-introduced native flags working while active rules still remove visible matches. Native
+command explicitly declares it (currently `workflow run --json`). Nonempty declared JSON
+must pass strict UTF-8, surrogate, decoded duplicate-key, single-value, and depth validation;
+malformed JSON never falls back to text. Decoded string keys and values are rewritten and
+the final JSON is bounded again. This keeps workflow dispatches, job-log reads, unmodeled
+uploads, and newly introduced native flags working within the declared-input boundary. Native
 children force `GH_HOST=github.com` and remove inherited `GH_REPO`; best-effort
 `--repo`/`-R` values are structurally checked before rewriting and normalized to
 `github.com/owner/repo`. Native `gh search` repository filters retain `owner/repo`, because the
@@ -610,6 +611,36 @@ Repo-capable commands without an explicit selector pin the current GitHub.com re
 Alternate API/repository hosts, explicit credential headers,
 unresolved API placeholders, invalid UTF-8, policy
 material, residual matches, and bounded-read failures remain blocked.
+
+For native `gh api --input`, a missing or empty effective `Content-Type` defaults to JSON;
+explicit JSON and `+json` media types also require strict JSON. A valid explicit non-JSON
+Content-Type keeps bounded UTF-8 text filtering without JSON reformatting, including
+JSON-looking text. Content-Type is a native capability, not an additional relay header.
+Repeated headers follow native `Header.Add` order: an empty first Content-Type selects the
+native JSON default; otherwise declarations must be equivalent, and conflicting or malformed
+media types block. Exactly zero-byte best-effort input retains native no-input compatibility;
+whitespace-only declared JSON blocks. Modeled API empty-body rules remain unchanged.
+
+Workflow JSON flags accept native Boolean spellings (`1/t/T/true/TRUE/True` and
+`0/f/F/false/FALSE/False`), validate every occurrence, and use the final assignment.
+Bare `--json` means true; `--json false` includes a positional `false`. Absent or final-false
+JSON flags do not cause preparation to read idle stdin. True workflow help also leaves
+JSON stdin unread; native short `-h` requests help immediately, while long `--help` uses
+its final Boolean assignment. Known API `-i` bundles preserve each include option and the
+following value-taking flag. Parser metadata never adds synthetic flag names or default
+values to the text being rewritten. Known option values retain their ownership, including
+flag-looking values and interleaved repository options. A real `--`
+ends declarations: subsequent arguments are visible text, not file/stdin sources or headers.
+Generated repository/hostname pins precede that delimiter.
+
+Original sources are captured before argument rewriting, and newly introduced sources are
+captured afterward. The stricter original/final JSON declaration applies to captured bytes;
+rewriting cannot downgrade inspection or reopen a substituted original path. Typed field
+sources remain literal text, and raw fields remain literal arguments. Only other commands'
+undeclared input retains the previous opportunistic JSON-or-text handling. These checks do
+not infer formats from filenames, endpoints, or bytes, decode nested obfuscation, or protect
+against downstream reinterpretation of deliberately mislabeled text. Binary API input has
+no exemption from UTF-8 validation. The existing 1 MiB content and aggregate budgets apply.
 
 For `gh repo clone`, positional repository checks apply only to the source, accounting for
 native clone options and their values. A `--` ends native option parsing; if the source has
@@ -624,7 +655,9 @@ input is passed through so native prompts still work, and deferred content sourc
 extension-owned files, or content native
 `gh` derives after the guard—cannot be inspected. Direct real `gh`, browsers, Git pushes,
 and deliberate encoding/obfuscation remain outside the boundary. Use a modeled command when
-publication content needs the strict guarantee.
+publication content needs the strict guarantee. Reads are byte-bounded, not time-bounded:
+an arbitrary producer can stall preparation before EOF or the limit. Existing child
+cancellation and snapshot cleanup do not make a blocked arbitrary reader interruptible.
 
 Modeled content paths also reject recognizable active rule material before rewriting
 and in the final text: complete JSON objects with exactly string `pattern` and


### PR DESCRIPTION
## Summary

Native workflow Boolean aliases and assignments, option values, delimiters, and API short bundles could hide declared sources or headers from protection. Malformed declared JSON could also fall through to weaker text handling.

Centralize known native declarations in a descriptor while preserving the caller's original argument spelling, so parsing metadata cannot introduce or erase policy matches. Validate nonempty declared JSON strictly; retain bounded UTF-8 handling for explicit non-JSON and typed fields, plus exactly zero-byte best-effort compatibility. Preserve original source capture, the stronger original/final JSON declaration, private snapshots, budgets, and cleanup. Reject malformed short bundles before they can become valid long options or delimiters, and leave JSON stdin unread for true workflow help.

Content-Type support is limited to the native path and does not widen relay headers. No dependency or Worker behavior changes. Unknown future grammar, interactive/deferred data, arbitrary-reader cancellation, downstream reinterpretation of mislabeled text, and hostile-writer atomicity are not newly guaranteed. CLI/admin documentation and the changelog describe the boundary.

## Validation

- Fresh post-commit focused Go 1.26.7 run passed all 232 declared-input cases (143 original + 89 bundle cases), plus existing protection, asset, attachment, clone, and merge coverage.
- Fresh post-commit full `pnpm check` passed generation, formatting, lint, 801 unit tests, 696 Worker tests, types/build, full Go tests, and vet. Existing pnpm 11.21.0 was invoked explicitly through Node and verified directly and through nested execution; synthetic configuration roots, installed dependency layout, and cleanup were preserved. No source or generated drift.
- Earlier regression evidence remains separate: original declarations 64 failures/36 controls; native bundles 29 failures/21 controls; malformed bundles 7 failures/7 controls; synthetic spelling 13 failures/1 control plus one original-match regression against the prior tree. All repaired cases pass in the fresh focused run.
- Bounded native evidence includes six successful owned-loopback POSTs, 13 offline help controls, and five malformed-bundle rejection controls. A separate raw-file probe did not complete a transfer and is not claimed as transfer proof. Native Windows execution remains a CI gate, not a cross-compilation claim.
