### PR TITLE
fix: preserve opaque GitHub response and log bytes

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -38,6 +38,15 @@ Default pagination
 media types and non-default query values still produce distinct entries. The key is
 pool-scoped, so pools never share cache entries.
 
+Non-default JSON `Accept` variants also carry `body_codec: lossless-v1`, using the
+same normalization as the vary headers. Raw blob/contents/README, octet-stream,
+diff/patch, and other custom media cannot reuse old opaque bodies or validators in
+edge, D1, identity caches, stale fallback, or fill coalescing. This field composes with
+the representation generations below. Default JSON keys stay warm: this is bounded
+media retirement, not a purge of hypothetical malformed non-JSON responses previously
+returned to default-JSON requests. Future opaque decoding is lossless regardless of
+the request's negotiation.
+
 Actions summaries also include a server-controlled representation generation
 (`actions-summary-metadata-v3`) in this common key. Run views, attempt-qualified views,
 and repository/workflow run lists, including canonical supersets and identity-specific
@@ -239,16 +248,24 @@ classification preserves cached bodies and raw response states.
 
 `job_logs` requests fetch the job endpoint without using edge or D1 metadata cache and
 require that fresh job payload's own `status` to be `completed`. A cached completed run can
-therefore never make an active job from a re-run terminal. Whole-run log routes likewise
-require a fresh uncached run payload whose current status is `completed`, plus a positive
-`run_attempt`; the attempt becomes part of the R2 key so a completed re-run cannot receive
-an earlier attempt's archive. Active, unknown, attempt-less, or failed metadata probes keep
+therefore never make an active job from a re-run terminal. Whole-run log archives are
+not admitted by the relay route manifest and remain native GitHub CLI fallback; only
+job-log routes use this cache. Active, unknown, or failed job metadata probes keep
 the previous large-payload bypass behavior. Only a successful 2xx anonymous metadata
 response records a public-repository proof. A proven-terminal log uses the dedicated
-`ACTIONS_LOGS` R2 bucket, keyed by pool, exact route path, and whole-run attempt when
-applicable, so immutable log downloads are shared without putting their large payloads in D1.
+`ACTIONS_LOGS` R2 bucket, keyed by pool and exact job route path, so immutable log
+downloads are shared without putting their large payloads in D1. Jobs from separate
+run attempts retain their distinct job IDs.
 
 R2 stores the raw log bytes, content type, original body encoding, and a retention timestamp.
+Corrected writers also set the exact `body-codec: lossless-v1` object metadata marker.
+Objects with a missing or different marker are misses before serving or existence-only
+renewal. The Worker downloads the original bytes after fresh completion proof, then
+replaces the object; a failed download or write leaves the previous object intact.
+Legacy base64 objects were already reversible but also miss once under this format
+contract. A late old writer produces another marker miss. The bucket prefix and
+seven-day lifecycle are unchanged; no purge or bucket migration is required.
+
 After the fresh terminal-status proof, an object younger than one hour can be served without
 contacting the log endpoint. Older objects also make an authenticated log request without
 following its redirect: a validated `302 Location` confirms existence and refreshes the

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -79,7 +79,14 @@ and patch hosts.
 
 - `headers` are filtered to a safe allowlist (content negotiation, caching,
   rate-limit, request id). Authorization and cookies never leave the Worker.
-- `body_encoding` is `json`, `text`, or `base64`. Binary responses are base64-encoded.
+- `body_encoding` is `json`, `text`, or `base64`. Opaque API and public diff/patch
+  responses preserve bytes: invalid UTF-8, a leading UTF-8 BOM, or NUL in the first
+  1,024 bytes selects base64. Other valid UTF-8 stays text, including literal U+FFFD,
+  CRLF, and later NUL bytes. Empty API responses remain null/text; empty public
+  diff/patch responses remain empty-string/text. Successful `application/json`
+  parsing retains existing JSON value semantics, without promising original JSON
+  bytes or whitespace; malformed JSON falls back to lossless opaque encoding.
+  The response cap applies to upstream bytes before base64 or envelope expansion.
 - `repo_view` returns a fixed public metadata subset before caching so token-specific
   repository fields such as identity permissions are not shared.
 - Release list/latest/tag/id reads and top-level `gh release view` summaries use the

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -75,13 +75,14 @@ export async function githubCacheKey(
   route: RouteInfo,
   identity?: Pick<Identity, "id" | "kind">,
 ): Promise<string> {
+  const varyHeaders = cacheVaryHeaders(request.headers);
   const stable = {
     protocol_epoch: CACHE_PUBLICATION_EPOCH,
     pool,
     method: request.method,
     path: request.path,
     query: normalizedCacheQuery(request.query ?? {}),
-    headers: stableRecord(cacheVaryHeaders(request.headers)),
+    headers: stableRecord(varyHeaders),
     route_key: route.routeKey,
     state: cacheStateDiscriminator(route),
     // Retire contaminated page shapes for existing clients in every cache/fill path.
@@ -96,6 +97,7 @@ export async function githubCacheKey(
     // Old raw event bodies may contain privileged references, even after a 304
     // republished an identity entry as anonymous. Retire every variant together.
     ...(isIssueEventRoute(route.kind) ? { representation: "issue-events-public-v2" } : {}),
+    ...(varyHeaders.accept === undefined ? {} : { body_codec: "lossless-v1" }),
     ...(identity === undefined ? {} : { identity: `${identity.kind}:${identity.id}` }),
   };
   return hashToken(JSON.stringify(stable));

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -6,6 +6,28 @@ export function bytesToBase64(bytes: Uint8Array): string {
   return btoa(binary);
 }
 
+export function encodeOpaqueBytes(bytes: Uint8Array): {
+  body: string;
+  encoding: "text" | "base64";
+} {
+  if (!bytes.subarray(0, 1024).includes(0)) {
+    try {
+      const text = new TextDecoder("utf-8", { fatal: true, ignoreBOM: false }).decode(bytes);
+      const encoded = new TextEncoder().encode(text);
+      // Default decoding strips a leading BOM even when UTF-8 is valid.
+      if (
+        encoded.length === bytes.length &&
+        encoded.every((byte, index) => byte === bytes[index])
+      ) {
+        return { body: text, encoding: "text" };
+      }
+    } catch {
+      // Invalid UTF-8 must remain reversible in the wire envelope.
+    }
+  }
+  return { body: bytesToBase64(bytes), encoding: "base64" };
+}
+
 export function bytesToBase64URL(bytes: Uint8Array): string {
   return bytesToBase64(bytes).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
 }

--- a/src/github-public-content.ts
+++ b/src/github-public-content.ts
@@ -1,4 +1,4 @@
-import { bytesToBase64 } from "./encoding";
+import { bytesToBase64, encodeOpaqueBytes } from "./encoding";
 import { responseCapBytes } from "./github-limits";
 import { encodedPathSegments, safeRelativePath } from "./github-path";
 import {
@@ -52,13 +52,16 @@ export function mediaWebRequest(
     headers: { accept: `${contentType}, text/plain, */*`, "user-agent": "octopool" },
     capBytes: responseCapBytes(env),
     usesApiQuota: false,
-    payload: (body, headers, status) => ({
-      status,
-      headers: publicResponseHeaders(headers, contentType),
-      body: new TextDecoder().decode(body),
-      body_encoding: "text",
-      backend: "web",
-    }),
+    payload: (bytes, headers, status) => {
+      const { body, encoding } = encodeOpaqueBytes(bytes);
+      return {
+        status,
+        headers: publicResponseHeaders(headers, contentType),
+        body,
+        body_encoding: encoding,
+        backend: "web",
+      };
+    },
   };
 }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,4 +1,4 @@
-import { bytesToBase64 } from "./encoding";
+import { encodeOpaqueBytes } from "./encoding";
 import type { GitHubEgressEnv } from "./github-egress";
 import { requestTimeoutMs, responseCapBytes } from "./github-limits";
 import { appendRelayQuery } from "./github-path";
@@ -206,25 +206,13 @@ function decodeBody(
   if (bytes.length === 0) {
     return { body: null, encoding: "text" };
   }
-  const text = new TextDecoder().decode(bytes);
   if (contentType.includes("application/json")) {
     try {
+      const text = new TextDecoder().decode(bytes);
       return { body: JSON.parse(text) as unknown, encoding: "json" };
     } catch {
-      return { body: text, encoding: "text" };
+      // Malformed JSON falls back to the same lossless opaque representation.
     }
   }
-  if (isMostlyText(bytes)) {
-    return { body: text, encoding: "text" };
-  }
-  return { body: bytesToBase64(bytes), encoding: "base64" };
-}
-
-function isMostlyText(bytes: Uint8Array): boolean {
-  for (const byte of bytes.slice(0, 1024)) {
-    if (byte === 0) {
-      return false;
-    }
-  }
-  return true;
+  return encodeOpaqueBytes(bytes);
 }

--- a/src/terminal-log-cache.ts
+++ b/src/terminal-log-cache.ts
@@ -13,6 +13,8 @@ const LOG_REVALIDATE_SECONDS = 60 * 60;
 const LOG_KEY_PREFIX = "github-actions-logs/v1/";
 const CREATED_AT_METADATA = "created-at";
 const BODY_ENCODING_METADATA = "body-encoding";
+const BODY_CODEC_METADATA = "body-codec";
+const BODY_CODEC = "lossless-v1";
 
 export type CachedTerminalLog = GitHubRelayResponse & {
   created_at: string;
@@ -21,9 +23,8 @@ export type CachedTerminalLog = GitHubRelayResponse & {
 
 export type TerminalLogCacheProof = { key: string };
 
-export function terminalLogCacheKey(request: RelayRequest, runAttempt?: number): string {
-  const base = `${LOG_KEY_PREFIX}${encodeURIComponent(request.pool)}${request.path}`;
-  return runAttempt === undefined ? base : `${base}/attempt-${String(runAttempt)}`;
+export function terminalLogCacheKey(request: RelayRequest): string {
+  return `${LOG_KEY_PREFIX}${encodeURIComponent(request.pool)}${request.path}`;
 }
 
 export async function terminalLogCacheProof(
@@ -38,40 +39,20 @@ export async function terminalLogCacheProof(
       return undefined;
     }
     const jobID = /\/actions\/jobs\/([0-9]+)\/logs$/.exec(request.path)?.[1];
-    if (jobID !== undefined) {
-      const job = await fetchFreshMetadata(
-        env,
-        metadataRequest(request, `/repos/${route.owner}/${route.repo}/actions/jobs/${jobID}`),
-        policy,
-      );
-      return metadataProvesCompleted(job) ? { key: terminalLogCacheKey(request) } : undefined;
-    }
-    const runID = /\/actions\/runs\/([0-9]+)\/logs$/.exec(request.path)?.[1];
-    if (runID === undefined) {
+    if (jobID === undefined) {
       return undefined;
     }
-    const run = await fetchFreshMetadata(
+    const job = await fetchFreshMetadata(
       env,
-      metadataRequest(request, `/repos/${route.owner}/${route.repo}/actions/runs/${runID}`),
+      metadataRequest(request, `/repos/${route.owner}/${route.repo}/actions/jobs/${jobID}`),
       policy,
     );
-    const runAttempt = completedRunAttempt(run);
-    return runAttempt === undefined ? undefined : { key: terminalLogCacheKey(request, runAttempt) };
+    return metadataProvesCompleted(job) ? { key: terminalLogCacheKey(request) } : undefined;
   } catch (error) {
     rethrowStringRewriteDenial(error);
     console.error("actions log completion preflight failed", error);
     return undefined;
   }
-}
-
-export async function terminalLogRunCompleted(
-  env: GitHubEgressEnv,
-  ctx: ExecutionContext,
-  request: RelayRequest,
-  route: RouteInfo,
-  policy: PoolPolicy,
-): Promise<boolean> {
-  return (await terminalLogCacheProof(env, ctx, request, route, policy)) !== undefined;
 }
 
 export function terminalLogNeedsRevalidation(cached: CachedTerminalLog): boolean {
@@ -103,11 +84,17 @@ export async function readTerminalLogCache(
       !Number.isFinite(createdAtMs) ||
       Date.now() - createdAtMs >= LOG_TTL_SECONDS * 1000
     ) {
+      await object.body.cancel();
       try {
         await env.ACTIONS_LOGS.delete(key);
       } catch (error) {
         console.error("expired actions log deletion failed", error);
       }
+      return undefined;
+    }
+    if (object.customMetadata?.[BODY_CODEC_METADATA] !== BODY_CODEC) {
+      // Reject legacy bytes before serving or existence-only renewal; replace only after download.
+      await object.body.cancel();
       return undefined;
     }
     const bytes = new Uint8Array(await object.arrayBuffer());
@@ -144,6 +131,7 @@ export async function writeTerminalLogCache(
     customMetadata: {
       [CREATED_AT_METADATA]: createdAt,
       [BODY_ENCODING_METADATA]: encoding,
+      [BODY_CODEC_METADATA]: BODY_CODEC,
     },
   });
 }
@@ -169,16 +157,6 @@ function metadataProvesCompleted(response: GitHubRelayResponse | undefined): boo
     isRecord(response.body) &&
     response.body.status === "completed"
   );
-}
-
-function completedRunAttempt(response: GitHubRelayResponse | undefined): number | undefined {
-  if (response === undefined || !metadataProvesCompleted(response) || !isRecord(response.body)) {
-    return undefined;
-  }
-  const attempt = response.body.run_attempt;
-  return typeof attempt === "number" && Number.isSafeInteger(attempt) && attempt > 0
-    ? attempt
-    : undefined;
 }
 
 function metadataRequest(request: RelayRequest, path: string): RelayRequest {

--- a/test/e2e/actions-cache-terminal-log.test.ts
+++ b/test/e2e/actions-cache-terminal-log.test.ts
@@ -5,14 +5,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { githubCacheKey, readGitHubCache } from "../../src/cache";
 import { deleteEdgeJSON } from "../../src/edge-cache";
 import { classifyRoute, defaultPolicy } from "../../src/policy";
-import {
-  terminalLogCacheKey,
-  terminalLogCacheProof,
-  terminalLogRunCompleted,
-} from "../../src/terminal-log-cache";
+import { terminalLogCacheKey, terminalLogCacheProof } from "../../src/terminal-log-cache";
 import type { RelayRequest } from "../../src/types";
 import { bearer, jsonResponse, rateHeaders, relay, seedPool, runWithContext } from "./harness";
 import { historicalHead, runCard } from "../fixtures/actions-ownership";
+import { envelopeBytes, opaqueBytes } from "../fixtures/opaque-bytes";
 
 type RelayEnvelope = {
   status: number;
@@ -25,6 +22,114 @@ type RelayEnvelope = {
 const LOG_PATH = "/repos/openclaw/octopool/actions/jobs/42/logs";
 describe("terminal Actions log cache", () => {
   beforeEach(seedPool);
+
+  it.each([opaqueBytes[0], opaqueBytes[2], opaqueBytes[5], opaqueBytes[6]])(
+    "stores literal $name bytes in native R2 and reuses them after fresh completion",
+    async (fixture) => {
+      const upstream = terminalLogUpstream("completed", new Uint8Array(fixture.bytes));
+      vi.stubGlobal("fetch", upstream);
+      const key = terminalLogCacheKey({ pool: "maintainers", method: "GET", path: LOG_PATH });
+      for (const cache of ["miss", "hit"]) {
+        const response = await relay(LOG_PATH);
+        expect(response.status).toBe(200);
+        const wire = await response.json<RelayEnvelope>();
+        expect.soft(envelopeBytes(wire)).toEqual(fixture.bytes);
+        expect.soft(wire).toMatchObject({
+          status: 200,
+          body_encoding: fixture.encoding,
+          headers: { "content-type": "text/plain" },
+          relay: { cache },
+        });
+        const object = await env.ACTIONS_LOGS.get(key);
+        expect(object).not.toBeNull();
+        expect.soft([...new Uint8Array(await object!.arrayBuffer())]).toEqual(fixture.bytes);
+        expect.soft(object!.customMetadata).toMatchObject({
+          "body-codec": "lossless-v1",
+          "body-encoding": fixture.encoding,
+          "created-at": expect.any(String),
+        });
+      }
+      expect(jobMetadataCalls(upstream)).toBe(2);
+      expect(logBackendCalls(upstream)).toBe(1);
+      expect(downloadCalls(upstream)).toBe(1);
+    },
+  );
+
+  it.each([
+    { marker: undefined, age: "-10 minutes", encoding: "text", body: "�A" },
+    { marker: undefined, age: "-2 hours", encoding: "text", body: "�A" },
+    { marker: "lossless-v0", age: "-2 hours", encoding: "text", body: "�A" },
+    { marker: "lossless-v1-extra", age: "-10 minutes", encoding: "text", body: "�A" },
+    {
+      marker: undefined,
+      age: "-10 minutes",
+      encoding: "base64",
+      body: new Uint8Array([0xff, 0x41]),
+    },
+  ])(
+    "redownloads legacy R2 $encoding / $marker / $age before serving or renewing",
+    async (fixture) => {
+      const original = [0xff, 0x41];
+      const key = terminalLogCacheKey({ pool: "maintainers", method: "GET", path: LOG_PATH });
+      await seedLegacyLog(key, fixture);
+      const rejected = await env.ACTIONS_LOGS.get(key);
+      expect(rejected).not.toBeNull();
+      const cancel = vi.spyOn(rejected!.body, "cancel");
+      vi.spyOn(env.ACTIONS_LOGS, "get").mockResolvedValueOnce(rejected);
+      const upstream = terminalLogUpstream("completed", new Uint8Array(original));
+      vi.stubGlobal("fetch", upstream);
+      const remove = vi.spyOn(env.ACTIONS_LOGS, "delete");
+      const wire = await (await relay(LOG_PATH)).json<RelayEnvelope>();
+      expect.soft(envelopeBytes(wire)).toEqual(original);
+      expect.soft(wire.relay.cache).toBe("miss");
+      expect.soft(downloadCalls(upstream)).toBe(1);
+      expect(remove).not.toHaveBeenCalled();
+      expect(cancel).toHaveBeenCalledOnce();
+      const object = await env.ACTIONS_LOGS.get(key);
+      expect.soft([...new Uint8Array(await object!.arrayBuffer())]).toEqual(original);
+      expect
+        .soft(object!.customMetadata)
+        .toMatchObject({ "body-codec": "lossless-v1", "body-encoding": "base64" });
+    },
+  );
+
+  it("keeps a rejected object's bytes until a download and replacement succeed, including a late old writer", async () => {
+    const key = terminalLogCacheKey({ pool: "maintainers", method: "GET", path: LOG_PATH });
+    await seedLegacyLog(key, { age: "-2 hours", encoding: "text", body: "�A" });
+    const before = await env.ACTIONS_LOGS.get(key);
+    const oldBytes = [...new Uint8Array(await before!.arrayBuffer())];
+    const base = terminalLogUpstream("completed", new Uint8Array([0xff, 0x41]));
+    const failed = vi.fn<typeof fetch>(async (input, init) =>
+      new URL(new Request(input, init).url).hostname ===
+      "results-receiver.actions.githubusercontent.com"
+        ? new Response("download unavailable", { status: 503 })
+        : base(input, init),
+    );
+    vi.stubGlobal("fetch", failed);
+    const remove = vi.spyOn(env.ACTIONS_LOGS, "delete");
+    const failedWire = await (await relay(LOG_PATH)).json<RelayEnvelope>();
+    expect.soft(failedWire.status).toBe(503);
+    const retained = await env.ACTIONS_LOGS.get(key);
+    expect.soft([...new Uint8Array(await retained!.arrayBuffer())]).toEqual(oldBytes);
+    expect.soft(retained!.customMetadata).toEqual(before!.customMetadata);
+    vi.stubGlobal("fetch", base);
+    const put = vi
+      .spyOn(env.ACTIONS_LOGS, "put")
+      .mockRejectedValueOnce(new Error("synthetic replacement failure"));
+    const goodWire = await (await relay(LOG_PATH)).json<RelayEnvelope>();
+    expect.soft(envelopeBytes(goodWire)).toEqual([0xff, 0x41]);
+    put.mockRestore();
+    const afterFailure = await env.ACTIONS_LOGS.get(key);
+    expect.soft([...new Uint8Array(await afterFailure!.arrayBuffer())]).toEqual(oldBytes);
+    expect.soft(afterFailure!.customMetadata).toEqual(before!.customMetadata);
+    expect.soft((await (await relay(LOG_PATH)).json<RelayEnvelope>()).relay.cache).toBe("miss");
+    await seedLegacyLog(key, { age: "-10 minutes", encoding: "text", body: "�A" });
+    const afterOldWriter = await (await relay(LOG_PATH)).json<RelayEnvelope>();
+    expect.soft(envelopeBytes(afterOldWriter)).toEqual([0xff, 0x41]);
+    expect.soft(afterOldWriter.relay.cache).toBe("miss");
+    expect.soft(downloadCalls(base)).toBe(3);
+    expect(remove).not.toHaveBeenCalled();
+  });
 
   it.each(["in_progress", "unavailable"])(
     "keeps fresh %s job metadata authoritative over misleading summaries and stored logs",
@@ -210,7 +315,7 @@ describe("terminal Actions log cache", () => {
 
     await expect(
       runWithContext((ctx) =>
-        terminalLogRunCompleted(
+        terminalLogCacheProof(
           withGitHubEgress(env, []),
           ctx,
           request,
@@ -218,72 +323,29 @@ describe("terminal Actions log cache", () => {
           policy,
         ),
       ),
-    ).resolves.toBe(false);
+    ).resolves.toBeUndefined();
     expect(
       await env.DB.prepare("SELECT COUNT(*) AS count FROM github_public_repo_proofs").first(),
     ).toEqual({ count: 0 });
   });
 
-  it.each([
-    ["in_progress", 2, false],
-    ["completed", undefined, false],
-    ["completed", 2, true],
-  ] as const)(
-    "uses fresh whole-run status %s attempt %s instead of cached completion",
-    async (status, runAttempt, cacheable) => {
-      const policy = defaultPolicy("openclaw");
-      const runRequest: RelayRequest = {
-        pool: "maintainers",
-        method: "GET",
-        path: "/repos/openclaw/octopool/actions/runs/99",
-      };
-      const runRoute = classifyRoute(runRequest, policy);
-      await writeGitHubCache(
-        env,
-        await githubCacheKey(runRequest.pool, runRequest, runRoute),
-        runRequest,
-        runRoute,
-        {
-          status: 200,
-          headers: { "content-type": "application/json" },
-          body: { id: 99, status: "completed", run_attempt: 1 },
-          body_encoding: "json",
-        },
-      );
-      const upstream = vi.fn<typeof fetch>(async (input, init) => {
-        const request = new Request(input, init);
-        if (new URL(request.url).pathname === runRequest.path) {
-          return jsonResponse({
-            id: 99,
-            status,
-            ...(runAttempt === undefined ? {} : { run_attempt: runAttempt }),
-          });
-        }
-        return jsonResponse({ message: "unavailable" }, 503);
-      });
+  it.each(["/actions/runs/99/logs", "/actions/runs/99/attempts/2/logs"])(
+    "denies whole-run %s at the Worker without upstream or R2 access",
+    async (suffix) => {
+      const upstream = vi.fn<typeof fetch>();
       vi.stubGlobal("fetch", upstream);
-      const logRequest: RelayRequest = {
-        pool: "maintainers",
-        method: "GET",
-        path: "/repos/openclaw/octopool/actions/runs/99/logs",
-      };
-      const logRoute = classifyRoute(
-        { pool: "maintainers", method: "GET", path: LOG_PATH },
-        policy,
-      );
-
-      const proof = await runWithContext((ctx) =>
-        terminalLogCacheProof(withGitHubEgress(env, []), ctx, logRequest, logRoute, policy),
-      );
-      expect(proof).toEqual(
-        cacheable ? { key: terminalLogCacheKey(logRequest, runAttempt) } : undefined,
-      );
-      expect(
-        upstream.mock.calls.filter(([input, init]) => {
-          const request = new Request(input, init);
-          return new URL(request.url).pathname === runRequest.path;
-        }),
-      ).toHaveLength(1);
+      const get = vi.spyOn(env.ACTIONS_LOGS, "get");
+      const put = vi.spyOn(env.ACTIONS_LOGS, "put");
+      const remove = vi.spyOn(env.ACTIONS_LOGS, "delete");
+      const response = await relay(`/repos/openclaw/octopool${suffix}`);
+      expect(response.status).toBe(424);
+      expect(await response.json()).toMatchObject({
+        error: { code: "fallback_local", details: { reason: "route_denied" } },
+      });
+      expect(upstream).not.toHaveBeenCalled();
+      expect(get).not.toHaveBeenCalled();
+      expect(put).not.toHaveBeenCalled();
+      expect(remove).not.toHaveBeenCalled();
     },
   );
 
@@ -468,7 +530,7 @@ describe("terminal Actions log cache", () => {
   });
 });
 
-function terminalLogUpstream(status: "completed" | "in_progress") {
+function terminalLogUpstream(status: "completed" | "in_progress", bytes?: Uint8Array) {
   return vi.fn<typeof fetch>(async (input, init) => {
     const request = new Request(input, init);
     const url = new URL(request.url);
@@ -487,7 +549,8 @@ function terminalLogUpstream(status: "completed" | "in_progress") {
       });
     }
     if (url.hostname === "results-receiver.actions.githubusercontent.com") {
-      return new Response("build log\n", {
+      expect(request.headers.has("authorization")).toBe(false);
+      return new Response(bytes === undefined ? "build log\n" : new Uint8Array(bytes), {
         headers: { "content-type": "text/plain" },
       });
     }
@@ -499,6 +562,40 @@ function terminalLogUpstream(status: "completed" | "in_progress") {
     }
     return jsonResponse({ message: "not found" }, 404);
   });
+}
+
+function downloadCalls(upstream: ReturnType<typeof vi.fn<typeof fetch>>): number {
+  return upstream.mock.calls.filter(
+    ([input, init]) =>
+      new URL(new Request(input, init).url).hostname ===
+      "results-receiver.actions.githubusercontent.com",
+  ).length;
+}
+
+async function seedLegacyLog(
+  key: string,
+  fixture: {
+    age: string;
+    encoding: string;
+    body: string | Uint8Array;
+    marker?: string | undefined;
+  },
+) {
+  const row = await env.DB.prepare("SELECT datetime('now', ?) AS created_at")
+    .bind(fixture.age)
+    .first<{ created_at: string }>();
+  await env.ACTIONS_LOGS.put(
+    key,
+    typeof fixture.body === "string" ? fixture.body : new Uint8Array(fixture.body),
+    {
+      httpMetadata: { contentType: "text/plain" },
+      customMetadata: {
+        "created-at": row!.created_at,
+        "body-encoding": fixture.encoding,
+        ...(fixture.marker === undefined ? {} : { "body-codec": fixture.marker }),
+      },
+    },
+  );
 }
 function logBackendCalls(upstream: ReturnType<typeof vi.fn<typeof fetch>>): number {
   return upstream.mock.calls.filter(([input, init]) => {

--- a/test/e2e/identity-routing-lifecycle.test.ts
+++ b/test/e2e/identity-routing-lifecycle.test.ts
@@ -549,7 +549,11 @@ describe("identity routing lifecycle boundaries", () => {
       const createdAt = new Date(Date.now() - 3_700_000).toISOString();
       await env.ACTIONS_LOGS.put(key, "old synthetic log", {
         httpMetadata: { contentType: "text/plain" },
-        customMetadata: { "created-at": createdAt, "body-encoding": "text" },
+        customMetadata: {
+          "created-at": createdAt,
+          "body-encoding": "text",
+          "body-codec": "lossless-v1",
+        },
       });
       let probes = 0;
       const upstream = vi.fn<typeof fetch>(async (input, init) => {

--- a/test/e2e/opaque-bytes.test.ts
+++ b/test/e2e/opaque-bytes.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { envelopeBytes, opaqueBytes } from "../fixtures/opaque-bytes";
+import { bearer, jsonResponse, rateHeaders, relay, seedPool } from "./harness";
+import { requestWithEnv } from "./identity-routing-support";
+
+type Envelope = {
+  status: number;
+  headers: Record<string, string>;
+  body: unknown;
+  body_encoding: string;
+  relay: { cache: string; backend: string };
+};
+const apiPath = "/repos/openclaw/octopool/contents/README.md";
+const mediaPath = "/repos/openclaw/octopool/pulls/12";
+
+describe("opaque Worker wire bytes", () => {
+  beforeEach(seedPool);
+
+  it.each(["application/vnd.github.raw", "application/vnd.github+json"])(
+    "keeps malformed JSON bytes lossless with %s negotiation",
+    async (accept) => {
+      const bytes = [0x7b, 0xff];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>(async (input, init) => {
+          if (bearer(input, init) === "test-org-token") return jsonResponse({ private: false });
+          return new Response(new Uint8Array(bytes), {
+            headers: { "content-type": "application/json" },
+          });
+        }),
+      );
+      const response = await relay(apiPath, undefined, { headers: { accept } });
+      expect(response.status).toBe(200);
+      const wire = await response.json<Envelope>();
+      expect(envelopeBytes(wire)).toEqual(bytes);
+      expect(wire.body_encoding).toBe("base64");
+    },
+  );
+
+  it.each(opaqueBytes)("preserves pooled API $name through fill and hit", async (fixture) => {
+    const upstream = vi.fn<typeof fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      if (bearer(request) === "test-org-token") return jsonResponse({ private: false });
+      expect(new URL(request.url).pathname).toBe(apiPath);
+      expect(bearer(request)).toBe("test-primary-token");
+      return new Response(new Uint8Array(fixture.bytes), {
+        headers: {
+          "content-type": "text/plain",
+          etag: '"wire"',
+          ...rateHeaders({ remaining: 4998 }),
+        },
+      });
+    });
+    vi.stubGlobal("fetch", upstream);
+    for (const cache of ["miss", "hit"]) {
+      const response = await relay(apiPath, undefined, {
+        headers: { accept: "application/vnd.github.raw" },
+      });
+      expect(response.status).toBe(200);
+      const wire = await response.json<Envelope>();
+      expect.soft(envelopeBytes(wire)).toEqual(fixture.bytes);
+      expect.soft(wire).toMatchObject({
+        status: 200,
+        body_encoding: fixture.encoding,
+        headers: { "content-type": "text/plain", etag: '"wire"' },
+        relay: { cache },
+      });
+      if (fixture.bytes.length === 0) expect(wire.body).toBeNull();
+    }
+    expect(
+      upstream.mock.calls.filter(([input, init]) => bearer(input, init) === "test-primary-token"),
+    ).toHaveLength(1);
+  });
+
+  it.each(
+    opaqueBytes.map((fixture, index) => ({ ...fixture, media: index % 2 ? "patch" : "diff" })),
+  )("preserves preferred public $media $name through fill and hit", async (fixture) => {
+    const upstream = vi.fn<typeof fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      expect(request.url).toBe(`https://github.com/openclaw/octopool/pull/12.${fixture.media}`);
+      expect(request.headers.has("authorization")).toBe(false);
+      return new Response(new Uint8Array(fixture.bytes), {
+        headers: { "content-type": `text/x-${fixture.media}`, etag: '"media"' },
+      });
+    });
+    vi.stubGlobal("fetch", upstream);
+    for (const cache of ["miss", "hit"]) {
+      const response = await relay(mediaPath, undefined, {
+        headers: { accept: `application/vnd.github.${fixture.media}` },
+      });
+      expect(response.status).toBe(200);
+      const wire = await response.json<Envelope>();
+      expect.soft(envelopeBytes(wire)).toEqual(fixture.bytes);
+      expect
+        .soft(wire)
+        .toMatchObject({ status: 200, body_encoding: fixture.encoding, relay: { cache } });
+      if (fixture.bytes.length === 0) expect(wire.body).toBe("");
+    }
+    expect(upstream).toHaveBeenCalledOnce();
+  });
+
+  it.each(["api", "diff"])(
+    "caps chunked %s before envelope expansion and cancels on overflow",
+    async (transport) => {
+      let size = 4;
+      let pulls = 0;
+      const cancel = vi.fn();
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>(async (input, init) => {
+          const request = new Request(input, init);
+          if (bearer(request) === "test-org-token") return jsonResponse({ private: false });
+          if (transport === "diff" && new URL(request.url).hostname === "api.github.com")
+            return jsonResponse({ message: "unavailable" }, 503);
+          if (transport === "diff") expect(request.headers.has("authorization")).toBe(false);
+          else expect(bearer(request)).toBe("test-primary-token");
+          let sent = 0;
+          return new Response(
+            new ReadableStream<Uint8Array>(
+              {
+                pull(controller) {
+                  pulls++;
+                  if (sent === size) {
+                    controller.close();
+                    return;
+                  }
+                  controller.enqueue(new Uint8Array([0xff, 0xfe]));
+                  sent += 2;
+                },
+                cancel,
+              },
+              { highWaterMark: 0 },
+            ),
+            { headers: { "content-type": "text/plain" } },
+          );
+        }),
+      );
+      const path = transport === "api" ? apiPath : mediaPath;
+      const headers = {
+        accept: transport === "api" ? "application/vnd.github.raw" : "application/vnd.github.diff",
+        "cache-control": "max-age=0",
+      };
+      const exact = await requestWithEnv({ MAX_RESPONSE_BYTES: "4" }, path, { headers });
+      expect(exact.status).toBe(200);
+      const wire = await exact.json<Envelope>();
+      expect(envelopeBytes(wire)).toEqual([0xff, 0xfe, 0xff, 0xfe]);
+      expect(wire.body_encoding).toBe("base64");
+      expect(String(wire.body).length).toBeGreaterThan(4);
+      expect(cancel).not.toHaveBeenCalled();
+      size = 8;
+      pulls = 0;
+      const overflow = await requestWithEnv({ MAX_RESPONSE_BYTES: "4" }, path, { headers });
+      expect(overflow.status).toBeGreaterThanOrEqual(400);
+      expect(cancel).toHaveBeenCalled();
+      // Each attempted backend cancels on the third 2-byte chunk, before consuming 8 bytes.
+      expect(pulls).toBe(cancel.mock.calls.length * 3);
+    },
+  );
+});

--- a/test/e2e/opaque-cache.test.ts
+++ b/test/e2e/opaque-cache.test.ts
@@ -1,0 +1,216 @@
+import { env } from "cloudflare:workers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { githubCacheKey } from "../../src/cache";
+import { deleteEdgeJSON } from "../../src/edge-cache";
+import { classifyRoute, defaultPolicy, validateRelayRequest } from "../../src/policy";
+import type { Identity } from "../../src/types";
+import { opaqueCacheKeys, unchangedJSONKeys } from "../fixtures/opaque-cache-keys";
+import { envelopeBytes } from "../fixtures/opaque-bytes";
+import { seedPublicRepoProof, writeOwnedGitHubCache } from "./cache-publication-fixture";
+import { bearer, jsonResponse, rateHeaders, relay, seedPool } from "./harness";
+
+const fixture = opaqueCacheKeys[0];
+const identity: Identity = {
+  id: "primary",
+  kind: "pat",
+  login: "primary",
+  secret_ref: "TEST_PAT_PRIMARY",
+  installation_id: null,
+  weight: 200,
+};
+type Envelope = { body: unknown; body_encoding: string; relay: { cache: string } };
+
+describe("opaque cache retirement at the Worker", () => {
+  beforeEach(seedPool);
+
+  it.each(["edge", "shared", "identity"])(
+    "ignores fresh old %s bytes and a late old writer",
+    async (layer) => {
+      const { request, route } = await seedOld(layer !== "identity");
+      if (layer !== "edge") await deleteEdgeJSON("github-publication-v1", fixture.shared);
+      const upstream = upstreamBytes();
+      const first = await (await relay(request.path, undefined, request)).json<Envelope>();
+      expect.soft(envelopeBytes(first)).toEqual([0xff, 0x41]);
+      expect.soft(first.relay.cache).toBe("miss");
+      await seedOld();
+      const calls = upstream.mock.calls.length;
+      const second = await (await relay(request.path, undefined, request)).json<Envelope>();
+      expect.soft(envelopeBytes(second)).toEqual([0xff, 0x41]);
+      expect.soft(second.relay.cache).toBe("hit");
+      // Identity hits still run the existing fresh public-repository guard.
+      expect(
+        upstream.mock.calls.slice(calls).map(([input, init]) => new Request(input, init).url),
+      ).toEqual(["https://api.github.com/repos/openclaw/octopool"]);
+      expect(
+        upstream.mock.calls.filter(
+          ([input, init]) => new URL(new Request(input, init).url).pathname === request.path,
+        ),
+      ).toHaveLength(1);
+      expect(
+        await env.DB.prepare(
+          "SELECT count(*) AS n FROM github_cache_entries WHERE cache_key IN (?, ?) AND body_json = ?",
+        )
+          .bind(fixture.shared, fixture.identity, JSON.stringify("�A"))
+          .first(),
+      ).toEqual({ n: 2 });
+      expect
+        .soft(await githubCacheKey(request.pool, request, route, identity))
+        .not.toBe(fixture.identity);
+    },
+  );
+
+  it("retires old shared and identity validators while retaining new 304 and stale behavior", async () => {
+    const { request, route } = await seedOld();
+    await expire(fixture.shared);
+    await expire(fixture.identity);
+    let outage = false;
+    const upstream = vi.fn<typeof fetch>(async (input, init) => {
+      const fetchRequest = new Request(input, init);
+      if (new URL(fetchRequest.url).pathname === "/repos/openclaw/octopool")
+        return jsonResponse({ private: false });
+      const validator = fetchRequest.headers.get("if-none-match");
+      if (outage)
+        return jsonResponse(
+          { message: "rate limited" },
+          429,
+          rateHeaders({ remaining: 0, retryAfter: 60 }),
+        );
+      if (validator !== null)
+        return new Response(null, {
+          status: 304,
+          headers: { etag: validator, ...rateHeaders({ remaining: 4998 }) },
+        });
+      expect(bearer(fetchRequest)).toBe("test-primary-token");
+      return new Response(new Uint8Array([0xff, 0x41]), {
+        headers: {
+          "content-type": "text/plain",
+          etag: '"lossless"',
+          ...rateHeaders({ remaining: 4998 }),
+        },
+      });
+    });
+    vi.stubGlobal("fetch", upstream);
+    const filled = await (await relay(request.path, undefined, request)).json<Envelope>();
+    expect.soft(envelopeBytes(filled)).toEqual([0xff, 0x41]);
+    expect.soft(filled.relay.cache).toBe("miss");
+    expect
+      .soft(
+        upstream.mock.calls.map(([input, init]) =>
+          new Request(input, init).headers.get("if-none-match"),
+        ),
+      )
+      .not.toContain('"old-lossy"');
+    const newKey = await githubCacheKey(request.pool, request, route, identity);
+    await expire(newKey);
+    const revalidated = await (await relay(request.path, undefined, request)).json<Envelope>();
+    expect.soft(envelopeBytes(revalidated)).toEqual([0xff, 0x41]);
+    expect.soft(revalidated.relay.cache).toBe("hit");
+    expect
+      .soft(
+        upstream.mock.calls.map(([input, init]) =>
+          new Request(input, init).headers.get("if-none-match"),
+        ),
+      )
+      .toContain('"lossless"');
+    await expire(newKey);
+    outage = true;
+    const stale = await (await relay(request.path, undefined, request)).json<Envelope>();
+    expect.soft(envelopeBytes(stale)).toEqual([0xff, 0x41]);
+    expect.soft(stale.relay.cache).toBe("stale");
+  });
+
+  it("never serves old shared or identity stale bodies during an outage", async () => {
+    const { request } = await seedOld();
+    await expire(fixture.shared);
+    await expire(fixture.identity);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) =>
+        new URL(new Request(input, init).url).pathname === "/repos/openclaw/octopool"
+          ? jsonResponse({ private: false })
+          : jsonResponse(
+              { message: "rate limited" },
+              429,
+              rateHeaders({ remaining: 0, retryAfter: 60 }),
+            ),
+      ),
+    );
+    const response = await relay(request.path, undefined, request);
+    const text = await response.text();
+    expect.soft(text).not.toContain("�A");
+    expect.soft(text).not.toContain('"cache":"stale"');
+  });
+
+  it("keeps a frozen default JSON body warm", async () => {
+    const frozen = unchangedJSONKeys[0];
+    const request = validateRelayRequest(frozen.request);
+    const route = classifyRoute(request, defaultPolicy("openclaw"));
+    await seedPublicRepoProof(env, route);
+    expect(
+      await writeOwnedGitHubCache(env, frozen.shared, request, route, {
+        status: 200,
+        headers: {},
+        body: { content: "QQ==", encoding: "base64" },
+        body_encoding: "json",
+      }),
+    ).toBe("shared");
+    const upstream = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", upstream);
+    expect(await (await relay(request.path, undefined, request)).json()).toMatchObject({
+      body: { content: "QQ==" },
+      relay: { cache: "hit" },
+    });
+    expect(upstream).not.toHaveBeenCalled();
+  });
+});
+
+async function seedOld(shared = true) {
+  const request = validateRelayRequest(fixture.request);
+  const route = classifyRoute(request, defaultPolicy("openclaw"));
+  await seedPublicRepoProof(env, route);
+  for (const owner of [undefined, identity]) {
+    if (!shared && owner === undefined) continue;
+    expect(
+      await writeOwnedGitHubCache(
+        env,
+        owner === undefined ? fixture.shared : fixture.identity,
+        request,
+        route,
+        {
+          status: 200,
+          headers: {
+            "content-type": "text/plain",
+            etag: '"old-lossy"',
+            ...rateHeaders({ remaining: 4998 }),
+          },
+          body: "�A",
+          body_encoding: "text",
+        },
+        owner,
+      ),
+    ).toBe("shared");
+  }
+  return { request, route };
+}
+
+async function expire(key: string) {
+  await env.DB.prepare(
+    "UPDATE github_cache_entries SET expires_at = datetime('now', '-1 second'), stale_expires_at = datetime('now', '+1 hour') WHERE cache_key = ?",
+  )
+    .bind(key)
+    .run();
+  await deleteEdgeJSON("github-publication-v1", key);
+}
+
+function upstreamBytes() {
+  const upstream = vi.fn<typeof fetch>(async (input, init) => {
+    if (new URL(new Request(input, init).url).pathname === "/repos/openclaw/octopool")
+      return jsonResponse({ private: false });
+    expect(bearer(input, init)).toBe("test-primary-token");
+    return new Response(new Uint8Array([0xff, 0x41]), {
+      headers: { "content-type": "text/plain", ...rateHeaders({ remaining: 4998 }) },
+    });
+  });
+  vi.stubGlobal("fetch", upstream);
+  return upstream;
+}

--- a/test/fixtures/opaque-bytes.ts
+++ b/test/fixtures/opaque-bytes.ts
@@ -1,0 +1,27 @@
+import { Buffer } from "node:buffer";
+
+// Literal wire bytes and classifications, never the production decoder as an oracle.
+export const opaqueBytes = [
+  { name: "invalid UTF-8", bytes: [0xff, 0xfe, 0x41], encoding: "base64" },
+  {
+    name: "late invalid UTF-8",
+    bytes: [...Array<number>(1024).fill(0x61), 0xff],
+    encoding: "base64",
+  },
+  { name: "leading BOM", bytes: [0xef, 0xbb, 0xbf, 0x61], encoding: "base64" },
+  { name: "Unicode", bytes: [0xc3, 0xa9, 0xf0, 0x9f, 0xa6, 0x9e], encoding: "text" },
+  { name: "literal replacement character", bytes: [0xef, 0xbf, 0xbd], encoding: "text" },
+  { name: "CRLF", bytes: [0x61, 0x0d, 0x0a, 0x62, 0x0d, 0x0a], encoding: "text" },
+  { name: "NUL at 1023", bytes: [...Array<number>(1023).fill(0x61), 0], encoding: "base64" },
+  { name: "NUL at 1024", bytes: [...Array<number>(1024).fill(0x61), 0], encoding: "text" },
+  { name: "empty", bytes: [], encoding: "text" },
+  { name: "JSON-looking text", bytes: [0x7b, 0x7d], encoding: "text" },
+] as const;
+
+export function envelopeBytes(response: { body: unknown; body_encoding?: string }): number[] {
+  if (response.body === null && response.body_encoding === "text") return [];
+  if (typeof response.body !== "string") throw new Error("Expected opaque wire body");
+  if (response.body_encoding !== "text" && response.body_encoding !== "base64")
+    throw new Error("Expected text or base64 envelope");
+  return [...Buffer.from(response.body, response.body_encoding === "base64" ? "base64" : "utf8")];
+}

--- a/test/fixtures/opaque-cache-keys.ts
+++ b/test/fixtures/opaque-cache-keys.ts
@@ -1,0 +1,212 @@
+// Frozen by the actual key owner at 211e9cf, before the opaque codec generation.
+// Literal digests keep retirement tests independent of the current key implementation.
+export const opaqueCacheKeys = [
+  {
+    name: "raw blob",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/git/blobs/abc1234",
+      headers: {
+        accept: "application/vnd.github.raw",
+      },
+    },
+    shared: "clSNYK013hjfEoxuK0FKHzaAIV_Fqo36yohKnGqtjIo",
+    identity: "q2dYHqrm3LPiWNOPYPmVZFxhyUoBCyepAjbFJ1ewUo0",
+  },
+  {
+    name: "raw contents",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/README.md",
+      headers: {
+        accept: "application/vnd.github.raw",
+      },
+    },
+    shared: "1BGppmAK_r7_g5lqvUeYGlGMgJx5I9NsgcNxiGpr0w0",
+    identity: "uCozzBVYFheVP4M-P8QVdioKayolqrxD0rwx_MQOrCc",
+  },
+  {
+    name: "raw readme",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/readme",
+      headers: {
+        accept: "application/vnd.github.raw",
+      },
+    },
+    shared: "HZdS9GXnXM17ir2gMrLyqr_blfqdLHkSpS5gO_WITG4",
+    identity: "u8mkb4YEwwJduqR-Av0ERSniBdtSKbhJNpogzBbpeVY",
+  },
+  {
+    name: "octet stream",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/README.md",
+      headers: {
+        accept: "application/octet-stream",
+      },
+    },
+    shared: "sZpHU8dw9j2eO3KC3oVdXeStiXoAf0a26-tkD57CplY",
+    identity: "EQ8Xmp01jO4x_7aBfgZJcluR5rDefdm014BHBCpRNj8",
+  },
+  {
+    name: "diff",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/pulls/12",
+      headers: {
+        accept: "application/vnd.github.diff",
+      },
+    },
+    shared: "jdpcKO0AmDFCd3Ekk4S6mnVvmBtEUqvSbMC9VzkGn1A",
+    identity: "_EGSoukEpWXms6xWe1jGj2iW2xo3KMubmlHoGjwXMFM",
+  },
+  {
+    name: "patch",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/pulls/12",
+      headers: {
+        accept: "application/vnd.github.patch",
+      },
+    },
+    shared: "BR7lrxtUFOf1mC1nAhxxe-y5-rr8fJUYGOoN6tpMakk",
+    identity: "uQZlo-XhoLlJIRLb44BxE-PiMLc-qfd4stoa6v1SmaM",
+  },
+  {
+    name: "custom JSON",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/issues/12",
+      headers: {
+        accept: "application/vnd.github.full+json",
+      },
+    },
+    shared: "_GELCI0ATgduVLonkpC8eZUramcc3YUeF_U9ADKe4JY",
+    identity: "mnTnrWmE3q7DzEj8geK58RQ4jiDv-PIX_vg-BHwKU5s",
+  },
+  {
+    name: "blank accept",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/issues/12",
+      headers: {
+        accept: "",
+      },
+    },
+    shared: "5JjfgBfRWhDPE1THcScXebogQwsachSzlURBTECkLb4",
+    identity: "mBC_GCIrKXYCi0N6A0yQLnRZ00Io_-zuItZWjBreADo",
+  },
+  {
+    name: "Actions custom",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/actions/runs/99",
+      headers: {
+        accept: "application/vnd.github.raw",
+        "x-octopool-public-shape": "actions-summary-v1",
+      },
+    },
+    shared: "8ysdcZJBBWNCb5VHeS02HEK6UgrUfZ3ALzpSkCM6J1I",
+    identity: "Qs21EFbMufsOdoC53IDc4salAFTzjlskZeanupm92VE",
+  },
+  {
+    name: "release custom",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/releases/latest",
+      headers: {
+        accept: "application/vnd.github.raw",
+        "x-octopool-public-shape": "release-summary-v1",
+      },
+    },
+    shared: "80ZA_xxUU6DfeJaMH-mCko1gnxh_bHhs1fefpCdRacA",
+    identity: "oyy9LLe4_iQuFJhRa_FqHR59jLG5-WsgTDcXmnP6rPk",
+  },
+  {
+    name: "event custom",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/issues/12/events",
+      headers: {
+        accept: "application/vnd.github.raw",
+      },
+    },
+    shared: "ehL_CtVISDu7s5mxEzH2O5IIjtGmhWOqcPDUxILgUEA",
+    identity: "68xOYDlSn0KHCtf2anrG4Qg4IidpzjbaYMgS5-l4xSg",
+  },
+] as const;
+export const unchangedJSONKeys = [
+  {
+    name: "default JSON",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/git/blobs/abc1234",
+      headers: {},
+    },
+    shared: "YrggK6f6E9YQzLvANPrlswuTc4cJDMnCGSdEr0PVPu4",
+    identity: "vJlhZLlac044XT-77kbtsnX8enod95t02_5QJwxWC_Q",
+  },
+  {
+    name: "Actions JSON",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/actions/runs/99",
+      headers: {
+        "x-octopool-public-shape": "actions-summary-v1",
+      },
+    },
+    shared: "0pVeb2WHHYXmtnvahq4bJ3cIAw7Z2Tl9je-0PQNpyOg",
+    identity: "yhytp06UBbXYjiz73t8bpOppnExFMXLQiWXLOGfYUOE",
+  },
+  {
+    name: "release JSON",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/releases/latest",
+      headers: {
+        "x-octopool-public-shape": "release-summary-v1",
+      },
+    },
+    shared: "IW8GTqJYZGRDRACPwieFPOWWrbRvgv3Jnvdj8aQUQVw",
+    identity: "RVPH6W_dfj72c6pREDmVo98G-j7bI6Dsh4YI1nYWY8o",
+  },
+  {
+    name: "event JSON",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/issues/12/events",
+      headers: {},
+    },
+    shared: "_NFlXimWhvHiNn8Q63JPRM3ObCweHjY3CW2WaaKE550",
+    identity: "_57Yhxfd5F1OP5rY4bKQjgDkprBYdoZqi3HUjUAL8EY",
+  },
+  {
+    name: "attempt jobs",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/actions/runs/99/attempts/2/jobs",
+      headers: {
+        "x-octopool-public-shape": "actions-jobs-v1",
+      },
+    },
+    shared: "jiJ5V_ttqoefYTJdIUFMq15e-q9nVKzWS5S21hDz5_8",
+    identity: "pIKjI16NpLq1Ie4H5Pic8bdLks9cyGmzTCyX1T-KQYo",
+  },
+] as const;

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -3,12 +3,104 @@ import { callPublicGitHub } from "../src/github";
 import { withGitHubEgress, type GitHubEgressEnv } from "../src/github-egress";
 import { responseCapBytes } from "../src/github-limits";
 import { classifyRoute, defaultPolicy, validateRelayRequest } from "../src/policy";
+import { envelopeBytes, opaqueBytes } from "./fixtures/opaque-bytes";
 
 describe("github api provider", () => {
   const policy = defaultPolicy("openclaw");
 
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  it.each(opaqueBytes)("round-trips API $name without changing bytes", async (fixture) => {
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/README.md",
+    });
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(new Uint8Array(fixture.bytes), {
+          headers: { "content-type": "text/plain", etag: '"bytes"' },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const response = await callPublicGitHub(env(), request, classifyRoute(request, policy));
+    expect(envelopeBytes(response)).toEqual(fixture.bytes);
+    expect(response).toMatchObject({
+      status: 200,
+      body_encoding: fixture.encoding,
+      headers: { "content-type": "text/plain", etag: '"bytes"' },
+    });
+    if (fixture.bytes.length === 0) expect(response.body).toBeNull();
+  });
+
+  it.each([
+    [' {"a":1} \r\n', { a: 1 }],
+    ["[1,true]", [1, true]],
+    ["null", null],
+    ["9007199254740993", 9007199254740992],
+    ['"\\ud800"', "\ud800"],
+    ["\ufeff42", 42],
+  ])("retains parsed JSON semantics for %s", async (text, body) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () => new Response(String(text), { headers: { "content-type": "application/json" } }),
+      ),
+    );
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/README.md",
+    });
+    expect(await callPublicGitHub(env(), request, classifyRoute(request, policy))).toMatchObject({
+      body,
+      body_encoding: "json",
+    });
+  });
+
+  it.each([
+    { bytes: [0x7b, 0xff], encoding: "base64" },
+    { bytes: [0xef, 0xbb, 0xbf, 0x7b], encoding: "base64" },
+    { bytes: [0x7b, 0x61], encoding: "text" },
+  ])("round-trips malformed JSON fallback $bytes", async ({ bytes, encoding }) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(new Uint8Array(bytes), { headers: { "content-type": "application/json" } }),
+      ),
+    );
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/README.md",
+    });
+    const response = await callPublicGitHub(env(), request, classifyRoute(request, policy));
+    expect(envelopeBytes(response)).toEqual(bytes);
+    expect(response.body_encoding).toBe(encoding);
+  });
+
+  it("retains successful JSON parsing after the existing nonfatal JSON decode", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(new Uint8Array([0x22, 0xff, 0x22]), {
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+    );
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/README.md",
+    });
+    expect(await callPublicGitHub(env(), request, classifyRoute(request, policy))).toMatchObject({
+      body: "�",
+      body_encoding: "json",
+    });
   });
 
   it("fetches user profiles without pooled authorization", async () => {

--- a/test/opaque-cache-generation.test.ts
+++ b/test/opaque-cache-generation.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { githubCacheKey } from "../src/cache";
+import { classifyRoute, defaultPolicy, validateRelayRequest } from "../src/policy";
+import { opaqueCacheKeys, unchangedJSONKeys } from "./fixtures/opaque-cache-keys";
+
+describe("opaque cache codec generation", () => {
+  it.each(opaqueCacheKeys)("retires old $name shared and identity keys", async (fixture) => {
+    const request = validateRelayRequest(fixture.request);
+    const route = classifyRoute(request, defaultPolicy("openclaw"));
+    expect(await githubCacheKey(request.pool, request, route)).not.toBe(fixture.shared);
+    expect(
+      await githubCacheKey(request.pool, request, route, { kind: "pat", id: "primary" }),
+    ).not.toBe(fixture.identity);
+    const upper = {
+      ...request,
+      headers: { ...request.headers, accept: request.headers!.accept!.toUpperCase() },
+    };
+    expect(await githubCacheKey(request.pool, upper, route)).toBe(
+      await githubCacheKey(request.pool, request, route),
+    );
+  });
+
+  it.each(unchangedJSONKeys)(
+    "keeps $name and normalized default JSON keys warm",
+    async (fixture) => {
+      for (const accept of [
+        undefined,
+        "application/json",
+        "application/vnd.github+json",
+        "APPLICATION/VND.GITHUB.V3+JSON",
+      ]) {
+        const request = validateRelayRequest({
+          ...fixture.request,
+          headers: { ...fixture.request.headers, ...(accept === undefined ? {} : { accept }) },
+        });
+        const route = classifyRoute(request, defaultPolicy("openclaw"));
+        expect(await githubCacheKey(request.pool, request, route)).toBe(fixture.shared);
+        expect(
+          await githubCacheKey(request.pool, request, route, { kind: "pat", id: "primary" }),
+        ).toBe(fixture.identity);
+      }
+    },
+  );
+
+  it.each([
+    [8, "actions-summary-metadata-v3"],
+    [9, "release-summary-raw-v2"],
+    [10, "issue-events-public-v2"],
+  ] as const)(
+    "composes codec with %s / %s instead of replacing representation",
+    async (index, representation) => {
+      const request = validateRelayRequest(opaqueCacheKeys[index].request);
+      const digest = vi.spyOn(crypto.subtle, "digest");
+      try {
+        await githubCacheKey(
+          request.pool,
+          request,
+          classifyRoute(request, defaultPolicy("openclaw")),
+        );
+        const material = JSON.parse(
+          new TextDecoder().decode(digest.mock.calls[0]![1] as Uint8Array),
+        );
+        expect(material).toMatchObject({
+          protocol_epoch: "publication-v1",
+          representation,
+          body_codec: "lossless-v1",
+        });
+      } finally {
+        digest.mockRestore();
+      }
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Opaque responses were decoded as ordinary text before their encoding was chosen. Invalid UTF-8 became replacement characters and a leading BOM disappeared; those changed bytes could then be cached and stored in job-log R2 objects. One shared opaque encoder now uses fatal UTF-8 decoding and a byte round-trip check, selecting base64 when text cannot preserve the input. API and preferred public diff/patch paths use the same owner.

Preserve ordinary Unicode, literal replacement characters, CRLF, and the existing first-1,024-byte NUL classification. Empty API and public diff responses retain their distinct contracts. Successful JSON parsing keeps its existing value semantics; this does not introduce strict JSON, change number/null handling, or promise original parsed-JSON bytes. Limits still apply to upstream bytes before envelope expansion.

A separate codec discriminator retires old non-default-Accept cache entries while leaving normalized default JSON keys warm and composing with existing representation generations. R2 keeps its current keyspace/lifecycle, but requires an exact codec marker before serving or existence-only renewal. Legacy objects are redownloaded before replacement; failed downloads/writes do not delete them first. Rejected object streams are released.

The manifest supports job logs, not whole-run archives. Remove the unreachable whole-run cache branch and test-only wrapper, and replace impossible helper tests with real Worker route-denial/no-upstream/no-R2 proof. Whole-run archives still use native fallback. CLI stdout newline behavior remains a separate queued scope; no dependency, runtime configuration, deployment, or release is included.

## Verification

- Native pre-fix byte/R2 regressions and corrected old-cache retirement regressions failed before repair; owner tests independently reproduced the codec/key defects.
- Literal-byte tests cover invalid UTF-8 early/late, BOM, real U+FFFD, Unicode, CRLF, NUL boundaries, empty and JSON-looking text, malformed-JSON fallback, and preserved parsed-JSON semantics.
- Native controls cover exact/over-cap chunked streams, API/diff fills and hits, actual R2 bytes, fresh completion, marker misses before renewal, cancellation, failed replacement, late old writers, old shared/identity validators and stale bodies, and unchanged default JSON.
- Full `pnpm check` passes: 838 unit tests, 892 native Worker tests, generation/format/lint/build/type checks, Go 1.26 tests, and vet.
- Independent parent verification passed 134 native cases across eight files; complete P2 review is clean. Fresh post-commit verification and exact-head CI are required before merge.

External HTTP, content, redirects, and credentials were synthetic; Worker/D1/DO/Cache API/R2 execution was native. This is not hosted corruption inventory, installed CLI stdout, or live GitHub proof. Fixture setup/type/assertion corrections are retained separately from product reds, with no test-runtime safeguards weakened. The bounded cache retirement does not purport to purge hypothetical old malformed default-JSON responses.

Release-note context: Preserve opaque GitHub API, public diff/patch, and completed job-log bytes; retire old media/log formats safely; clarify native fallback for whole-run archives.

### Fresh post-commit proof

Verified commit `6d5c807d9b9e7a72144f6324e385c9645897259e` without a rebase: 134 focused native cases across eight files passed in 8.26s. Fresh `pnpm check` passed 838 unit tests (609ms), 892 native Worker tests (18.28s), generation/format/lint/build/type checks, Go 1.26.7 tests (84.945s), and vet. Both commands exited zero on their first landing attempt; no generated drift or source changes.
