### PR TITLE
fix: bind Actions summaries to owned metadata

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -39,13 +39,18 @@ media types and non-default query values still produce distinct entries. The key
 pool-scoped, so pools never share cache entries.
 
 Actions summaries also include a server-controlled representation generation
-(`actions-summary-owned-v2`) in this common key. Run views, attempt-qualified views,
+(`actions-summary-metadata-v3`) in this common key. Run views, attempt-qualified views,
 and repository/workflow run lists, including canonical supersets and identity-specific
-entries, cannot reuse summaries cached before the ownership fix. Existing
+entries, cannot reuse summaries from `actions-summary-owned-v2` or earlier generations. Existing
 `actions-summary-v1` clients keep the same wire format but miss those old entries in
 edge, D1, stale fallback, fill coalescing, and conditional revalidation. Raw REST and
 unrelated shapes have no Actions representation discriminator; the common publication
 epoch still applies. No cache purge is needed.
+
+The generation also isolates late old writers and their validators; new readers never
+join old summary fills or revive old bodies through `304` revalidation. Actions jobs,
+raw REST, public-repository proofs, and terminal-log R2 keys retain their existing
+representations.
 
 Release views and latest-release reads with `release-summary-v1` similarly include
 `release-summary-raw-v2`. Existing clients cannot reuse the old HTML-derived bodies
@@ -176,6 +181,17 @@ elsewhere cannot supply it. List cards end at their own closing element, so a fo
 card or region cannot lend its SHA. Missing or conflicting ownership falls back to exact
 anonymous REST, then the existing pool path. In particular, title-only pages use REST's
 historical top-level `head_sha`, never the mutable `pull_requests[].head.sha`.
+
+Run status comes only from the recognized status prefix before the first colon on the
+owned run link (or the owned status icon on a run page). Workflow names, display titles,
+and branch prose cannot supply status or conclusion. A list card's trigger belongs only
+to the interval between its unique workflow span and sibling timestamp. The supported
+forms are `#N: pull request`, `#N: schedule`/`scheduled`, `#N: workflow dispatch`, and
+`#N: Commit <owned commit link> pushed`; commit-link text cannot supply an event.
+Missing, conflicting, unknown, or differently structured metadata falls back to REST.
+This deliberately bounded markup contract can cost more API reads when GitHub changes
+its layout. Valid known cards retain the existing wire fields, filters, and state-based
+TTLs; fresh job/attempt metadata still independently governs terminal caching.
 
 These ownership regions use parse5's HTML DOM and source locations, not markup
 stripping or regular-expression boundaries. Scripts, comments, styles, templates,

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -87,7 +87,7 @@ export async function githubCacheKey(
     // Retire contaminated page shapes for existing clients in every cache/fill path.
     ...(request.headers?.["x-octopool-public-shape"] === PUBLIC_SHAPES.actionsSummary &&
     ["run_view", "run_list", "workflow_run_list"].includes(route.kind)
-      ? { representation: "actions-summary-owned-v2" }
+      ? { representation: "actions-summary-metadata-v3" }
       : {}),
     ...(request.headers?.["x-octopool-public-shape"] === PUBLIC_SHAPES.releaseSummary &&
     ["release_view", "release_latest"].includes(route.kind)

--- a/src/github-html-actions.ts
+++ b/src/github-html-actions.ts
@@ -56,15 +56,15 @@ export function parseActionsRunListHTML(
     const workflow = onlyElement(
       contents.filter((element) => element.tagName === "span" && hasClass(element, "text-bold")),
     );
-    const runNumber = /^#([0-9]+):/.exec(actionsText(adjacentNode(workflow, 1)))?.[1];
-    const createdAt = attribute(
-      onlyElement(contents.filter((element) => element.tagName === "relative-time")),
-      "datetime",
+    const timestamp = onlyElement(
+      contents.filter((element) => element.tagName === "relative-time"),
     );
+    const trigger = actionsListTrigger(workflow, timestamp, owner, repo);
+    const createdAt = attribute(timestamp, "datetime");
     if (
       title === undefined ||
       workflow === undefined ||
-      runNumber === undefined ||
+      trigger === undefined ||
       createdAt === undefined
     ) {
       return undefined;
@@ -89,13 +89,13 @@ export function parseActionsRunListHTML(
       id,
       name: actionsText(workflow),
       display_title: actionsText(title),
-      run_number: Number(runNumber),
+      run_number: trigger.runNumber,
       status: state.status,
       conclusion: state.conclusion,
       html_url: `https://github.com/${owner}/${repo}/actions/runs/${id}`,
       head_branch: branch.name ?? null,
       head_sha: commit.sha ?? null,
-      event: runEvent(actionsText(card)),
+      event: trigger.event,
       created_at: createdAt,
       updated_at: addDuration(createdAt, duration) ?? createdAt,
     });
@@ -636,8 +636,9 @@ function firstTimestamp(items: Record<string, unknown>[], field: string): string
 }
 
 function runState(label: string): RunState | undefined {
-  const normalized = label.trim().toLowerCase();
-  if (normalized.includes("completed successfully")) {
+  // The suffix contains arbitrary workflow/title prose, not status evidence.
+  const normalized = /^([^:]+):/.exec(label)?.[1]?.trim().toLowerCase().replace(/\s+/g, " ");
+  if (normalized === "completed successfully") {
     return { status: "completed", conclusion: "success" };
   }
   for (const [needle, conclusion] of [
@@ -650,32 +651,83 @@ function runState(label: string): RunState | undefined {
     ["stale", "stale"],
     ["startup failure", "startup_failure"],
   ] as const) {
-    if (normalized.includes(needle)) {
+    if (normalized === needle) {
       return { status: "completed", conclusion };
     }
   }
   for (const status of ["in progress", "queued", "waiting", "pending"] as const) {
-    if (normalized.includes(status)) {
+    if (normalized === status) {
       return { status: status.replace(" ", "_"), conclusion: null };
     }
   }
   return undefined;
 }
 
-function runEvent(card: string): string | null {
-  if (/\bpushed\b/i.test(card)) {
-    return "push";
+function actionsListTrigger(
+  workflow: ActionsElement | undefined,
+  timestamp: ActionsElement | undefined,
+  owner: string,
+  repo: string,
+): { runNumber: number; event: string } | undefined {
+  const siblings = workflow?.parentNode?.childNodes;
+  if (
+    workflow === undefined ||
+    timestamp === undefined ||
+    siblings === undefined ||
+    workflow.parentNode !== timestamp.parentNode
+  )
+    return undefined;
+  const start = siblings.indexOf(workflow);
+  const end = siblings.indexOf(timestamp);
+  if (end <= start) return undefined;
+  // Only the retained workflow-to-time interval owns the trigger. Other markup
+  // costs a REST fallback rather than letting branch/title/link prose supply it.
+  const interval = siblings.slice(start + 1, end).filter((node) => node.nodeName !== "#comment");
+  const elements = interval.filter((node): node is ActionsElement => "tagName" in node);
+  if (interval.some((node) => !("value" in node) && !("tagName" in node))) return undefined;
+  let match: RegExpExecArray | null;
+  let event: string;
+  if (elements.length === 0) {
+    match = /^#([1-9][0-9]*):\s*(pull request|schedule|scheduled|workflow dispatch)$/i.exec(
+      interval
+        .map((node) => actionsText(node))
+        .join(" ")
+        .trim(),
+    );
+    const trigger = match?.[2]?.toLowerCase();
+    if (trigger === undefined) return undefined;
+    event = trigger === "scheduled" ? "schedule" : trigger.replace(" ", "_");
+  } else {
+    const commit = onlyElement(elements);
+    if (
+      commit === undefined ||
+      !isHTMLAnchor(commit) ||
+      actionsCommitSHA([commit], owner, repo)?.sha === undefined
+    )
+      return undefined;
+    const index = interval.indexOf(commit);
+    match = /^#([1-9][0-9]*):\s*Commit$/i.exec(
+      interval
+        .slice(0, index)
+        .map((node) => actionsText(node))
+        .join(" ")
+        .trim(),
+    );
+    if (
+      !/^pushed$/i.test(
+        interval
+          .slice(index + 1)
+          .map((node) => actionsText(node))
+          .join(" ")
+          .trim(),
+      )
+    ) {
+      return undefined;
+    }
+    event = "push";
   }
-  if (/\bpull request\b/i.test(card)) {
-    return "pull_request";
-  }
-  if (/\bschedule(?:d)?\b/i.test(card)) {
-    return "schedule";
-  }
-  if (/\bworkflow dispatch\b/i.test(card)) {
-    return "workflow_dispatch";
-  }
-  return null;
+  const runNumber = Number(match?.[1]);
+  return Number.isSafeInteger(runNumber) && runNumber > 0 ? { runNumber, event } : undefined;
 }
 
 function addDuration(date: string, duration: string | undefined): string | undefined {

--- a/test/actions-cache-generation.test.ts
+++ b/test/actions-cache-generation.test.ts
@@ -3,8 +3,26 @@ import { githubCacheKey } from "../src/cache";
 import { classifyRoute, defaultPolicy, validateRelayRequest } from "../src/policy";
 import { runListSupersetView } from "../src/run-list-superset";
 import { legacyActionsKey } from "./fixtures/actions-legacy-cache";
+import { currentV2ActionsKeys } from "./fixtures/actions-current-v2-cache";
 
 describe("Actions summary cache generation", () => {
+  it.each(currentV2ActionsKeys)(
+    "retires current-v2 $name shared and identity keys",
+    async (fixture) => {
+      const request = validateRelayRequest({
+        pool: "maintainers",
+        method: "GET",
+        path: fixture.path,
+        query: fixture.query,
+        headers: { "x-octopool-public-shape": "actions-summary-v1" },
+      });
+      const route = classifyRoute(request, defaultPolicy("openclaw"));
+      expect(await githubCacheKey(request.pool, request, route)).not.toBe(fixture.shared);
+      expect(
+        await githubCacheKey(request.pool, request, route, { kind: "pat", id: "primary" }),
+      ).not.toBe(fixture.identity);
+    },
+  );
   it.each([
     ["actions/runs/33167365292", {}],
     ["actions/runs/33167365221/attempts/1", {}],

--- a/test/actions-ownership.test.ts
+++ b/test/actions-ownership.test.ts
@@ -21,6 +21,142 @@ import {
 afterEach(() => vi.unstubAllGlobals());
 
 describe("Actions run ownership", () => {
+  it.each([
+    ["completed successfully", "completed", "success"],
+    ["cancelled", "completed", "cancelled"],
+    ["failed", "completed", "failure"],
+    ["timed out", "completed", "timed_out"],
+    ["action required", "completed", "action_required"],
+    ["neutral", "completed", "neutral"],
+    ["skipped", "completed", "skipped"],
+    ["stale", "completed", "stale"],
+    ["startup failure", "completed", "startup_failure"],
+    ["in progress", "in_progress", null],
+    ["queued", "queued", null],
+    ["waiting", "waiting", null],
+    ["pending", "pending", null],
+  ])(
+    "owns the %s prefix independently of title and workflow prose",
+    async (state, status, conclusion) => {
+      const upstream = vi.fn(
+        async () =>
+          new Response(
+            `<strong>1 workflow run</strong>${runCard(runIDs[0]!, historicalHead, {
+              state,
+              title: "completed successfully: cancelled failed pushed",
+              workflow: "in progress scheduled workflow dispatch",
+              branch: "pending pushed pull request",
+            })}`,
+          ),
+      );
+      vi.stubGlobal("fetch", upstream);
+      expect(await readList()).toMatchObject({
+        backend: "web",
+        body: {
+          workflow_runs: [{ status, conclusion, event: "pull_request", head_sha: historicalHead }],
+        },
+      });
+      expect(upstream).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each([
+    ["pull request", "pull_request"],
+    ["schedule", "schedule"],
+    ["scheduled", "schedule"],
+    ["workflow dispatch", "workflow_dispatch"],
+    [
+      `Commit <a href="/openclaw/Peekaboo/commit/${historicalHead}">failed workflow dispatch</a> pushed`,
+      "push",
+    ],
+  ])("owns the bounded trigger %s", async (trigger, event) => {
+    const upstream = vi.fn(
+      async () =>
+        new Response(
+          `<strong>1 workflow run</strong>${runCard(
+            runIDs[0]!,
+            event === "push" ? undefined : historicalHead,
+            {
+              state: " IN   PROGRESS ",
+              title: "failed pushed scheduled",
+              workflow: "pull request workflow dispatch",
+              trigger,
+            },
+          )}`,
+        ),
+    );
+    vi.stubGlobal("fetch", upstream);
+    expect(await readList()).toMatchObject({
+      backend: "web",
+      body: { workflow_runs: [{ status: "in_progress", conclusion: null, event }] },
+    });
+    expect(upstream).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["missing status delimiter", (html: string) => html.replace("failed: Run", "failed Run")],
+    [
+      "missing status label",
+      (html: string) => html.replace('aria-label="failed:', 'aria-label=":'),
+    ],
+    ["missing trigger", (html: string) => html.replace("#651: pull request", "#651:")],
+    [
+      "conflicting trigger",
+      (html: string) => html.replace("#651: pull request", "#651: pull request scheduled"),
+    ],
+    ["missing workflow", (html: string) => html.replace('<span class="text-bold">CI</span>', "")],
+    [
+      "different timestamp parent",
+      (html: string) =>
+        html
+          .replace("<relative-time", "<span><relative-time")
+          .replace("</relative-time>", "</relative-time></span>"),
+    ],
+    [
+      "reversed interval",
+      (html: string) =>
+        html
+          .replace('<span class="text-bold">CI</span>', "")
+          .replace("</relative-time>", '</relative-time><span class="text-bold">CI</span>'),
+    ],
+    [
+      "duplicate timestamp",
+      (html: string) =>
+        html.replace(
+          "</relative-time>",
+          '</relative-time><relative-time datetime="2026-08-28T11:29:48Z"></relative-time>',
+        ),
+    ],
+    ["invalid run number", (html: string) => html.replace("#651:", "#0:")],
+    ["unsafe run number", (html: string) => html.replace("#651:", "#99999999999999999999:")],
+    [
+      "branch in trigger",
+      (html: string) =>
+        html.replace(
+          "#651: pull request",
+          '#651: <a href="/openclaw/Peekaboo/tree/refs/heads/pull-request">pull request</a>',
+        ),
+    ],
+    [
+      "title in trigger",
+      (html: string) => html.replace("#651: pull request", "#651: <span>pull request</span>"),
+    ],
+  ])("falls through to exact REST for %s", async (_name, transform) => {
+    const body = { total_count: 1, workflow_runs: [exactRun(runIDs[0]!)] };
+    const upstream = vi.fn(async (input: string) =>
+      input.startsWith("https://github.com/")
+        ? new Response(
+            `<strong>1 workflow run</strong>${transform(runCard(runIDs[0]!, historicalHead))}`,
+          )
+        : Response.json(body),
+    );
+    vi.stubGlobal("fetch", upstream);
+    expect(await readList()).toMatchObject({ backend: "github", body });
+    expect(upstream.mock.calls.map(([url]) => url)).toEqual([
+      "https://github.com/openclaw/Peekaboo/actions",
+      "https://api.github.com/repos/openclaw/Peekaboo/actions/runs?per_page=25",
+    ]);
+  });
   it.each(runIDs)("uses historical REST ownership for saved run %i", async (id) => {
     const fetched: string[] = [];
     vi.stubGlobal(
@@ -520,6 +656,21 @@ describe("Actions run ownership", () => {
     },
   );
 });
+
+async function readList() {
+  const request = validateRelayRequest({
+    pool: "maintainers",
+    method: "GET",
+    path: "/repos/openclaw/Peekaboo/actions/runs",
+    query: { per_page: "25" },
+    headers: { "x-octopool-public-shape": "actions-summary-v1" },
+  });
+  return callGitHubWeb(
+    withGitHubEgress({} as Env, []),
+    request,
+    classifyRoute(request, defaultPolicy("openclaw")),
+  );
+}
 
 describe("commit patch ownership", () => {
   it("expands a single matching commit", () => {

--- a/test/e2e/actions-cache-run-jobs.test.ts
+++ b/test/e2e/actions-cache-run-jobs.test.ts
@@ -1,6 +1,7 @@
 import { env } from "cloudflare:workers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { bearer, jsonResponse, relay, seedPool } from "./harness";
+import { historicalHead, runPage } from "../fixtures/actions-ownership";
 
 type RelayEnvelope = {
   status: number;
@@ -62,10 +63,23 @@ describe("Actions attempt job-list cache", () => {
   });
 
   it("keeps completed-looking jobs short-lived until the owning attempt is terminal", async () => {
+    const urls: string[] = [];
     vi.stubGlobal(
       "fetch",
       vi.fn<typeof fetch>(async (input) => {
         const url = new URL(new Request(input).url);
+        urls.push(url.toString());
+        if (url.hostname === "github.com" && url.pathname.endsWith("/attempts/2")) {
+          return new Response(
+            runPage(42, historicalHead, 2)
+              .replaceAll("openclaw/Peekaboo", "openclaw/octopool")
+              .replace('aria-label="failed: "', 'aria-label="in progress: "')
+              .replace(
+                '<span class="markdown-title">fixture</span>',
+                '<span class="markdown-title">completed successfully: failed pushed workflow dispatch</span>',
+              ),
+          );
+        }
         if (url.hostname === "github.com") {
           return jsonResponse({ message: "public parser unavailable" }, 404);
         }
@@ -94,6 +108,10 @@ describe("Actions attempt job-list cache", () => {
          FROM github_cache_entries WHERE route_kind = 'run_jobs'`,
       ).first(),
     ).toEqual({ ttl: 60 });
+    expect(urls).toContain("https://github.com/openclaw/octopool/actions/runs/42/attempts/2");
+    expect(urls).not.toContain(
+      "https://api.github.com/repos/openclaw/octopool/actions/runs/42/attempts/2",
+    );
   });
 
   it("merges and caches all API pages for a 250-job run", async () => {

--- a/test/e2e/actions-cache-run-list-superset.test.ts
+++ b/test/e2e/actions-cache-run-list-superset.test.ts
@@ -1,6 +1,7 @@
 import { env } from "cloudflare:workers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { bearer, jsonResponse, relay, seedPool } from "./harness";
+import { historicalHead, runCard } from "../fixtures/actions-ownership";
 
 type RelayEnvelope = {
   status: number;
@@ -14,6 +15,143 @@ const RUNS_PATH = "/repos/openclaw/octopool/actions/runs";
 
 describe("Actions run-list superset", () => {
   beforeEach(seedPool);
+
+  it("owns misleading metadata through canonical fill, filtering, hits, and active TTL", async () => {
+    const urls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        const request = new Request(input, init);
+        expect(bearer(request)).toBeUndefined();
+        urls.push(request.url);
+        if (new URL(request.url).hostname === "api.github.com") {
+          return jsonResponse({
+            total_count: 1,
+            workflow_runs: [run(103, "main", "completed", "failure")],
+          });
+        }
+        return new Response(
+          `<strong>2 workflow runs</strong>${
+            runCard(101, historicalHead, {
+              state: "in progress",
+              title: "Fix failed test: Handle pushed commits",
+              workflow: "scheduled workflow dispatch",
+              branch: "completed successfully pushed",
+            }) + runCard(102, historicalHead, { state: "queued", title: "cancelled pull request" })
+          }`.replaceAll("openclaw/Peekaboo", "openclaw/octopool"),
+        );
+      }),
+    );
+    const first = await shapedRunList({ limit: "2" });
+    expect(first.body).toMatchObject({
+      total_count: 2,
+      workflow_runs: [
+        {
+          id: 101,
+          status: "in_progress",
+          conclusion: null,
+          event: "pull_request",
+          head_sha: historicalHead,
+        },
+        { id: 102, status: "queued", conclusion: null, event: "pull_request" },
+      ],
+    });
+    expect(first.relay.cache).toBe("miss");
+    expect(
+      await env.DB.prepare(
+        "SELECT unixepoch(expires_at) - unixepoch(created_at) AS ttl FROM github_cache_entries WHERE route_kind = 'run_list'",
+      ).first(),
+    ).toEqual({ ttl: 60 });
+    const active = await shapedRunList({ status: "in_progress", limit: "1" });
+    expect(runIDs(active.body)).toEqual([101]);
+    expect(active.relay.cache).toBe("hit");
+    const completed = await shapedRunList({ status: "completed", limit: "1" });
+    expect(runIDs(completed.body)).toEqual([103]);
+    expect(runIDs((await shapedRunList({ status: "completed", limit: "1" })).body)).toEqual([103]);
+    expect(urls.map((url) => new URL(url).origin + new URL(url).pathname)).toEqual([
+      "https://github.com/openclaw/octopool/actions",
+      "https://api.github.com/repos/openclaw/octopool/actions/runs",
+    ]);
+    expect(Object.fromEntries(new URL(urls[1]!).searchParams)).toEqual({
+      status: "completed",
+      per_page: "1",
+    });
+    const repeated = await shapedRunList({ limit: "2" });
+    expect(repeated.body).toEqual(first.body);
+    expect(repeated.relay.cache).toBe("hit");
+  });
+
+  it.each([
+    ["completed successfully", "success"],
+    ["failed", "failure"],
+    ["timed out", "timed_out"],
+    ["startup failure", "startup_failure"],
+  ])("keeps owned terminal %s metadata and the completed list TTL", async (state, conclusion) => {
+    const upstream = vi.fn<typeof fetch>(
+      async () =>
+        new Response(
+          `<strong>1 workflow run</strong>${runCard(101, historicalHead, {
+            state,
+            title: "queued cancelled failed pushed",
+            workflow: "pending scheduled",
+            branch: "in progress",
+          })}`.replaceAll("openclaw/Peekaboo", "openclaw/octopool"),
+        ),
+    );
+    vi.stubGlobal("fetch", upstream);
+    const first = await shapedRunList({ limit: "1" });
+    expect(first.body).toMatchObject({
+      workflow_runs: [{ id: 101, status: "completed", conclusion, event: "pull_request" }],
+    });
+    expect(
+      await env.DB.prepare(
+        "SELECT unixepoch(expires_at) - unixepoch(created_at) AS ttl FROM github_cache_entries WHERE route_kind = 'run_list'",
+      ).first(),
+    ).toEqual({ ttl: 120 });
+    expect((await shapedRunList({ status: "completed", limit: "1" })).relay.cache).toBe("hit");
+    expect(upstream).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["unknown status", "not failed", "pull request"],
+    ["conflicting status", "queued failed", "pull request"],
+    ["missing trigger", "in progress", ""],
+    ["conflicting trigger", "in progress", "pull request pushed"],
+    ["unknown trigger", "in progress", "repository dispatch"],
+    [
+      "linked prose",
+      "in progress",
+      '<a href="/openclaw/octopool/tree/refs/heads/pull-request">pull request</a>',
+    ],
+  ])("uses exact REST and caches its metadata for %s", async (_name, state, trigger) => {
+    const urls: string[] = [];
+    const body = {
+      total_count: 1,
+      workflow_runs: [{ ...run(301, "main", "queued", null), event: "workflow_dispatch" }],
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        const request = new Request(input, init);
+        expect(bearer(request)).toBeUndefined();
+        urls.push(request.url);
+        return new URL(request.url).hostname === "github.com"
+          ? new Response(
+              `<strong>1 workflow run</strong>${runCard(101, historicalHead, { state, trigger, title: "completed successfully pushed" })}`.replaceAll(
+                "openclaw/Peekaboo",
+                "openclaw/octopool",
+              ),
+            )
+          : jsonResponse(body);
+      }),
+    );
+    expect((await shapedRunList({ limit: "1" })).body).toEqual(body);
+    expect((await shapedRunList({ limit: "1" })).relay.cache).toBe("hit");
+    expect(urls).toEqual([
+      "https://github.com/openclaw/octopool/actions",
+      "https://api.github.com/repos/openclaw/octopool/actions/runs?page=1&per_page=25",
+    ]);
+  });
 
   it("serves branch, status, and limit variants from one canonical fill", async () => {
     const upstream = vi.fn<typeof fetch>(async (input, init) => {

--- a/test/e2e/actions-cache-terminal-log.test.ts
+++ b/test/e2e/actions-cache-terminal-log.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../../src/terminal-log-cache";
 import type { RelayRequest } from "../../src/types";
 import { bearer, jsonResponse, rateHeaders, relay, seedPool, runWithContext } from "./harness";
+import { historicalHead, runCard } from "../fixtures/actions-ownership";
 
 type RelayEnvelope = {
   status: number;
@@ -24,6 +25,74 @@ type RelayEnvelope = {
 const LOG_PATH = "/repos/openclaw/octopool/actions/jobs/42/logs";
 describe("terminal Actions log cache", () => {
   beforeEach(seedPool);
+
+  it.each(["in_progress", "unavailable"])(
+    "keeps fresh %s job metadata authoritative over misleading summaries and stored logs",
+    async (metadata) => {
+      vi.stubGlobal("fetch", terminalLogUpstream("completed"));
+      expect((await (await relay(LOG_PATH)).json<RelayEnvelope>()).relay.cache).toBe("miss");
+      const download = terminalLogUpstream("in_progress");
+      const upstream = vi.fn<typeof fetch>(async (input, init) => {
+        const request = new Request(input, init);
+        const url = new URL(request.url);
+        if (url.hostname === "github.com" && url.pathname === "/openclaw/octopool/actions") {
+          return new Response(
+            `<strong>1 workflow run</strong>${runCard(99, historicalHead, { state: "in progress", title: "Fix failed test Handle pushed commits" })}`.replaceAll(
+              "openclaw/Peekaboo",
+              "openclaw/octopool",
+            ),
+          );
+        }
+        if (url.pathname === "/repos/openclaw/octopool/actions/jobs/42") {
+          expect(bearer(request)).toBeUndefined();
+          expect(request.headers.has("x-octopool-public-shape")).toBe(false);
+          expect(request.headers.has("if-none-match")).toBe(false);
+          if (metadata === "unavailable") return jsonResponse({ message: "unavailable" }, 503);
+        }
+        return download(input, init);
+      });
+      vi.stubGlobal("fetch", upstream);
+      const list = await relay("/repos/openclaw/octopool/actions/runs", undefined, {
+        query: { limit: "1" },
+        headers: { "x-octopool-public-shape": "actions-summary-v1" },
+      });
+      expect((await list.json<RelayEnvelope>()).relay.cache).toBe("miss");
+      for (const suffix of ["runs/99", "jobs/42"]) {
+        for (const shape of [undefined, "actions-summary-v1"]) {
+          const request: RelayRequest = {
+            pool: "maintainers",
+            method: "GET",
+            path: `/repos/openclaw/octopool/actions/${suffix}`,
+            ...(shape === undefined ? {} : { headers: { "x-octopool-public-shape": shape } }),
+          };
+          const route = classifyRoute(request, defaultPolicy("openclaw"));
+          const key = await githubCacheKey(request.pool, request, route);
+          await writeGitHubCache(env, key, request, route, {
+            status: 200,
+            headers: {},
+            body: { id: 42, run_id: 99, status: "completed", run_attempt: 1 },
+            body_encoding: "json",
+          });
+          expect(await readGitHubCache(env, key)).toMatchObject({ body: { status: "completed" } });
+        }
+      }
+      const get = vi.spyOn(env.ACTIONS_LOGS, "get");
+      const put = vi.spyOn(env.ACTIONS_LOGS, "put");
+      try {
+        expect(await (await relay(LOG_PATH)).json<RelayEnvelope>()).toMatchObject({
+          body: "build log\n",
+          relay: { cache: "bypass" },
+        });
+        expect(jobMetadataCalls(upstream)).toBe(1);
+        expect(logBackendCalls(upstream)).toBe(1);
+        expect(get).not.toHaveBeenCalled();
+        expect(put).not.toHaveBeenCalled();
+      } finally {
+        get.mockRestore();
+        put.mockRestore();
+      }
+    },
+  );
 
   it("caches a fresh completed job and reuses its log after another fresh proof", async () => {
     const upstream = terminalLogUpstream("completed");

--- a/test/e2e/actions-ownership-cache.test.ts
+++ b/test/e2e/actions-ownership-cache.test.ts
@@ -1,14 +1,20 @@
 import { writeOwnedGitHubCache as writeGitHubCache } from "./cache-publication-fixture";
 import { env } from "cloudflare:workers";
+import { runInDurableObject } from "cloudflare:test";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { githubCacheKey } from "../../src/cache";
+import { acquireOwnedCacheFill } from "../../src/cache-fill";
+import { bodyPublicationResource } from "../../src/cache-publication";
+import { poolCoordinatorStub } from "../../src/pool-coordinator";
 import { deleteEdgeJSON } from "../../src/edge-cache";
 import { classifyRoute, defaultPolicy, validateRelayRequest } from "../../src/policy";
 import { seedPublicRepoProof as recordPublicGitHubRepo } from "./cache-publication-fixture";
 import { runListSupersetView } from "../../src/run-list-superset";
 import { legacyActionsKey } from "../fixtures/actions-legacy-cache";
+import { currentV2ActionsKeys } from "../fixtures/actions-current-v2-cache";
+import type { Identity } from "../../src/types";
 import { exactRun, historicalHead, runIDs, wrongPatchHead } from "../fixtures/actions-ownership";
-import { jsonResponse, rateHeaders, relay, seedPool } from "./harness";
+import { bearer, jsonResponse, rateHeaders, relay, seedPool } from "./harness";
 import { ownedWork } from "./owned-work";
 
 const headers = { "x-octopool-public-shape": "actions-summary-v1" };
@@ -17,6 +23,120 @@ type Envelope = { body: unknown; relay: { cache: string; coalesced?: boolean } }
 
 describe("Actions ownership cache migration", () => {
   beforeEach(seedPool);
+
+  it.each(currentV2ActionsKeys)(
+    "ignores current-v2 $name in edge, shared, and identity storage",
+    async (fixture) => {
+      const seeded = await seedCurrentV2(fixture);
+      const upstream = mockUpstream(seeded.body);
+      const first = await relay(fixture.path, undefined, seeded.request);
+      expect(await first.json<Envelope>()).toMatchObject({
+        body: seeded.body,
+        relay: { cache: "miss" },
+      });
+      // A late old writer can republish both old keys, but cannot replace the new representation.
+      await seedCurrentV2(fixture);
+      const calls = upstream.mock.calls.length;
+      expect(
+        await (await relay(fixture.path, undefined, seeded.request)).json<Envelope>(),
+      ).toMatchObject({ body: seeded.body, relay: { cache: "hit" } });
+      expect(upstream).toHaveBeenCalledTimes(calls);
+      expect(
+        await env.DB.prepare(
+          "SELECT COUNT(*) AS count FROM github_cache_entries WHERE cache_key IN (?, ?) AND body_json LIKE '%contaminated-v2%'",
+        )
+          .bind(fixture.shared, fixture.identity)
+          .first(),
+      ).toEqual({ count: 2 });
+    },
+  );
+
+  it("never revives current-v2 validators or stale bodies, including identity entries", async () => {
+    const fixture = currentV2ActionsKeys[0];
+    const { request, body } = await seedCurrentV2(fixture);
+    await expire(fixture.shared);
+    await expire(fixture.identity);
+    const upstream = mockUpstream(body);
+    expect(await (await relay(fixture.path, undefined, request)).json<Envelope>()).toMatchObject({
+      body,
+      relay: { cache: "miss" },
+    });
+    expect(upstream.mock.calls.length).toBeGreaterThan(0);
+    expect(
+      upstream.mock.calls.map(([input, init]) =>
+        new Request(input, init).headers.get("if-none-match"),
+      ),
+    ).not.toContain('"contaminated-v2"');
+  });
+
+  it("refuses current-v2 outage stale data", async () => {
+    const fixture = currentV2ActionsKeys[0];
+    const { request } = await seedCurrentV2(fixture);
+    await expire(fixture.shared);
+    await expire(fixture.identity);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => outageResponse(new Request(input, init))),
+    );
+    const response = await relay(fixture.path, undefined, request);
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(await response.text()).not.toContain("contaminated-v2");
+  });
+
+  it.each(["fresh", "expired"])(
+    "bypasses %s current-v2 identity data and validators on pooled reads",
+    async (age) => {
+      const fixture = currentV2ActionsKeys[0];
+      const { request, body } = await seedCurrentV2(fixture);
+      await expire(fixture.shared);
+      if (age === "expired") await expire(fixture.identity);
+      const upstream = vi.fn<typeof fetch>(async (input, init) => {
+        const fetchRequest = new Request(input, init);
+        if (bearer(fetchRequest) === "test-primary-token")
+          return jsonResponse(body, 200, rateHeaders({ remaining: 4998 }));
+        if (new URL(fetchRequest.url).pathname.toLowerCase() === "/repos/openclaw/peekaboo")
+          return jsonResponse({ private: false });
+        return jsonResponse({ message: "unavailable" }, 503);
+      });
+      vi.stubGlobal("fetch", upstream);
+      expect(await (await relay(fixture.path, undefined, request)).json<Envelope>()).toMatchObject({
+        body,
+        relay: { cache: "miss" },
+      });
+      expect(await (await relay(fixture.path, undefined, request)).json<Envelope>()).toMatchObject({
+        body,
+        relay: { cache: "hit" },
+      });
+      const requests = upstream.mock.calls.map(([input, init]) => new Request(input, init));
+      expect(requests.filter((item) => bearer(item) === "test-primary-token")).toHaveLength(1);
+      expect(requests.map((item) => item.headers.get("if-none-match"))).not.toContain(
+        '"contaminated-v2"',
+      );
+    },
+  );
+
+  it("does not join an outstanding current-v2 fill", async () => {
+    const fixture = currentV2ActionsKeys[0];
+    const { request, body } = await seedCurrentV2(fixture);
+    await expire(fixture.shared);
+    await expire(fixture.identity);
+    const oldFill = await acquireOwnedCacheFill(
+      poolCoordinatorStub(env, request.pool),
+      bodyPublicationResource(fixture.shared),
+    );
+    if (oldFill.kind !== "owner") throw new Error("Old fixture fill was not acquired");
+    const unregister = ownedWork.registerRelease(() => oldFill.owner.fail());
+    try {
+      mockUpstream(body);
+      expect(await (await relay(fixture.path, undefined, request)).json<Envelope>()).toMatchObject({
+        body,
+        relay: { cache: "miss" },
+      });
+    } finally {
+      await oldFill.owner.fail();
+      unregister();
+    }
+  });
 
   it.each([
     [path, "edge"],
@@ -55,75 +175,148 @@ describe("Actions ownership cache migration", () => {
     expect(await response.text()).not.toContain(wrongPatchHead);
   });
 
-  it("coalesces a clean fill, revalidates only its new key, and serves only clean stale data", async () => {
-    const { request, oldKey, body, route } = await seedLegacy(path);
-    await expire(oldKey);
-    let started!: () => void;
-    const { promise: gate, release } = ownedWork.gate();
-    const entered = new Promise<void>((resolve) => {
-      started = resolve;
-    });
-    const conditionals: (string | null)[] = [];
-    let phase: "fill" | "revalidate" | "outage" = "fill";
-    let apiCalls = 0;
-    vi.stubGlobal(
-      "fetch",
-      vi.fn<typeof fetch>(async (input, init) => {
-        const upstream = new Request(input, init);
-        if (phase === "outage") return outageResponse(upstream);
-        if (new URL(upstream.url).hostname === "github.com")
-          return new Response("no page", { status: 404 });
-        apiCalls++;
-        conditionals.push(upstream.headers.get("if-none-match"));
-        if (phase === "fill") {
-          started();
-          await gate;
-        }
-        if (upstream.headers.has("if-none-match"))
-          return new Response(null, {
-            status: 304,
-            headers: { ...rateHeaders({ remaining: 59 }), etag: '"clean"' },
-          });
-        return jsonResponse(body, 200, { ...rateHeaders({ remaining: 59 }), etag: '"clean"' });
-      }),
-    );
-    const leader = relay(path, undefined, request);
-    const requests = [leader];
-    try {
-      await entered;
-      const follower = relay(path, undefined, request);
-      requests.push(follower);
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      release();
-      const filled = await Promise.all(
-        [leader, follower].map(async (response) => (await response).json<Envelope>()),
+  it.each(["legacy", "current-v2"])(
+    "coalesces a clean fill past %s, revalidates only its new key, and serves only clean stale data",
+    async (generation) => {
+      const { request, oldKey, body, route } =
+        generation === "legacy"
+          ? await seedLegacy(path)
+          : await seedCurrentV2(currentV2ActionsKeys[0]);
+      await expire(oldKey);
+      if (generation === "current-v2") await expire(currentV2ActionsKeys[0].identity);
+      let started!: () => void;
+      const { promise: gate, release } = ownedWork.gate();
+      const entered = new Promise<void>((resolve) => {
+        started = resolve;
+      });
+      const conditionals: (string | null)[] = [];
+      let phase: "fill" | "revalidate" | "outage" = "fill";
+      let apiCalls = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>(async (input, init) => {
+          const upstream = new Request(input, init);
+          if (phase === "outage") return outageResponse(upstream);
+          if (new URL(upstream.url).hostname === "github.com")
+            return new Response("no page", { status: 404 });
+          apiCalls++;
+          conditionals.push(upstream.headers.get("if-none-match"));
+          if (phase === "fill") {
+            started();
+            await gate;
+          }
+          if (upstream.headers.has("if-none-match"))
+            return new Response(null, {
+              status: 304,
+              headers: { ...rateHeaders({ remaining: 59 }), etag: '"clean"' },
+            });
+          return jsonResponse(body, 200, { ...rateHeaders({ remaining: 59 }), etag: '"clean"' });
+        }),
       );
-      expect(filled.map((item) => item.body)).toEqual([body, body]);
-      expect(filled[1]?.relay.coalesced).toBe(true);
-      expect(apiCalls).toBe(1);
-      expect(conditionals).toEqual([null]);
-    } finally {
-      release();
-      await Promise.allSettled(requests);
-    }
+      const leader = relay(path, undefined, request);
+      const requests = [leader];
+      try {
+        await entered;
+        const follower = relay(path, undefined, request);
+        requests.push(follower);
+        // Elapsed time is not proof that the native follower has registered.
+        await vi.waitFor(
+          async () => {
+            const waiting = await runInDurableObject(
+              poolCoordinatorStub(env, request.pool),
+              (instance) =>
+                (instance as unknown as { publicationWaiters: Map<string, unknown> })
+                  .publicationWaiters.size,
+            );
+            expect(waiting).toBe(1);
+          },
+          { timeout: 5_000 },
+        );
+        release();
+        const filled = await Promise.all(
+          [leader, follower].map(async (response) => (await response).json<Envelope>()),
+        );
+        expect(filled.map((item) => item.body)).toEqual([body, body]);
+        expect(filled[1]?.relay.coalesced).toBe(true);
+        expect(apiCalls).toBe(1);
+        expect(conditionals).toEqual([null]);
+      } finally {
+        release();
+        await Promise.allSettled(requests);
+      }
 
-    const newKey = await githubCacheKey(request.pool, request, route);
-    expect(newKey).not.toBe(oldKey);
-    await expire(newKey);
-    phase = "revalidate";
-    expect(await (await relay(path, undefined, request)).json<Envelope>()).toMatchObject({
-      body,
-      relay: { cache: "hit" },
-    });
-    expect(conditionals).toEqual([null, '"clean"']);
-    await expire(newKey);
-    phase = "outage";
-    expect(await (await relay(path, undefined, request)).json<Envelope>()).toMatchObject({
-      body,
-      relay: { cache: "stale" },
-    });
-  });
+      const newKey = await githubCacheKey(request.pool, request, route);
+      expect(newKey).not.toBe(oldKey);
+      await expire(newKey);
+      phase = "revalidate";
+      expect(await (await relay(path, undefined, request)).json<Envelope>()).toMatchObject({
+        body,
+        relay: { cache: "hit" },
+      });
+      expect(conditionals).toEqual([null, '"clean"']);
+      await expire(newKey);
+      phase = "outage";
+      expect(await (await relay(path, undefined, request)).json<Envelope>()).toMatchObject({
+        body,
+        relay: { cache: "stale" },
+      });
+    },
+  );
 });
+
+async function seedCurrentV2(fixture: (typeof currentV2ActionsKeys)[number]) {
+  const request = validateRelayRequest({
+    pool: "maintainers",
+    method: "GET",
+    path: fixture.path,
+    query: fixture.query,
+    headers,
+  });
+  const route = classifyRoute(request, defaultPolicy("openclaw"));
+  const run = exactRun(runIDs[0]!);
+  const list = fixture.path.endsWith("/runs");
+  const body = list ? { total_count: 1, workflow_runs: [run] } : run;
+  const contaminated = {
+    ...run,
+    display_title: "contaminated-v2",
+    status: "completed",
+    conclusion: "success",
+    event: "push",
+  };
+  await recordPublicGitHubRepo(env, route);
+  const identity: Identity = {
+    id: "primary",
+    kind: "pat",
+    login: "primary",
+    secret_ref: "TEST_PAT_PRIMARY",
+    installation_id: null,
+    weight: 200,
+  };
+  for (const owner of [undefined, identity]) {
+    const key = owner === undefined ? fixture.shared : fixture.identity;
+    expect(
+      await writeGitHubCache(
+        env,
+        key,
+        request,
+        route,
+        {
+          status: 200,
+          headers: { ...rateHeaders({ remaining: 59 }), etag: '"contaminated-v2"' },
+          body: list ? { total_count: 1, workflow_runs: [contaminated] } : contaminated,
+          body_encoding: "json",
+        },
+        owner,
+      ),
+    ).toBe("shared");
+  }
+  // Alternate cases exercise D1-only old storage as well as real Cache API entries.
+  if (fixture.name !== "run view" && fixture.name !== "workflow canonical") {
+    await deleteEdgeJSON("github-publication-v1", fixture.shared);
+    await deleteEdgeJSON("github-publication-v1", fixture.identity);
+  }
+  return { request, body, route, oldKey: fixture.shared };
+}
 
 async function seedLegacy(routePath: string) {
   const list = routePath.endsWith("/runs");
@@ -163,7 +356,6 @@ async function expire(key: string) {
 function mockUpstream(body: unknown) {
   const upstream = vi.fn<typeof fetch>(async (input, init) => {
     const request = new Request(input, init);
-    expect(request.headers.get("if-none-match")).toBeNull();
     return new URL(request.url).hostname === "github.com"
       ? new Response("no page", { status: 404 })
       : jsonResponse(body);

--- a/test/fixtures/actions-current-v2-cache.ts
+++ b/test/fixtures/actions-current-v2-cache.ts
@@ -1,0 +1,56 @@
+// Frozen at d889518b: publication-v1 + actions-summary-owned-v2, including pat:primary.
+// Literal digests intentionally do not call or reproduce the current key generator.
+export const currentV2ActionsKeys = [
+  {
+    name: "run view",
+    path: "/repos/openclaw/Peekaboo/actions/runs/33167365292",
+    query: {},
+    shared: "9xNZu-zUwttyqWXYFdBmX0yQQsCDJiJy667ck7CcVz8",
+    identity: "cXVga4RdgZBKVTQCbWBLdLYNnt0-B8j66y1jh0u4S-c",
+  },
+  {
+    name: "attempt view",
+    path: "/repos/openclaw/Peekaboo/actions/runs/33167365292/attempts/1",
+    query: {},
+    shared: "EMlmicYruCeMZFd3mnFiZSG0XTok1W0ztoJrWUk5S2Y",
+    identity: "eceje0t6MfeuDTtAjT4oHLauTBTj8_ZzyI1HIX3JPyY",
+  },
+  {
+    name: "canonical 25",
+    path: "/repos/openclaw/Peekaboo/actions/runs",
+    query: {
+      per_page: "25",
+    },
+    shared: "D0m2aO5VIbWOtCfTn5xvYzua9bTqMzo2LQhBQ4xxQjI",
+    identity: "dlZGyAtqA9MFzGDBY9xPG7ziEr-alZBV9n5se8Zym1U",
+  },
+  {
+    name: "canonical 100",
+    path: "/repos/openclaw/Peekaboo/actions/runs",
+    query: {
+      per_page: "100",
+    },
+    shared: "owF0w3prvduQeDbfQ4fy_4utL7xIiox21HvRFLp5Sfw",
+    identity: "tcKSD_kBRvTcxLRypafpGDG5iEEiPBsZPx3QhoCiLhU",
+  },
+  {
+    name: "exact filtered",
+    path: "/repos/openclaw/Peekaboo/actions/runs",
+    query: {
+      page: "2",
+      per_page: "1",
+      status: "completed",
+    },
+    shared: "ihSbzf7lLFX2xZuCVAZtLmvp_yF1VB8lLgMjQdSKBXE",
+    identity: "MFY9gHvbSyq-RUs6QbxZyD6-ivkMOSWy--FRVR9dxg8",
+  },
+  {
+    name: "workflow canonical",
+    path: "/repos/openclaw/Peekaboo/actions/workflows/ci.yml/runs",
+    query: {
+      per_page: "25",
+    },
+    shared: "l-l6C18vI_HBxMJvKc8_hQwRkTNQkBMke_aTOHAUzdc",
+    identity: "_jxH52JA6hYjrGQj7PkRmWJNuYxk_b6fHxMTdHkmHPU",
+  },
+] as const;

--- a/test/fixtures/actions-ownership.ts
+++ b/test/fixtures/actions-ownership.ts
@@ -63,11 +63,29 @@ export const mergePatch = [
   )
   .join("\n");
 
-export function runCard(id: number, sha?: string): string {
+export function runCard(
+  id: number,
+  sha?: string,
+  metadata: {
+    state?: string;
+    title?: string;
+    workflow?: string;
+    trigger?: string;
+    branch?: string;
+  } = {},
+): string {
+  const {
+    state = "failed",
+    title = "fixture",
+    workflow = "CI",
+    trigger = "pull request",
+    branch,
+  } = metadata;
   return `<div class="Box-row js-socket-channel js-updatable-content">
-    <a href="/openclaw/Peekaboo/actions/runs/${id}" aria-label="failed: Run 651 of CI. fixture"><span class="h4 markdown-title">fixture</span></a>
-    <div><span class="text-bold">CI</span> #651: pull request
+    <a href="/openclaw/Peekaboo/actions/runs/${id}" aria-label="${state}: Run 651 of ${workflow}. ${title}"><span class="h4 markdown-title">${title}</span></a>
+    <div><span class="text-bold">${workflow}</span> #651: ${trigger}
     <relative-time datetime="2026-08-28T11:29:48Z"></relative-time>
+    ${branch === undefined ? "" : `<a class="branch-name" href="/openclaw/Peekaboo/tree/refs/heads/${branch}">${branch}</a>`}
     ${sha === undefined ? "" : `<a href="/openclaw/Peekaboo/commit/${sha}">${sha}</a>`}</div>
   </div>`;
 }


### PR DESCRIPTION
## Summary

Actions summary parsing searched status labels and whole cards for words that could also appear in workflow names, titles, or branches. An in-progress run titled “Fix failed test: Handle pushed commits” could therefore become a completed failure with a push event, affecting filters, cache hits, and TTLs.

Status now comes from the exact recognized prefix of the owned status label. Run number and event come from the bounded workflow-to-timestamp interval; push requires owned commit-link scaffolding and does not trust link display text. Missing, conflicting, or unfamiliar markup uses the existing API fallback rather than guessing. This bounded contract deliberately trades an API read for correctness when GitHub changes its layout.

Advance the common shaped Actions representation to `actions-summary-metadata-v3`, so existing clients cannot reuse current-v2 bodies, validators, stale entries, identity variants, or old in-flight fills. No purge is needed. Wire format, raw REST, jobs, public proofs, and terminal-log/R2 representations remain unchanged. Native controls confirm that fresh job and attempt metadata—not list titles—continues to govern terminal caching.

## Verification

- Actual pre-fix native proof: 19 expected failures with 42 passing controls for metadata contamination and current-v2 cache reuse. Owner tests separately reproduced 32 expected failures with 110 passing controls.
- Owner/adapter/generation tests pass. All 65 focused native controls pass, covering filters, active/terminal TTLs, exact API fallback, real edge/D1/identity storage, old validators/stale/fills, late old writers, and terminal/attempt isolation.
- The final parent `pnpm check` passed with 799 unit tests, 853 native Worker tests, generation/format/lint/build/type checks, Go 1.26 tests, and vet. All 65 focused native controls also passed independently.
- Complete independent P2 review is clean. A touched coalescing fixture now observes real native waiter registration instead of relying on a 100 ms delay; its overall deadline and cleanup safeguards are unchanged. Fresh post-commit verification and exact-head CI are required before merge.

Native Worker/storage boundaries were real; external HTML/API/log-download fixtures were synthetic. This is not a live GitHub DOM inventory or hosted R2/installed-CLI proof. Fixture-development errors and an interrupted tooling phase are preserved separately from product regressions. The exact same pnpm version was restored in task-owned storage after its shared-store path disappeared; no repository dependency, global tool, runtime, policy, or production setting changed. No deployment or release is included.

Release-note context: Keep Actions summary status and event metadata owned by the run’s status/trigger markup, preventing title/workflow/branch prose from contaminating cached summaries and retiring prior shaped representations.

## Fresh landing verification

Post-commit verification passed on `050e9c2183ee54d5a0bb65eac26af83c59c1641a`: 65 focused native tests in 4.04 s; full `pnpm check` passed with 799 unit tests (0.993 s), 853 native Worker tests (17.75 s), Go 1.26.7 tests (80.837 s), vet, and generation/format/lint/build/type checks. The committed tree and all eleven reviewed file blobs match the approved candidate exactly, with no generated drift. No rebase or local gate retry was needed.
