### PR TITLE
fix: cap PR-state metadata before caching proof

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -106,6 +106,19 @@ that already know the current PR state can use that to avoid mixing entries acro
 SHAs while letting Octopool keep `files` warm longer. Hints are first checked against
 GitHub and then cached briefly in `github_pr_state_proofs`, so repeated cache hits do not
 need to re-contact GitHub just to validate the hint.
+
+PR-state metadata uses the same `MAX_RESPONSE_BYTES` cap as response bodies: exactly the
+cap is accepted, and the first chunk crossing it cancels the read before JSON parsing or
+proof storage. Failed metadata reads, parsing, or matching do not insert or refresh a
+proof; the request continues with the ordinary unhinted files cache key. Proofs last
+300 seconds. If a fresh proof's keyed body is missing, live verification is required
+before filling it. A failed live check ignores that discriminator for the current request,
+including stale-cache selection, while leaving the stored proof intact. A failed proof
+storage attempt also returns no newly trusted hint; an unknown write acknowledgment does
+not establish whether the write committed. These metadata failures preserve the unhinted
+route fallback; an oversized actual files response still uses the existing
+`424 fallback_local` / `github_response_too_large` handoff.
+
 The `gh pr view --json files` shim resolves the head with `max-age=0`, sends a dedicated
 `pr-files-v1` shape plus the verified head on every bounded page, and resolves the head
 again after all hydration. If the head moved, the entire command falls back to real `gh`

--- a/src/pr-state.ts
+++ b/src/pr-state.ts
@@ -1,7 +1,9 @@
 import { isStateAwarePRRoute } from "./cache-policy";
 import { rethrowStringRewriteDenial, type GitHubEgressEnv } from "./github-egress";
 import { queries } from "./generated/sql";
-import { requestTimeoutMs } from "./github-limits";
+import { requestTimeoutMs, responseCapBytes } from "./github-limits";
+import { HttpError } from "./http";
+import { readBodyCapped } from "./response-body";
 import type { RelayRequest, RouteInfo } from "./types";
 
 type PullResponse = {
@@ -65,7 +67,12 @@ async function verifyPRStateHintInternal(
     if (!response.ok) {
       return route;
     }
-    const body = (await response.json()) as PullResponse;
+    const bytes = await readBodyCapped(
+      response,
+      responseCapBytes(env),
+      () => new HttpError(502, "github_response_too_large", "GitHub response exceeded relay cap"),
+    );
+    const body = JSON.parse(new TextDecoder().decode(bytes)) as PullResponse;
     if (hintMatchesPR(stateHint, body)) {
       await upsertPRStateProof(env, route, number, stateHint);
       return { ...route, state_hint: stateHint, state_hint_source: "live" };

--- a/test/e2e/identity-routing-support.ts
+++ b/test/e2e/identity-routing-support.ts
@@ -10,7 +10,7 @@ export const conditional = { headers: { "if-none-match": '"identity-routing"' } 
 export function requestWithEnv(
   overrides: Record<string, unknown> = {},
   path = PATH,
-  options: Pick<RelayRequest, "headers" | "query"> = conditional,
+  options: Pick<RelayRequest, "headers" | "query" | "route_hint"> = conditional,
 ): Promise<Response> {
   clearConfigCache();
   return requestWithWarmEnv(overrides, path, options);
@@ -19,7 +19,7 @@ export function requestWithEnv(
 export function requestWithWarmEnv(
   overrides: Record<string, unknown> = {},
   path = PATH,
-  options: Pick<RelayRequest, "headers" | "query"> = conditional,
+  options: Pick<RelayRequest, "headers" | "query" | "route_hint"> = conditional,
 ): Promise<Response> {
   return runWithContext((ctx) =>
     worker.fetch(

--- a/test/e2e/pr-state-cache.test.ts
+++ b/test/e2e/pr-state-cache.test.ts
@@ -2,6 +2,14 @@ import { env } from "cloudflare:workers";
 import { describe, expect, it, vi } from "vitest";
 import { deleteEdgeJSON } from "../../src/edge-cache";
 import { jsonResponse, relay, seedPool } from "./harness";
+import { requestWithEnv } from "./identity-routing-support";
+import {
+  matchingPRMetadata,
+  oversizedPRMetadata,
+  oversizedPRStream,
+  PR_METADATA_CAP,
+  prMetadataStream,
+} from "../fixtures/pr-state-metadata";
 
 const HEAD = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const FORGED_HEAD = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
@@ -13,6 +21,224 @@ type RelayEnvelope = {
 };
 
 describe("Worker end-to-end PR-state cache", () => {
+  describe.each(["proof miss", "forced live"])("bounded metadata: %s", (mode) => {
+    it.each(oversizedPRMetadata)(
+      "rejects $name and uses the unhinted files cache",
+      async (definition) => {
+        await seedPool();
+        const oldBody = mode === "forced live" ? await primeStaleHintedBody() : null;
+        const before = await proofRows();
+        const fixture = oversizedPRStream(definition);
+        const upstream = filesUpstream(() => fixture.response);
+        vi.stubGlobal("fetch", upstream);
+
+        const response = await cappedRelay();
+        const wire = await response.json<RelayEnvelope>();
+        const after = await proofRows();
+        const rowsAfterHint = await fileCacheRows();
+        const following = await requestWithEnv(
+          { MAX_RESPONSE_BYTES: String(PR_METADATA_CAP) },
+          FILES_PATH,
+          {},
+        );
+        const unhinted = await following.json<RelayEnvelope>();
+        const rowsAfterUnhinted = await fileCacheRows();
+        const calls = outgoingCalls(upstream);
+        console.info(
+          "PR metadata cap observations",
+          JSON.stringify({
+            mode,
+            case: definition.name,
+            stream: fixture.observations,
+            locked: fixture.stream.locked,
+            responseStatus: response.status,
+            wire,
+            before,
+            after,
+            oldBody,
+            rowsAfterHint,
+            rowsAfterUnhinted,
+            unhinted,
+            calls,
+          }),
+        );
+
+        expect.soft(response.status).toBe(200);
+        expect.soft(wire).toMatchObject({
+          body: [{ filename: "safe-unhinted.ts" }],
+          relay: { cache: "miss", backend: "web" },
+        });
+        expect.soft(fixture.observations).toEqual({
+          pulls: definition.pulled.length,
+          chunkBytes: definition.pulled,
+          cancellations: 1,
+        });
+        expect.soft(fixture.stream.locked).toBe(false);
+        expect.soft(after).toEqual(before);
+        expect.soft(unhinted).toMatchObject({
+          body: [{ filename: "safe-unhinted.ts" }],
+          relay: { cache: "hit", backend: "web" },
+        });
+        expect.soft(calls).toEqual([
+          { path: "/repos/openclaw/octopool/pulls/42", authorization: null },
+          { path: FILES_PATH, authorization: null },
+        ]);
+        expect.soft(rowsAfterHint).toHaveLength(mode === "forced live" ? 2 : 1);
+        expect.soft(rowsAfterUnhinted).toEqual(rowsAfterHint);
+        if (oldBody !== null) expect.soft(rowsAfterHint).toContainEqual(oldBody);
+      },
+    );
+
+    it.each(["malformed JSON", "read failure", "non-2xx", "network", "mismatch"])(
+      "leaves D1 proofs unchanged after %s",
+      async (failure) => {
+        await seedPool();
+        if (mode === "forced live") await primeStaleHintedBody();
+        const before = await proofRows();
+        const fixture = prMetadataStream([matchingPRMetadata().slice(0, 128)], { failAtPull: 2 });
+        const upstream = filesUpstream(() => {
+          if (failure === "network") throw new Error("metadata unavailable");
+          if (failure === "read failure") return fixture.response;
+          if (failure === "non-2xx") return jsonResponse({ message: "unavailable" }, 503);
+          if (failure === "mismatch") return jsonResponse({ head: { sha: FORGED_HEAD } });
+          return new Response('{"head":');
+        });
+        vi.stubGlobal("fetch", upstream);
+        const response = await cappedRelay();
+        expect(response.status).toBe(200);
+        expect(await response.json<RelayEnvelope>()).toMatchObject({
+          body: [{ filename: "safe-unhinted.ts" }],
+          relay: { cache: "miss" },
+        });
+        expect(await proofRows()).toEqual(before);
+        const following = await requestWithEnv(
+          { MAX_RESPONSE_BYTES: String(PR_METADATA_CAP) },
+          FILES_PATH,
+          {},
+        );
+        expect(await following.json<RelayEnvelope>()).toMatchObject({
+          body: [{ filename: "safe-unhinted.ts" }],
+          relay: { cache: "hit" },
+        });
+        expect(outgoingCalls(upstream)).toEqual([
+          { path: "/repos/openclaw/octopool/pulls/42", authorization: null },
+          { path: FILES_PATH, authorization: null },
+        ]);
+        if (failure === "read failure") {
+          expect(fixture.observations).toEqual({ pulls: 2, chunkBytes: [128], cancellations: 0 });
+        }
+      },
+    );
+  });
+
+  it("accepts exact-cap JSON into real D1 and reuses the proof plus keyed body", async () => {
+    await seedPool();
+    const bytes = matchingPRMetadata();
+    const fixture = prMetadataStream([bytes.slice(0, 128), bytes.slice(128)], {
+      contentLength: "1",
+    });
+    const upstream = filesUpstream(() => fixture.response);
+    vi.stubGlobal("fetch", upstream);
+    for (const cache of ["miss", "hit"]) {
+      const response = await cappedRelay();
+      expect(response.status).toBe(200);
+      expect(await response.json<RelayEnvelope>()).toMatchObject({
+        body: [{ filename: "safe-unhinted.ts" }],
+        relay: { cache },
+      });
+    }
+    expect(fixture.observations).toEqual({ pulls: 3, chunkBytes: [128, 128], cancellations: 0 });
+    expect(outgoingCalls(upstream)).toEqual([
+      { path: "/repos/openclaw/octopool/pulls/42", authorization: null },
+      { path: FILES_PATH, authorization: null },
+    ]);
+    expect(
+      await env.DB.prepare(`SELECT owner, repo, number, state_hint,
+      unixepoch(expires_at) - unixepoch(checked_at) AS ttl FROM github_pr_state_proofs`).all(),
+    ).toMatchObject({
+      results: [
+        {
+          owner: "openclaw",
+          repo: "octopool",
+          number: 42,
+          state_hint: `pr-head:${HEAD}`,
+          ttl: 300,
+        },
+      ],
+    });
+    expect(await fileCacheRows()).toHaveLength(1);
+    console.info(
+      "PR exact-cap observations",
+      JSON.stringify({
+        stream: fixture.observations,
+        locked: fixture.stream.locked,
+        proofs: await proofRows(),
+        calls: outgoingCalls(upstream),
+      }),
+    );
+  });
+
+  it("retains actual files-body overflow mapping after successful metadata verification", async () => {
+    await seedPool();
+    const metadata = prMetadataStream([matchingPRMetadata()]);
+    const files: ReturnType<typeof prMetadataStream>[] = [];
+    const upstream = vi.fn<typeof fetch>(async (input, init) => {
+      const path = new URL(new Request(input, init).url).pathname;
+      if (path === "/repos/openclaw/octopool/pulls/42") return metadata.response;
+      if (path === "/repos/openclaw/octopool") return jsonResponse({ private: false });
+      if (path === FILES_PATH) {
+        const attempt = prMetadataStream([
+          new TextEncoder().encode(" ".repeat(256)),
+          new Uint8Array([32]),
+          new Uint8Array([32]),
+        ]);
+        files.push(attempt);
+        return attempt.response;
+      }
+      return jsonResponse({ message: "unexpected actual-body overflow request" }, 500);
+    });
+    vi.stubGlobal("fetch", upstream);
+    const response = await cappedRelay();
+    const wire = await response.json();
+    const calls = outgoingCalls(upstream);
+    const proofs = await proofRows();
+    const cacheRows = await fileCacheRows();
+    console.info(
+      "PR actual-body overflow observations",
+      JSON.stringify({
+        wire,
+        calls,
+        proofs,
+        cacheRows,
+        metadata: metadata.observations,
+        files: files.map(({ observations, stream }) => ({
+          ...observations,
+          locked: stream.locked,
+        })),
+      }),
+    );
+    expect(response.status).toBe(424);
+    expect(wire).toMatchObject({
+      error: { code: "fallback_local", details: { reason: "github_response_too_large" } },
+    });
+    expect(metadata.observations).toEqual({ pulls: 2, chunkBytes: [256], cancellations: 0 });
+    expect(proofs).toMatchObject([
+      { owner: "openclaw", repo: "octopool", number: 42, state_hint: `pr-head:${HEAD}` },
+    ]);
+    expect(cacheRows).toEqual([]);
+    expect(calls).toEqual([
+      { path: "/repos/openclaw/octopool/pulls/42", authorization: null },
+      { path: FILES_PATH, authorization: null },
+      { path: "/repos/openclaw/octopool", authorization: "Bearer test-org-token" },
+      { path: FILES_PATH, authorization: "Bearer test-primary-token" },
+    ]);
+    expect(files).toHaveLength(2);
+    for (const attempt of files) {
+      expect(attempt.observations).toEqual({ pulls: 2, chunkBytes: [256, 1], cancellations: 1 });
+      expect(attempt.stream.locked).toBe(false);
+    }
+  });
+
   it("isolates verified state keys and revalidates stale or forged hints", async () => {
     await seedPool();
     const fileBodies = ["head.ts", "closed.ts", "unhinted.ts"];
@@ -224,6 +450,80 @@ describe("Worker end-to-end PR-state cache", () => {
     });
   });
 });
+
+function cappedRelay(): Promise<Response> {
+  return requestWithEnv({ MAX_RESPONSE_BYTES: String(PR_METADATA_CAP) }, FILES_PATH, {
+    route_hint: { pr_head_sha: HEAD },
+  });
+}
+
+function filesUpstream(
+  metadata: () => Response,
+  files = () => jsonResponse([{ filename: "safe-unhinted.ts" }]),
+) {
+  return vi.fn<typeof fetch>(async (input, init) => {
+    const path = new URL(new Request(input, init).url).pathname;
+    if (path === "/repos/openclaw/octopool/pulls/42") return metadata();
+    if (path === FILES_PATH) return files();
+    return jsonResponse({ message: "unexpected PR metadata request" }, 500);
+  });
+}
+
+function outgoingCalls(upstream: ReturnType<typeof filesUpstream>) {
+  return upstream.mock.calls.map(([input, init]) => {
+    const request = new Request(input, init);
+    return {
+      path: new URL(request.url).pathname,
+      authorization: request.headers.get("authorization"),
+    };
+  });
+}
+
+async function proofRows() {
+  return (
+    await env.DB.prepare(
+      "SELECT owner, repo, number, state_hint, checked_at, expires_at FROM github_pr_state_proofs ORDER BY state_hint",
+    ).all()
+  ).results;
+}
+
+async function fileCacheRows() {
+  return (
+    await env.DB.prepare(
+      "SELECT cache_key, body_json, expires_at, stale_expires_at FROM github_cache_entries WHERE route_kind = 'pr_files' ORDER BY cache_key",
+    ).all<{ cache_key: string; body_json: string; expires_at: string; stale_expires_at: string }>()
+  ).results;
+}
+
+async function primeStaleHintedBody() {
+  const upstream = filesUpstream(
+    () => jsonResponse({ head: { sha: HEAD } }),
+    () => jsonResponse([{ filename: "old-hinted.ts" }]),
+  );
+  vi.stubGlobal("fetch", upstream);
+  const response = await cappedRelay();
+  expect(response.status).toBe(200);
+  expect(await response.json<RelayEnvelope>()).toMatchObject({
+    body: [{ filename: "old-hinted.ts" }],
+    relay: { cache: "miss" },
+  });
+  expect(outgoingCalls(upstream)).toEqual([
+    { path: "/repos/openclaw/octopool/pulls/42", authorization: null },
+    { path: FILES_PATH, authorization: null },
+  ]);
+  await env.DB.prepare(
+    `UPDATE github_pr_state_proofs SET checked_at = datetime('now', '-1 minute'), expires_at = datetime('now', '+4 minutes')`,
+  ).run();
+  const rows = await fileCacheRows();
+  expect(rows).toHaveLength(1);
+  await env.DB.prepare(
+    `UPDATE github_cache_entries SET expires_at = datetime('now', '-1 second'), stale_expires_at = datetime('now', '+1 hour') WHERE cache_key = ?`,
+  )
+    .bind(rows[0]!.cache_key)
+    .run();
+  await deleteEdgeJSON("github-publication-v1", rows[0]!.cache_key);
+  return (await fileCacheRows())[0]!;
+}
 
 function hintedRelay(route_hint: { pr_head_sha?: string; pr_state?: string }): Promise<Response> {
   return relay(FILES_PATH, undefined, { route_hint });

--- a/test/fixtures/pr-state-metadata.ts
+++ b/test/fixtures/pr-state-metadata.ts
@@ -1,0 +1,67 @@
+export const PR_HEAD = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+export const PR_METADATA_CAP = 256;
+
+export function matchingPRMetadata(size = PR_METADATA_CAP): Uint8Array {
+  const json = JSON.stringify({
+    head: { sha: PR_HEAD },
+    state: "closed",
+    merged_at: "2026-05-29T00:00:00Z",
+    title: "é",
+  });
+  const bytes = new TextEncoder().encode(json);
+  return new TextEncoder().encode(json + " ".repeat(size - bytes.byteLength));
+}
+
+// Demand-driven, with a separate EOF pull so cancellation remains observable.
+export function prMetadataStream(
+  chunks: Uint8Array[],
+  options: { contentLength?: string; cancelThrows?: boolean; failAtPull?: number } = {},
+) {
+  const observations = { pulls: 0, chunkBytes: [] as number[], cancellations: 0 };
+  const stream = new ReadableStream<Uint8Array>(
+    {
+      pull(controller) {
+        observations.pulls++;
+        if (observations.pulls === options.failAtPull) {
+          controller.error(new Error("metadata read failed"));
+          return;
+        }
+        const chunk = chunks[observations.pulls - 1];
+        if (chunk === undefined) controller.close();
+        else {
+          observations.chunkBytes.push(chunk.byteLength);
+          controller.enqueue(chunk);
+        }
+      },
+      cancel() {
+        observations.cancellations++;
+        if (options.cancelThrows) throw new Error("metadata cancel failed");
+      },
+    },
+    { highWaterMark: 0 },
+  );
+  const headers = new Headers({ "content-type": "application/json" });
+  if (options.contentLength !== undefined) headers.set("content-length", options.contentLength);
+  return { response: new Response(stream, { headers }), stream, observations };
+}
+
+export const oversizedPRMetadata = [
+  { name: "one byte over cap", sizes: [257], pulled: [257] },
+  { name: "crossing chunk with unread tail", sizes: [128, 128, 1, 64], pulled: [128, 128, 1] },
+  { name: "matching head before long tail", sizes: [256, 64, 64], pulled: [256, 64] },
+  { name: "false Content-Length", sizes: [256, 1, 64], pulled: [256, 1], contentLength: "1" },
+  { name: "throwing cancellation", sizes: [256, 1, 64], pulled: [256, 1], cancelThrows: true },
+];
+
+export function oversizedPRStream(fixture: (typeof oversizedPRMetadata)[number]) {
+  const bytes = matchingPRMetadata(fixture.sizes.reduce((sum, size) => sum + size, 0));
+  let offset = 0;
+  return prMetadataStream(
+    fixture.sizes.map((size) => {
+      const chunk = bytes.slice(offset, offset + size);
+      offset += size;
+      return chunk;
+    }),
+    fixture,
+  );
+}

--- a/test/pr-state.test.ts
+++ b/test/pr-state.test.ts
@@ -1,7 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withGitHubEgress, type GitHubEgressEnv } from "../src/github-egress";
 import { classifyRoute, defaultPolicy, validateRelayRequest } from "../src/policy";
-import { verifyPRStateHint } from "../src/pr-state";
+import { verifyPRStateHint, verifyPRStateHintLive } from "../src/pr-state";
+import {
+  matchingPRMetadata,
+  oversizedPRMetadata,
+  oversizedPRStream,
+  PR_HEAD,
+  PR_METADATA_CAP,
+  prMetadataStream,
+} from "./fixtures/pr-state-metadata";
 
 describe("PR state hint verification", () => {
   const policy = defaultPolicy("openclaw");
@@ -83,7 +91,7 @@ describe("PR state hint verification", () => {
     expect(route.state_hint).toBeUndefined();
   });
 
-  it("drops the discriminator when proof storage fails", async () => {
+  it("drops the discriminator when proof lookup fails", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
     const first = vi.fn(async () => {
@@ -123,6 +131,128 @@ describe("PR state hint verification", () => {
     expect(route.state_hint).toBe("pr-state:merged");
     expect(route.state_hint_source).toBe("live");
   });
+
+  describe.each([
+    { name: "ordinary", verify: verifyPRStateHint },
+    { name: "forced live", verify: verifyPRStateHintLive },
+  ])("bounded $name verification", ({ name, verify }) => {
+    function input() {
+      const request = requestWithHint({ pr_head_sha: PR_HEAD, pr_state: "merged" });
+      const classified = classifyRoute(request, policy);
+      const route =
+        name === "ordinary"
+          ? classified
+          : {
+              ...classified,
+              state_hint: `pr-head:${PR_HEAD}`,
+              state_hint_source: "cached" as const,
+            };
+      const database = databaseWithFreshProof(name === "ordinary" ? null : { "1": 1 });
+      return { request, route, database };
+    }
+
+    it("accepts exactly cap bytes and keeps head precedence, anonymous egress and TTL", async () => {
+      const body = matchingPRMetadata();
+      const fixture = prMetadataStream([body.slice(0, 128), body.slice(128)]);
+      const upstream = vi.fn(async () => fixture.response);
+      vi.stubGlobal("fetch", upstream);
+      const { request, route, database } = input();
+      const result = await verify(env(database), request, route);
+      expect(result).toMatchObject({ state_hint: `pr-head:${PR_HEAD}`, state_hint_source: "live" });
+      expect(fixture.observations).toEqual({ pulls: 3, chunkBytes: [128, 128], cancellations: 0 });
+      expect(database.run).toHaveBeenCalledOnce();
+      expect(database.bind).toHaveBeenLastCalledWith(
+        "openclaw",
+        "openclaw",
+        "42",
+        `pr-head:${PR_HEAD}`,
+        "+300 seconds",
+      );
+      expect(upstream).toHaveBeenCalledOnce();
+      const [url, init] = upstream.mock.calls[0] as unknown as [string, RequestInit];
+      expect(url).toBe("https://api.github.com/repos/openclaw/openclaw/pulls/42");
+      expect(new Headers(init.headers).get("authorization")).toBeNull();
+      expect(init.redirect).toBe("manual");
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+      expect(init.signal?.aborted).toBe(false);
+      if (name === "forced live") expect(database.first).not.toHaveBeenCalled();
+    });
+
+    it.each(oversizedPRMetadata)("rejects $name before writing a proof", async (definition) => {
+      const fixture = oversizedPRStream(definition);
+      const upstream = vi.fn(async () => fixture.response);
+      vi.stubGlobal("fetch", upstream);
+      const { request, route, database } = input();
+      const result = await verify(env(database), request, route);
+      expect.soft(result.state_hint).toBeUndefined();
+      expect.soft(result.state_hint_source).toBeUndefined();
+      expect.soft(database.run).not.toHaveBeenCalled();
+      expect.soft(fixture.observations).toEqual({
+        pulls: definition.pulled.length,
+        chunkBytes: definition.pulled,
+        cancellations: 1,
+      });
+      expect(fixture.stream.locked).toBe(false);
+      expect(upstream).toHaveBeenCalledOnce();
+    });
+
+    it.each(["malformed JSON", "read failure", "non-2xx", "network", "head mismatch", "null JSON"])(
+      "does not write or retain a trusted hint after %s",
+      async (failure) => {
+        const fixture = prMetadataStream([matchingPRMetadata().slice(0, 128)], { failAtPull: 2 });
+        const upstream = vi.fn(async () => {
+          if (failure === "network") throw new Error("network down");
+          if (failure === "read failure") return fixture.response;
+          if (failure === "non-2xx") return new Response("unavailable", { status: 503 });
+          if (failure === "head mismatch")
+            return Response.json({
+              head: { sha: PR_HEAD.toUpperCase() },
+              state: "closed",
+              merged_at: "now",
+            });
+          return new Response(failure === "null JSON" ? "null" : '{"head":');
+        });
+        vi.stubGlobal("fetch", upstream);
+        const { request, route, database } = input();
+        const result = await verify(env(database), request, route);
+        expect(result.state_hint).toBeUndefined();
+        expect(result.state_hint_source).toBeUndefined();
+        expect(database.run).not.toHaveBeenCalled();
+        expect(upstream).toHaveBeenCalledOnce();
+        if (failure === "read failure") {
+          expect(fixture.observations).toEqual({ pulls: 2, chunkBytes: [128], cancellations: 0 });
+        }
+      },
+    );
+
+    it("does not return a newly trusted hint after a failed write acknowledgment", async () => {
+      const upstream = vi.fn(async () => Response.json({ head: { sha: PR_HEAD } }));
+      vi.stubGlobal("fetch", upstream);
+      const { request, route, database } = input();
+      database.run.mockRejectedValueOnce(new Error("write acknowledgment unavailable"));
+      const result = await verify(env(database), request, route);
+      expect(result.state_hint).toBeUndefined();
+      expect(result.state_hint_source).toBeUndefined();
+      expect(database.run).toHaveBeenCalledOnce();
+      expect(upstream).toHaveBeenCalledOnce();
+      // This controls the caller result; a rejected acknowledgment says nothing about commit.
+    });
+
+    it("preserves hard string-protection denial", async () => {
+      const upstream = vi.fn();
+      vi.stubGlobal("fetch", upstream);
+      const { request, route, database } = input();
+      const guarded = withGitHubEgress(env(database), [
+        { pattern: "^https://api.github.com/", replacement: "public" },
+      ]);
+      await expect(verify(guarded, request, route)).rejects.toMatchObject({
+        status: 403,
+        code: "string_rewrite_denied",
+      });
+      expect(upstream).not.toHaveBeenCalled();
+      expect(database.run).not.toHaveBeenCalled();
+    });
+  });
 });
 
 function requestWithHint(route_hint: Record<string, string>) {
@@ -136,6 +266,8 @@ function requestWithHint(route_hint: Record<string, string>) {
 
 type TestDB = {
   run: ReturnType<typeof vi.fn>;
+  first: ReturnType<typeof vi.fn>;
+  bind: ReturnType<typeof vi.fn>;
   prepare: ReturnType<typeof vi.fn>;
 };
 
@@ -143,6 +275,7 @@ function env(database: TestDB): GitHubEgressEnv {
   return withGitHubEgress(
     {
       REQUEST_TIMEOUT_MS: "15000",
+      MAX_RESPONSE_BYTES: String(PR_METADATA_CAP),
       DB: database,
     } as unknown as Env,
     [],
@@ -154,5 +287,5 @@ function databaseWithFreshProof(row: { "1": number } | null): TestDB {
   const run = vi.fn(async () => ({}));
   const bind = vi.fn(() => ({ first, run }));
   const prepare = vi.fn(() => ({ bind }));
-  return { prepare, run };
+  return { prepare, run, first, bind };
 }

--- a/test/shared-github-primitives.test.ts
+++ b/test/shared-github-primitives.test.ts
@@ -77,20 +77,26 @@ describe("shared GitHub primitives", () => {
     expect(defaultGitHubJSONAccept("text/html")).toBe(false);
   });
 
-  it("combines streamed chunks within the cap", async () => {
-    const response = new Response(
-      new ReadableStream({
-        start(controller) {
-          controller.enqueue(new Uint8Array([1, 2]));
-          controller.enqueue(new Uint8Array([3]));
-          controller.close();
+  it.each(["success", "read error"])("releases the reader after exact-cap %s", async (outcome) => {
+    let pulls = 0;
+    const failure = new Error("read failed");
+    const stream = new ReadableStream<Uint8Array>(
+      {
+        pull(controller) {
+          pulls++;
+          if (pulls === 1) controller.enqueue(new Uint8Array([1, 2]));
+          else if (pulls === 2) controller.enqueue(new Uint8Array([3]));
+          else if (outcome === "read error") controller.error(failure);
+          else controller.close();
         },
-      }),
+      },
+      { highWaterMark: 0 },
     );
-
-    await expect(readBodyCapped(response, 3, () => new Error("too large"))).resolves.toEqual(
-      new Uint8Array([1, 2, 3]),
-    );
+    const read = readBodyCapped(new Response(stream), 3, () => new Error("too large"));
+    if (outcome === "read error") await expect(read).rejects.toBe(failure);
+    else await expect(read).resolves.toEqual(new Uint8Array([1, 2, 3]));
+    expect(pulls).toBe(3);
+    expect(stream.locked).toBe(false);
   });
 
   it("cancels an oversized stream and preserves the configured error", async () => {
@@ -109,4 +115,29 @@ describe("shared GitHub primitives", () => {
     );
     expect(cancel).toHaveBeenCalledOnce();
   });
+
+  it.each([false, true])(
+    "releases the crossing-chunk reader when cancellation throws: %s",
+    async (throws) => {
+      let pulls = 0;
+      const cancel = vi.fn(() => {
+        if (throws) throw new Error("cancel failed");
+      });
+      const stream = new ReadableStream<Uint8Array>(
+        {
+          pull(controller) {
+            pulls++;
+            controller.enqueue(new Uint8Array([1, 2]));
+          },
+          cancel,
+        },
+        { highWaterMark: 0 },
+      );
+      const failure = new Error("configured cap error");
+      await expect(readBodyCapped(new Response(stream), 4, () => failure)).rejects.toBe(failure);
+      expect(pulls).toBe(3);
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(stream.locked).toBe(false);
+    },
+  );
 });


### PR DESCRIPTION
## Summary

PR-state verification previously parsed GitHub's pull-request metadata with an uncapped `Response.json()` before deciding whether to cache a proof. Both initial verification and forced-live revalidation could therefore consume a response beyond the configured relay cap.

Read that metadata through the existing capped-body reader before JSON parsing. Exact-cap responses remain accepted; the first crossing chunk cancels the stream. Read, parse, size and head-matching failures do not create or refresh a proof, and the files request continues through the existing unhinted route/cache path. This does not change proof TTLs, existing proof rows, cache generations or the actual files-body overflow response.

The regression coverage exercises cancellation, unread tails, misleading Content-Length, matching-head prefixes, throwing cancellation, real D1 proof preservation and unhinted cache selection. Shared-reader tests own the stream-lock cleanup contract. Documentation now describes the metadata cap.

## Validation

- Independent review found no actionable P0–P2 findings in the seven-file patch.
- Route/SQL generation checks, formatting, lint and all 983 unit tests passed.
- All 25 native PR-state tests passed. The full native run passed 957 of 958 tests; one existing identity-routing test failed its waiter-readiness assertion. That failure remains recorded rather than being called a successful full run.
- One isolated, instrumented execution of that existing test passed every original assertion with unchanged deadlines, observing real waiter samples of `0, 0, 0, 1`. It does not establish the earlier failure's cause. The instrumentation was removed byte-for-byte and is not part of this PR.
- Build/type checks, Go tests and Go vet passed separately after the failed native stage. The Go tests took 439.467 seconds.

Full exact-head Linux and Windows CI plus CodeQL are required before merge. The broader local test-runtime reliability assessment remains open; this change makes no claim to resolve it.
