### PR TITLE
fix: require complete Git ref advertisements

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -56,6 +56,21 @@ Contents without a scalar ref, custom media (including their `body_codec`), blob
 README routes, and unrelated representations retain their keys. No publication epoch,
 public-repository proof, or R2 generation changes or cache purge are required.
 
+Default JSON `git_ref` and `git_matching_refs` keys include `git-refs-framing-v1`.
+This retires older potentially incomplete ref objects and arrays for exact and matching
+heads/tags across shared and identity entries, edge/D1 hits, stale fallback, validators,
+and fill coalescing. Complete API-origin entries may also miss once; stored provenance
+is not guessed. Branch lists/views, Git objects, custom media, contents, Actions, R2,
+and public-repository proof keys retain their existing generations. No purge or schema
+change is needed.
+
+The contents and Git-ref representation predicates follow their adapters' JSON
+eligibility, including missing, empty, and whitespace-only `Accept`. Explicit blank
+values keep their existing distinct vary-header keys and `body_codec: lossless-v1`;
+they are not folded into absent headers or into each other. This also retires old
+blank-Accept contents self-links from before the self-link correction. Raw/custom
+non-JSON media and contents without a nonempty scalar ref retain their keys.
+
 Actions summaries also include a server-controlled representation generation
 (`actions-summary-metadata-v3`) in this common key. Run views, attempt-qualified views,
 and repository/workflow run lists, including canonical supersets and identity-specific

--- a/docs/token-free.md
+++ b/docs/token-free.md
@@ -65,10 +65,23 @@ links retain their existing semantics. Missing or unsafe refs, ambiguous query v
 ineligible file paths, raw misses, and oversized raw bodies retain the existing exact
 anonymous API fallback; traversal and route restrictions are unchanged.
 
-Git ref responses also read
+Git refs require an `application/x-git-upload-pack-advertisement` response and a
+complete bounded v0 envelope: the upload-pack service packet, its header flush,
+nonempty supported ref records, and a separate terminal flush at exact end of body.
+Packets use byte lengths and are limited to 65,520 bytes including the four-byte
+prefix. Truncation, reserved records, empty ref records, trailing bytes, and unsupported
+version/shallow/metadata forms fall back to the existing exact anonymous API. The
+streamed response cap still applies; `Content-Length` is not completion evidence.
+This is a conservative adapter subset, not a full Git protocol implementation.
+
+Only after accepting the whole advertisement do Git ref responses read
 `https://github.com/{owner}/{repo}/issues?q=is%3Aissue` to recover the repository node
 ID needed for exact REST-compatible ref node IDs. Lightweight tags remain anonymous
 API-only because the advertisement cannot prove their target object type.
+
+Contents and Git-ref JSON adapters accept missing, empty, and whitespace-only
+`Accept` as well as the supported JSON media types. Their cache representation
+generations cover these eligible blanks while preserving distinct blank-header keys.
 
 ### Bounded CLI shapes
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -98,11 +98,17 @@ export async function githubCacheKey(
     // Old raw event bodies may contain privileged references, even after a 304
     // republished an identity entry as anonymous. Retire every variant together.
     ...(isIssueEventRoute(route.kind) ? { representation: "issue-events-public-v2" } : {}),
+    // Adapter JSON eligibility includes blanks that intentionally remain in vary headers.
     // Old JSON file objects contain unescaped self-links, even for raw-origin fills.
     ...(route.kind === "contents" &&
     scalarQuery(request.query, "ref") !== undefined &&
-    varyHeaders.accept === undefined
+    defaultGitHubJSONAccept(request.headers?.accept)
       ? { representation: "contents-self-links-v1" }
+      : {}),
+    // Retire partial advertisements across every body, validator, and fill owner.
+    ...((route.kind === "git_ref" || route.kind === "git_matching_refs") &&
+    defaultGitHubJSONAccept(request.headers?.accept)
+      ? { representation: "git-refs-framing-v1" }
       : {}),
     ...(varyHeaders.accept === undefined ? {} : { body_codec: "lossless-v1" }),
     ...(identity === undefined ? {} : { identity: `${identity.kind}:${identity.id}` }),

--- a/src/github-git.ts
+++ b/src/github-git.ts
@@ -5,8 +5,10 @@ export type AdvertisedGitRefs = Map<string, string>;
 
 export function parseGitUploadPackAdvertisement(body: Uint8Array): AdvertisedGitRefs | undefined {
   const refs = new Map<string, string>();
-  const decoder = new TextDecoder();
+  const decoder = new TextDecoder("utf-8", { fatal: false, ignoreBOM: true });
   let offset = 0;
+  let phase: "service" | "header-flush" | "refs" = "service";
+  let firstRef = true;
   while (offset < body.byteLength) {
     if (offset + 4 > body.byteLength) {
       return undefined;
@@ -17,18 +19,38 @@ export function parseGitUploadPackAdvertisement(body: Uint8Array): AdvertisedGit
     }
     const length = Number.parseInt(lengthText, 16);
     offset += 4;
-    if (length === 0 || length === 1 || length === 2) {
-      continue;
+    if (length === 0) {
+      if (phase === "header-flush") {
+        phase = "refs";
+        continue;
+      }
+      // Only the separate terminal flush at exact EOF commits the whole listing.
+      return phase === "refs" && refs.size > 0 && offset === body.byteLength ? refs : undefined;
     }
-    if (length < 4 || offset + length - 4 > body.byteLength) {
+    if (
+      phase === "header-flush" ||
+      length < 4 ||
+      length > 65_520 ||
+      offset + length - 4 > body.byteLength
+    ) {
       return undefined;
     }
     const payload = decoder.decode(body.slice(offset, offset + length - 4));
     offset += length - 4;
-    if (payload.startsWith("# service=")) {
+    if (phase === "service") {
+      if (payload !== "# service=git-upload-pack" && payload !== "# service=git-upload-pack\n") {
+        return undefined;
+      }
+      phase = "header-flush";
       continue;
     }
-    const line = payload.replace(/\n$/, "").split("\0", 1)[0]!;
+    const record = payload.replace(/\n$/, "");
+    const capabilities = record.indexOf("\0");
+    if (capabilities !== -1 && !firstRef) {
+      return undefined;
+    }
+    firstRef = false;
+    const line = capabilities === -1 ? record : record.slice(0, capabilities);
     const match = /^([0-9a-fA-F]{40}|[0-9a-fA-F]{64}) (HEAD|refs\/[^\s]+)$/.exec(line);
     if (match === null) {
       return undefined;
@@ -41,7 +63,7 @@ export function parseGitUploadPackAdvertisement(body: Uint8Array): AdvertisedGit
     }
     refs.set(match[2]!, match[1]!.toLowerCase());
   }
-  return refs.size === 0 ? undefined : refs;
+  return undefined;
 }
 
 export function gitRefResponse(

--- a/src/github-public-git.ts
+++ b/src/github-public-git.ts
@@ -48,6 +48,10 @@ export function gitRefRequest(
     capBytes: responseCapBytes(env),
     usesApiQuota: false,
     payload: async (body, headers, status) => {
+      const mediaType = headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
+      if (mediaType !== "application/x-git-upload-pack-advertisement") {
+        return undefined;
+      }
       const refs = parseGitUploadPackAdvertisement(body);
       if (refs === undefined) {
         return undefined;

--- a/test/e2e/contents-cache.test.ts
+++ b/test/e2e/contents-cache.test.ts
@@ -10,6 +10,10 @@ import { seedPublicRepoProof, writeOwnedGitHubCache } from "./cache-publication-
 import { bearer, jsonResponse, rateHeaders, relay, seedPool } from "./harness";
 
 const frozen = contentsCacheKeys[0];
+const blankFixtures = contentsCacheKeys.filter(
+  (fixture) =>
+    fixture.name === "blank nested contents" || fixture.name === "whitespace nested contents",
+);
 const expected = contentsLinks[5].body;
 const oldURL =
   "https://api.github.com/repos/openclaw/octopool/contents/docs/a#b?c% name🦞.txt?ref=feature%2Ftopic%26mode%3Dfast%23part";
@@ -22,18 +26,24 @@ const identity: Identity = {
   installation_id: null,
   weight: 200,
 };
-const request = validateRelayRequest(frozen.request);
-const route = classifyRoute(request, defaultPolicy("openclaw"));
 type Envelope = { body: unknown; relay: { cache: string } };
 
 describe("contents cache retirement at the Worker", () => {
   beforeEach(seedPool);
 
-  it.each(["edge", "shared", "identity"])(
-    "ignores fresh old %s objects and late old writers",
-    async (layer) => {
-      await seedOld(layer !== "identity");
-      if (layer !== "edge") await deleteEdgeJSON("github-publication-v1", frozen.shared);
+  it.each([
+    ...["edge", "shared", "identity"].map((layer) => ({ layer, fixture: frozen })),
+    ...blankFixtures.map((fixture, index) => ({
+      layer: index === 0 ? "shared" : "identity",
+      fixture,
+    })),
+  ])(
+    "ignores fresh old $layer objects and late old writers ($fixture.name)",
+    async ({ layer, fixture }) => {
+      const request = validateRelayRequest(fixture.request);
+      const route = classifyRoute(request, defaultPolicy("openclaw"));
+      await seedOld(layer !== "identity", fixture);
+      if (layer !== "edge") await deleteEdgeJSON("github-publication-v1", fixture.shared);
       const upstream = vi.fn<typeof fetch>(async (input, init) => {
         const fetched = new Request(input, init);
         if (fetched.url === "https://api.github.com/repos/openclaw/octopool")
@@ -56,7 +66,14 @@ describe("contents cache retirement at the Worker", () => {
       expect
         .soft(await response.json())
         .toMatchObject({ body: expected, relay: { cache: "miss" } });
-      await seedOld();
+      expect
+        .soft(
+          upstream.mock.calls.map(([input, init]) =>
+            new Request(input, init).headers.get("if-none-match"),
+          ),
+        )
+        .not.toContain('"old-links"');
+      await seedOld(true, fixture);
       const calls = upstream.mock.calls.length;
       expect
         .soft(await (await relay(request.path, undefined, request)).json())
@@ -80,96 +97,105 @@ describe("contents cache retirement at the Worker", () => {
         await env.DB.prepare(
           "SELECT count(*) AS n FROM github_cache_entries WHERE cache_key IN (?, ?) AND body_json = ?",
         )
-          .bind(frozen.shared, frozen.identity, JSON.stringify(oldBody))
+          .bind(fixture.shared, fixture.identity, JSON.stringify(oldBody))
           .first(),
       ).toEqual({ n: 2 });
-      expect.soft(await githubCacheKey(request.pool, request, route)).not.toBe(frozen.shared);
+      expect.soft(await githubCacheKey(request.pool, request, route)).not.toBe(fixture.shared);
       expect
         .soft(await githubCacheKey(request.pool, request, route, identity))
-        .not.toBe(frozen.identity);
+        .not.toBe(fixture.identity);
     },
   );
 
-  it("retires old validators and preserves new API 304 and stale semantics", async () => {
-    await seedOld();
-    await expire(frozen.shared);
-    await expire(frozen.identity);
-    let outage = false;
-    const upstream = vi.fn<typeof fetch>(async (input, init) => {
-      const fetched = new Request(input, init);
-      if (fetched.url === "https://api.github.com/repos/openclaw/octopool")
-        return jsonResponse({ private: false });
-      if (fetched.url === expected.download_url) return new Response(null, { status: 404 });
-      expect(fetched.url).toBe(expected.url);
-      if (outage)
+  it.each([frozen, ...blankFixtures])(
+    "retires old validators and preserves new API 304 and stale semantics ($name)",
+    async (fixture) => {
+      const request = validateRelayRequest(fixture.request);
+      const route = classifyRoute(request, defaultPolicy("openclaw"));
+      await seedOld(true, fixture);
+      await expire(fixture.shared);
+      await expire(fixture.identity);
+      let outage = false;
+      const upstream = vi.fn<typeof fetch>(async (input, init) => {
+        const fetched = new Request(input, init);
+        if (fetched.url === "https://api.github.com/repos/openclaw/octopool")
+          return jsonResponse({ private: false });
+        if (fetched.url === expected.download_url) return new Response(null, { status: 404 });
+        expect(fetched.url).toBe(expected.url);
+        if (outage)
+          return jsonResponse(
+            { message: "rate limited" },
+            429,
+            rateHeaders({ remaining: 0, retryAfter: 60 }),
+          );
+        const validator = fetched.headers.get("if-none-match");
+        if (validator !== null)
+          return new Response(null, {
+            status: 304,
+            headers: { etag: validator, ...rateHeaders({ remaining: 4998 }) },
+          });
+        return jsonResponse(expected, 200, {
+          etag: '"new-links"',
+          ...rateHeaders({ remaining: 4998 }),
+        });
+      });
+      vi.stubGlobal("fetch", upstream);
+      const filled = await (await relay(request.path, undefined, request)).json<Envelope>();
+      expect.soft(filled).toMatchObject({ body: expected, relay: { cache: "miss" } });
+      expect
+        .soft(
+          upstream.mock.calls.map(([input, init]) =>
+            new Request(input, init).headers.get("if-none-match"),
+          ),
+        )
+        .not.toContain('"old-links"');
+      const key = await githubCacheKey(request.pool, request, route);
+      await expire(key);
+      expect
+        .soft(await (await relay(request.path, undefined, request)).json())
+        .toMatchObject({ body: expected, relay: { cache: "hit" } });
+      expect
+        .soft(
+          upstream.mock.calls.map(([input, init]) =>
+            new Request(input, init).headers.get("if-none-match"),
+          ),
+        )
+        .toContain('"new-links"');
+      await expire(key);
+      outage = true;
+      expect
+        .soft(await (await relay(request.path, undefined, request)).json())
+        .toMatchObject({ body: expected, relay: { cache: "stale" } });
+    },
+  );
+
+  it.each([frozen, ...blankFixtures])(
+    "never serves old shared or identity stale links during an outage ($name)",
+    async (fixture) => {
+      const request = validateRelayRequest(fixture.request);
+      await seedOld(true, fixture);
+      await expire(fixture.shared);
+      await expire(fixture.identity);
+      const upstream = vi.fn<typeof fetch>(async (input, init) => {
+        const fetched = new Request(input, init);
+        if (fetched.url === "https://api.github.com/repos/openclaw/octopool")
+          return jsonResponse({ private: false });
+        expect([expected.url, expected.download_url]).toContain(fetched.url);
         return jsonResponse(
           { message: "rate limited" },
           429,
           rateHeaders({ remaining: 0, retryAfter: 60 }),
         );
-      const validator = fetched.headers.get("if-none-match");
-      if (validator !== null)
-        return new Response(null, {
-          status: 304,
-          headers: { etag: validator, ...rateHeaders({ remaining: 4998 }) },
-        });
-      return jsonResponse(expected, 200, {
-        etag: '"new-links"',
-        ...rateHeaders({ remaining: 4998 }),
       });
-    });
-    vi.stubGlobal("fetch", upstream);
-    const filled = await (await relay(request.path, undefined, request)).json<Envelope>();
-    expect.soft(filled).toMatchObject({ body: expected, relay: { cache: "miss" } });
-    expect
-      .soft(
-        upstream.mock.calls.map(([input, init]) =>
-          new Request(input, init).headers.get("if-none-match"),
-        ),
-      )
-      .not.toContain('"old-links"');
-    const key = await githubCacheKey(request.pool, request, route);
-    await expire(key);
-    expect
-      .soft(await (await relay(request.path, undefined, request)).json())
-      .toMatchObject({ body: expected, relay: { cache: "hit" } });
-    expect
-      .soft(
-        upstream.mock.calls.map(([input, init]) =>
-          new Request(input, init).headers.get("if-none-match"),
-        ),
-      )
-      .toContain('"new-links"');
-    await expire(key);
-    outage = true;
-    expect
-      .soft(await (await relay(request.path, undefined, request)).json())
-      .toMatchObject({ body: expected, relay: { cache: "stale" } });
-  });
-
-  it("never serves old shared or identity stale links during an outage", async () => {
-    await seedOld();
-    await expire(frozen.shared);
-    await expire(frozen.identity);
-    const upstream = vi.fn<typeof fetch>(async (input, init) => {
-      const fetched = new Request(input, init);
-      if (fetched.url === "https://api.github.com/repos/openclaw/octopool")
-        return jsonResponse({ private: false });
-      expect([expected.url, expected.download_url]).toContain(fetched.url);
-      return jsonResponse(
-        { message: "rate limited" },
-        429,
-        rateHeaders({ remaining: 0, retryAfter: 60 }),
-      );
-    });
-    vi.stubGlobal("fetch", upstream);
-    const response = await relay(request.path, undefined, request);
-    expect.soft(response.status).toBe(424);
-    const wire = await response.json();
-    expect.soft(wire).toMatchObject({ error: { code: "fallback_local" } });
-    expect.soft(JSON.stringify(wire)).not.toContain(oldURL);
-    expect.soft(JSON.stringify(wire)).not.toContain('"cache":"stale"');
-  });
+      vi.stubGlobal("fetch", upstream);
+      const response = await relay(request.path, undefined, request);
+      expect.soft(response.status).toBe(424);
+      const wire = await response.json();
+      expect.soft(wire).toMatchObject({ error: { code: "fallback_local" } });
+      expect.soft(JSON.stringify(wire)).not.toContain(oldURL);
+      expect.soft(JSON.stringify(wire)).not.toContain('"cache":"stale"');
+    },
+  );
 
   it("keeps a frozen no-ref JSON contents body warm", async () => {
     const fixture = contentsCacheKeys[4];
@@ -192,14 +218,19 @@ describe("contents cache retirement at the Worker", () => {
   });
 });
 
-async function seedOld(shared = true) {
+async function seedOld(
+  shared = true,
+  fixture: { request: unknown; shared: string; identity: string } = frozen,
+) {
+  const request = validateRelayRequest(fixture.request);
+  const route = classifyRoute(request, defaultPolicy("openclaw"));
   await seedPublicRepoProof(env, route);
   for (const owner of [undefined, identity]) {
     if (!shared && owner === undefined) continue;
     expect(
       await writeOwnedGitHubCache(
         env,
-        owner === undefined ? frozen.shared : frozen.identity,
+        owner === undefined ? fixture.shared : fixture.identity,
         request,
         route,
         {

--- a/test/e2e/coordinator-retention.test.ts
+++ b/test/e2e/coordinator-retention.test.ts
@@ -71,20 +71,27 @@ async function rows() {
     })),
   );
 }
-async function backlog(count: number) {
-  for (let i = 0; i < count; i++) {
-    const input = contents(`old-${i}`);
-    expect((await select(input)).kind).toBe("selected");
-    await ownedWork.track(
-      coordinator().recordResult({
-        identityId: "a",
-        routeKey: input.routeKey,
-        resource: input.resource,
-        status: 403,
-        rate: { remaining: 100, resetAt: NOW / 1000 + 60 },
-      }),
-    );
-  }
+function seedContents(count: number, prefix: "old" | "live") {
+  return ownedWork.track(
+    runInDurableObject(coordinator(), (instance) => {
+      const feedback =
+        prefix === "old"
+          ? { identityId: "a", rate: { remaining: 100, resetAt: NOW / 1000 + 60 } }
+          : { identityId: "b" };
+      // Keep real selection/feedback order while avoiding per-entry setup RPCs.
+      for (let i = 0; i < count; i++) {
+        const input = contents(`${prefix}-${i}`, feedback.identityId);
+        expect(instance.selectIdentity(input).kind).toBe("selected");
+        instance.recordResult({
+          ...feedback,
+          routeKey: input.routeKey,
+          resource: input.resource,
+          status: 403,
+        });
+      }
+      return count;
+    }),
+  );
 }
 
 beforeEach(() => {
@@ -103,7 +110,7 @@ describe("native coordinator expiry retention", () => {
       expect((await select(input)).kind).toBe("selected");
     }
     expect(runKeys.size).toBe(1);
-    await backlog(40);
+    await seedContents(40, "old");
     const before = await rows();
     expect(before.leases).toHaveLength(41);
     expect(before.cooldowns).toHaveLength(40);
@@ -136,20 +143,9 @@ describe("native coordinator expiry retention", () => {
   it.each([40, 160])(
     "measures indexed native work with %s expired routes and a live tail",
     async (size) => {
-      await backlog(size);
+      await seedContents(size, "old");
       vi.setSystemTime(NOW + 9_999);
-      for (let i = 0; i < size; i++) {
-        const input = contents(`live-${i}`, "b");
-        await select(input);
-        await ownedWork.track(
-          coordinator().recordResult({
-            identityId: "b",
-            routeKey: input.routeKey,
-            resource: input.resource,
-            status: 403,
-          }),
-        );
-      }
+      await seedContents(size, "live");
       vi.setSystemTime(NOW + 10_000);
       const leaseBoundary = await observedSelection(contents("lease-cost", "c"));
       expect(leaseBoundary.calls[0]).toMatchObject({
@@ -162,6 +158,15 @@ describe("native coordinator expiry retention", () => {
       const before = await rows();
       expect(before.leases).toHaveLength(size * 2 - 30);
       expect(before.cooldowns).toHaveLength(size * 2);
+      expect(before.rates).toEqual([
+        {
+          identity_id: "a",
+          resource: "core",
+          limit_count: 5000,
+          remaining: 100,
+          reset_at: NOW + 60_000,
+        },
+      ]);
       vi.setSystemTime(NOW + 120_000);
       const observed = await observedSelection(contents("cost", "c"));
       expect(observed.clockCalls).toBe(1);
@@ -295,7 +300,7 @@ describe("native coordinator expiry retention", () => {
   );
 
   it("retains live independent cooldown scopes, credential health and rate history through cleanup", async () => {
-    await backlog(20);
+    await seedContents(20, "old");
     vi.setSystemTime(NOW + 120_000);
     const route = contents("live-scopes");
     for (const [identityId, status, resource] of [
@@ -349,7 +354,7 @@ describe("native coordinator expiry retention", () => {
   });
 
   it("retains persisted state and idempotent indexes through graceful eviction and a following request", async () => {
-    await backlog(20);
+    await seedContents(20, "old");
     const before = await rows();
     const indexes = () =>
       ownedWork.track(
@@ -386,7 +391,7 @@ describe("native coordinator expiry retention", () => {
   it.each([40, 160])(
     "measures additive expiry index construction over %s retained rows without deleting state",
     async (size) => {
-      await backlog(size);
+      await seedContents(size, "old");
       const before = await rows();
       const costs = await ownedWork.track(
         runInDurableObject(coordinator(), (_instance, state) => {

--- a/test/e2e/git-framing-cache.test.ts
+++ b/test/e2e/git-framing-cache.test.ts
@@ -1,0 +1,406 @@
+import { env } from "cloudflare:workers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { githubCacheKey } from "../../src/cache";
+import { acquireOwnedCacheFill } from "../../src/cache-fill";
+import { bodyPublicationResource } from "../../src/cache-publication";
+import { deleteEdgeJSON } from "../../src/edge-cache";
+import { poolCoordinatorStub } from "../../src/pool-coordinator";
+import { classifyRoute, defaultPolicy, validateRelayRequest } from "../../src/policy";
+import type { Identity } from "../../src/types";
+import { gitCacheKeys } from "../fixtures/git-cache-keys";
+import {
+  completeGitAdvertisement,
+  exactGitRefs,
+  gitAdvertisementURL,
+  gitMIME,
+  gitNodeHTML,
+  gitNodeURL,
+  malformedGitAdvertisements,
+} from "../fixtures/git-advertisement";
+import { seedPublicRepoProof, writeOwnedGitHubCache } from "./cache-publication-fixture";
+import { bearer, jsonResponse, rateHeaders, relay, seedPool } from "./harness";
+import { requestWithEnv } from "./identity-routing-support";
+
+const frozen = gitCacheKeys[0];
+const blankFixtures = gitCacheKeys.filter(
+  (fixture) =>
+    fixture.name === "blank matching heads" || fixture.name === "whitespace matching heads",
+);
+const request = validateRelayRequest(frozen.request);
+const route = classifyRoute(request, defaultPolicy("openclaw"));
+const apiURL = `https://api.github.com${request.path}`;
+const repoURL = "https://api.github.com/repos/openclaw/octopool";
+const oldBody = exactGitRefs.slice(0, 1);
+const identity: Identity = {
+  id: "primary",
+  kind: "pat",
+  login: "primary",
+  secret_ref: "TEST_PAT_PRIMARY",
+  installation_id: null,
+  weight: 200,
+};
+
+describe("Git framing and cache retirement at the Worker", () => {
+  beforeEach(seedPool);
+
+  it.each([
+    malformedGitAdvertisements[0],
+    malformedGitAdvertisements[8],
+    malformedGitAdvertisements[15],
+  ])("fills and hits complete anonymous JSON for %s", async (_name, wire) => {
+    await seedPublicRepoProof(env, route);
+    const upstream = stubAdvertisement(wire);
+    const response = await relay(request.path);
+    expect(response.status).toBe(200);
+    expect
+      .soft(await response.json())
+      .toMatchObject({ body: exactGitRefs, relay: { cache: "miss", backend: "web" } });
+    expect.soft(urls(upstream)).toEqual([gitAdvertisementURL, apiURL]);
+    expect(
+      await env.DB.prepare(
+        "SELECT backend FROM audit_events WHERE route_kind = 'git_matching_refs'",
+      ).all(),
+    ).toMatchObject({ results: [{ backend: "github_api" }] });
+    const calls = upstream.mock.calls.length;
+    expect
+      .soft(await (await relay(request.path)).json())
+      .toMatchObject({ body: exactGitRefs, relay: { cache: "hit" } });
+    expect(upstream.mock.calls).toHaveLength(calls);
+    expect(upstream.mock.calls.every(([input, init]) => bearer(input, init) === undefined)).toBe(
+      true,
+    );
+  });
+
+  it("keeps complete Git advertisements cacheable", async () => {
+    await seedPublicRepoProof(env, route);
+    const upstream = stubAdvertisement(completeGitAdvertisement);
+    const response = await relay(request.path);
+    const wire = await response.json<{
+      body: unknown;
+      relay: { cache: string; backend: string };
+    }>();
+    expect(wire).toMatchObject({
+      body: [{ ref: "refs/heads/main" }, { ref: "refs/heads/maint" }],
+      relay: { cache: "miss", backend: "web" },
+    });
+    expect(urls(upstream)).toEqual([gitAdvertisementURL, gitNodeURL]);
+    expect(await (await relay(request.path)).json()).toMatchObject({
+      body: wire.body,
+      relay: { cache: "hit" },
+    });
+    expect(upstream).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects the wrong advertisement MIME before node lookup and caches the exact API fill", async () => {
+    await seedPublicRepoProof(env, route);
+    const upstream = vi.fn<typeof fetch>(async (input, init) =>
+      new Request(input, init).url === gitAdvertisementURL
+        ? new Response(completeGitAdvertisement, { headers: { "content-type": "text/plain" } })
+        : jsonResponse(exactGitRefs),
+    );
+    vi.stubGlobal("fetch", upstream);
+    expect(await (await relay(request.path)).json()).toMatchObject({
+      body: exactGitRefs,
+      relay: { cache: "miss" },
+    });
+    expect(await (await relay(request.path)).json()).toMatchObject({
+      body: exactGitRefs,
+      relay: { cache: "hit" },
+    });
+    expect(urls(upstream)).toEqual([gitAdvertisementURL, apiURL]);
+  });
+
+  it("cancels an oversized advertisement before filling and hitting exact API JSON", async () => {
+    await seedPublicRepoProof(env, route);
+    const cancel = vi.fn();
+    let pulls = 0;
+    const upstream = vi.fn<typeof fetch>(async (input, init) =>
+      new Request(input, init).url === gitAdvertisementURL
+        ? new Response(
+            new ReadableStream<Uint8Array>(
+              {
+                pull(controller) {
+                  pulls++;
+                  controller.enqueue(new Uint8Array(1025));
+                },
+                cancel,
+              },
+              { highWaterMark: 0 },
+            ),
+            { headers: { "content-type": gitMIME, "content-length": "1" } },
+          )
+        : jsonResponse(exactGitRefs),
+    );
+    vi.stubGlobal("fetch", upstream);
+    expect(
+      await (await requestWithEnv({ MAX_RESPONSE_BYTES: "1024" }, request.path, {})).json(),
+    ).toMatchObject({ body: exactGitRefs, relay: { cache: "miss" } });
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(pulls).toBe(1);
+    expect(await (await relay(request.path)).json()).toMatchObject({
+      body: exactGitRefs,
+      relay: { cache: "hit" },
+    });
+    expect(urls(upstream)).toEqual([gitAdvertisementURL, apiURL]);
+  });
+
+  it.each([
+    ...["edge", "shared", "identity"].map((layer) => ({ layer, fixture: frozen })),
+    ...blankFixtures.map((fixture, index) => ({
+      layer: index === 0 ? "shared" : "identity",
+      fixture,
+    })),
+  ])(
+    "retires fresh old $layer partial refs and late old writers ($fixture.name)",
+    async ({ layer, fixture }) => {
+      const request = validateRelayRequest(fixture.request);
+      await seedOld(layer !== "identity", fixture);
+      if (layer !== "edge") await deleteEdgeJSON("github-publication-v1", fixture.shared);
+      const upstream = stubAdvertisement(malformedGitAdvertisements[0][1], layer === "identity");
+      const response = await relay(request.path, undefined, request);
+      expect
+        .soft(await response.json())
+        .toMatchObject({ body: exactGitRefs, relay: { cache: "miss" } });
+      expect
+        .soft(urls(upstream))
+        .toEqual(
+          layer === "identity"
+            ? [gitAdvertisementURL, apiURL, repoURL, apiURL]
+            : [gitAdvertisementURL, apiURL],
+        );
+      expect
+        .soft(
+          upstream.mock.calls.map(([input, init]) =>
+            new Request(input, init).headers.get("if-none-match"),
+          ),
+        )
+        .not.toContain('"old-partial"');
+      await seedOld(true, fixture);
+      const calls = upstream.mock.calls.length;
+      expect
+        .soft(await (await relay(request.path, undefined, request)).json())
+        .toMatchObject({ body: exactGitRefs, relay: { cache: "hit" } });
+      expect(urls(upstream).slice(calls)).toEqual(
+        layer === "identity" ? [gitAdvertisementURL, apiURL, repoURL] : [],
+      );
+      expect(
+        await env.DB.prepare(
+          "SELECT count(*) AS n FROM github_cache_entries WHERE cache_key IN (?, ?) AND body_json = ?",
+        )
+          .bind(fixture.shared, fixture.identity, JSON.stringify(oldBody))
+          .first(),
+      ).toEqual({ n: 2 });
+    },
+  );
+
+  it.each([frozen, ...blankFixtures])(
+    "retires old validators and retains new API 304 and stale behavior ($name)",
+    async (fixture) => {
+      const request = validateRelayRequest(fixture.request);
+      const route = classifyRoute(request, defaultPolicy("openclaw"));
+      await seedOld(true, fixture);
+      await expire(fixture.shared);
+      await expire(fixture.identity);
+      let outage = false;
+      const upstream = vi.fn<typeof fetch>(async (input, init) => {
+        const fetched = new Request(input, init);
+        if (fetched.url === repoURL) return jsonResponse({ private: false });
+        if (fetched.url === gitAdvertisementURL) return new Response(null, { status: 404 });
+        if (outage)
+          return jsonResponse(
+            { message: "rate limited" },
+            429,
+            rateHeaders({ remaining: 0, retryAfter: 60 }),
+          );
+        const validator = fetched.headers.get("if-none-match");
+        return validator === null
+          ? jsonResponse(exactGitRefs, 200, {
+              etag: '"complete"',
+              ...rateHeaders({ remaining: 4998 }),
+            })
+          : new Response(null, {
+              status: 304,
+              headers: { etag: validator, ...rateHeaders({ remaining: 4998 }) },
+            });
+      });
+      vi.stubGlobal("fetch", upstream);
+      expect
+        .soft(await (await relay(request.path, undefined, request)).json())
+        .toMatchObject({ body: exactGitRefs, relay: { cache: "miss" } });
+      expect
+        .soft(
+          upstream.mock.calls.map(([input, init]) =>
+            new Request(input, init).headers.get("if-none-match"),
+          ),
+        )
+        .not.toContain('"old-partial"');
+      const key = await githubCacheKey(request.pool, request, route);
+      await expire(key);
+      expect
+        .soft(await (await relay(request.path, undefined, request)).json())
+        .toMatchObject({ body: exactGitRefs, relay: { cache: "hit" } });
+      expect
+        .soft(
+          upstream.mock.calls.map(([input, init]) =>
+            new Request(input, init).headers.get("if-none-match"),
+          ),
+        )
+        .toContain('"complete"');
+      await expire(key);
+      outage = true;
+      expect
+        .soft(await (await relay(request.path, undefined, request)).json())
+        .toMatchObject({ body: exactGitRefs, relay: { cache: "stale" } });
+      expect(
+        urls(upstream).every((url) => [repoURL, gitAdvertisementURL, apiURL].includes(url)),
+      ).toBe(true);
+    },
+  );
+
+  it.each([frozen, ...blankFixtures])(
+    "never serves old shared or identity stale partial refs during an outage ($name)",
+    async (fixture) => {
+      const request = validateRelayRequest(fixture.request);
+      await seedOld(true, fixture);
+      await expire(fixture.shared);
+      await expire(fixture.identity);
+      const upstream = vi.fn<typeof fetch>(async (input, init) =>
+        new Request(input, init).url === repoURL
+          ? jsonResponse({ private: false })
+          : jsonResponse(
+              { message: "rate limited" },
+              429,
+              rateHeaders({ remaining: 0, retryAfter: 60 }),
+            ),
+      );
+      vi.stubGlobal("fetch", upstream);
+      const response = await relay(request.path, undefined, request);
+      expect.soft(response.status).toBe(424);
+      const wire = await response.json();
+      expect.soft(wire).toMatchObject({ error: { code: "fallback_local" } });
+      expect.soft(JSON.stringify(wire)).not.toContain("REF_exact_main");
+      expect.soft(JSON.stringify(wire)).not.toContain('"cache":"stale"');
+      expect(
+        urls(upstream).every((url) => [repoURL, gitAdvertisementURL, apiURL].includes(url)),
+      ).toBe(true);
+    },
+  );
+
+  it.each([false, true])(
+    "gives the new generation independent fill authority (identity=%s)",
+    async (useIdentity) => {
+      const oldKey = useIdentity ? frozen.identity : frozen.shared;
+      const key = await githubCacheKey(
+        request.pool,
+        request,
+        route,
+        useIdentity ? identity : undefined,
+      );
+      expect(key).not.toBe(oldKey);
+      const coordinator = poolCoordinatorStub(env, request.pool);
+      const old = await acquireOwnedCacheFill(coordinator, bodyPublicationResource(oldKey));
+      expect(old.kind).toBe("owner");
+      if (old.kind !== "owner") throw new Error("Fixture old fill busy");
+      try {
+        const current = await acquireOwnedCacheFill(coordinator, bodyPublicationResource(key));
+        expect(current.kind).toBe("owner");
+        if (current.kind !== "owner") throw new Error("New generation joined old fill");
+        try {
+          expect(
+            await env.DB.prepare(
+              "SELECT count(*) AS n FROM cache_publication_owners WHERE resource_key IN (?, ?)",
+            )
+              .bind(bodyPublicationResource(oldKey), bodyPublicationResource(key))
+              .first(),
+          ).toEqual({ n: 2 });
+        } finally {
+          await current.owner.fail();
+        }
+      } finally {
+        await old.owner.fail();
+      }
+    },
+  );
+
+  it("keeps frozen branch-list data warm", async () => {
+    const fixture = gitCacheKeys[4];
+    const sibling = validateRelayRequest(fixture.request);
+    const siblingRoute = classifyRoute(sibling, defaultPolicy("openclaw"));
+    await seedPublicRepoProof(env, siblingRoute);
+    const body = [{ name: "main", protected: false }];
+    expect(
+      await writeOwnedGitHubCache(env, fixture.shared, sibling, siblingRoute, {
+        status: 200,
+        headers: {},
+        body,
+        body_encoding: "json",
+      }),
+    ).toBe("shared");
+    const upstream = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", upstream);
+    expect(await (await relay(sibling.path)).json()).toMatchObject({
+      body,
+      relay: { cache: "hit" },
+    });
+    expect(upstream).not.toHaveBeenCalled();
+  });
+});
+
+function stubAdvertisement(wire: string, pooled = false) {
+  const upstream = vi.fn<typeof fetch>(async (input, init) => {
+    const fetched = new Request(input, init);
+    if (fetched.url === repoURL) return jsonResponse({ private: false });
+    if (fetched.url === gitAdvertisementURL)
+      return new Response(new TextEncoder().encode(wire), { headers: { "content-type": gitMIME } });
+    if (fetched.url === gitNodeURL) return new Response(gitNodeHTML);
+    if (pooled && bearer(fetched) === undefined)
+      return jsonResponse({ message: "unavailable" }, 503);
+    return jsonResponse(exactGitRefs, 200, rateHeaders({ remaining: 4998 }));
+  });
+  vi.stubGlobal("fetch", upstream);
+  return upstream;
+}
+
+function urls(upstream: ReturnType<typeof stubAdvertisement>) {
+  return upstream.mock.calls.map(([input, init]) => new Request(input, init).url);
+}
+
+async function seedOld(
+  shared = true,
+  fixture: { request: unknown; shared: string; identity: string } = frozen,
+) {
+  const request = validateRelayRequest(fixture.request);
+  const route = classifyRoute(request, defaultPolicy("openclaw"));
+  await seedPublicRepoProof(env, route);
+  for (const owner of [undefined, identity]) {
+    if (!shared && owner === undefined) continue;
+    expect(
+      await writeOwnedGitHubCache(
+        env,
+        owner === undefined ? fixture.shared : fixture.identity,
+        request,
+        route,
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            etag: '"old-partial"',
+            ...rateHeaders({ remaining: 4998 }),
+          },
+          body: oldBody,
+          body_encoding: "json",
+        },
+        owner,
+      ),
+    ).toBe("shared");
+  }
+}
+
+async function expire(key: string) {
+  await env.DB.prepare(
+    "UPDATE github_cache_entries SET expires_at = datetime('now', '-1 second'), stale_expires_at = datetime('now', '+1 hour') WHERE cache_key = ?",
+  )
+    .bind(key)
+    .run();
+  await deleteEdgeJSON("github-publication-v1", key);
+}

--- a/test/e2e/string-rewrites.test.ts
+++ b/test/e2e/string-rewrites.test.ts
@@ -132,7 +132,12 @@ describe("canonical relay egress protection", () => {
       packet(`${sha} HEAD\0symref=HEAD:refs/heads/main\n`) +
       packet(`${sha} refs/heads/main\n`) +
       "0000";
-    const upstream = vi.fn<typeof fetch>(async () => new Response(advertisement));
+    const upstream = vi.fn<typeof fetch>(
+      async () =>
+        new Response(advertisement, {
+          headers: { "content-type": "application/x-git-upload-pack-advertisement" },
+        }),
+    );
     vi.stubGlobal("fetch", upstream);
     expect((await relay("/repos/example/demo/git/ref/heads/main")).status).toBe(403);
     expect(upstream).toHaveBeenCalledTimes(1);

--- a/test/fixtures/contents-cache-keys.ts
+++ b/test/fixtures/contents-cache-keys.ts
@@ -115,7 +115,7 @@ export const contentsCacheKeys = [
   },
   {
     name: "blank accept contents",
-    retire: false,
+    retire: true,
     request: {
       pool: "maintainers",
       method: "GET",
@@ -255,5 +255,104 @@ export const contentsCacheKeys = [
     },
     shared: "zMFcT0oAupjrxbyrsp_CLTOK48QTtmMSq1DdQp41Ml0",
     identity: "DHOyLYkFddGF_akosOvg154AIXNvf6RSf3rwSi8nuvw",
+  },
+  {
+    name: "blank nested contents",
+    retire: true,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/docs/a%23b%3Fc%25%20name%F0%9F%A6%9E.txt",
+      query: {
+        ref: "feature/topic&mode=fast#part",
+      },
+      headers: {
+        accept: "",
+      },
+    },
+    shared: "5LZxwUE6vuajKMsNFk9dKxhGp3Hjcfw9datJAlwhhjQ",
+    identity: "sQw_8Va3HLseJXYJHG6kUUnneNOkQQ_5RccNbTurK4Q",
+  },
+  {
+    name: "whitespace nested contents",
+    retire: true,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/docs/a%23b%3Fc%25%20name%F0%9F%A6%9E.txt",
+      query: {
+        ref: "feature/topic&mode=fast#part",
+      },
+      headers: {
+        accept: " \t ",
+      },
+    },
+    shared: "yfYli2DCLDbcHKWPHmSTURIoCEDPl3ETL2P3YEaheU8",
+    identity: "fp-SLWJ7SN-qmNqSDv3cs8qIAcNqWK671jWfbpcQrMc",
+  },
+  {
+    name: "whitespace plain contents",
+    retire: true,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/README.md",
+      query: {
+        ref: "main",
+      },
+      headers: {
+        accept: " \t ",
+      },
+    },
+    shared: "bZ9Oc3s_qMGYWY_QAppK2b02vItKP93Zi2aw6oKz_fE",
+    identity: "KNSZSNeXWc3nPNe44Iuyk3ZVUd8yo7GhP28uGQ2BPDM",
+  },
+  {
+    name: "whitespace no-ref contents",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/README.md",
+      headers: {
+        accept: " \t ",
+      },
+    },
+    shared: "H4hwp_zAlqTfxKHv0-om5QbscdbZ0twur743326anbA",
+    identity: "8nkP3qGQGmSKBEVjzJBcuI0RR1SnIZbTIE_AS7oIY1I",
+  },
+  {
+    name: "whitespace empty-ref contents",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/README.md",
+      query: {
+        ref: "",
+      },
+      headers: {
+        accept: " \t ",
+      },
+    },
+    shared: "5psxSOpTQ5SZ3zdnM6Q_S0mDTq-bZNh5b34o9GjB7zM",
+    identity: "vCPg8yZL10uXg-ylAF_Kc-dMBmNRNErf8uqbLgEXofM",
+  },
+  {
+    name: "whitespace array-ref contents",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/contents/README.md",
+      query: {
+        ref: ["main", "topic"],
+      },
+      headers: {
+        accept: " \t ",
+      },
+    },
+    shared: "uO1GruEM6bcg5aBcr7aK2jNXMq1FVIQhwrk4D26rKx4",
+    identity: "wrt_1ckeAG4RGMH7DUC398htBOONyoFCzTC402qVpb0",
   },
 ] as const;

--- a/test/fixtures/git-advertisement.ts
+++ b/test/fixtures/git-advertisement.ts
@@ -1,0 +1,57 @@
+// Synthetic wire fixtures: an encoder, never an independent parser/oracle.
+export const gitSHA = "0123456789012345678901234567890123456789";
+export const gitOtherSHA = "abcdefabcdefabcdefabcdefabcdefabcdefabcd";
+export const gitService = "001e# service=git-upload-pack\n0000";
+export const gitMain = `003d${gitSHA} refs/heads/main\n`;
+export const gitMaint = `003e${gitOtherSHA} refs/heads/maint\n`;
+export const completeGitAdvertisement = gitService + gitMain + gitMaint + "0000";
+export const gitAdvertisementURL =
+  "https://github.com/openclaw/octopool.git/info/refs?service=git-upload-pack";
+export const gitNodeURL = "https://github.com/openclaw/octopool/issues?q=is%3Aissue";
+export const gitMIME = "application/x-git-upload-pack-advertisement";
+export const gitNodeHTML =
+  '<script type="application/json" data-target="react-app.embeddedData">{"payload":{"preloadedQueries":[{"queryName":"IssueIndexPageQuery","result":{"data":{"repository":{"id":"R_kgDOSoyMqw"}}}}]}}</script>';
+export const exactGitRefs = [
+  { ref: "refs/heads/main", node_id: "REF_exact_main", object: { sha: gitSHA, type: "commit" } },
+  {
+    ref: "refs/heads/maint",
+    node_id: "REF_exact_sentinel",
+    object: { sha: gitOtherSHA, type: "commit" },
+    exact_field: "retained",
+  },
+];
+
+export function gitPacket(payload: string): string {
+  return (new TextEncoder().encode(payload).byteLength + 4).toString(16).padStart(4, "0") + payload;
+}
+
+export const malformedGitAdvertisements = [
+  ["packet-boundary EOF", gitService + gitMain],
+  ["missing terminal flush", completeGitAdvertisement.slice(0, -4)],
+  ["partial prefix", gitService + gitMain + "003"],
+  ["partial payload", gitService + gitMain + gitMaint.slice(0, -2)],
+  ["header flush only", gitService],
+  ["missing service", gitMain + "0000"],
+  ["wrong service", gitPacket("# service=git-receive-pack\n") + "0000" + gitMain + "0000"],
+  ["missing header flush", gitService.slice(0, -4) + gitMain + "0000"],
+  ["reserved delimiter", gitService + gitMain + "0001" + gitMaint + "0000"],
+  ["reserved response end", gitService + gitMain + "0002" + gitMaint + "0000"],
+  ["reserved length three", gitService + gitMain + "0003" + "0000"],
+  ["empty data record", gitService + gitMain + "0004" + "0000"],
+  ["empty data instead of completion", gitService + gitMain + "0004"],
+  ["trailing garbage", completeGitAdvertisement + "garbage"],
+  ["extra flush", completeGitAdvertisement + "0000"],
+  ["appended refs", completeGitAdvertisement + gitPacket(`${gitSHA} refs/heads/extra\n`) + "0000"],
+  ["repeated service", gitService + gitMain + gitService + "0000"],
+  ["version two", gitService + gitPacket("version 2\n") + gitMain + "0000"],
+  ["shallow metadata", gitService + gitMain + gitPacket(`shallow ${gitSHA}\n`) + "0000"],
+  [
+    "late capabilities",
+    gitService + gitMain + gitPacket(`${gitOtherSHA} refs/heads/maint\0multi_ack\n`) + "0000",
+  ],
+  [
+    "BOM before service",
+    gitPacket("\ufeff# service=git-upload-pack\n") + "0000" + gitMain + "0000",
+  ],
+  ["extra ref LF", gitService + gitPacket(`${gitSHA} refs/heads/main\n\n`) + "0000"],
+] as const;

--- a/test/fixtures/git-cache-keys.ts
+++ b/test/fixtures/git-cache-keys.ts
@@ -1,0 +1,198 @@
+// Frozen by the actual key owner at b08d2e2, before Git framing retirement.
+// Both digests include publication-v1; nondefault media retain lossless-v1.
+export const gitCacheKeys = [
+  {
+    name: "matching heads",
+    retire: true,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/git/matching-refs/heads/ma",
+    },
+    shared: "Cmg-d1lu22tQ3qpsNopxN5RNZLubvOc8xMRT8dM9oDA",
+    identity: "zSgZULDWBYZtGywl0DUK0gA9PvcAljWexEhH0H0RP1w",
+  },
+  {
+    name: "exact head",
+    retire: true,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/git/ref/heads/main",
+    },
+    shared: "s6-vo9j43IkKL76W0GvOLenj999a0JPrxfSbkEK78OU",
+    identity: "-sCnW3xNxKI9TWJrBee_FHsSV4L1_3xs8d1pIKYNg4o",
+  },
+  {
+    name: "matching tags",
+    retire: true,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/git/matching-refs/tags/v1",
+    },
+    shared: "P4Ns2LJKo-8L02Kbepmc6143ARuzUnriouKgtTyE4n0",
+    identity: "DWXq43xqwxCgfY1Q2SmTVI8dELOjLg2nS1XRpJm_02M",
+  },
+  {
+    name: "exact tag",
+    retire: true,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/git/ref/tags/v1.0.0",
+    },
+    shared: "oxZEJ9KBSN8IP4-LZkyoHiKC1sMGjdM5Hh0Cp5oE97Y",
+    identity: "KjiX9Rf0FIahQ6r7z34EWKIRgHgjiODoNO9fumth4Qc",
+  },
+  {
+    name: "branch list",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/branches",
+    },
+    shared: "hVOuiU8QbfmD8C29bNr4PiRsx5evsFW7bxIzVN_b9mE",
+    identity: "N0-Tv00LvleuYKJDZlcvOxYTXPsmvutG8kO7GuKYiXo",
+  },
+  {
+    name: "branch view",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/branches/main",
+    },
+    shared: "7UKpTu2GuXLIja70TQ3x2cUQu3-pYjS0uB_61SD6MEo",
+    identity: "o5RByGGZaFu3n461Qit-2Vj5rpo26Qml_Ul3vcRZDTk",
+  },
+  {
+    name: "Git commit",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/git/commits/abc1234",
+    },
+    shared: "cmBa4nXsf3sQE1MpbhSoyik-NACTbBUObHFByqvVQXU",
+    identity: "HoZU48Ub7f7ZXdJm165j9UDRg0a82p9jiqTp4JIpzEg",
+  },
+  {
+    name: "Git tree",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/git/trees/abc1234",
+    },
+    shared: "SOVTx6oLrQeZ6fvFeZts3dKVErHSM9ZQwxbFv9104sQ",
+    identity: "kk4O2RDZ65srlzRLA8VFwzhunzEHpWO0ZAkFk3a-hQk",
+  },
+  {
+    name: "Git tag object",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/git/tags/abc1234",
+    },
+    shared: "yZ-mDiXrWQ_5no2MQnwDOcG10CrLguNgNlvlcaIF_To",
+    identity: "h1BcHTiIGWcTZydSQPuH77DptDfQBm6X2I9asEK6gLk",
+  },
+  {
+    name: "Git blob",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/git/blobs/abc1234",
+    },
+    shared: "YrggK6f6E9YQzLvANPrlswuTc4cJDMnCGSdEr0PVPu4",
+    identity: "vJlhZLlac044XT-77kbtsnX8enod95t02_5QJwxWC_Q",
+  },
+  {
+    name: "raw ref",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/git/ref/heads/main",
+      headers: {
+        accept: "application/vnd.github.raw",
+      },
+    },
+    shared: "QCcQRBkoTl8qJzIC14LTptFyIbiq-NrDSNLJ0CqDUYI",
+    identity: "-R-bLiY5JW6rVpLFt_6mdum4wyWmgYDa0v2Ln9zTw4I",
+  },
+  {
+    name: "custom matching",
+    retire: false,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/git/matching-refs/heads/ma",
+      headers: {
+        accept: "application/octet-stream",
+      },
+    },
+    shared: "ZJ34SiapMNbHPurj4HFjfEg-vTXQJH7l62JV7cmGW_U",
+    identity: "CeYKGGknUxvqhF5dV4SUVx2mfPj609GMLh6BrR1OoW4",
+  },
+  {
+    name: "blank accept ref",
+    retire: true,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/git/ref/heads/main",
+      headers: {
+        accept: "",
+      },
+    },
+    shared: "iiIh8OnaMj-wnV2WUamaR89WkGwXiN-bICvAfrMwSfU",
+    identity: "jDH0RtUh9Ge2qemZJfEWaKsXgPUpfLAb_h0X6k-iOvs",
+  },
+  {
+    name: "blank matching heads",
+    retire: true,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/git/matching-refs/heads/ma",
+      headers: {
+        accept: "",
+      },
+    },
+    shared: "ytGo82Bt0YyAsHoi7fXAQzWsm_6GzYjDgeSUiGcRW24",
+    identity: "AfDC6_qHlralcaWjbZ_pqgUvc4NlVvOK6c2NNGU5zpM",
+  },
+  {
+    name: "whitespace matching heads",
+    retire: true,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/git/matching-refs/heads/ma",
+      headers: {
+        accept: " \t ",
+      },
+    },
+    shared: "uJ30S5-aEWr1NpPEksu5lkNjwpcNr80UtgAI8IdQbqY",
+    identity: "jJ4wcNte5JgOJfQIqi5N68pTmaP2wTIMzR8-a3sniOU",
+  },
+  {
+    name: "whitespace exact head",
+    retire: true,
+    request: {
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/git/ref/heads/main",
+      headers: {
+        accept: " \t ",
+      },
+    },
+    shared: "H7bMgbGMsRdYB5qNS6vxQUlBCaZ1Svxz2dp00LtjFDM",
+    identity: "phWcmm6g3o1N2-Ga7E0dzmdC8oMbZHNdwrrHyzIdYK8",
+  },
+] as const;

--- a/test/git-cache-generation.test.ts
+++ b/test/git-cache-generation.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { githubCacheKey } from "../src/cache";
-import { rawContentRequest } from "../src/github-public-content";
+import { gitRefRequest } from "../src/github-public-git";
+import { withGitHubEgress } from "../src/github-egress";
 import { classifyRoute, defaultPolicy, validateRelayRequest } from "../src/policy";
-import { contentsCacheKeys } from "./fixtures/contents-cache-keys";
+import { gitCacheKeys } from "./fixtures/git-cache-keys";
 
-describe("contents self-link cache generation", () => {
-  it.each(contentsCacheKeys)("bounds shared and identity retirement for $name", async (fixture) => {
+describe("Git framing cache generation", () => {
+  it.each(gitCacheKeys)("bounds shared and identity retirement for $name", async (fixture) => {
     const request = validateRelayRequest(fixture.request);
     const route = classifyRoute(request, defaultPolicy("openclaw"));
     const shared = await githubCacheKey(request.pool, request, route);
@@ -23,7 +24,7 @@ describe("contents self-link cache generation", () => {
         kind: "pat",
       });
       if (request.headers?.accept?.trim() === "") {
-        expect(rawContentRequest({} as Env, request, route)).toBeDefined();
+        expect(gitRefRequest(withGitHubEgress({} as Env, []), request, route)).toBeDefined();
         expect(shared).not.toBe(canonicalShared);
         expect(identity).not.toBe(canonicalIdentity);
         const otherBlank = {

--- a/test/github-git.test.ts
+++ b/test/github-git.test.ts
@@ -1,7 +1,79 @@
 import { describe, expect, it } from "vitest";
 import { gitRefResponse, parseGitUploadPackAdvertisement } from "../src/github-git";
+import {
+  completeGitAdvertisement,
+  gitMain,
+  gitPacket,
+  gitService,
+  gitSHA,
+  malformedGitAdvertisements,
+} from "./fixtures/git-advertisement";
 
 describe("Git smart HTTP refs", () => {
+  it.each(malformedGitAdvertisements)("rejects %s without exposing partial refs", (_name, wire) => {
+    expect(parseGitUploadPackAdvertisement(new TextEncoder().encode(wire))).toBeUndefined();
+  });
+
+  it("rejects every proper byte prefix of a canonical advertisement", () => {
+    const bytes = new TextEncoder().encode(completeGitAdvertisement);
+    expect(parseGitUploadPackAdvertisement(bytes)?.size).toBe(2);
+    for (let cut = 0; cut < bytes.length; cut++) {
+      expect
+        .soft(parseGitUploadPackAdvertisement(bytes.slice(0, cut)), `cut ${cut}`)
+        .toBeUndefined();
+    }
+  });
+
+  it("accepts optional LF, byte-counted UTF8, 64-hex IDs, HEAD, and deterministic matching", () => {
+    const sha = "ABCDEF01".repeat(8);
+    const wire =
+      gitPacket("# service=git-upload-pack") +
+      "0000" +
+      gitPacket(`${sha} HEAD\0multi_ack symref=HEAD:refs/heads/🦞`) +
+      gitPacket(`${sha} refs/heads/🦞`) +
+      gitMain +
+      "0000";
+    const refs = parseGitUploadPackAdvertisement(new TextEncoder().encode(wire));
+    expect([...refs!]).toEqual([
+      ["refs/heads/🦞", sha.toLowerCase()],
+      ["refs/heads/main", gitSHA],
+    ]);
+    expect(
+      gitRefResponse(refs!, "R_kgDOSoyMqw", "owner space", "repo#name", "heads", true),
+    ).toMatchObject([
+      { ref: "refs/heads/main", object: { type: "commit" } },
+      {
+        ref: "refs/heads/🦞",
+        url: "https://api.github.com/repos/owner%20space/repo%23name/git/refs/heads/%F0%9F%A6%9E",
+        object: { sha: sha.toLowerCase() },
+      },
+    ]);
+  });
+
+  it("enforces the 65520-byte total packet bound", () => {
+    const prefix = `${gitSHA} refs/heads/`;
+    const payload = prefix + "a".repeat(65516 - prefix.length);
+    expect(
+      parseGitUploadPackAdvertisement(
+        new TextEncoder().encode(gitService + gitPacket(payload) + "0000"),
+      )?.size,
+    ).toBe(1);
+    expect(
+      parseGitUploadPackAdvertisement(
+        new TextEncoder().encode(gitService + gitPacket(payload + "a") + "0000"),
+      ),
+    ).toBeUndefined();
+  });
+
+  it.each([
+    ["duplicate refs", gitService + gitMain + gitMain + "0000"],
+    ["HEAD only", gitService + gitPacket(`${gitSHA} HEAD\n`) + "0000"],
+    ["nonhex length", gitService + "003g" + gitMain.slice(4) + "0000"],
+    ["empty listing", gitService + "0000"],
+  ])("rejects %s", (_name, wire) => {
+    expect(parseGitUploadPackAdvertisement(new TextEncoder().encode(wire!))).toBeUndefined();
+  });
+
   it("reconstructs exact new-style branch ref responses", () => {
     const refs = parseGitUploadPackAdvertisement(
       advertisement([

--- a/test/github-web.test.ts
+++ b/test/github-web.test.ts
@@ -4,6 +4,15 @@ import { releaseHTML, releaseMarkdown } from "./fixtures/release-summary";
 import { contentsLinks } from "./fixtures/contents-links";
 import { withGitHubEgress, type GitHubEgressEnv } from "../src/github-egress";
 import { classifyRoute, defaultPolicy, validateRelayRequest } from "../src/policy";
+import {
+  completeGitAdvertisement,
+  exactGitRefs,
+  gitAdvertisementURL,
+  gitMIME,
+  gitNodeHTML,
+  gitNodeURL,
+  malformedGitAdvertisements,
+} from "./fixtures/git-advertisement";
 
 describe("github web provider", () => {
   const policy = defaultPolicy("openclaw");
@@ -1267,43 +1276,123 @@ describe("github web provider", () => {
     });
   });
 
-  it("prefers exact branch refs from Git smart HTTP", async () => {
-    const sha = "e05a16c766609e722571a448f606f6820a0bf249";
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(
-        new Response(gitAdvertisement([[sha, "refs/heads/main"]]), {
-          headers: { "content-type": "application/x-git-upload-pack-advertisement" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        new Response(embeddedPage("IssueIndexPageQuery", { id: "R_kgDOSoyMqw" })),
-      );
-    vi.stubGlobal("fetch", fetchMock);
+  it.each([
+    ...malformedGitAdvertisements.map(([name, wire]) => ({ name, wire, mime: gitMIME })),
+    ...[
+      undefined,
+      "text/plain",
+      "application/x-git-receive-pack-advertisement",
+      "application/x-git-upload-pack-advertisement-extra",
+    ].map((mime) => ({ name: `MIME ${mime}`, wire: completeGitAdvertisement, mime })),
+  ])("falls back exactly without a node-page fetch for $name", async ({ wire, mime }) => {
     const request = validateRelayRequest({
       pool: "maintainers",
       method: "GET",
-      path: "/repos/openclaw/octopool/git/ref/heads/main",
+      path: "/repos/openclaw/octopool/git/matching-refs/heads/ma",
     });
-
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const fetched = new Request(input, init);
+      if (fetched.url === gitAdvertisementURL)
+        return new Response(new TextEncoder().encode(wire), {
+          headers: {
+            ...(mime === undefined ? {} : { "content-type": mime }),
+            "content-length": String(new TextEncoder().encode(wire).byteLength),
+          },
+        });
+      if (fetched.url === gitNodeURL) return new Response(gitNodeHTML);
+      return Response.json(exactGitRefs);
+    });
+    vi.stubGlobal("fetch", fetchMock);
     const response = await callGitHubWeb(env(), request, classifyRoute(request, policy));
-
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      1,
-      "https://github.com/openclaw/octopool.git/info/refs?service=git-upload-pack",
-      expect.any(Object),
-    );
-    expect(response?.body).toEqual({
-      ref: "refs/heads/main",
-      node_id: "REF_kwDOSoyMq69yZWZzL2hlYWRzL21haW4",
-      url: "https://api.github.com/repos/openclaw/octopool/git/refs/heads/main",
-      object: {
-        sha,
-        type: "commit",
-        url: `https://api.github.com/repos/openclaw/octopool/git/commits/${sha}`,
-      },
-    });
+    expect.soft(response).toMatchObject({ body: exactGitRefs, backend: "github" });
+    const requests = fetchMock.mock.calls.map(([input, init]) => new Request(input, init));
+    expect(requests.map((fetched) => fetched.url)).toEqual([
+      gitAdvertisementURL,
+      `https://api.github.com${request.path}`,
+    ]);
+    expect(requests.every((fetched) => !fetched.headers.has("authorization"))).toBe(true);
   });
+
+  it("cancels an over-cap Git body and uses the exact anonymous API", async () => {
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/git/matching-refs/heads/ma",
+    });
+    const cancel = vi.fn();
+    let pulls = 0;
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      if (new Request(input, init).url !== gitAdvertisementURL) return Response.json(exactGitRefs);
+      return new Response(
+        new ReadableStream<Uint8Array>(
+          {
+            pull(controller) {
+              pulls++;
+              controller.enqueue(new Uint8Array(1025));
+            },
+            cancel,
+          },
+          { highWaterMark: 0 },
+        ),
+        { headers: { "content-type": gitMIME, "content-length": "1" } },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    expect(
+      await callGitHubWeb(
+        env({ MAX_RESPONSE_BYTES: "1024" }),
+        request,
+        classifyRoute(request, policy),
+      ),
+    ).toMatchObject({ body: exactGitRefs, backend: "github" });
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(pulls).toBe(1);
+    expect(fetchMock.mock.calls.map(([input, init]) => new Request(input, init).url)).toEqual([
+      gitAdvertisementURL,
+      `https://api.github.com${request.path}`,
+    ]);
+  });
+
+  it.each([gitMIME, "Application/X-Git-Upload-Pack-Advertisement; charset=UTF-8"])(
+    "prefers exact branch refs from Git smart HTTP with %s",
+    async (mime) => {
+      const sha = "e05a16c766609e722571a448f606f6820a0bf249";
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(gitAdvertisement([[sha, "refs/heads/main"]]), {
+            headers: { "content-type": mime },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(embeddedPage("IssueIndexPageQuery", { id: "R_kgDOSoyMqw" })),
+        );
+      vi.stubGlobal("fetch", fetchMock);
+      const request = validateRelayRequest({
+        pool: "maintainers",
+        method: "GET",
+        path: "/repos/openclaw/octopool/git/ref/heads/main",
+      });
+
+      const response = await callGitHubWeb(env(), request, classifyRoute(request, policy));
+
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        "https://github.com/openclaw/octopool.git/info/refs?service=git-upload-pack",
+        expect.any(Object),
+      );
+      expect(response?.body).toEqual({
+        ref: "refs/heads/main",
+        node_id: "REF_kwDOSoyMq69yZWZzL2hlYWRzL21haW4",
+        url: "https://api.github.com/repos/openclaw/octopool/git/refs/heads/main",
+        object: {
+          sha,
+          type: "commit",
+          url: `https://api.github.com/repos/openclaw/octopool/git/commits/${sha}`,
+        },
+      });
+    },
+  );
 
   it("falls back to the exact API response for ambiguous lightweight tags", async () => {
     const apiBody = {
@@ -1351,6 +1440,43 @@ describe("github web provider", () => {
       "https://api.github.com/repos/openclaw/octopool/git/ref/tags/v1.0.0",
       expect.any(Object),
     );
+  });
+
+  it("retains annotated tags and old repository node IDs through the adapter", async () => {
+    const sha = "0123456789012345678901234567890123456789";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          gitAdvertisement([
+            [sha, "refs/tags/v1.0.0"],
+            ["abcdefabcdefabcdefabcdefabcdefabcdefabcd", "refs/tags/v1.0.0^{}"],
+          ]),
+          { headers: { "content-type": gitMIME } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          embeddedPage("IssueIndexPageQuery", { id: "MDEwOlJlcG9zaXRvcnkyMTI2MTMwNDk=" }),
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const request = validateRelayRequest({
+      pool: "maintainers",
+      method: "GET",
+      path: "/repos/openclaw/octopool/git/matching-refs/tags/v1",
+    });
+    expect(await callGitHubWeb(env(), request, classifyRoute(request, policy))).toMatchObject({
+      backend: "web",
+      body: [
+        {
+          ref: "refs/tags/v1.0.0",
+          node_id: "MDM6UmVmMjEyNjEzMDQ5OnJlZnMvdGFncy92MS4wLjA=",
+          object: { sha, type: "tag" },
+        },
+      ],
+    });
+    expect(fetchMock.mock.calls.map(([input]) => input)).toEqual([gitAdvertisementURL, gitNodeURL]);
   });
 
   it("rejects workflow HTML without pagination completeness proof", async () => {


### PR DESCRIPTION
## Summary

A truncated Git advertisement could leave a usable prefix of refs and be cached as a complete REST response. Require the upload-pack advertisement media type and a bounded v0 envelope: service packet, header flush, supported nonempty ref records, and a separate terminal flush at exact end of body. Invalid, truncated, oversized-packet, trailing, or unsupported forms use the existing exact anonymous API fallback before repository-ID lookup. The streamed response cap remains authoritative.

Retire affected default-JSON exact and matching Git-ref cache entries across shared/identity bodies, edge/D1 hits, stale fallback, validators, and fill coalescing. The Git and contents generation predicates also cover empty and whitespace-only Accept values, following the [contents self-link correction](https://github.com/openclaw/octopool/pull/110). Distinct vary-header keys and the lossless body codec remain intact; custom media, unrelated routes, public-repository proof, and R2 generations retain their contracts. No purge or schema change is needed.

Add parser/MIME and frozen-producer cache regression coverage. Batch retention-test setup through the real coordinator methods while preserving method order, clocks, row assertions, ownership/drain behavior, and the 40/160 measured-cost bounds. For the 160 fixture, this replaces 640 explicit setup RPC calls with two owned callbacks; it does not establish a physical SDK message count or the cause of earlier timeouts.

## Validation

Original framing/cache/MIME regressions and the blank-Accept follow-up produced credible failing assertions before the fixes. The earlier full local retry passed 952 unit tests and all 20 Git plus 12 contents native cases, but remained **failed** overall: 927 native passes and nine failures, comprising the 160-route retention deadline and eight subsequent poisoned cases.

After the bounded type corrections and fixture cleanup, focused validation passed 34 parser units, 40 generation units, both TypeScript projects/build, and all 11 retention native cases. The retention measurements remained 64 rows read and 16 written at both 40 and 160. These are separate focused results, not a new final full-suite pass or proof of a universal timeout cause. The broader runtime investigation remains open.

The patch is integrated on the assessed [PR 111](https://github.com/openclaw/octopool/pull/111) base with all 16 approved patch blobs preserved. Fresh integrated Go 1.26.7 test/vet and an actual pnpm build are recorded below. Full Linux checks, native Windows Go/jq/vet, and all CodeQL analyses on this exact integrated head are required before merge.

Fresh local checks on integrated head `1709608b50db8cc6297107b19d1a34645f3676b8` passed:

- Go 1.26.7 `go test ./...` (199.189s) and `go vet ./...`.
- Actual pnpm 11.21.0 `build`: Wrangler type generation and both source/test TypeScript projects.

No additional local full Worker/check pipeline or native retry was run after integration. Exact-head hosted CI supplies the required full integrated validation.
