### PR TITLE
fix: derive pr create head from the current branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Unblock the standard `gh pr create` shape under active rewrite rules: pin a missing `--head` to the current branch (fail closed on detached HEAD or non-git directories), make `--base` optional, and accept `--dry-run`.
 - Allow typed attachments on protected `gh issue edit` and `gh issue comment` through existing strict snapshots and inline-reference rewriting, requiring explicit complete bodies for attachment edits.
 - Fence cache bodies and public-repository proofs with committed D1 ownership, isolate old writers across upgrades, and reclaim abandoned owners without adding authority calls to hot cache hits.
 - Honor native input declarations and reject malformed nonempty declared JSON before dispatch, preserving explicit UTF-8 text, zero-byte best-effort compatibility, and existing interactive-input limits.

--- a/cmd/octopool/string_rewrites_args.go
+++ b/cmd/octopool/string_rewrites_args.go
@@ -178,7 +178,7 @@ func prepareRewriteContent(policy stringRewritePolicy, args []string, stdin io.R
 	switch command {
 	case "pr create":
 		valueSpec += " --title,-t --body,-b --body-file,-F --head,-H --base,-B --label,-l --assignee,-a"
-		booleanSpec = "--draft,-d --no-maintainer-edit"
+		booleanSpec = "--draft,-d --no-maintainer-edit --dry-run"
 	case "pr edit":
 		valueSpec += " --title,-t --body,-b --body-file,-F --add-assignee --remove-assignee --add-label --remove-label"
 	case "issue edit":
@@ -277,8 +277,21 @@ func prepareRewriteContent(policy stringRewritePolicy, args []string, stdin io.R
 		return errRewriteBlocked
 	}
 	if command == "pr create" {
-		// gh explicitly skips all pushing/forking when --head is present.
-		if !flags.has("--head") || !rewriteRefPattern.MatchString(flags.values["--head"]) || !flags.has("--base") || !rewriteRefPattern.MatchString(flags.values["--base"]) {
+		// gh explicitly skips all pushing/forking when --head is present, so a
+		// missing head is pinned to the current branch instead of blocking the
+		// default invocation shape; an unpushed head fails at GitHub, not by push.
+		if !flags.has("--head") {
+			head, ok := rewriteCurrentBranch()
+			if !ok {
+				return errRewriteBlocked
+			}
+			flags.values["--head"] = head
+			flags.ordered = append(flags.ordered, rewriteFlag{name: "--head", value: head})
+		}
+		if !rewriteRefPattern.MatchString(flags.values["--head"]) {
+			return errRewriteBlocked
+		}
+		if flags.has("--base") && !rewriteRefPattern.MatchString(flags.values["--base"]) {
 			return errRewriteBlocked
 		}
 	}

--- a/cmd/octopool/string_rewrites_pr.go
+++ b/cmd/octopool/string_rewrites_pr.go
@@ -31,9 +31,8 @@ func prepareRewritePRLifecycle(policy stringRewritePolicy, args []string, stdin 
 		return errRewriteBlocked
 	}
 	if command == "pr ready" && len(flags.positionals) == 0 {
-		branch, err := exec.Command("git", "symbolic-ref", "--quiet", "--short", "HEAD").Output()
-		selector := strings.TrimSpace(string(branch))
-		if err != nil || !validRewriteReadyBranch(selector) {
+		selector, ok := rewriteCurrentBranch()
+		if !ok {
 			return errRewriteBlocked
 		}
 		flags.positionals = []string{selector}
@@ -92,6 +91,17 @@ func prepareRewritePRLifecycle(policy stringRewritePolicy, args []string, stdin 
 	}
 	prepared.stdin = strings.NewReader("")
 	return nil
+}
+
+// Current checkout branch, validated as a plain branch name. Detached HEAD,
+// non-git directories, and unusual ref shapes fail closed.
+func rewriteCurrentBranch() (string, bool) {
+	branch, err := exec.Command("git", "symbolic-ref", "--quiet", "--short", "HEAD").Output()
+	selector := strings.TrimSpace(string(branch))
+	if err != nil || !validRewriteReadyBranch(selector) {
+		return "", false
+	}
+	return selector, true
 }
 
 func validRewriteReadyBranch(selector string) bool {

--- a/cmd/octopool/string_rewrites_test.go
+++ b/cmd/octopool/string_rewrites_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -177,7 +179,7 @@ func TestStringRewriteFileReadBounded(t *testing.T) {
 func TestStringRewritePreparationRejectsUnknownShapes(t *testing.T) {
 	policy := testRewritePolicy(t, stringRewriteRule{"internal-model", "public"})
 	tests := [][]string{
-		{"pr", "create", "--title", "safe", "--body", "safe", "--repo", "acme/repo"},
+		{"pr", "create", "--title", "safe", "--body", "safe", "--repo", "acme/repo", "--head", "main", "--base", "bad base"},
 		{"pr", "create", "--title", "safe", "--body", "safe", "--repo", "acme/repo", "--head", "main", "--base", "main", "--fill"},
 		{"issue", "create", "--title", "safe", "--body", "safe", "--template", "x", "--repo", "acme/repo"},
 		{"pr", "edit", "--body", "safe", "--repo", "acme/repo"},
@@ -204,6 +206,47 @@ func TestStringRewritePreparationRejectsUnknownShapes(t *testing.T) {
 		})
 	}
 }
+func TestStringRewritePRCreateDerivesCurrentBranchHead(t *testing.T) {
+	policy := testRewritePolicy(t, stringRewriteRule{"internal-model", "public"})
+	repo := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "--quiet", "--initial-branch", "feature/derive-head", repo},
+		{"-C", repo, "remote", "add", "origin", "https://github.com/acme/repo"},
+	} {
+		if out, err := exec.CommandContext(t.Context(), "git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("synthetic repo: %v %s", err, out)
+		}
+	}
+	t.Chdir(repo)
+	body := filepath.Join(repo, "body.md")
+	if err := os.WriteFile(body, []byte("hello world\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p := &rewritePreparation{}
+	defer p.cleanup()
+	args := []string{"pr", "create", "--dry-run", "--draft", "--title", "t", "--body-file", body, "--repo", "acme/repo"}
+	if err := prepareRewriteContent(policy, args, nil, p); err != nil {
+		t.Fatalf("standard pr create blocked: %v", err)
+	}
+	if !slices.Contains(p.args, "--head=feature/derive-head") {
+		t.Fatalf("derived head missing: %v", p.args)
+	}
+	if !slices.Contains(p.args, "--dry-run=true") || !slices.Contains(p.args, "--draft=true") {
+		t.Fatalf("boolean flags dropped: %v", p.args)
+	}
+}
+
+func TestStringRewritePRCreateWithoutBranchBlocked(t *testing.T) {
+	policy := testRewritePolicy(t, stringRewriteRule{"internal-model", "public"})
+	t.Chdir(t.TempDir()) // not a git repository, so no branch can pin --head
+	p := &rewritePreparation{}
+	defer p.cleanup()
+	args := []string{"pr", "create", "--title", "safe", "--body", "safe", "--repo", "acme/repo"}
+	if err := prepareRewriteContent(policy, args, nil, p); err == nil {
+		t.Fatal("accepted pr create without a derivable head")
+	}
+}
+
 func TestStringRewriteLiteralReplacementAndFlags(t *testing.T) {
 	policy := testRewritePolicy(t, stringRewriteRule{"internal-model", "--web=$1"})
 	p := &rewritePreparation{}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -505,9 +505,12 @@ materialized/intermediate/final content. Match iteration is also bounded.
 With active rules, the initial local publication vocabulary is deliberately conservative:
 
 - PR/issue `create`, `edit`, `comment`, and PR `review`: explicit title/body flags, body
-  files, or stdin; numeric PR/issue selectors for existing items. PR creation requires
-  explicit `--head` and `--base`; the head must already be pushed. `--head` prevents gh
-  from implicitly pushing or forking. Reviews require one explicit review action. PR/issue creation
+  files, or stdin; numeric PR/issue selectors for existing items. PR creation pins
+  `--head` to the current branch when the flag is omitted (detached HEAD and non-git
+  directories are blocked); the head must already be pushed, since a pinned `--head`
+  prevents gh from implicitly pushing or forking. `--base` is optional and defaults to
+  the repository's default branch. `--dry-run` is accepted. Reviews require one
+  explicit review action. PR/issue creation
   accepts one `--label`/`-l` and one `--assignee`/`-a` value (use comma-separated lists),
   while PR/issue edits accept metadata-only add/remove label and assignee flags. Assignees may
   include native `@me` or `@copilot`. PR/issue create/edit/comment also accept repeated


### PR DESCRIPTION
## What Problem This Solves

With active string-rewrite rules, every standard `gh pr create` invocation through the shim failed with `error: string rewrite protection blocked unsafe input`. Reproduction from any repo:

```
printf 'hello world\n' > /tmp/t.md
gh pr create --dry-run --draft --title t --body-file /tmp/t.md
```

Two guard checks fired on the standard shape:

1. `--dry-run` was not in the `pr create` flag vocabulary, so `parseRewriteFlags` rejected the invocation outright.
2. The guard hard-required explicit `--head` **and** `--base` (`string_rewrites_args.go`), blocking the default invocation shape that infers the head from the current branch. Fully-specified `pr create --head X --base Y` passed the guard fine — the block was the vocabulary, not the policy.

The `--head` requirement exists for a real invariant: gh explicitly skips all implicit pushing/forking when `--head` is present, so the guard must never hand native gh a headless create.

## Why This Change Was Made

Preserve the invariant without blocking the default shape: when `--head` is omitted, the guard now derives the head from the current checkout branch (`git symbolic-ref --quiet --short HEAD`, the same derivation `pr ready` already uses, now shared as `rewriteCurrentBranch`) and pins it into the prepared arguments. Detached HEAD, non-git directories, and unusual ref shapes still fail closed. An unpushed head fails at GitHub with a clear error instead of triggering a push.

`--base` becomes optional (validated against the ref pattern when present); gh then targets the repository default branch, which has no push/fork implications. `--dry-run` joins the boolean vocabulary — it makes creation side-effect free and needs no extra guarding.

## User Impact

`gh pr create --draft --title ... --body-file ...` (the standard maintainer/agent flow) works through the shim again under active rewrite rules. Explicit `--head`/`--base` behave as before. Docs updated in `docs/cli.md`.

## Evidence

- Regression test `TestStringRewritePRCreateDerivesCurrentBranchHead` uses the exact reported invocation shape in a synthetic repo and asserts the pinned `--head`; verified it fails on pre-fix `main` with the exact reported error (`standard pr create blocked: string rewrite protection blocked unsafe input`) and passes with the fix.
- `TestStringRewritePRCreateWithoutBranchBlocked` proves the fail-closed path (non-git cwd).
- Rejection coverage retained: bad `--base` value and `--fill` remain blocked.
- Full `go test ./cmd/octopool -count=1` green locally (the slow `TestCompilerCacheAndConfigBoundary` needs >240s cold caches locally; unrelated to this change).
- Live probe after local shim rebuild: the previously failing invocation now reaches GitHub.
