### PR TITLE
perf: reclaim expired coordinator leases and cooldowns

### DIFF
--- a/docs/identities.md
+++ b/docs/identities.md
@@ -64,6 +64,11 @@ keeps four SQLite tables in DO storage:
 
 `selectIdentity` logic:
 
+Before selection, each invocation removes at most 16 expired leases and 16 expired
+cooldowns using two indexed, atomic SQL statements and one captured coordinator clock.
+This also runs for sticky reuse and unavailable selections. Live rows are preserved;
+the cleanup does not change rate history or publication ownership.
+
 1. If a live lease for the route key points at a candidate that is not cooling down and
    not quota-exhausted, reuse it (`reason: sticky`).
 2. Otherwise score each non-cooling candidate by `remaining + weight` (unknown rate
@@ -128,7 +133,11 @@ resource-wide exhaustion or invent a reset.
 Each cooldown key retains its greatest expiry and the status/reason attached to that
 deadline. Equal or shorter updates do nothing. Route, resource and global keys remain
 independent; a success or newer rate window does not clear a live cooldown. Selection
-and snapshots ignore expired rows at exact deadline equality, without deleting them.
+and snapshots ignore expired rows at exact deadline equality. Selection also physically
+removes bounded batches of expired leases and cooldowns; snapshots and feedback do not
+perform cleanup. Idle objects need not wake, so expiry is not a physical deletion deadline.
+An expired backlog drains as selection activity resumes, subject to the 16-row budget per
+table on each call. Rate history remains stored even after its reset window expires.
 Rate and cooldown writes for one result use a synchronous storage transaction, so a
 failed second write cannot leave a partially accepted observation.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -509,6 +509,30 @@ Worker's explicit Durable Object bindings and does **not** establish D1 dormancy
 through its service binding. Per-stub eviction remains appropriate for testing
 the coordinator's constructor and storage cleanup.
 
+## Coordinator expiry retention
+
+Every `PoolCoordinator.selectIdentity` invocation performs two synchronous, indexed
+deletions: at most 16 leases and 16 cooldowns whose expiry is at or before one captured
+coordinator clock. Each statement selects and deletes its batch atomically, so a prior
+lease renewal or cooldown extension that is still live survives. Sticky and unavailable
+selections also clean up. Feedback and snapshots do not trigger cleanup, and rate history
+is retained. Distinct contents paths can create distinct route keys; route normalization
+and cooldown scope remain unchanged.
+
+The DO constructor adds `leases_expiry (expires_at, route_key)` and
+`cooldowns_expiry (expires_at, identity_id, route_key)` idempotently. These covering indexes
+bound expiry batch selection without scanning or sorting the whole history; snapshots
+also use expiry indexes. This is additive DO schema initialization, not a D1 migration.
+The first activation builds each index over retained rows, and subsequent writes maintain
+it. Existing rows and legacy RPC/table contracts survive reconstruction. A Worker rollback
+can leave the harmless indexes in place; older code simply stops this cleanup.
+
+The per-call budget does not bound absolute storage during arbitrary bursts or guarantee
+when idle rows are physically deleted. No timer, alarm, new RPC, or global object sweep is
+added. Deletions make SQLite space reusable, without promising file-size shrinkage or
+hosted billing savings. Publication-owner acquisition cleanup and its hourly fallback
+retain their separate authority and budgets described in [Cache](cache.md).
+
 ## SQL catalog
 
 Runtime SQL lives in `sql/queries/*.sql` with sqlc annotations. `sqlc.yaml` points sqlc at

--- a/sql/queries/coordinator.sql
+++ b/sql/queries/coordinator.sql
@@ -40,6 +40,26 @@ SELECT identity_id, expires_at
 FROM leases
 WHERE route_key = ?;
 
+-- name: CreateLeasesExpiryIndex :exec
+CREATE INDEX IF NOT EXISTS leases_expiry ON leases(expires_at, route_key);
+
+-- name: CreateCooldownsExpiryIndex :exec
+CREATE INDEX IF NOT EXISTS cooldowns_expiry ON cooldowns(expires_at, identity_id, route_key);
+
+-- name: DeleteExpiredLeases :exec
+DELETE FROM leases
+WHERE route_key IN (
+  SELECT old.route_key FROM leases AS old WHERE old.expires_at <= ?1
+  ORDER BY old.expires_at LIMIT 16
+);
+
+-- name: DeleteExpiredCooldowns :exec
+DELETE FROM cooldowns
+WHERE (identity_id, route_key) IN (
+  SELECT old.identity_id, old.route_key FROM cooldowns AS old WHERE old.expires_at <= ?1
+  ORDER BY old.expires_at LIMIT 16
+);
+
 -- name: CreateLegacyCacheFillExpiryIndex :exec
 CREATE INDEX IF NOT EXISTS cache_fills_expiry ON cache_fills(expires_at);
 

--- a/sql/schema/coordinator.sql
+++ b/sql/schema/coordinator.sql
@@ -22,6 +22,9 @@ CREATE TABLE IF NOT EXISTS cooldowns (
   PRIMARY KEY (identity_id, route_key)
 );
 
+CREATE INDEX IF NOT EXISTS leases_expiry ON leases(expires_at, route_key);
+CREATE INDEX IF NOT EXISTS cooldowns_expiry ON cooldowns(expires_at, identity_id, route_key);
+
 CREATE TABLE IF NOT EXISTS cache_fills (
   cache_key TEXT PRIMARY KEY,
   owner_token TEXT NOT NULL,

--- a/src/generated/sql.ts
+++ b/src/generated/sql.ts
@@ -12,6 +12,14 @@ export const queries = {
   createCacheFillsTable:
     "CREATE TABLE IF NOT EXISTS cache_fills (\n  cache_key TEXT PRIMARY KEY,\n  owner_token TEXT NOT NULL,\n  expires_at INTEGER NOT NULL\n)",
   getLease: "SELECT identity_id, expires_at\nFROM leases\nWHERE route_key = ?",
+  createLeasesExpiryIndex:
+    "CREATE INDEX IF NOT EXISTS leases_expiry ON leases(expires_at, route_key)",
+  createCooldownsExpiryIndex:
+    "CREATE INDEX IF NOT EXISTS cooldowns_expiry ON cooldowns(expires_at, identity_id, route_key)",
+  deleteExpiredLeases:
+    "DELETE FROM leases\nWHERE route_key IN (\n  SELECT old.route_key FROM leases AS old WHERE old.expires_at <= ?1\n  ORDER BY old.expires_at LIMIT 16\n)",
+  deleteExpiredCooldowns:
+    "DELETE FROM cooldowns\nWHERE (identity_id, route_key) IN (\n  SELECT old.identity_id, old.route_key FROM cooldowns AS old WHERE old.expires_at <= ?1\n  ORDER BY old.expires_at LIMIT 16\n)",
   createLegacyCacheFillExpiryIndex:
     "CREATE INDEX IF NOT EXISTS cache_fills_expiry ON cache_fills(expires_at)",
   drainExpiredLegacyCacheFills:

--- a/src/pool-coordinator.ts
+++ b/src/pool-coordinator.ts
@@ -77,6 +77,8 @@ export class PoolCoordinator extends DurableObject<Env> {
         // Existing Durable Objects already have the column; new ones get it from CREATE TABLE.
       }
       this.ctx.storage.sql.exec(queries.createCooldownsTable);
+      this.ctx.storage.sql.exec(queries.createLeasesExpiryIndex);
+      this.ctx.storage.sql.exec(queries.createCooldownsExpiryIndex);
       this.ctx.storage.sql.exec(queries.createCacheFillsTable);
       this.ctx.storage.sql.exec(queries.createLegacyCacheFillExpiryIndex);
     });
@@ -239,6 +241,8 @@ export class PoolCoordinator extends DurableObject<Env> {
 
   selectIdentity(request: SelectionRequest): SelectionResult {
     const now = Date.now();
+    this.ctx.storage.sql.exec(queries.deleteExpiredLeases, now);
+    this.ctx.storage.sql.exec(queries.deleteExpiredCooldowns, now);
     const candidateIds = new Set(request.candidates.map((candidate) => candidate.id));
     const lease = this.ctx.storage.sql
       .exec<LeaseRow>(queries.getLease, request.routeKey)

--- a/test/e2e/coordinator-retention.test.ts
+++ b/test/e2e/coordinator-retention.test.ts
@@ -1,0 +1,452 @@
+import { env } from "cloudflare:workers";
+import { evictDurableObject, runInDurableObject } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { queries } from "../../src/generated/sql";
+import { poolCoordinatorStub } from "../../src/pool-coordinator";
+import { classifyRoute, defaultPolicy } from "../../src/policy";
+import type { SelectionRequest } from "../../src/types";
+import { githubUpstream, jsonResponse, seedPool } from "./harness";
+import { requestWithEnv } from "./identity-routing-support";
+import { ownedWork } from "./owned-work";
+
+const NOW = 1_800_000_000_000;
+const coordinator = () => poolCoordinatorStub(env, "coordinator-retention");
+const candidate = (id = "a") => [{ id, weight: 100 }];
+function request(path: string, id = "a"): SelectionRequest {
+  const route = classifyRoute(
+    { pool: "coordinator-retention", method: "GET", path },
+    defaultPolicy("openclaw"),
+  );
+  return { routeKey: route.routeKey, resource: route.resource, candidates: candidate(id) };
+}
+const contents = (name: string, id = "a") =>
+  request(`/repos/openclaw/octopool/contents/retention/${name}.txt`, id);
+const select = (input: SelectionRequest) => ownedWork.track(coordinator().selectIdentity(input));
+async function observedSelection(input: SelectionRequest) {
+  return ownedWork.track(
+    runInDurableObject(coordinator(), (instance, state) => {
+      const sql = state.storage.sql;
+      const exec = sql.exec.bind(sql);
+      const calls: {
+        statement: string;
+        bindings: unknown[];
+        cursor: SqlStorageCursor<Record<string, SqlStorageValue>>;
+      }[] = [];
+      const forwarding = vi.spyOn(sql, "exec").mockImplementation((statement, ...bindings) => {
+        const cursor = exec(statement, ...bindings);
+        calls.push({ statement, bindings, cursor });
+        return cursor;
+      });
+      const clock = vi.spyOn(Date, "now");
+      try {
+        const result = instance.selectIdentity(input);
+        return {
+          result,
+          clockCalls: clock.mock.calls.length,
+          constructorTime: new Date().getTime(),
+          calls: calls.map(({ statement, bindings, cursor }) => ({
+            statement,
+            bindings,
+            read: cursor.rowsRead,
+            written: cursor.rowsWritten,
+          })),
+        };
+      } finally {
+        clock.mockRestore();
+        forwarding.mockRestore();
+      }
+    }),
+  );
+}
+async function rows() {
+  return ownedWork.track(
+    runInDurableObject(coordinator(), (_instance, state) => ({
+      leases: state.storage.sql.exec("SELECT * FROM leases ORDER BY route_key").toArray(),
+      cooldowns: state.storage.sql
+        .exec("SELECT * FROM cooldowns ORDER BY identity_id, route_key")
+        .toArray(),
+      rates: state.storage.sql
+        .exec("SELECT * FROM rate_states ORDER BY identity_id, resource")
+        .toArray(),
+    })),
+  );
+}
+async function backlog(count: number) {
+  for (let i = 0; i < count; i++) {
+    const input = contents(`old-${i}`);
+    expect((await select(input)).kind).toBe("selected");
+    await ownedWork.track(
+      coordinator().recordResult({
+        identityId: "a",
+        routeKey: input.routeKey,
+        resource: input.resource,
+        status: 403,
+        rate: { remaining: 100, resetAt: NOW / 1000 + 60 },
+      }),
+    );
+  }
+}
+
+beforeEach(() => {
+  // Only JS coordination time moves; native D1 publication time is independent.
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(NOW);
+});
+afterEach(() => vi.useRealTimers());
+
+describe("native coordinator expiry retention", () => {
+  it("physically drains a distinct contents backlog in bounded batches on natural selection", async () => {
+    const runKeys = new Set<string>();
+    for (let i = 1; i <= 40; i++) {
+      const input = request(`/repos/openclaw/octopool/actions/runs/${i}`);
+      runKeys.add(input.routeKey);
+      expect((await select(input)).kind).toBe("selected");
+    }
+    expect(runKeys.size).toBe(1);
+    await backlog(40);
+    const before = await rows();
+    expect(before.leases).toHaveLength(41);
+    expect(before.cooldowns).toHaveLength(40);
+    expect(before.rates).toHaveLength(1);
+    vi.setSystemTime(NOW + 120_000);
+    expect(await coordinator().snapshot()).toEqual({ leases: [], cooldowns: [], rates: [] });
+    expect(await rows()).toEqual(before);
+
+    expect((await select(contents("following"))).kind).toBe("selected");
+    const first = await rows();
+    console.log("native retention first activity", {
+      before: { leases: before.leases.length, cooldowns: before.cooldowns.length },
+      after: { leases: first.leases.length, cooldowns: first.cooldowns.length },
+    });
+    expect(first.leases).toHaveLength(26);
+    expect(first.cooldowns).toHaveLength(24);
+    for (const [leases, cooldowns] of [
+      [10, 8],
+      [1, 0],
+      [1, 0],
+    ]) {
+      expect(await select(contents("following"))).toMatchObject({ reason: "sticky" });
+      const persisted = await rows();
+      expect(persisted.leases).toHaveLength(leases!);
+      expect(persisted.cooldowns).toHaveLength(cooldowns!);
+      expect(persisted.rates).toEqual(before.rates);
+    }
+  });
+
+  it.each([40, 160])(
+    "measures indexed native work with %s expired routes and a live tail",
+    async (size) => {
+      await backlog(size);
+      vi.setSystemTime(NOW + 9_999);
+      for (let i = 0; i < size; i++) {
+        const input = contents(`live-${i}`, "b");
+        await select(input);
+        await ownedWork.track(
+          coordinator().recordResult({
+            identityId: "b",
+            routeKey: input.routeKey,
+            resource: input.resource,
+            status: 403,
+          }),
+        );
+      }
+      vi.setSystemTime(NOW + 10_000);
+      const leaseBoundary = await observedSelection(contents("lease-cost", "c"));
+      expect(leaseBoundary.calls[0]).toMatchObject({
+        statement: queries.deleteExpiredLeases,
+        written: 16,
+      });
+      expect((await rows()).leases.filter((row) => row.identity_id === "b")).toHaveLength(size);
+      vi.setSystemTime(NOW + 119_999);
+      await select(contents("live-lease", "d"));
+      const before = await rows();
+      expect(before.leases).toHaveLength(size * 2 - 30);
+      expect(before.cooldowns).toHaveLength(size * 2);
+      vi.setSystemTime(NOW + 120_000);
+      const observed = await observedSelection(contents("cost", "c"));
+      expect(observed.clockCalls).toBe(1);
+      expect(observed.constructorTime).toBe(NOW + 120_000);
+      const deletions = observed.calls.filter((call) => call.statement.startsWith("DELETE"));
+      expect(deletions.map(({ statement }) => statement)).toEqual([
+        queries.deleteExpiredLeases,
+        queries.deleteExpiredCooldowns,
+      ]);
+      expect(deletions.map(({ bindings }) => bindings)).toEqual([[NOW + 120_000], [NOW + 120_000]]);
+      expect(deletions.map(({ written }) => written)).toEqual([16, 16]);
+      for (const deletion of deletions) expect(deletion.read).toBeLessThanOrEqual(80);
+      const after = await rows();
+      expect(after.leases).toHaveLength(before.leases.length - 15);
+      expect(after.leases.find((row) => row.identity_id === "d")).toEqual(
+        before.leases.find((row) => row.identity_id === "d"),
+      );
+      expect(after.cooldowns).toHaveLength(size * 2 - 16);
+      expect(after.cooldowns.filter((row) => row.identity_id === "b")).toEqual(
+        before.cooldowns.filter((row) => row.identity_id === "b"),
+      );
+      expect(after.rates).toEqual(before.rates);
+      const plans = await ownedWork.track(
+        runInDurableObject(coordinator(), (_instance, state) =>
+          [
+            queries.deleteExpiredLeases,
+            queries.deleteExpiredCooldowns,
+            queries.coordinatorLeases,
+            queries.coordinatorCooldowns,
+          ].map((statement) =>
+            state.storage.sql.exec(`EXPLAIN QUERY PLAN ${statement}`, NOW + 120_000).toArray(),
+          ),
+        ),
+      );
+      for (const [index, plan] of plans.entries()) {
+        const details = JSON.stringify(plan);
+        expect(details).toContain(index % 2 === 0 ? "leases_expiry" : "cooldowns_expiry");
+        expect(details).not.toMatch(/SCAN (?:old|leases|cooldowns)|TEMP B-TREE/);
+      }
+      console.log(
+        "native retention SQL cost",
+        JSON.stringify({ size, leaseBoundary, observed, plans }),
+      );
+    },
+  );
+
+  it("preserves live sticky leases and deletes at exact equality even when selection is unavailable", async () => {
+    const input = contents("boundary");
+    await select(input);
+    await ownedWork.track(
+      coordinator().recordResult({
+        identityId: "a",
+        routeKey: input.routeKey,
+        resource: input.resource,
+        status: 401,
+        rate: { retryAfter: 10 },
+      }),
+    );
+    vi.setSystemTime(NOW + 9_999);
+    const live = await rows();
+    const unavailable = await observedSelection(input);
+    expect(unavailable.result.kind).toBe("unavailable");
+    expect(unavailable.calls.filter((call) => call.statement.startsWith("DELETE"))).toHaveLength(2);
+    expect(await rows()).toEqual(live);
+    vi.setSystemTime(NOW + 10_000);
+    const empty = await observedSelection({ ...input, candidates: [] });
+    expect(empty.result.kind).toBe("unavailable");
+    expect(empty.clockCalls).toBe(1);
+    expect(await rows()).toEqual({ leases: [], cooldowns: [], rates: [] });
+    expect(await select(input)).toMatchObject({ reason: "highest_remaining" });
+    const renewed = await rows();
+    expect(renewed.leases[0]?.expires_at).toBe(NOW + 20_000);
+    expect(
+      await select({ ...input, candidates: [...candidate("b"), ...candidate()] }),
+    ).toMatchObject({
+      identityId: "a",
+      reason: "sticky",
+    });
+    expect(await rows()).toEqual(renewed);
+    console.log("native retention equality", { live, empty: { leases: 0, cooldowns: 0 }, renewed });
+  });
+
+  it.each(["renew-first", "collect-first"])(
+    "preserves lease renewal and cooldown extension in %s order",
+    async (order) => {
+      const lease = contents("renew-lease", "b");
+      const cooling = contents("extend-cooldown");
+      await select(lease);
+      await ownedWork.track(
+        coordinator().recordResult({
+          identityId: "a",
+          routeKey: cooling.routeKey,
+          resource: cooling.resource,
+          status: 403,
+        }),
+      );
+      vi.setSystemTime(NOW + 120_000);
+      const extend = () =>
+        ownedWork.track(
+          coordinator().recordResult({
+            identityId: "a",
+            routeKey: cooling.routeKey,
+            resource: cooling.resource,
+            status: 403,
+          }),
+        );
+      if (order === "collect-first") {
+        await select(contents("trigger", "c"));
+        expect((await rows()).cooldowns).toEqual([]);
+        expect((await rows()).leases.map((row) => row.route_key)).not.toContain(lease.routeKey);
+        await select(lease);
+        await extend();
+      } else {
+        // Feedback first extends the expired row before the next selection can collect it.
+        await extend();
+        await select(lease);
+      }
+      const live = await rows();
+      await select(contents("trigger", "c"));
+      expect((await rows()).cooldowns).toEqual(live.cooldowns);
+      expect((await rows()).leases.find((row) => row.route_key === lease.routeKey)).toEqual(
+        live.leases.find((row) => row.route_key === lease.routeKey),
+      );
+      expect(live.cooldowns[0]?.expires_at).toBe(NOW + 240_000);
+      expect(live.leases.find((row) => row.route_key === lease.routeKey)?.expires_at).toBe(
+        NOW + 130_000,
+      );
+      expect((await select(cooling)).kind).toBe("unavailable");
+      expect(await select(lease)).toMatchObject({ reason: "sticky", identityId: "b" });
+    },
+  );
+
+  it("retains live independent cooldown scopes, credential health and rate history through cleanup", async () => {
+    await backlog(20);
+    vi.setSystemTime(NOW + 120_000);
+    const route = contents("live-scopes");
+    for (const [identityId, status, resource] of [
+      ["route", 403, "core"],
+      ["resource", 429, "core"],
+      ["global", 401, "search"],
+    ] as const) {
+      await ownedWork.track(
+        coordinator().recordResult({ identityId, status, resource, routeKey: route.routeKey }),
+      );
+    }
+    await ownedWork.track(
+      coordinator().recordCredentialFailure({
+        identityId: "credential",
+        reason: "identity_secret_missing",
+      }),
+    );
+    await ownedWork.track(
+      coordinator().recordResult({
+        identityId: "exhausted",
+        status: 200,
+        resource: "core",
+        routeKey: route.routeKey,
+        rate: { remaining: 0, resetAt: NOW / 1000 + 300, limit: 6000 },
+      }),
+    );
+    const before = await rows();
+    expect(before.cooldowns).toHaveLength(24); // Feedback itself must not prune.
+    vi.setSystemTime(NOW + 120_000);
+    for (const id of ["route", "resource", "global", "credential", "exhausted"]) {
+      expect((await select({ ...route, candidates: candidate(id) })).kind).toBe("unavailable");
+    }
+    const retained = await rows();
+    expect(retained.cooldowns).toEqual(before.cooldowns.filter((row) => row.identity_id !== "a"));
+    expect(retained.rates).toEqual(before.rates);
+    expect((await select(contents("independent-route", "route"))).kind).toBe("selected");
+    expect(
+      (await select({ ...contents("independent-resource", "resource"), resource: "search" })).kind,
+    ).toBe("selected");
+    await ownedWork.track(
+      coordinator().recordResult({
+        identityId: "exhausted",
+        status: 200,
+        resource: "core",
+        routeKey: route.routeKey,
+        rate: { remaining: 4999, resetAt: NOW / 1000 + 200 },
+      }),
+    );
+    expect((await rows()).rates).toEqual(before.rates);
+    console.log("native retention preserved state", JSON.stringify({ before, retained }));
+  });
+
+  it("retains persisted state and idempotent indexes through graceful eviction and a following request", async () => {
+    await backlog(20);
+    const before = await rows();
+    const indexes = () =>
+      ownedWork.track(
+        runInDurableObject(coordinator(), (_instance, state) =>
+          state.storage.sql
+            .exec("SELECT name, sql FROM sqlite_master WHERE type = 'index' ORDER BY name")
+            .toArray(),
+        ),
+      );
+    const originalIndexes = await indexes();
+    expect(originalIndexes.map((row) => row.name)).toEqual(
+      expect.arrayContaining(["leases_expiry", "cooldowns_expiry"]),
+    );
+    vi.setSystemTime(NOW + 120_000);
+    await ownedWork.track(evictDurableObject(coordinator()));
+    // Constructor runs against retained storage; neither it nor snapshot collects rows.
+    expect(await rows()).toEqual(before);
+    expect(await indexes()).toEqual(originalIndexes);
+    expect(await coordinator().snapshot()).toEqual({ leases: [], cooldowns: [], rates: [] });
+    await select(contents("after-eviction", "b"));
+    const first = await rows();
+    expect(first.leases).toHaveLength(5);
+    expect(first.cooldowns).toHaveLength(4);
+    await ownedWork.track(evictDurableObject(coordinator()));
+    expect(await rows()).toEqual(first);
+    expect(await indexes()).toEqual(originalIndexes);
+    expect(await select(contents("after-eviction", "b"))).toMatchObject({ reason: "sticky" });
+    expect((await rows()).leases).toHaveLength(1);
+    expect((await rows()).cooldowns).toEqual([]);
+    expect((await rows()).rates).toEqual(before.rates);
+    console.log("native retention reconstruction", JSON.stringify({ originalIndexes, first }));
+  });
+
+  it.each([40, 160])(
+    "measures additive expiry index construction over %s retained rows without deleting state",
+    async (size) => {
+      await backlog(size);
+      const before = await rows();
+      const costs = await ownedWork.track(
+        runInDurableObject(coordinator(), (_instance, state) => {
+          const sql = state.storage.sql;
+          // Native shadow tables measure a first index build without removing real indexes/state.
+          return [
+            ["leases", queries.createLeasesTable, queries.createLeasesExpiryIndex],
+            ["cooldowns", queries.createCooldownsTable, queries.createCooldownsExpiryIndex],
+          ].map(([table, create, index]) => {
+            const shadow = `retention_build_${table}`;
+            sql.exec(create!.replace(`EXISTS ${table}`, `EXISTS ${shadow}`));
+            sql.exec(`INSERT INTO ${shadow} SELECT * FROM ${table}`);
+            const read = () => sql.exec(`SELECT * FROM ${shadow} ORDER BY rowid`).toArray();
+            const retained = read();
+            const statement = index!
+              .replace(`${table}_expiry`, `${shadow}_expiry`)
+              .replace(`ON ${table}(`, `ON ${shadow}(`);
+            const build = sql.exec(statement);
+            const built = { read: build.rowsRead, written: build.rowsWritten };
+            const repeated = sql.exec(statement);
+            return {
+              table,
+              statement,
+              built,
+              repeated: { read: repeated.rowsRead, written: repeated.rowsWritten },
+              retained,
+              after: read(),
+            };
+          });
+        }),
+      );
+      for (const cost of costs) {
+        expect(cost.retained).toHaveLength(size);
+        expect(cost.after).toEqual(cost.retained);
+        expect(cost.built.read).toBeGreaterThanOrEqual(size);
+        expect(cost.built.written).toBeGreaterThanOrEqual(size);
+        expect(cost.repeated).toEqual({ read: 0, written: 0 });
+      }
+      expect(await rows()).toEqual(before);
+      console.log(
+        "native retention index build",
+        JSON.stringify(
+          costs.map(({ retained, after: _after, ...cost }) => ({
+            ...cost,
+            retained: retained.length,
+          })),
+        ),
+      );
+    },
+  );
+
+  it("serves a following ordinary Worker request after the retention fixture has drained and reset", async () => {
+    // This full Worker control also reads native D1 auth/publication timestamps.
+    vi.useRealTimers();
+    expect(await rows()).toEqual({ leases: [], cooldowns: [], rates: [] });
+    await seedPool();
+    vi.stubGlobal("fetch", githubUpstream({ primary: jsonResponse({ private: false }) }));
+    const response = await requestWithEnv();
+    const body = await response.json();
+    expect(response.status, JSON.stringify(body)).toBe(200);
+    expect(body).toMatchObject({ identity: { id: "primary" } });
+  });
+});

--- a/test/e2e/identity-credentials.test.ts
+++ b/test/e2e/identity-credentials.test.ts
@@ -166,15 +166,7 @@ describe("selected identity credential failures", () => {
       const rows = await runInDurableObject(coordinator(), (_instance, state) =>
         state.storage.sql.exec("SELECT * FROM cooldowns").toArray(),
       );
-      expect(rows).toEqual([
-        {
-          identity_id: "primary",
-          route_key: "*",
-          status: 503,
-          reason: "identity_secret_missing",
-          expires_at: now + 120_000,
-        },
-      ]);
+      expect(rows).toEqual([]);
       await coordinator().recordResult({
         identityId: "primary",
         routeKey: "other",


### PR DESCRIPTION
## Summary

Expired coordinator rows stopped affecting routing but were never physically reclaimed. Distinct contents paths could therefore keep accumulating lease and cooldown history; an empty snapshot did not mean empty storage. Each identity selection now removes at most 16 expired leases and 16 expired cooldowns using two indexed, atomic statements and one captured coordinator clock.

Cleanup also runs for sticky and unavailable selections. Live leases and all cooldown scopes remain intact; feedback and snapshots do not prune, and rate history stays at its existing owner. Publication ownership, cache-fill coordination, and their separate cleanup budgets are unchanged.

The constructor adds two covering expiry indexes idempotently. This is additive Durable Object initialization, not a D1 migration. First activation pays the index-build cost over retained rows; the per-call budget is not an absolute storage bound or an idle deletion deadline. There is no new timer, alarm, RPC, or object sweep, and no claim of hosted billing savings or file-size shrinkage. This PR does not deploy the Workers.

## Verification

- Native pre-fix proof: an empty snapshot still had 41 expired leases and 40 cooldowns in SQLite; the next selection increased leases to 42 instead of reclaiming a bounded batch.
- Eleven native controls cover physical backlog draining, expiry equality, sticky/unavailable/empty-candidate selection, both extension/cleanup orders, live cooldown and quota preservation, graceful reconstruction, and a following ordinary Worker request.
- Actual forwarded SQL and native query plans confirm covering-index batch selection without a full-history scan or temporary sort. At both tested backlog sizes, a 16-row deletion read 64 rows and wrote 16; first index construction and idempotent reconstruction were measured separately. These are local runtime counters, not hosted billing units.
- Full `pnpm check` passes: 763 unit tests, 828 native Worker tests, route/SQL generation, formatting, lint, build/type checks, Go 1.26 tests and vet.
- Independent parent verification passed 289 native cases across 15 files. Complete P2 review is clean.

Two fixture-development failures are retained separately from the product red: a missing TypeScript cursor parameter, and a full-Worker control whose synthetic future clock made native D1 membership timestamps look stale. Both were corrected without changing production auth behavior, test deadlines, isolation, concurrency, or runtime. The historical initialization timing issue is not claimed fixed.

Release-note context: Reclaim expired coordinator leases and cooldowns during identity selection with bounded indexed work, preserving live routing and rate history.

Fresh post-commit verification at `05d616593125890b11120d4dec339e457449ecc6`: 167 native cases across the seven focused files passed in 10.02s. Full `pnpm check` passed again with 763 unit cases and 828 native Worker cases (17.70s), generation/format/lint/build/type checks, and Go 1.26.7 tests and vet; full runner wall time was 84.20s. No generated drift.

Exact-head hosted verification: [CI](https://github.com/openclaw/octopool/actions/runs/33446755900) passed both Check and Windows jobs; [CodeQL](https://github.com/openclaw/octopool/actions/runs/33446753461) passed Actions, Go, and JavaScript/TypeScript analyses. Both runs passed on attempt 1 at the head above.
