### PR TITLE
fix: encode generated contents self-links exactly once

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -47,6 +47,15 @@ media retirement, not a purge of hypothetical malformed non-JSON responses previ
 returned to default-JSON requests. Future opaque decoding is lossless regardless of
 the request's negotiation.
 
+Default-JSON contents reads with a nonempty scalar `ref` carry
+`contents-self-links-v1`. This retires old generated file objects whose API self-links
+did not escape filename characters, across shared and identity keys, edge/D1 hits,
+validators, stale fallback, and late old fills. The predicate covers plain filenames
+too; it does not infer safety from filename characters or duplicate raw-adapter validation.
+Contents without a scalar ref, custom media (including their `body_codec`), blobs,
+README routes, and unrelated representations retain their keys. No publication epoch,
+public-repository proof, or R2 generation changes or cache purge are required.
+
 Actions summaries also include a server-controlled representation generation
 (`actions-summary-metadata-v3`) in this common key. Run views, attempt-qualified views,
 and repository/workflow run lists, including canonical supersets and identity-specific

--- a/docs/token-free.md
+++ b/docs/token-free.md
@@ -56,6 +56,15 @@ that known patch host.
 | `GET /repos/{owner}/{repo}/git/ref/tags/{tag}`               | Same Git smart HTTP advertisement                                         | Annotated tags only                                                         |
 | `GET /repos/{owner}/{repo}/git/matching-refs/tags/{prefix}`  | Same Git smart HTTP advertisement                                         | Only when every matched tag is annotated                                    |
 
+Successful raw contents reads preserve the decoded file `path` and `name`, binary
+content/base64, byte size, and Git blob SHA. The generated API `url` and `_links.self`
+match and encode each path segment once, retaining directory separators and literal
+`#`, `?`, `%`, spaces, and Unicode. A literal filename `%23` arrives as `%2523` and
+stays literal; `ref` is one encoded query value. Raw/download, HTML, and Git object
+links retain their existing semantics. Missing or unsafe refs, ambiguous query values,
+ineligible file paths, raw misses, and oversized raw bodies retain the existing exact
+anonymous API fallback; traversal and route restrictions are unchanged.
+
 Git ref responses also read
 `https://github.com/{owner}/{repo}/issues?q=is%3Aissue` to recover the repository node
 ID needed for exact REST-compatible ref node IDs. Lightweight tags remain anonymous

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -14,6 +14,7 @@ import {
 import { readEdgeJSON, writeEdgeJSON } from "./edge-cache";
 import { queries } from "./generated/sql";
 import { defaultGitHubJSONAccept } from "./github-response";
+import { scalarQuery } from "./github-public-utils";
 import { PUBLIC_SHAPES } from "./github-public-shapes";
 import { isRecord } from "./object";
 import { parseSQLiteTimestamp, sqliteTimestamp } from "./sqlite-time";
@@ -97,6 +98,12 @@ export async function githubCacheKey(
     // Old raw event bodies may contain privileged references, even after a 304
     // republished an identity entry as anonymous. Retire every variant together.
     ...(isIssueEventRoute(route.kind) ? { representation: "issue-events-public-v2" } : {}),
+    // Old JSON file objects contain unescaped self-links, even for raw-origin fills.
+    ...(route.kind === "contents" &&
+    scalarQuery(request.query, "ref") !== undefined &&
+    varyHeaders.accept === undefined
+      ? { representation: "contents-self-links-v1" }
+      : {}),
     ...(varyHeaders.accept === undefined ? {} : { body_codec: "lossless-v1" }),
     ...(identity === undefined ? {} : { identity: `${identity.kind}:${identity.id}` }),
   };

--- a/src/github-public-content.ts
+++ b/src/github-public-content.ts
@@ -95,7 +95,7 @@ export function rawContentRequest(
     usesApiQuota: false,
     payload: (body, headers, status) => {
       const sha = gitBlobSHA(body);
-      const apiPath = `/repos/${route.owner}/${route.repo}/contents/${contentPath}`;
+      const apiPath = `/${encodedPathSegments(["repos", route.owner!, route.repo!, "contents", contentPath])}`;
       const apiURL = `https://api.github.com${apiPath}?ref=${encodeURIComponent(ref)}`;
       const htmlURL = `https://github.com/${encodedPathSegments([route.owner!, route.repo!, "blob", ref, contentPath])}`;
       return publicJSONResponse(headers, status, {

--- a/test/contents-cache-generation.test.ts
+++ b/test/contents-cache-generation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { githubCacheKey } from "../src/cache";
+import { classifyRoute, defaultPolicy, validateRelayRequest } from "../src/policy";
+import { contentsCacheKeys } from "./fixtures/contents-cache-keys";
+
+describe("contents self-link cache generation", () => {
+  it.each(contentsCacheKeys)("bounds shared and identity retirement for $name", async (fixture) => {
+    const request = validateRelayRequest(fixture.request);
+    const route = classifyRoute(request, defaultPolicy("openclaw"));
+    const shared = await githubCacheKey(request.pool, request, route);
+    const identity = await githubCacheKey(request.pool, request, route, {
+      id: "primary",
+      kind: "pat",
+    });
+    expect(shared === fixture.shared).toBe(!fixture.retire);
+    expect(identity === fixture.identity).toBe(!fixture.retire);
+    if (fixture.retire) {
+      for (const accept of [
+        "application/json",
+        "application/vnd.github+json",
+        "APPLICATION/VND.GITHUB.V3+JSON",
+      ]) {
+        const variant = { ...request, headers: { accept } };
+        expect(await githubCacheKey(request.pool, variant, route)).toBe(shared);
+        expect(
+          await githubCacheKey(request.pool, variant, route, { id: "primary", kind: "pat" }),
+        ).toBe(identity);
+      }
+    }
+  });
+});

--- a/test/e2e/contents-cache.test.ts
+++ b/test/e2e/contents-cache.test.ts
@@ -1,0 +1,228 @@
+import { env } from "cloudflare:workers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { githubCacheKey } from "../../src/cache";
+import { deleteEdgeJSON } from "../../src/edge-cache";
+import { classifyRoute, defaultPolicy, validateRelayRequest } from "../../src/policy";
+import type { Identity } from "../../src/types";
+import { contentsCacheKeys } from "../fixtures/contents-cache-keys";
+import { contentsLinks } from "../fixtures/contents-links";
+import { seedPublicRepoProof, writeOwnedGitHubCache } from "./cache-publication-fixture";
+import { bearer, jsonResponse, rateHeaders, relay, seedPool } from "./harness";
+
+const frozen = contentsCacheKeys[0];
+const expected = contentsLinks[5].body;
+const oldURL =
+  "https://api.github.com/repos/openclaw/octopool/contents/docs/a#b?c% name🦞.txt?ref=feature%2Ftopic%26mode%3Dfast%23part";
+const oldBody = { ...expected, url: oldURL, _links: { ...expected._links, self: oldURL } };
+const identity: Identity = {
+  id: "primary",
+  kind: "pat",
+  login: "primary",
+  secret_ref: "TEST_PAT_PRIMARY",
+  installation_id: null,
+  weight: 200,
+};
+const request = validateRelayRequest(frozen.request);
+const route = classifyRoute(request, defaultPolicy("openclaw"));
+type Envelope = { body: unknown; relay: { cache: string } };
+
+describe("contents cache retirement at the Worker", () => {
+  beforeEach(seedPool);
+
+  it.each(["edge", "shared", "identity"])(
+    "ignores fresh old %s objects and late old writers",
+    async (layer) => {
+      await seedOld(layer !== "identity");
+      if (layer !== "edge") await deleteEdgeJSON("github-publication-v1", frozen.shared);
+      const upstream = vi.fn<typeof fetch>(async (input, init) => {
+        const fetched = new Request(input, init);
+        if (fetched.url === "https://api.github.com/repos/openclaw/octopool")
+          return jsonResponse({ private: false });
+        expect(fetched.headers.has("if-none-match")).toBe(false);
+        if (fetched.url === expected.download_url) {
+          expect(bearer(fetched)).toBeUndefined();
+          return layer === "identity"
+            ? new Response(null, { status: 404 })
+            : new Response(new Uint8Array([0, 255, 65]));
+        }
+        expect(fetched.url).toBe(expected.url);
+        if (bearer(fetched) === undefined) return jsonResponse({ message: "unavailable" }, 503);
+        expect(bearer(fetched)).toBe("test-primary-token");
+        return jsonResponse(expected, 200, rateHeaders({ remaining: 4998 }));
+      });
+      vi.stubGlobal("fetch", upstream);
+      const response = await relay(request.path, undefined, request);
+      expect(response.status).toBe(200);
+      expect
+        .soft(await response.json())
+        .toMatchObject({ body: expected, relay: { cache: "miss" } });
+      await seedOld();
+      const calls = upstream.mock.calls.length;
+      expect
+        .soft(await (await relay(request.path, undefined, request)).json())
+        .toMatchObject({ body: expected, relay: { cache: "hit" } });
+      expect(
+        upstream.mock.calls.slice(calls).map(([input, init]) => new Request(input, init).url),
+      ).toEqual(
+        layer === "identity"
+          ? [expected.download_url, expected.url, "https://api.github.com/repos/openclaw/octopool"]
+          : [],
+      );
+      expect(
+        upstream.mock.calls.filter(
+          ([input, init]) => new Request(input, init).url === expected.download_url,
+        ),
+      ).toHaveLength(layer === "identity" ? 2 : 1);
+      expect(
+        upstream.mock.calls.filter(([input, init]) => bearer(input, init) === "test-primary-token"),
+      ).toHaveLength(layer === "identity" ? 1 : 0);
+      expect(
+        await env.DB.prepare(
+          "SELECT count(*) AS n FROM github_cache_entries WHERE cache_key IN (?, ?) AND body_json = ?",
+        )
+          .bind(frozen.shared, frozen.identity, JSON.stringify(oldBody))
+          .first(),
+      ).toEqual({ n: 2 });
+      expect.soft(await githubCacheKey(request.pool, request, route)).not.toBe(frozen.shared);
+      expect
+        .soft(await githubCacheKey(request.pool, request, route, identity))
+        .not.toBe(frozen.identity);
+    },
+  );
+
+  it("retires old validators and preserves new API 304 and stale semantics", async () => {
+    await seedOld();
+    await expire(frozen.shared);
+    await expire(frozen.identity);
+    let outage = false;
+    const upstream = vi.fn<typeof fetch>(async (input, init) => {
+      const fetched = new Request(input, init);
+      if (fetched.url === "https://api.github.com/repos/openclaw/octopool")
+        return jsonResponse({ private: false });
+      if (fetched.url === expected.download_url) return new Response(null, { status: 404 });
+      expect(fetched.url).toBe(expected.url);
+      if (outage)
+        return jsonResponse(
+          { message: "rate limited" },
+          429,
+          rateHeaders({ remaining: 0, retryAfter: 60 }),
+        );
+      const validator = fetched.headers.get("if-none-match");
+      if (validator !== null)
+        return new Response(null, {
+          status: 304,
+          headers: { etag: validator, ...rateHeaders({ remaining: 4998 }) },
+        });
+      return jsonResponse(expected, 200, {
+        etag: '"new-links"',
+        ...rateHeaders({ remaining: 4998 }),
+      });
+    });
+    vi.stubGlobal("fetch", upstream);
+    const filled = await (await relay(request.path, undefined, request)).json<Envelope>();
+    expect.soft(filled).toMatchObject({ body: expected, relay: { cache: "miss" } });
+    expect
+      .soft(
+        upstream.mock.calls.map(([input, init]) =>
+          new Request(input, init).headers.get("if-none-match"),
+        ),
+      )
+      .not.toContain('"old-links"');
+    const key = await githubCacheKey(request.pool, request, route);
+    await expire(key);
+    expect
+      .soft(await (await relay(request.path, undefined, request)).json())
+      .toMatchObject({ body: expected, relay: { cache: "hit" } });
+    expect
+      .soft(
+        upstream.mock.calls.map(([input, init]) =>
+          new Request(input, init).headers.get("if-none-match"),
+        ),
+      )
+      .toContain('"new-links"');
+    await expire(key);
+    outage = true;
+    expect
+      .soft(await (await relay(request.path, undefined, request)).json())
+      .toMatchObject({ body: expected, relay: { cache: "stale" } });
+  });
+
+  it("never serves old shared or identity stale links during an outage", async () => {
+    await seedOld();
+    await expire(frozen.shared);
+    await expire(frozen.identity);
+    const upstream = vi.fn<typeof fetch>(async (input, init) => {
+      const fetched = new Request(input, init);
+      if (fetched.url === "https://api.github.com/repos/openclaw/octopool")
+        return jsonResponse({ private: false });
+      expect([expected.url, expected.download_url]).toContain(fetched.url);
+      return jsonResponse(
+        { message: "rate limited" },
+        429,
+        rateHeaders({ remaining: 0, retryAfter: 60 }),
+      );
+    });
+    vi.stubGlobal("fetch", upstream);
+    const response = await relay(request.path, undefined, request);
+    expect.soft(response.status).toBe(424);
+    const wire = await response.json();
+    expect.soft(wire).toMatchObject({ error: { code: "fallback_local" } });
+    expect.soft(JSON.stringify(wire)).not.toContain(oldURL);
+    expect.soft(JSON.stringify(wire)).not.toContain('"cache":"stale"');
+  });
+
+  it("keeps a frozen no-ref JSON contents body warm", async () => {
+    const fixture = contentsCacheKeys[4];
+    const noRef = validateRelayRequest(fixture.request);
+    const noRefRoute = classifyRoute(noRef, defaultPolicy("openclaw"));
+    await seedPublicRepoProof(env, noRefRoute);
+    const body = { name: "README.md", content: "QQ==", encoding: "base64" };
+    expect(
+      await writeOwnedGitHubCache(env, fixture.shared, noRef, noRefRoute, {
+        status: 200,
+        headers: {},
+        body,
+        body_encoding: "json",
+      }),
+    ).toBe("shared");
+    const upstream = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", upstream);
+    expect(await (await relay(noRef.path)).json()).toMatchObject({ body, relay: { cache: "hit" } });
+    expect(upstream).not.toHaveBeenCalled();
+  });
+});
+
+async function seedOld(shared = true) {
+  await seedPublicRepoProof(env, route);
+  for (const owner of [undefined, identity]) {
+    if (!shared && owner === undefined) continue;
+    expect(
+      await writeOwnedGitHubCache(
+        env,
+        owner === undefined ? frozen.shared : frozen.identity,
+        request,
+        route,
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            etag: '"old-links"',
+            ...rateHeaders({ remaining: 4998 }),
+          },
+          body: oldBody,
+          body_encoding: "json",
+        },
+        owner,
+      ),
+    ).toBe("shared");
+  }
+}
+
+async function expire(key: string) {
+  await env.DB.prepare(
+    "UPDATE github_cache_entries SET expires_at = datetime('now', '-1 second'), stale_expires_at = datetime('now', '+1 hour') WHERE cache_key = ?",
+  )
+    .bind(key)
+    .run();
+  await deleteEdgeJSON("github-publication-v1", key);
+}

--- a/test/e2e/contents-links.test.ts
+++ b/test/e2e/contents-links.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { contentsLinks } from "../fixtures/contents-links";
+import { relay, seedPool } from "./harness";
+
+type Envelope = {
+  body: (typeof contentsLinks)[number]["body"];
+  body_encoding: string;
+  relay: { cache: string; backend: string };
+};
+
+describe("contents self-links at the Worker", () => {
+  beforeEach(seedPool);
+
+  it.each([
+    ["../file.txt", 400, "invalid_path"],
+    ["%2e%2e/file.txt", 400, "invalid_path"],
+    ["docs/./file.txt", 400, "invalid_path"],
+    ["", 424, "fallback_local"],
+  ])("retains the existing path boundary for %s", async (suffix, status, code) => {
+    const upstream = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", upstream);
+    const response = await relay(`/repos/openclaw/octopool/contents/${suffix}`, undefined, {
+      query: { ref: "main" },
+    });
+    expect(response.status).toBe(status);
+    expect(await response.json()).toMatchObject({ error: { code } });
+    expect(upstream).not.toHaveBeenCalled();
+  });
+
+  it.each(contentsLinks)(
+    "preserves $label through a real raw fill and cache hit",
+    async (fixture) => {
+      const upstream = vi.fn<typeof fetch>(async (input, init) => {
+        const request = new Request(input, init);
+        expect(request.url).toBe(fixture.body.download_url);
+        expect(request.headers.has("authorization")).toBe(false);
+        return new Response(new Uint8Array([0, 255, 65]), {
+          headers: { "content-type": "application/octet-stream" },
+        });
+      });
+      vi.stubGlobal("fetch", upstream);
+      for (const cache of ["miss", "hit"]) {
+        const response = await relay(fixture.request.path, undefined, fixture.request);
+        expect(response.status).toBe(200);
+        const wire = await response.json<Envelope>();
+        expect.soft(wire.body).toEqual(fixture.body);
+        expect
+          .soft(wire)
+          .toMatchObject({ body_encoding: "json", relay: { cache, backend: "web" } });
+        expect.soft(wire.body.url).toBe(wire.body._links.self);
+        const url = new URL(wire.body.url);
+        expect.soft(url.hash).toBe("");
+        expect
+          .soft(decodeURIComponent(url.pathname))
+          .toBe(`/repos/openclaw/octopool/contents/${fixture.body.path}`);
+        expect.soft([...url.searchParams]).toEqual([["ref", fixture.request.query.ref]]);
+        expect
+          .soft(Array.from(atob(wire.body.content), (char) => char.charCodeAt(0)))
+          .toEqual([0, 255, 65]);
+      }
+      expect(upstream).toHaveBeenCalledExactlyOnceWith(
+        fixture.body.download_url,
+        expect.any(Object),
+      );
+    },
+  );
+});

--- a/test/fixtures/contents-cache-keys.ts
+++ b/test/fixtures/contents-cache-keys.ts
@@ -1,0 +1,259 @@
+// Frozen by the actual key owner at fec6a1d, before contents self-link retirement.
+// Shared and identity digests include publication-v1 and the current opaque body codec.
+export const contentsCacheKeys = [
+  {
+    name: "nested links",
+    retire: true,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/docs/a%23b%3Fc%25%20name%F0%9F%A6%9E.txt",
+      query: {
+        ref: "feature/topic&mode=fast#part",
+      },
+    },
+    shared: "xWPXCPHS2DQwL9SjnCSAx2vZdmlZuIKFk5HJwNMBJtY",
+    identity: "6pNL_mxgILprOKRrCzRC6DwmxyEYivjwC5heW_B24eM",
+  },
+  {
+    name: "plain filename",
+    retire: true,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/README.md",
+      query: {
+        ref: "main",
+      },
+    },
+    shared: "OGyiz-X838qe7z1K7E50eWjFIE5jSA0qVoZF0mde1bQ",
+    identity: "PLfE0_agw0XmiZ99k-ci3EgMn3W_J_FQzncEQ9MBfls",
+  },
+  {
+    name: "literal percent escape",
+    retire: true,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/literal%2523.txt",
+      query: {
+        ref: "main",
+      },
+    },
+    shared: "QwKu0VK30L55LaLgbDKmcKPLvHX38EHx5TVq1MCxTk0",
+    identity: "Qmhdcfatl1FDwiPexCoBptSpuMeL1fvAkdUPyyb16Js",
+  },
+  {
+    name: "scalar fallback ref",
+    retire: true,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/README.md",
+      query: {
+        ref: "../main",
+      },
+    },
+    shared: "PcYREN8DtYfqTFaEduIiWwCbxlddFvnyncMvApxYvN8",
+    identity: "JD-K0tmNvXNRktEcXd65Uusu54GjOfCSnhmm6VpAPlY",
+  },
+  {
+    name: "no ref contents",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/README.md",
+    },
+    shared: "_xlm8E-Vj4z9StmRNxeeiRxIxnDD3EzW0eh-Tc_1lro",
+    identity: "Cf9Whf81Lh9BFC5TGzJ-XYxsNzx2cdtOXPDI_GU_VEU",
+  },
+  {
+    name: "empty ref contents",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/README.md",
+      query: {
+        ref: "",
+      },
+    },
+    shared: "C40xUBySIesgJwCQC-cEUgye4RDJQaOwSZ8Zfi8nqUs",
+    identity: "a0QxEpfCT8f_Zi_bU6qhN3idnb5TLxpr21ESxzhf4dA",
+  },
+  {
+    name: "array ref contents",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/README.md",
+      query: {
+        ref: ["main", "topic"],
+      },
+    },
+    shared: "SPbfmfs61zY1jHVE3b0xqVTVOfCG4v9tH2BXJCyV1ac",
+    identity: "R_dNBnZ_SzX8fACIjvAR3Wk4uUEoELTljKOLUMNtSZw",
+  },
+  {
+    name: "raw contents",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/README.md",
+      query: {
+        ref: "main",
+      },
+      headers: {
+        accept: "application/vnd.github.raw",
+      },
+    },
+    shared: "78KL_YT9x-hKUcRB1UnZEDft1Qx6iaW79kBTYZInVuM",
+    identity: "h8Mb_D_8werXmv_zKPjrLxhF7S6bGX5XnZQ9g1LPi8I",
+  },
+  {
+    name: "blank accept contents",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/README.md",
+      query: {
+        ref: "main",
+      },
+      headers: {
+        accept: "",
+      },
+    },
+    shared: "f1jpVswl4dKikLpzBBitTr7uiiJ-Szh2PN4_0PEbOQ4",
+    identity: "-a8a1g5Coj7V5iMuu5a1W_mKmLbCRrSC2QcafFJe3gQ",
+  },
+  {
+    name: "octet contents",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/README.md",
+      query: {
+        ref: "main",
+      },
+      headers: {
+        accept: "application/octet-stream",
+      },
+    },
+    shared: "h5xzy2AW5MbVAhsgye6CMHWzwkm9bFA54SZhyzfiaX8",
+    identity: "l0PLyL20zR0g5bMoPn6csOl1OxRfbbaH7j9Xz-7x-6Y",
+  },
+  {
+    name: "raw blob",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/git/blobs/abc1234",
+      headers: {
+        accept: "application/vnd.github.raw",
+      },
+    },
+    shared: "KaLB42UNhbUApjepGQI7KTNdybeZDAuWql4aQZ3F-i4",
+    identity: "9Vk4rMvihoZr3wAzI8KgAk3rAU-S-LBdaLq8I0HBDK4",
+  },
+  {
+    name: "JSON blob",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/git/blobs/abc1234",
+    },
+    shared: "YrggK6f6E9YQzLvANPrlswuTc4cJDMnCGSdEr0PVPu4",
+    identity: "vJlhZLlac044XT-77kbtsnX8enod95t02_5QJwxWC_Q",
+  },
+  {
+    name: "raw README",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/readme",
+      query: {
+        ref: "main",
+      },
+      headers: {
+        accept: "application/vnd.github.raw",
+      },
+    },
+    shared: "_UVgCzi6o2HpNZOIm8rcxgZRSAxe_JUSmQZ-LZTnMxc",
+    identity: "hihbNxBtLo7AxzMUIVtqYhZFxwuMIi9c4raI0SSO0Ls",
+  },
+  {
+    name: "JSON README",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/readme",
+      query: {
+        ref: "main",
+      },
+    },
+    shared: "vZfey4xc9i7gSHZ0Dph9aqyoXDnwy72pvuKEc2c7yrk",
+    identity: "9rDxOo1Enhxnftd1PrGNFTRr_0ceNKLf-gp24KIRM2c",
+  },
+  {
+    name: "Actions",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/actions/runs/99",
+      headers: {
+        "x-octopool-public-shape": "actions-summary-v1",
+      },
+    },
+    shared: "0pVeb2WHHYXmtnvahq4bJ3cIAw7Z2Tl9je-0PQNpyOg",
+    identity: "yhytp06UBbXYjiz73t8bpOppnExFMXLQiWXLOGfYUOE",
+  },
+  {
+    name: "release",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/releases/latest",
+      headers: {
+        "x-octopool-public-shape": "release-summary-v1",
+      },
+    },
+    shared: "IW8GTqJYZGRDRACPwieFPOWWrbRvgv3Jnvdj8aQUQVw",
+    identity: "RVPH6W_dfj72c6pREDmVo98G-j7bI6Dsh4YI1nYWY8o",
+  },
+  {
+    name: "events",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/issues/12/events",
+    },
+    shared: "_NFlXimWhvHiNn8Q63JPRM3ObCweHjY3CW2WaaKE550",
+    identity: "_57Yhxfd5F1OP5rY4bKQjgDkprBYdoZqi3HUjUAL8EY",
+  },
+  {
+    name: "diff",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/pulls/12",
+      headers: {
+        accept: "application/vnd.github.diff",
+      },
+    },
+    shared: "zMFcT0oAupjrxbyrsp_CLTOK48QTtmMSq1DdQp41Ml0",
+    identity: "DHOyLYkFddGF_akosOvg154AIXNvf6RSf3rwSi8nuvw",
+  },
+] as const;

--- a/test/fixtures/contents-links.ts
+++ b/test/fixtures/contents-links.ts
@@ -1,0 +1,248 @@
+// Literal expectations for synthetic bytes 00 ff 41; no production encoder or predicate oracle.
+export const contentsLinks = [
+  {
+    label: "hash",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/hash%23.txt",
+      query: {
+        ref: "main",
+      },
+    },
+    body: {
+      type: "file",
+      encoding: "base64",
+      name: "hash#.txt",
+      path: "hash#.txt",
+      sha: "a41c182af24c4b6d785ce3df3490d5f894b23e08",
+      size: 3,
+      content: "AP9B",
+      url: "https://api.github.com/repos/openclaw/octopool/contents/hash%23.txt?ref=main",
+      html_url: "https://github.com/openclaw/octopool/blob/main/hash%23.txt",
+      git_url:
+        "https://api.github.com/repos/openclaw/octopool/git/blobs/a41c182af24c4b6d785ce3df3490d5f894b23e08",
+      download_url: "https://raw.githubusercontent.com/openclaw/octopool/main/hash%23.txt",
+      _links: {
+        self: "https://api.github.com/repos/openclaw/octopool/contents/hash%23.txt?ref=main",
+        git: "https://api.github.com/repos/openclaw/octopool/git/blobs/a41c182af24c4b6d785ce3df3490d5f894b23e08",
+        html: "https://github.com/openclaw/octopool/blob/main/hash%23.txt",
+      },
+    },
+  },
+  {
+    label: "question",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/question%3F.txt",
+      query: {
+        ref: "main",
+      },
+    },
+    body: {
+      type: "file",
+      encoding: "base64",
+      name: "question?.txt",
+      path: "question?.txt",
+      sha: "a41c182af24c4b6d785ce3df3490d5f894b23e08",
+      size: 3,
+      content: "AP9B",
+      url: "https://api.github.com/repos/openclaw/octopool/contents/question%3F.txt?ref=main",
+      html_url: "https://github.com/openclaw/octopool/blob/main/question%3F.txt",
+      git_url:
+        "https://api.github.com/repos/openclaw/octopool/git/blobs/a41c182af24c4b6d785ce3df3490d5f894b23e08",
+      download_url: "https://raw.githubusercontent.com/openclaw/octopool/main/question%3F.txt",
+      _links: {
+        self: "https://api.github.com/repos/openclaw/octopool/contents/question%3F.txt?ref=main",
+        git: "https://api.github.com/repos/openclaw/octopool/git/blobs/a41c182af24c4b6d785ce3df3490d5f894b23e08",
+        html: "https://github.com/openclaw/octopool/blob/main/question%3F.txt",
+      },
+    },
+  },
+  {
+    label: "percent",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/percent%25.txt",
+      query: {
+        ref: "main",
+      },
+    },
+    body: {
+      type: "file",
+      encoding: "base64",
+      name: "percent%.txt",
+      path: "percent%.txt",
+      sha: "a41c182af24c4b6d785ce3df3490d5f894b23e08",
+      size: 3,
+      content: "AP9B",
+      url: "https://api.github.com/repos/openclaw/octopool/contents/percent%25.txt?ref=main",
+      html_url: "https://github.com/openclaw/octopool/blob/main/percent%25.txt",
+      git_url:
+        "https://api.github.com/repos/openclaw/octopool/git/blobs/a41c182af24c4b6d785ce3df3490d5f894b23e08",
+      download_url: "https://raw.githubusercontent.com/openclaw/octopool/main/percent%25.txt",
+      _links: {
+        self: "https://api.github.com/repos/openclaw/octopool/contents/percent%25.txt?ref=main",
+        git: "https://api.github.com/repos/openclaw/octopool/git/blobs/a41c182af24c4b6d785ce3df3490d5f894b23e08",
+        html: "https://github.com/openclaw/octopool/blob/main/percent%25.txt",
+      },
+    },
+  },
+  {
+    label: "space",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/My%20File.md",
+      query: {
+        ref: "main",
+      },
+    },
+    body: {
+      type: "file",
+      encoding: "base64",
+      name: "My File.md",
+      path: "My File.md",
+      sha: "a41c182af24c4b6d785ce3df3490d5f894b23e08",
+      size: 3,
+      content: "AP9B",
+      url: "https://api.github.com/repos/openclaw/octopool/contents/My%20File.md?ref=main",
+      html_url: "https://github.com/openclaw/octopool/blob/main/My%20File.md",
+      git_url:
+        "https://api.github.com/repos/openclaw/octopool/git/blobs/a41c182af24c4b6d785ce3df3490d5f894b23e08",
+      download_url: "https://raw.githubusercontent.com/openclaw/octopool/main/My%20File.md",
+      _links: {
+        self: "https://api.github.com/repos/openclaw/octopool/contents/My%20File.md?ref=main",
+        git: "https://api.github.com/repos/openclaw/octopool/git/blobs/a41c182af24c4b6d785ce3df3490d5f894b23e08",
+        html: "https://github.com/openclaw/octopool/blob/main/My%20File.md",
+      },
+    },
+  },
+  {
+    label: "Unicode",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/caf%C3%A9%F0%9F%A6%9E.txt",
+      query: {
+        ref: "main",
+      },
+    },
+    body: {
+      type: "file",
+      encoding: "base64",
+      name: "café🦞.txt",
+      path: "café🦞.txt",
+      sha: "a41c182af24c4b6d785ce3df3490d5f894b23e08",
+      size: 3,
+      content: "AP9B",
+      url: "https://api.github.com/repos/openclaw/octopool/contents/caf%C3%A9%F0%9F%A6%9E.txt?ref=main",
+      html_url: "https://github.com/openclaw/octopool/blob/main/caf%C3%A9%F0%9F%A6%9E.txt",
+      git_url:
+        "https://api.github.com/repos/openclaw/octopool/git/blobs/a41c182af24c4b6d785ce3df3490d5f894b23e08",
+      download_url:
+        "https://raw.githubusercontent.com/openclaw/octopool/main/caf%C3%A9%F0%9F%A6%9E.txt",
+      _links: {
+        self: "https://api.github.com/repos/openclaw/octopool/contents/caf%C3%A9%F0%9F%A6%9E.txt?ref=main",
+        git: "https://api.github.com/repos/openclaw/octopool/git/blobs/a41c182af24c4b6d785ce3df3490d5f894b23e08",
+        html: "https://github.com/openclaw/octopool/blob/main/caf%C3%A9%F0%9F%A6%9E.txt",
+      },
+    },
+  },
+  {
+    label: "nested combined",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/docs/a%23b%3Fc%25%20name%F0%9F%A6%9E.txt",
+      query: {
+        ref: "feature/topic&mode=fast#part",
+      },
+    },
+    body: {
+      type: "file",
+      encoding: "base64",
+      name: "a#b?c% name🦞.txt",
+      path: "docs/a#b?c% name🦞.txt",
+      sha: "a41c182af24c4b6d785ce3df3490d5f894b23e08",
+      size: 3,
+      content: "AP9B",
+      url: "https://api.github.com/repos/openclaw/octopool/contents/docs/a%23b%3Fc%25%20name%F0%9F%A6%9E.txt?ref=feature%2Ftopic%26mode%3Dfast%23part",
+      html_url:
+        "https://github.com/openclaw/octopool/blob/feature/topic%26mode%3Dfast%23part/docs/a%23b%3Fc%25%20name%F0%9F%A6%9E.txt",
+      git_url:
+        "https://api.github.com/repos/openclaw/octopool/git/blobs/a41c182af24c4b6d785ce3df3490d5f894b23e08",
+      download_url:
+        "https://raw.githubusercontent.com/openclaw/octopool/feature/topic%26mode%3Dfast%23part/docs/a%23b%3Fc%25%20name%F0%9F%A6%9E.txt",
+      _links: {
+        self: "https://api.github.com/repos/openclaw/octopool/contents/docs/a%23b%3Fc%25%20name%F0%9F%A6%9E.txt?ref=feature%2Ftopic%26mode%3Dfast%23part",
+        git: "https://api.github.com/repos/openclaw/octopool/git/blobs/a41c182af24c4b6d785ce3df3490d5f894b23e08",
+        html: "https://github.com/openclaw/octopool/blob/feature/topic%26mode%3Dfast%23part/docs/a%23b%3Fc%25%20name%F0%9F%A6%9E.txt",
+      },
+    },
+  },
+  {
+    label: "literal percent escape",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/literal%2523.txt",
+      query: {
+        ref: "main",
+      },
+    },
+    body: {
+      type: "file",
+      encoding: "base64",
+      name: "literal%23.txt",
+      path: "literal%23.txt",
+      sha: "a41c182af24c4b6d785ce3df3490d5f894b23e08",
+      size: 3,
+      content: "AP9B",
+      url: "https://api.github.com/repos/openclaw/octopool/contents/literal%2523.txt?ref=main",
+      html_url: "https://github.com/openclaw/octopool/blob/main/literal%2523.txt",
+      git_url:
+        "https://api.github.com/repos/openclaw/octopool/git/blobs/a41c182af24c4b6d785ce3df3490d5f894b23e08",
+      download_url: "https://raw.githubusercontent.com/openclaw/octopool/main/literal%2523.txt",
+      _links: {
+        self: "https://api.github.com/repos/openclaw/octopool/contents/literal%2523.txt?ref=main",
+        git: "https://api.github.com/repos/openclaw/octopool/git/blobs/a41c182af24c4b6d785ce3df3490d5f894b23e08",
+        html: "https://github.com/openclaw/octopool/blob/main/literal%2523.txt",
+      },
+    },
+  },
+  {
+    label: "query-sensitive ref",
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/README.md",
+      query: {
+        ref: "feature/topic&mode=fast#part",
+      },
+    },
+    body: {
+      type: "file",
+      encoding: "base64",
+      name: "README.md",
+      path: "README.md",
+      sha: "a41c182af24c4b6d785ce3df3490d5f894b23e08",
+      size: 3,
+      content: "AP9B",
+      url: "https://api.github.com/repos/openclaw/octopool/contents/README.md?ref=feature%2Ftopic%26mode%3Dfast%23part",
+      html_url:
+        "https://github.com/openclaw/octopool/blob/feature/topic%26mode%3Dfast%23part/README.md",
+      git_url:
+        "https://api.github.com/repos/openclaw/octopool/git/blobs/a41c182af24c4b6d785ce3df3490d5f894b23e08",
+      download_url:
+        "https://raw.githubusercontent.com/openclaw/octopool/feature/topic%26mode%3Dfast%23part/README.md",
+      _links: {
+        self: "https://api.github.com/repos/openclaw/octopool/contents/README.md?ref=feature%2Ftopic%26mode%3Dfast%23part",
+        git: "https://api.github.com/repos/openclaw/octopool/git/blobs/a41c182af24c4b6d785ce3df3490d5f894b23e08",
+        html: "https://github.com/openclaw/octopool/blob/feature/topic%26mode%3Dfast%23part/README.md",
+      },
+    },
+  },
+] as const;

--- a/test/github-web.test.ts
+++ b/test/github-web.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { callGitHubWeb } from "../src/github-web";
 import { releaseHTML, releaseMarkdown } from "./fixtures/release-summary";
+import { contentsLinks } from "./fixtures/contents-links";
 import { withGitHubEgress, type GitHubEgressEnv } from "../src/github-egress";
 import { classifyRoute, defaultPolicy, validateRelayRequest } from "../src/policy";
 
@@ -97,6 +98,122 @@ describe("github web provider", () => {
       path: "README.md",
       content: "aGVsbG8K",
     });
+  });
+
+  it.each(contentsLinks)("encodes successful raw $label links exactly once", async (fixture) => {
+    const fetchMock = vi.fn(async () => new Response(new Uint8Array([0, 255, 65])));
+    vi.stubGlobal("fetch", fetchMock);
+    const request = validateRelayRequest(fixture.request);
+    const response = await callGitHubWeb(env(), request, classifyRoute(request, policy));
+    expect(response).toMatchObject({ status: 200, body_encoding: "json", backend: "web" });
+    expect(response?.body).toEqual(fixture.body);
+    expect(fetchMock).toHaveBeenCalledExactlyOnceWith(
+      fixture.body.download_url,
+      expect.objectContaining({
+        headers: expect.not.objectContaining({ authorization: expect.any(String) }),
+      }),
+    );
+    const body = response!.body as typeof fixture.body;
+    const self = new URL(body.url);
+    expect(body._links.self).toBe(body.url);
+    expect(self.hash).toBe("");
+    expect(decodeURIComponent(self.pathname)).toBe(
+      `/repos/openclaw/octopool/contents/${fixture.body.path}`,
+    );
+    expect([...self.searchParams]).toEqual([["ref", fixture.request.query.ref]]);
+    expect(Array.from(atob(body.content), (char) => char.charCodeAt(0))).toEqual([0, 255, 65]);
+  });
+
+  it.each([
+    { label: "empty ref", path: "README.md", query: { ref: "" }, suffix: "README.md?ref=" },
+    {
+      label: "ambiguous ref",
+      path: "README.md",
+      query: { ref: ["main", "topic"] },
+      suffix: "README.md?ref=main&ref=topic",
+    },
+    {
+      label: "empty ref segment",
+      path: "README.md",
+      query: { ref: "feature//topic" },
+      suffix: "README.md?ref=feature%2F%2Ftopic",
+    },
+    {
+      label: "malformed escape",
+      path: "bad%GG.txt",
+      query: { ref: "main" },
+      suffix: "bad%GG.txt?ref=main",
+    },
+    {
+      label: "empty path segment",
+      path: "docs//file.txt",
+      query: { ref: "main" },
+      suffix: "docs//file.txt?ref=main",
+    },
+    { label: "directory path", path: "docs/", query: { ref: "main" }, suffix: "docs/?ref=main" },
+    {
+      label: "encoded leading slash",
+      path: "%2Ffile.txt",
+      query: { ref: "main" },
+      suffix: "%2Ffile.txt?ref=main",
+    },
+  ])("retains exact anonymous API fallback for $label", async ({ path, query, suffix }) => {
+    const body = { name: "exact API fallback" };
+    const fetchMock = vi.fn(async () => Response.json(body));
+    vi.stubGlobal("fetch", fetchMock);
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: `/repos/openclaw/octopool/contents/${path}`,
+      query,
+    });
+    expect(await callGitHubWeb(env(), request, classifyRoute(request, policy))).toMatchObject({
+      body,
+      backend: "github",
+    });
+    expect(fetchMock).toHaveBeenCalledExactlyOnceWith(
+      `https://api.github.com/repos/openclaw/octopool/contents/${suffix}`,
+      expect.any(Object),
+    );
+  });
+
+  it("falls back to exact API JSON after a capped raw response", async () => {
+    const cancel = vi.fn();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          new ReadableStream(
+            {
+              pull(controller) {
+                controller.enqueue(new Uint8Array(1025));
+              },
+              cancel,
+            },
+            { highWaterMark: 0 },
+          ),
+        ),
+      )
+      .mockResolvedValueOnce(Response.json({ name: "exact API fallback" }));
+    vi.stubGlobal("fetch", fetchMock);
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/README.md",
+      query: { ref: "main" },
+    });
+    expect(
+      await callGitHubWeb(
+        env({ MAX_RESPONSE_BYTES: "1024" }),
+        request,
+        classifyRoute(request, policy),
+      ),
+    ).toMatchObject({ body: { name: "exact API fallback" }, backend: "github" });
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "https://raw.githubusercontent.com/openclaw/octopool/main/README.md",
+      "https://api.github.com/repos/openclaw/octopool/contents/README.md?ref=main",
+    ]);
   });
 
   it("falls back to the anonymous contents API when raw content is unavailable", async () => {


### PR DESCRIPTION
## Summary

The raw contents adapter preserved file bytes but interpolated the decoded filename directly into its API self-link. Characters such as `#`, `?`, `%`, spaces, and Unicode could therefore change URL meaning or produce malformed links. Reuse the existing segment encoder so `url` and `_links.self` preserve the intended path exactly, while `ref` remains one encoded query value.

Semantic path/name, binary content, base64, size, Git blob SHA, raw/download/HTML/git links, and existing ref/path eligibility stay unchanged. A bounded `contents-self-links-v1` representation retires old default-JSON contents objects with a nonempty scalar ref, including shared/identity bodies, validators, stale data, and late old publications. Other contents requests, custom media and their byte codec, blobs, README, and unrelated generations keep their keys; no purge or R2/schema change is needed.

## Historical verification on the identical tree

- Native pre-fix tests reproduced seven link failures with one ref control, plus old-cache retirement failures. The successful raw path was exercised rather than relying on the existing raw-404 fallback fixture.
- Literal full-object tests cover separate and nested special characters, a literal `%23` supplied as `%2523`, and a valid slash/query-sensitive ref. Native fill/hit assertions preserve exact content, size/SHA, link semantics, and one raw fetch.
- Compact native cache tests cover old edge/shared/identity entries, validators, stale/outage handling, late old writers, new 304/stale behavior, and a warm no-ref JSON control. Existing unsafe/missing/ambiguous input and capped raw fallback remain tested.
- Before the commit was created, full `pnpm check` passed on the identical reviewed tree: 872 unit tests, 910 native Worker tests, generation/format/lint/build/type checks, Go 1.26.7 tests (122.720s), and vet.
- Independent pre-commit verification passed 193 native cases across twelve files in 8.84s; the complete P2 review is scoped-clean. These are historical results, not a successful fresh post-commit local gate.

Fixture failures are retained separately: one draft held the same renewable fill it was awaiting and self-deadlocked; removing that fixture hold resolved it without changing deadlines or isolation. Identity-hit expectations were also corrected to preserve the existing public-attempt/guard sequence. The historical upstream content was synthetic and storage/Worker execution native; those results do not establish live-repository, installed-CLI, or hosted proof. No deployment, release, dependency, runtime, policy, or credential change is included.

## Exact-head hosted verification and accepted landing basis

[CI run 33464133665](https://github.com/openclaw/octopool/actions/runs/33464133665) and [CodeQL run 33464131603](https://github.com/openclaw/octopool/actions/runs/33464131603) passed on attempt 1 for the unchanged reviewed commit `37d590261c30437211eca95dce49f4b193d8b021` (tree `7ecd87ad2e6ae09310338f3240cd9bffd3d1f57d`). Linux completed all 16 steps, including full `pnpm check`, docs build, and a nonpublishing snapshot build. Native Windows completed all 10 steps, including staging/filesystem protection, jq support, the full Go suite, and vet. All three CodeQL analyses ran and succeeded; only language-inapplicable Go setup steps skipped. These are exact-head hosted job/step results, not newly measured hosted counts for the historical tests above. Conditional automation skips are not product proof.

The first post-commit local attempt stopped when the initial `pnpm --version` preflight exceeded its existing 30-second timeout, before tests started. Its cause remains unknown. A subsequent bounded startup diagnostic passed the direct and nested version checks; that does not establish the cause or resolution of the earlier timeout.

The latest post-commit focused attempt passed both pnpm preflights, then all six native suites failed at the common isolation hook before any of their 92 test bodies executed. The isolation hook exceeded the existing Vitest deadline, poisoned isolation, and the framework skipped all 92 bodies. This is a failed local startup/isolation gate, with zero executed test bodies; it does not establish a failing product assertion or a source defect. It is a separate observation from the earlier pnpm timeout. The full post-commit local gate was not reached.

A separate instrumented diagnostic stopped in its own configuration guard before native initialization or collection: an empty test-line selection array was incorrectly treated as a filter. It supplied no native timing or test evidence and was not repaired or rerun. Its original failure and incomplete-cleanup report remain preserved; later independent cleanup verification is separate.

The parent explicitly accepts this unchanged reviewed fix for one normal pinned squash merge based on the complete scoped-clean review, the identical-tree pre-commit local proof above, and the exact-head hosted success. This bounded acceptance does not relabel either local failure or the inconclusive diagnostic as a successful fresh local gate. The unresolved local baseline timing assessment remains separately tracked as Task 26 and blocks release completion. Original failure and diagnostic evidence is retained. No local test retry, source/test edit, safeguard weakening, runtime-policy change, workflow change, or CI rerun is included in this finish.

Release-note context: Preserve special filename characters and explicit refs in generated contents self-links, and retire cached JSON objects with older broken links without changing payload or fallback behavior.
