### PR TITLE
fix: preserve pending statistics and revalidation audit accuracy

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -76,7 +76,20 @@ bounded pagination window also fall back.
 
 ### What is cached
 
-Only successful `2xx` responses on cacheable routes are stored. The edge + D1 cache is
+Only successful `2xx` responses on cacheable routes are stored, except pending `202`
+responses on repository statistics routes (`contributors`, `commit_activity`,
+`code_frequency`, `participation`, and `punch_card`). These responses reach the caller
+unchanged and store no body, so the next poll can reach GitHub's completed result.
+Concurrent followers reacquire fill ownership before fetching; there is no retry timer.
+A successful anonymous pending response may still warm the separate public-repository proof.
+
+Readers also reject existing statistics `202` entries from edge, D1, identity-specific keys,
+coalesced completions, revalidation and outage stale fallback, including late old writes.
+No generation change or purge is needed. A forced refresh that returns pending leaves any
+ready body's original timestamps and contents intact. Statistics `200`/`204`, their validators
+and bounded stale windows, and unrelated routes' `202` behavior remain unchanged.
+
+The edge + D1 cache is
 **bypassed** when:
 
 - the route is a large-payload route or `rate_limit` (completed Actions logs use the
@@ -345,9 +358,11 @@ publication, explicit guards or first-page aggregation. Internal response/time m
 keeps that evidence and its original expiry through SQL acknowledgment without adding fields
 to the relay payload or stored user body.
 
-Storage (`shared`, `edge_only`, `failed`, `rejected`, `unknown`) and completion acknowledgment
+Storage (`shared`, `edge_only`, `none`, `failed`, `rejected`, `unknown`) and completion acknowledgment
 (`accepted`, `lost`, `unknown`) are distinct internal results. A zero-row write is rejected
 unless an exact immutable already-committed receipt recovers a replay/lost acknowledgment.
+Intentional statistics nonpublication uses `none` without a publication ID; it revokes the
+exact owner, including expired cleanup, without claiming that absent data is shared.
 A stored denial completes successfully before returning `repo_not_public`. Shared proof
 completions identify the actual published or reused proof, not the notifier's newer ownership
 ID. Ownership-only completion does not fabricate a publication receipt. Shared waiters
@@ -400,6 +415,11 @@ count both fresh and stale hits as saved GitHub requests and expose an eligible 
 that excludes failed misses and deliberate local fallback responses.
 Successful `304` refreshes use the existing `hit` status so current stats and CLI parsers count
 the saved request, with `fallback_reason = cache_revalidated` as the distinct audit marker.
+Audit backend describes the resource fetch or verifier for that request: anonymous API
+`200` replacements and `304` validations use `github_api`, regardless of the cached body's
+source. Request-only verifier metadata does not alter stored identity, body encoding, delivered
+status, or the broad relay backend label. A following cache-only hit has no audit backend;
+an ancillary visibility probe does not supply one or spend pooled identity quota.
 
 Identity availability feedback is separate from cache-source eligibility. Overlapping
 identity responses merge quota and cooldown observations conservatively in the pool

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -549,6 +549,11 @@ without unbounded D1 growth.
 
 `GET /v1/pools/<pool>/stats?since=24h` returns pool-, caller-, and client-specific cache stats,
 plus bounded backend-by-route and local-fallback-reason aggregates.
+Anonymous API conditional replacements and `304` verifications are attributed to `github_api`
+prospectively. Existing misattributed history is not backfilled and expires under normal audit
+retention. This correction requires no schema or cache-generation change. During a rolling
+upgrade, old Workers may still emit the former attribution and serve cached statistics `202`;
+new readers reject pending entries, including late writes, without purging valid ready data.
 The CLI wraps this as `octopool stats`. The browser dashboard at `/dashboard` exposes the
 same data plus identity health, live leases, seven-day normalized request patterns and
 outcome causes, and per-caller/client usage — see

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -118,6 +118,12 @@ and patch hosts.
   `cache_expires_at` are included on those responses.
 - `backend` is present as `web` or `github_public` when a cache miss or identity-less cache hit
   was served without a pooled API identity.
+  Audit backend separately describes the resource fetch/verifier: anonymous API replacements
+  and `304` validations count as `github_api`; a cache-only hit has no audit backend.
+- Repository statistics `202` responses are returned unchanged without body caching. Each
+  later poll can reach upstream readiness; old pending entries cannot serve hits, revalidate,
+  or supply outage stale data. A forced pending refresh preserves any ready entry's original
+  lifetime, and unrelated routes keep their existing `202` behavior.
 - `lease_reason` is `sticky` or `highest_remaining` — see
   [Identities & routing](identities.md).
 

--- a/src/cache-fill.ts
+++ b/src/cache-fill.ts
@@ -1,6 +1,6 @@
 import type { PublicationOwner } from "./cache-publication";
 
-export type CacheFillOutcome = "shared" | "edge_only" | "failed" | "rejected" | "unknown";
+export type CacheFillOutcome = "shared" | "edge_only" | "none" | "failed" | "rejected" | "unknown";
 
 export type CacheFillAcquisition =
   | { kind: "owner"; owner: PublicationOwner }

--- a/src/cache-policy.ts
+++ b/src/cache-policy.ts
@@ -1,5 +1,20 @@
 import type { RouteKind } from "./route-manifest";
 
+export function cacheResponseEligible(kind: RouteKind, status: number): boolean {
+  if (status < 200 || status >= 300) return false;
+  if (status !== 202) return true;
+  switch (kind) {
+    case "repo_stats_contributors":
+    case "repo_stats_commit_activity":
+    case "repo_stats_code_frequency":
+    case "repo_stats_participation":
+    case "repo_stats_punch_card":
+      return false;
+    default:
+      return true;
+  }
+}
+
 export type CacheFreshStrategy =
   | { kind: "static"; seconds: number }
   | { kind: "pr" }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -8,6 +8,7 @@ import { hashToken } from "./auth";
 import {
   type CacheFreshStrategy,
   cachePolicyForRouteKind,
+  cacheResponseEligible,
   isStateAwarePRRoute,
 } from "./cache-policy";
 import { readEdgeJSON, writeEdgeJSON } from "./edge-cache";
@@ -192,7 +193,11 @@ export async function readStaleGitHubCache(
   const row = await env.DB.prepare(queries.readGitHubCacheAny)
     .bind(cacheKey, CACHE_PUBLICATION_EPOCH)
     .first<CacheRow>();
-  if (row === null || !staleCacheAllowed(row, route)) {
+  if (
+    row === null ||
+    !cacheResponseEligible(route.kind, row.status) ||
+    !staleCacheAllowed(row, route)
+  ) {
     return undefined;
   }
   const cached = cacheRowResponse(row);
@@ -278,6 +283,9 @@ export async function writeGitHubCache(
     return "rejected";
   if (response.status < 200 || response.status >= 300) {
     return "failed";
+  }
+  if (!cacheResponseEligible(route.kind, response.status)) {
+    return "none";
   }
   const ttlSeconds = cacheTTLSeconds(route, response);
   const staleSeconds = staleCacheSeconds(route, ttlSeconds);

--- a/src/github-web.ts
+++ b/src/github-web.ts
@@ -94,7 +94,13 @@ export async function callAnonymousGitHubAPI(
   }
   try {
     const body = await readWebBody(response, api.capBytes);
-    return await api.payload(new Uint8Array(body), response.headers, response.status, responseURL);
+    const payload = await api.payload(
+      new Uint8Array(body),
+      response.headers,
+      response.status,
+      responseURL,
+    );
+    return payload === undefined ? undefined : { ...payload, backend: "github" };
   } catch (error) {
     rethrowStringRewriteDenial(error);
     return undefined;

--- a/src/pool-coordinator.ts
+++ b/src/pool-coordinator.ts
@@ -150,7 +150,7 @@ export class PoolCoordinator extends DurableObject<Env> {
       throw new Error("Invalid publication completion");
     }
     const row = await this.env.DB.prepare(
-      outcome === "failed" || outcome === "rejected" || outcome === "unknown"
+      outcome === "none" || outcome === "failed" || outcome === "rejected" || outcome === "unknown"
         ? queries.revokePublicationOwner
         : queries.completePublicationOwner,
     )

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -16,6 +16,7 @@ import {
   writeGitHubCache,
 } from "./cache";
 import { coalesceGitHubCacheMiss } from "./cache-coalesce";
+import { cacheResponseEligible } from "./cache-policy";
 import type { CacheFillOutcome, OwnedCacheFill } from "./cache-fill";
 import { insertAudit, loadIdentities, loadPoolPolicy } from "./db";
 import { callGitHub, callPublicGitHub, probeGitHubLog } from "./github";
@@ -122,6 +123,7 @@ type RelaySuccess = {
   rate?: GitHubRate;
   revalidated?: boolean;
   upstreamStatus?: number;
+  upstreamBackend?: GitHubRelayResponse["backend"];
 };
 
 type RevalidationCandidate = {
@@ -647,6 +649,7 @@ async function finishRevalidation(
     rate: rateFromHeaders(github.headers),
     revalidated: true,
     upstreamStatus: 304,
+    upstreamBackend: github.backend,
   });
 }
 
@@ -1203,7 +1206,10 @@ function auditBackend(result: RelaySuccess): AuditBackend | undefined {
   if (result.identity !== undefined) {
     return "github_identity";
   }
-  if (result.backend === "github_public" || result.github.backend === "github") {
+  if (
+    result.backend === "github_public" ||
+    (result.upstreamBackend ?? result.github.backend) === "github"
+  ) {
     return "github_api";
   }
   return result.backend === "web" ? "github_web" : undefined;
@@ -1578,6 +1584,7 @@ async function cachedResponseAvailable(
   selectedIdentity?: Pick<Identity, "id" | "kind">,
   stale = false,
 ): Promise<boolean> {
+  if (!cacheResponseEligible(route.kind, cached.status)) return false;
   const identityAvailable = stale
     ? staleCachedIdentityAvailable(env, pool, route, cached.identity, selectedIdentity)
     : cachedIdentityAvailable(env, pool, route, cached.identity, selectedIdentity);

--- a/test/e2e/cache-revalidation.test.ts
+++ b/test/e2e/cache-revalidation.test.ts
@@ -1,7 +1,21 @@
 import { env } from "cloudflare:workers";
 import { describe, expect, it, vi } from "vitest";
 import { deleteEdgeJSON } from "../../src/edge-cache";
-import { bearer, jsonResponse, rateHeaders, relay, seedPool } from "./harness";
+import {
+  bearer,
+  CALLER_TOKEN,
+  callWorker,
+  jsonResponse,
+  POOL,
+  rateHeaders,
+  relay,
+  seedPool,
+} from "./harness";
+import { poolCoordinatorStub } from "../../src/pool-coordinator";
+import { githubCacheKey } from "../../src/cache";
+import { loadIdentities } from "../../src/db";
+import { classifyRoute, defaultPolicy } from "../../src/policy";
+import { seedPublicRepoProof, writeOwnedGitHubCache } from "./cache-publication-fixture";
 import { ownedWork } from "./owned-work";
 
 const RUN_PATH = "/repos/openclaw/octopool/actions/runs/123";
@@ -56,24 +70,30 @@ describe("Worker end-to-end cache revalidation", () => {
     },
   );
 
-  it.each([undefined, 0, 20])(
-    "refreshes an anonymous API entry on 304 with max-age=%s",
-    async (maxAge) => {
+  // Persisted audit/stats must describe this API verifier, not the materialized body.
+  // Existing native 304 coverage omitted backend/identity accounting; no new seam.
+  it.each([
+    [undefined, "etag"],
+    [0, "etag"],
+    [20, "etag"],
+    [undefined, "last-modified"],
+  ] as const)(
+    "refreshes an anonymous API entry on 304 with max-age=%s and %s",
+    async (maxAge, validator) => {
       await seedPool();
       let apiCalls = 0;
+      const value = validator === "etag" ? '"run-v1"' : "Mon, 31 Aug 2026 00:00:00 GMT";
+      const validatorHeader = validator === "etag" ? "if-none-match" : "if-modified-since";
+      const headers = { ...rateHeaders({ remaining: 59 }), [validator]: value };
       const upstream = vi.fn<typeof fetch>(async (input, init) => {
         const request = new Request(input, init);
         expect(bearer(request)).toBeUndefined();
         expect(request.url).toBe(`https://api.github.com${RUN_PATH}`);
         apiCalls++;
-        if (request.headers.get("if-none-match") === '"run-v1"') {
-          return new Response(null, { status: 304, headers: apiHeaders('"run-v1"') });
+        if (request.headers.get(validatorHeader) === value) {
+          return new Response(null, { status: 304, headers });
         }
-        return jsonResponse(
-          { id: 123, status: "in_progress", conclusion: null },
-          200,
-          apiHeaders('"run-v1"'),
-        );
+        return jsonResponse({ id: 123, status: "in_progress", conclusion: null }, 200, headers);
       });
       vi.stubGlobal("fetch", upstream);
 
@@ -84,8 +104,11 @@ describe("Worker end-to-end cache revalidation", () => {
       });
 
       expect(await response.json<RelayEnvelope>()).toMatchObject({
+        status: 200,
+        body_encoding: "json",
+        headers: { [validator]: value },
         body: { id: 123, status: "in_progress" },
-        relay: { cache: "hit", route_kind: "run_view" },
+        relay: { backend: "web", cache: "hit", route_kind: "run_view" },
       });
       expect(apiCalls).toBe(2);
       expect(
@@ -96,18 +119,27 @@ describe("Worker end-to-end cache revalidation", () => {
       ).toEqual({ ttl: 60 });
       expect(
         await env.DB.prepare(
-          "SELECT cache_status, fallback_reason FROM audit_events ORDER BY rowid DESC LIMIT 1",
+          "SELECT backend, identity_id, status, cache_status, fallback_reason FROM audit_events ORDER BY rowid DESC LIMIT 1",
         ).first(),
-      ).toEqual({ cache_status: "hit", fallback_reason: "cache_revalidated" });
+      ).toEqual({
+        backend: "github_api",
+        identity_id: null,
+        status: 200,
+        cache_status: "hit",
+        fallback_reason: "cache_revalidated",
+      });
       const shared = await relay(RUN_PATH);
       expect(await shared.json<RelayEnvelope>()).toMatchObject({
         body: { id: 123, status: "in_progress" },
         relay: { cache: "hit" },
       });
       expect(apiCalls).toBe(2);
+      await expectAnonymousAuditStats(true);
     },
   );
 
+  // Conditional 200 uses the actual API payload marker; observe stored audits and stats.
+  // This extends the real replacement fixture rather than testing a private classifier.
   it.each([undefined, 0, 20])(
     "stores a conditional 200 replacement with max-age=%s",
     async (maxAge) => {
@@ -147,6 +179,17 @@ describe("Worker end-to-end cache revalidation", () => {
       expect(apiCalls).toBe(2);
       expect(
         await env.DB.prepare(
+          "SELECT backend, identity_id, status, cache_status, fallback_reason FROM audit_events ORDER BY rowid DESC LIMIT 1",
+        ).first(),
+      ).toEqual({
+        backend: "github_api",
+        identity_id: null,
+        status: 200,
+        cache_status: "miss",
+        fallback_reason: null,
+      });
+      expect(
+        await env.DB.prepare(
           `SELECT json_extract(body_json, '$.status') AS status,
                 unixepoch(expires_at) - unixepoch(created_at) AS ttl
          FROM github_cache_entries WHERE route_kind = 'run_view'`,
@@ -158,6 +201,7 @@ describe("Worker end-to-end cache revalidation", () => {
         relay: { cache: "hit" },
       });
       expect(apiCalls).toBe(2);
+      await expectAnonymousAuditStats(false);
     },
   );
 
@@ -358,6 +402,80 @@ describe("Worker end-to-end cache revalidation", () => {
     ).toHaveLength(1);
   });
 
+  // Behavior: the anonymous verifier owns audit attribution while original source
+  // eligibility and body storage retain their contracts. Gap: no native cross-source
+  // audit proof existed; reuse the actual owned publication fixture and stats endpoint.
+  it("audits an anonymous 304 of an eligible identity body without pooled quota", async () => {
+    await seedPool();
+    const request = { pool: POOL, method: "GET" as const, path: RUN_PATH };
+    const route = classifyRoute(request, defaultPolicy("openclaw"));
+    const identity = (await loadIdentities(env, POOL, route))[0]!;
+    const key = await githubCacheKey(POOL, request, route, identity);
+    await seedPublicRepoProof(env, route);
+    expect(
+      await writeOwnedGitHubCache(
+        env,
+        key,
+        request,
+        route,
+        {
+          status: 200,
+          headers: apiHeaders('"identity-run"') as Record<string, string>,
+          body: { id: 123, status: "in_progress" },
+          body_encoding: "json",
+        },
+        identity,
+      ),
+    ).toBe("shared");
+    await expireCacheEntry("run_view");
+    const original = await env.DB.prepare("SELECT * FROM github_cache_entries WHERE cache_key = ?")
+      .bind(key)
+      .first();
+    const upstream = vi.fn<typeof fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      expect(request.url).toBe(`https://api.github.com${RUN_PATH}`);
+      expect(bearer(request)).toBeUndefined();
+      expect(request.headers.get("if-none-match")).toBe('"identity-run"');
+      return new Response(null, { status: 304, headers: apiHeaders('"identity-run"') });
+    });
+    vi.stubGlobal("fetch", upstream);
+    const result = await (await relay(RUN_PATH)).json<Record<string, unknown>>();
+    expect(result).toMatchObject({
+      status: 200,
+      body: { id: 123, status: "in_progress" },
+      body_encoding: "json",
+      relay: { backend: "web", cache: "hit" },
+    });
+    expect(result).not.toHaveProperty("identity");
+    expect(result).not.toHaveProperty("upstreamBackend");
+    expect(
+      await env.DB.prepare("SELECT * FROM github_cache_entries WHERE cache_key = ?")
+        .bind(key)
+        .first(),
+    ).toEqual(original);
+    expect(
+      await env.DB.prepare(
+        "SELECT identity_id, body_json FROM github_cache_entries WHERE cache_key != ?",
+      )
+        .bind(key)
+        .first(),
+    ).toEqual({ identity_id: null, body_json: '{"id":123,"status":"in_progress"}' });
+    expect(
+      await env.DB.prepare(
+        "SELECT backend, identity_id, status, cache_status, fallback_reason FROM audit_events",
+      ).first(),
+    ).toEqual({
+      backend: "github_api",
+      identity_id: null,
+      status: 200,
+      cache_status: "hit",
+      fallback_reason: "cache_revalidated",
+    });
+    await relay(RUN_PATH);
+    await expectAnonymousAuditStats(true, 1);
+    expect(upstream).toHaveBeenCalledTimes(1);
+  });
+
   it("fails closed before authenticated revalidation when a repository becomes private", async () => {
     await seedPool();
     const path = "/repos/openclaw/octopool/pulls/42";
@@ -515,4 +633,39 @@ async function expireCacheEntry(routeKind: string): Promise<void> {
 
 function apiHeaders(etag: string): HeadersInit {
   return { ...rateHeaders({ remaining: 59 }), etag };
+}
+
+async function expectAnonymousAuditStats(revalidated: boolean, requests = 2): Promise<void> {
+  expect(
+    await env.DB.prepare(
+      "SELECT backend, identity_id, status, cache_status, fallback_reason FROM audit_events ORDER BY rowid DESC LIMIT 1",
+    ).first(),
+  ).toEqual({
+    backend: null,
+    identity_id: null,
+    status: 200,
+    cache_status: "hit",
+    fallback_reason: null,
+  });
+  const stats = await callWorker(`/v1/pools/${POOL}/stats`, {
+    headers: { authorization: `Bearer ${CALLER_TOKEN}` },
+  });
+  expect(stats.status).toBe(200);
+  expect(await stats.json()).toMatchObject({
+    backends: [
+      {
+        backend: "github_api",
+        route_kind: "run_view",
+        requests,
+        cache_misses: revalidated ? requests - 1 : requests,
+        revalidated: revalidated ? 1 : 0,
+      },
+    ],
+  });
+  expect((await poolCoordinatorStub(env, POOL).snapshot()).rates).toEqual([]);
+  expect(
+    await env.DB.prepare(
+      "SELECT remaining FROM github_public_api_rates WHERE resource = 'core'",
+    ).first(),
+  ).toEqual({ remaining: 59 });
 }

--- a/test/e2e/repo-stats-cache.test.ts
+++ b/test/e2e/repo-stats-cache.test.ts
@@ -1,0 +1,518 @@
+import { env } from "cloudflare:workers";
+import { runInDurableObject } from "cloudflare:test";
+import { describe, expect, it, vi } from "vitest";
+import {
+  GITHUB_EDGE_CACHE_NAMESPACE,
+  githubCacheKey,
+  writeGitHubCache,
+  type CachedGitHubResponse,
+} from "../../src/cache";
+import { CACHE_PUBLICATION_EPOCH, bodyPublicationResource } from "../../src/cache-publication";
+import { loadIdentities } from "../../src/db";
+import { deleteEdgeJSON, readEdgeJSON, writeEdgeJSON } from "../../src/edge-cache";
+import { poolCoordinatorStub } from "../../src/pool-coordinator";
+import { classifyRoute, defaultPolicy } from "../../src/policy";
+import { seedPublicRepoProof, writeOwnedGitHubCache } from "./cache-publication-fixture";
+import { bearer, jsonResponse, POOL, rateHeaders, relay, seedPool } from "./harness";
+import { ownedWork } from "./owned-work";
+
+const STATS = ["contributors", "commit_activity", "code_frequency", "participation", "punch_card"];
+const pathFor = (kind: string) => `/repos/openclaw/octopool/stats/${kind}`;
+
+describe("Worker repository statistics cache lifecycle", () => {
+  // Behavior: pending polls progress. Regression/gap: generic 2xx storage pinned 202 for an hour.
+  // Native requests, D1 and Cache API observe publication; no production test seam.
+  it.each(STATS)("does not store pending %s and lets the next poll reach ready", async (kind) => {
+    await seedPool();
+    const path = pathFor(kind);
+    let calls = 0;
+    const upstream = vi.fn<typeof fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      expect(request.url).toBe(`https://api.github.com${path}`);
+      expect(bearer(request)).toBeUndefined();
+      calls++;
+      return jsonResponse(calls === 1 ? {} : [1, 2, 3], calls === 1 ? 202 : 200, {
+        ...rateHeaders({ remaining: 59 }),
+        etag: calls === 1 ? '"pending"' : '"ready"',
+      });
+    });
+    vi.stubGlobal("fetch", upstream);
+    const request = { pool: POOL, method: "GET" as const, path };
+    const route = classifyRoute(request, defaultPolicy("openclaw"));
+    const key = await githubCacheKey(POOL, request, route);
+
+    const pending = await relay(path);
+    expect(pending.status).toBe(200);
+    expect(await pending.json()).toMatchObject({
+      status: 202,
+      body: {},
+      body_encoding: "json",
+      headers: { etag: '"pending"' },
+      relay: { cache: "miss", backend: "web", cacheable: true },
+    });
+    expect(await env.DB.prepare("SELECT status FROM github_cache_entries").all()).toMatchObject({
+      results: [],
+    });
+    expect(await readEdgeJSON(GITHUB_EDGE_CACHE_NAMESPACE, key)).toBeUndefined();
+    expect(await env.DB.prepare("SELECT id FROM cache_publication_owners").all()).toMatchObject({
+      results: [],
+    });
+    expect(await env.DB.prepare("SELECT is_public FROM github_public_repo_proofs").first()).toEqual(
+      {
+        is_public: 1,
+      },
+    );
+    expect(await (await relay(path)).json()).toMatchObject({
+      status: 200,
+      body: [1, 2, 3],
+      relay: { cache: "miss" },
+    });
+    expect(await (await relay(path)).json()).toMatchObject({
+      status: 200,
+      body: [1, 2, 3],
+      relay: { cache: "hit" },
+    });
+    expect(calls).toBe(2);
+  });
+
+  // Behavior: even late current-epoch legacy pending data cannot be served or validated.
+  // Gap: fresh/identity/age/stale readers used to accept it. Real persisted ready receipts
+  // are converted into frozen legacy rows, independently of the new writer predicate.
+  it.each([
+    ["edge", "etag"],
+    ["shared", "etag"],
+    ["identity", "etag"],
+    ["max-age=0", "etag"],
+    ["max-age=20", "last-modified"],
+    ["stale", "etag"],
+    ["stale", "last-modified"],
+  ] as const)("refuses legacy pending %s with %s", async (mode, validator) => {
+    await seedPool();
+    const request = { pool: POOL, method: "GET" as const, path: pathFor("commit_activity") };
+    const route = classifyRoute(request, defaultPolicy("openclaw"));
+    const identity = mode === "identity" ? (await loadIdentities(env, POOL, route))[0] : undefined;
+    const key = await githubCacheKey(POOL, request, route, identity);
+    await seedPublicRepoProof(env, route);
+    expect(
+      await writeOwnedGitHubCache(
+        env,
+        key,
+        request,
+        route,
+        {
+          status: 200,
+          body: [7],
+          headers: {
+            ...rateHeaders({ remaining: 59 }),
+            [validator]: validator === "etag" ? '"legacy"' : "Mon, 31 Aug 2026 00:00:00 GMT",
+          } as Record<string, string>,
+        },
+        identity,
+      ),
+    ).toBe("shared");
+    await makeLegacyPending(key);
+    if (mode === "stale") await env.DB.prepare("UPDATE identities SET status = 'disabled'").run();
+    if (mode !== "edge") await deleteEdgeJSON(GITHUB_EDGE_CACHE_NAMESPACE, key);
+    if (mode === "stale" || mode.startsWith("max-age")) {
+      await env.DB.prepare(`UPDATE github_cache_entries
+        SET created_at = datetime('now', '-180 seconds'), expires_at = datetime('now', '-1 second')
+        WHERE cache_key = ?`)
+        .bind(key)
+        .run();
+    }
+    let resourceCalls = 0;
+    let validators = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        const upstream = new Request(input, init);
+        if (bearer(upstream) === "test-org-token") return jsonResponse({ private: false });
+        expect(upstream.url).toBe(`https://api.github.com${request.path}`);
+        resourceCalls++;
+        if (upstream.headers.has("if-none-match") || upstream.headers.has("if-modified-since")) {
+          validators++;
+          return new Response(null, { status: 304, headers: rateHeaders({ remaining: 59 }) });
+        }
+        if (mode === "stale" || (mode === "identity" && bearer(upstream) === undefined)) {
+          return jsonResponse({ message: "unavailable" }, 503);
+        }
+        return jsonResponse([8], 200, rateHeaders({ remaining: 59 }));
+      }),
+    );
+    const result = await relay(request.path, undefined, {
+      headers: mode.startsWith("max-age") ? { "cache-control": mode } : {},
+    });
+    if (mode === "stale") {
+      expect(result.status).toBe(424);
+    } else {
+      expect(await result.json()).toMatchObject({
+        status: 200,
+        body: [8],
+        relay: { cache: "miss" },
+      });
+    }
+    expect(validators).toBe(0);
+    expect(resourceCalls).toBeGreaterThan(0);
+  });
+
+  // Behavior: a real waiting request reacquires after intentional nonpublication.
+  // Regression: the old shared notification served the leader's pending body. Only
+  // fetch is gated; scalar native DO state establishes registration, with owned drains.
+  it("serializes a pending leader and lets its follower fetch ready", async () => {
+    await seedPool();
+    const path = pathFor("contributors");
+    const entered = ownedWork.gate();
+    const gate = ownedWork.gate();
+    let calls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        expect(new Request(input, init).url).toBe(`https://api.github.com${path}`);
+        calls++;
+        if (calls === 1) {
+          entered.release();
+          await gate.promise;
+          return jsonResponse({}, 202, rateHeaders({ remaining: 59 }));
+        }
+        return jsonResponse([9], 200, rateHeaders({ remaining: 59 }));
+      }),
+    );
+    const leader = relay(path);
+    const requests = [leader];
+    try {
+      await entered.promise;
+      const follower = relay(path);
+      requests.push(follower);
+      await waitForFollower(follower);
+      expect(calls).toBe(1);
+      gate.release();
+      expect(await (await leader).json()).toMatchObject({
+        status: 202,
+        body: {},
+        relay: { cache: "miss" },
+      });
+      expect(await (await follower).json()).toMatchObject({
+        status: 200,
+        body: [9],
+        relay: { cache: "miss" },
+      });
+      expect(calls).toBe(2);
+      expect(await env.DB.prepare("SELECT status FROM github_cache_entries").first()).toEqual({
+        status: 200,
+      });
+    } finally {
+      gate.release();
+      await Promise.allSettled(requests);
+    }
+  });
+
+  // Behavior: a late old writer's completed shared result is still rejected by followers.
+  // Gap: a publication notification alone says nothing about status eligibility. A real
+  // owner writes ready data, then the fixture freezes legacy 202 before actual completion.
+  it("rejects a late legacy pending publication after a follower registered", async () => {
+    await seedPool();
+    const request = { pool: POOL, method: "GET" as const, path: pathFor("contributors") };
+    const route = classifyRoute(request, defaultPolicy("openclaw"));
+    const key = await githubCacheKey(POOL, request, route);
+    await seedPublicRepoProof(env, route);
+    const coordinator = poolCoordinatorStub(env, POOL);
+    const owner = (await coordinator.tryAcquirePublication(bodyPublicationResource(key)))!;
+    const follower = relay(request.path);
+    try {
+      await waitForFollower(follower);
+      expect(
+        await writeGitHubCache(
+          env,
+          key,
+          request,
+          route,
+          {
+            status: 200,
+            body: [1],
+            headers: rateHeaders({ remaining: 59 }) as Record<string, string>,
+          },
+          owner,
+        ),
+      ).toBe("shared");
+      await makeLegacyPending(key);
+      const upstream = vi.fn(async () => jsonResponse([2], 200, rateHeaders({ remaining: 59 })));
+      vi.stubGlobal("fetch", upstream);
+      expect(await coordinator.completePublication(owner, "shared", owner.id)).toBe(true);
+      expect(await (await follower).json()).toMatchObject({
+        status: 200,
+        body: [2],
+        relay: { cache: "miss" },
+      });
+      expect(upstream).toHaveBeenCalledTimes(1);
+    } finally {
+      await coordinator.completePublication(owner, "failed");
+      await Promise.allSettled([follower]);
+    }
+  });
+
+  // Behavior: forced pending leaves ready bytes and original lifetime intact.
+  // Regression: 202 used to overwrite/renew the row. Advancing metadata Date together
+  // makes lifetime extension observable; timers and native D1 clocks remain real.
+  it("keeps the ready publication unchanged after a forced pending response", async () => {
+    await seedPool();
+    const path = pathFor("participation");
+    let calls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        const request = new Request(input, init);
+        expect(request.url).toBe(`https://api.github.com${path}`);
+        calls++;
+        if (calls === 2) {
+          expect(request.headers.get("if-none-match")).toBe('"ready"');
+          return jsonResponse({}, 202, { etag: '"pending"', ...rateHeaders({ remaining: 59 }) });
+        }
+        return jsonResponse([3], 200, { etag: '"ready"', ...rateHeaders({ remaining: 59 }) });
+      }),
+    );
+    await relay(path);
+    const before = await env.DB.prepare("SELECT * FROM github_cache_entries").first<{
+      cache_key: string;
+    }>();
+    const edgeBefore = await readEdgeJSON(GITHUB_EDGE_CACHE_NAMESPACE, before!.cache_key);
+    const later = Date.now() + 10_000;
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(later);
+    try {
+      expect(
+        await (await relay(path, undefined, { headers: { "cache-control": "max-age=0" } })).json(),
+      ).toMatchObject({
+        status: 202,
+        body: {},
+        headers: { etag: '"pending"' },
+        relay: { cache: "miss" },
+      });
+      expect(await env.DB.prepare("SELECT * FROM github_cache_entries").first()).toEqual(before);
+      expect(await readEdgeJSON(GITHUB_EDGE_CACHE_NAMESPACE, before!.cache_key)).toEqual(
+        edgeBefore,
+      );
+      expect(await (await relay(path)).json()).toMatchObject({
+        status: 200,
+        body: [3],
+        relay: { cache: "hit" },
+      });
+      expect(calls).toBe(2);
+    } finally {
+      await ownedWork.drain();
+      vi.useRealTimers();
+    }
+  });
+
+  // Behavior: intentional nonpublication revokes only its exact owner, never invents
+  // a data ID, and expired cleanup cannot signal live completion. Native D1/RPC
+  // receipts cover the new outcome without mocking ownership decisions.
+  it.each([false, true])("completes no-store truthfully with expired=%s", async (expired) => {
+    await seedPool();
+    const request = { pool: POOL, method: "GET" as const, path: pathFor("contributors") };
+    const route = classifyRoute(request, defaultPolicy("openclaw"));
+    const key = await githubCacheKey(POOL, request, route);
+    const coordinator = poolCoordinatorStub(env, POOL);
+    const owner = (await coordinator.tryAcquirePublication(bodyPublicationResource(key)))!;
+    const follower = ownedWork.track(coordinator.acquirePublication(owner.resource_key));
+    try {
+      await waitForFollower(follower);
+      expect(
+        await writeGitHubCache(
+          env,
+          key,
+          request,
+          route,
+          { status: 202, headers: {}, body: {} },
+          owner,
+        ),
+      ).toBe("none");
+      // Catch invalid arguments inside the native DO, not across the long-lived
+      // Runner RPC lifetime. Valid completion and waiter delivery below remain RPCs.
+      await runInDurableObject(coordinator, async (instance) => {
+        await expect(instance.completePublication(owner, "none", owner.id)).rejects.toThrow(
+          "Invalid publication completion",
+        );
+      });
+      expect(
+        await coordinator.completePublication({ ...owner, owner_token: "wrong-token" }, "none"),
+      ).toBe(false);
+      if (expired)
+        await env.DB.prepare("UPDATE cache_publication_owners SET lease_until_ms = 0 WHERE id = ?")
+          .bind(owner.id)
+          .run();
+      expect(await coordinator.completePublication(owner, "none")).toBe(!expired);
+      expect(await follower).toEqual(
+        expired ? { kind: "retry" } : { kind: "completed", outcome: "none" },
+      );
+      expect(
+        await env.DB.prepare("SELECT id FROM cache_publication_owners WHERE id = ?")
+          .bind(owner.id)
+          .first(),
+      ).toBeNull();
+      expect(await env.DB.prepare("SELECT status FROM github_cache_entries").first()).toBeNull();
+      expect(await readEdgeJSON(GITHUB_EDGE_CACHE_NAMESPACE, key)).toBeUndefined();
+      const next = (await coordinator.tryAcquirePublication(owner.resource_key))!;
+      expect(next.id).toBeGreaterThan(owner.id);
+      expect(await coordinator.completePublication(owner, "none")).toBe(false);
+      expect(await coordinator.renewPublication(next)).toBe(true);
+      await coordinator.completePublication(next, "failed");
+    } finally {
+      await coordinator.completePublication(owner, "failed");
+      await Promise.allSettled([follower]);
+    }
+  });
+
+  // Behavior: caller conditionals retain exact responses and bypass all body storage.
+  // Gap: statistics-specific no-store must not change the existing conditional contract.
+  // Real relay requests and row snapshots exercise both validator headers without a seam.
+  it.each(["if-none-match", "if-modified-since"])(
+    "preserves caller %s for pending statistics",
+    async (header) => {
+      await seedPool();
+      const path = pathFor("code_frequency");
+      const value = header === "if-none-match" ? '"caller"' : "Mon, 31 Aug 2026 00:00:00 GMT";
+      const upstream = vi.fn<typeof fetch>(async (input, init) => {
+        const request = new Request(input, init);
+        if (bearer(request) === "test-org-token") return jsonResponse({ private: false });
+        expect(request.headers.get(header)).toBe(value);
+        return jsonResponse({}, 202, { etag: '"pending"', ...rateHeaders({ remaining: 59 }) });
+      });
+      vi.stubGlobal("fetch", upstream);
+      expect(
+        await (await relay(path, undefined, { headers: { [header]: value } })).json(),
+      ).toMatchObject({
+        status: 202,
+        body: {},
+        body_encoding: "json",
+        relay: { cache: "bypass" },
+      });
+      expect(await env.DB.prepare("SELECT status FROM github_cache_entries").first()).toBeNull();
+    },
+  );
+
+  // Behavior: ready statistics still revalidate and use bounded outage stale fallback.
+  // The status rejection must not retire valid data. Real fills/expiry fixtures exercise
+  // both allowed reuse and a caller age bound, without new production hooks.
+  it.each(["304", "outage", "bounded-outage"])(
+    "preserves ready statistics through %s",
+    async (mode) => {
+      await seedPool();
+      const path = pathFor("commit_activity");
+      let primed = false;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>(async (input, init) => {
+          const request = new Request(input, init);
+          if (bearer(request) === "test-org-token") {
+            expect(request.url).toBe("https://api.github.com/repos/openclaw/octopool");
+            return jsonResponse({ private: false });
+          }
+          expect(request.url).toBe(`https://api.github.com${path}`);
+          if (!primed)
+            return jsonResponse([4], 200, { etag: '"ready"', ...rateHeaders({ remaining: 59 }) });
+          if (mode === "304") {
+            expect(request.headers.get("if-none-match")).toBe('"ready"');
+            return new Response(null, { status: 304, headers: rateHeaders({ remaining: 59 }) });
+          }
+          return jsonResponse({ message: "unavailable" }, 503);
+        }),
+      );
+      await relay(path);
+      primed = true;
+      const row = await env.DB.prepare("SELECT cache_key FROM github_cache_entries").first<{
+        cache_key: string;
+      }>();
+      await env.DB.prepare(
+        "UPDATE github_cache_entries SET created_at = datetime('now', '-180 seconds'), expires_at = datetime('now', '-1 second')",
+      ).run();
+      await deleteEdgeJSON(GITHUB_EDGE_CACHE_NAMESPACE, row!.cache_key);
+      await env.DB.prepare("UPDATE identities SET status = 'disabled'").run();
+      const result = await relay(path, undefined, {
+        headers: mode === "bounded-outage" ? { "cache-control": "max-age=20" } : {},
+      });
+      if (mode === "bounded-outage") expect(result.status).toBe(424);
+      else
+        expect(await result.json()).toMatchObject({
+          status: 200,
+          body: [4],
+          relay: { cache: mode === "304" ? "hit" : "stale" },
+        });
+    },
+  );
+
+  // Behavior: only stats 202 changes. Native ready/empty/negative responses preserve
+  // the existing success gate and payload encoding; no private predicate oracle.
+  it.each([
+    [pathFor("punch_card"), 200],
+    [pathFor("punch_card"), 204],
+    [pathFor("punch_card"), 404],
+    [pathFor("punch_card"), 422],
+    [pathFor("punch_card"), 500],
+    ["/repos/openclaw/octopool/languages", 202],
+  ] as const)("preserves %s status %i cache behavior", async (path, status) => {
+    await seedPool();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        if (bearer(input, init) === "test-org-token") return jsonResponse({ private: false });
+        return status === 204
+          ? new Response(null, { status, headers: rateHeaders({ remaining: 59 }) })
+          : jsonResponse([], status, rateHeaders({ remaining: 59 }));
+      }),
+    );
+    const first = await relay(path);
+    expect(first.status).toBe(200);
+    expect(await first.json()).toMatchObject({ status, body: status === 204 ? null : [] });
+    const rows = await env.DB.prepare("SELECT status FROM github_cache_entries").all();
+    expect(rows.results).toEqual(status < 300 ? [{ status }] : []);
+    if (status < 300)
+      expect(await (await relay(path)).json()).toMatchObject({
+        status,
+        body: status === 204 ? null : [],
+        relay: { cache: "hit" },
+      });
+  });
+});
+
+async function makeLegacyPending(key: string): Promise<void> {
+  const edge = await readEdgeJSON<CachedGitHubResponse & { protocol_epoch: string }>(
+    GITHUB_EDGE_CACHE_NAMESPACE,
+    key,
+  );
+  expect(edge).toMatchObject({ status: 200, protocol_epoch: CACHE_PUBLICATION_EPOCH });
+  await env.DB.prepare(
+    "UPDATE github_cache_entries SET status = 202, body_json = '{}' WHERE cache_key = ? AND publication_epoch = ?",
+  )
+    .bind(key, CACHE_PUBLICATION_EPOCH)
+    .run();
+  expect(
+    await env.DB.prepare(
+      "SELECT status, publication_id FROM github_cache_entries WHERE cache_key = ?",
+    )
+      .bind(key)
+      .first(),
+  ).toMatchObject({ status: 202, publication_id: expect.any(Number) });
+  expect(
+    await writeEdgeJSON(GITHUB_EDGE_CACHE_NAMESPACE, key, { ...edge, status: 202, body: {} }, 3600),
+  ).toBe(true);
+}
+
+async function waitForFollower(follower: Promise<unknown>): Promise<void> {
+  await Promise.race([
+    vi.waitFor(
+      async () => {
+        const waiting = await runInDurableObject(
+          poolCoordinatorStub(env, POOL),
+          (instance) =>
+            (instance as unknown as { publicationWaiters: Map<string, unknown> }).publicationWaiters
+              .size,
+        );
+        expect(waiting).toBe(1);
+      },
+      { timeout: 5_000 },
+    ),
+    follower.then(() => {
+      throw new Error("Follower completed before coordinator waiting");
+    }),
+  ]);
+}


### PR DESCRIPTION
## Summary

Repository statistics endpoints can return `202` while GitHub computes a result. Treating that as an ordinary successful cache fill pinned the pending body for an hour, so later polls could not reach the ready result. The five statistics routes now return pending responses unchanged without storing their bodies. One eligibility rule also rejects old pending entries across fresh, identity-specific, coalesced, revalidation, and stale paths, including late writes from older Workers. A forced pending refresh leaves an existing ready entry and its original lifetime untouched.

Anonymous API conditional replacements and `304` validations now name the actual API verifier in new audit/statistics records. Request-only verifier metadata keeps this separate from the cached body's identity and the public relay backend. Cache-only hits still have no audit backend; no pooled quota or publication receipt is invented.

This patch needs no migration, cache-generation bump, purge, history backfill, or dependency change. It does not deploy the Workers; rollout remains part of the release. Documentation covers pending progress, truthful nonpublication, and prospective audit attribution. Release-note context is retained here until release generation.

## Verification

- Native pre-fix regressions reproduced pending-body caching and incorrect conditional API audit attribution; separate legacy-entry regressions reproduced inappropriate hits, validation, stale use, and ready-body replacement.
- All 46 statistics/revalidation cases pass after the fixes, including actual waiting followers, live versus expired completion, old-writer rejection, ready/empty/negative and unrelated `202` controls, caller validators, and cross-source audit/quota accounting.
- Full `pnpm check` passes on the complete candidate: 763 unit tests, 817 native Worker tests, route/SQL generation, formatting, lint, build/type checks, Go 1.26 tests, and vet.
- Complete independent P2 review is clean.
- Fresh post-commit verification passed on `fb2d006b7ea138fb823e92cff295ec96d6f11a3a`: 46 focused native cases in 7.10s; full check with 763 unit tests in 616ms, 817 native Worker tests in 17.53s, all generation/format/lint/build/type gates, Go 1.26.7 tests in 43.517s, and vet. Both runners exited 0 without retries, and the approved tree remained unchanged.

The first final focused run exposed a test-boundary problem: an intentional invalid completion was caught locally but reported as an unhandled native RPC rejection, followed by a reset timeout. The validation now runs inside the real Durable Object; valid completion and waiter delivery still use RPC. Following resets pass with the original deadlines and isolation safeguards. Two previously blocked outage fixtures were also corrected to answer the existing repository-visibility probe. No test/runtime errors were suppressed, and the historical initialization timing issue is not claimed fixed.
