### PR TITLE
fix: match native PR checks output and metadata

### DIFF
--- a/cmd/octopool/cli_e2e_test.go
+++ b/cmd/octopool/cli_e2e_test.go
@@ -171,9 +171,9 @@ func TestCLIEndToEndRelayAndFallback(t *testing.T) {
 						writeCLIFallback(t, w, "relay_overloaded")
 						return
 					}
-					writeCLIEnvelope(t, w, map[string]any{"head": map[string]any{"sha": "abc1234"}})
+					writeCLIEnvelope(t, w, map[string]any{"head": map[string]any{"sha": "abc1234", "ref": "feature"}})
 				case strings.HasSuffix(path, "/check-runs"):
-					writeCLIEnvelope(t, w, map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "name": "CI", "status": "completed", "conclusion": "success"}}})
+					writeCLIEnvelope(t, w, map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "head_sha": "abc1234", "app": map[string]any{"id": 999, "slug": "third-party"}, "check_suite": map[string]any{"id": 201}, "name": "CI", "status": "completed", "conclusion": "success"}}})
 				case strings.HasSuffix(path, "/status"):
 					writeCLIEnvelope(t, w, map[string]any{"total_count": 0, "statuses": []any{}})
 				default:

--- a/cmd/octopool/cli_protocol_e2e_test.go
+++ b/cmd/octopool/cli_protocol_e2e_test.go
@@ -121,36 +121,99 @@ func TestCLIEndToEndCheckExitCodes(t *testing.T) {
 	}{
 		{name: "failed", status: "completed", conclusion: "failure", wantExit: 1},
 		{name: "pending", status: "in_progress", conclusion: nil, wantExit: 8},
+		{name: "mixed", status: "completed", conclusion: "failure", wantExit: 1},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			fixture := newPRChecksFixture()
+			fixture.checks[0].(map[string]any)["status"] = test.status
+			fixture.checks[0].(map[string]any)["conclusion"] = test.conclusion
+			if test.name == "mixed" {
+				pending := prChecksCheck(2, "pending", "queued", "")
+				pending["started_at"] = "2026-09-01T00:00:00Z"
+				fixture.checks = append(fixture.checks, pending)
+			}
 			server := cliRelayServer(t, func(w http.ResponseWriter, r *http.Request) {
 				body := decodeCLIRequest(t, w, r)
 				if body == nil {
 					return
 				}
-				switch body["path"] {
-				case "/repos/openclaw/octopool/pulls/7":
-					writeCLIEnvelope(t, w, map[string]any{"head": map[string]any{"sha": "abc123"}})
-				case "/repos/openclaw/octopool/commits/abc123/check-runs":
-					writeCLIEnvelope(t, w, map[string]any{"total_count": 1, "check_runs": []map[string]any{{
-						"id": 1, "name": "CI", "status": test.status, "conclusion": test.conclusion,
-					}}})
-				case "/repos/openclaw/octopool/commits/abc123/status":
-					writeCLIEnvelope(t, w, map[string]any{"total_count": 0, "statuses": []any{}})
-				default:
-					http.Error(w, "unexpected checks path", http.StatusBadRequest)
-				}
+				writeCLIEnvelope(t, w, fixture.response(t, body))
 			})
-			result := runCLI(t, bin, server.URL, nil,
-				"gh", "pr", "checks", "7", "-R", "openclaw/octopool", "--json", "name,state,bucket",
-			)
-			var exitErr *exec.ExitError
-			if !errors.As(result.err, &exitErr) || exitErr.ExitCode() != test.wantExit {
-				t.Fatalf("err=%v stdout=%q stderr=%q", result.err, result.stdout, result.stderr)
+			for _, mode := range []struct{ name, filter, want string }{
+				{"json", "", ""}, {"jq-string", ".[0].name", "unit\n"},
+				{"jq-false", "false", "false\n"}, {"jq-null", "null", "null\n"},
+				{"jq-empty", "empty", ""}, {"jq-error", ".[", ""}, {"human", "", ""},
+			} {
+				t.Run(mode.name, func(t *testing.T) {
+					args := []string{"gh", "pr", "checks", "7", "-R", "acme/repo"}
+					if mode.name != "human" {
+						args = append(args, "--json", "name,state,bucket")
+					}
+					if mode.filter != "" {
+						if !jqAvailable() {
+							t.Fatal("focused proof requires jq")
+						}
+						args = append(args, "--jq", mode.filter)
+					}
+					result := runCLI(t, bin, server.URL, map[string]string{"OCTOPOOL_NO_FALLBACK": "1", "OCTOPOOL_RELAY_RETRIES": "0"}, args...)
+					if mode.name == "human" {
+						var exitErr *exec.ExitError
+						if !errors.As(result.err, &exitErr) || exitErr.ExitCode() != test.wantExit || result.stderr != "" || !strings.Contains(result.stdout, "unit\t") {
+							t.Fatalf("human outcome exit: err=%v stdout=%q stderr=%q", result.err, result.stdout, result.stderr)
+						}
+						return
+					}
+					if mode.name == "jq-error" {
+						if result.err == nil || result.stdout != "" {
+							t.Fatalf("jq error lost: %+v", result)
+						}
+						return
+					}
+					if result.err != nil || result.stderr != "" {
+						t.Errorf("successful export must exit 0 regardless of outcome: err=%v stdout=%q stderr=%q", result.err, result.stdout, result.stderr)
+					}
+					if mode.name == "json" {
+						if !strings.Contains(result.stdout, `"name":"unit"`) {
+							t.Errorf("stdout=%q", result.stdout)
+						}
+					} else if result.stdout != mode.want {
+						t.Errorf("stdout=%q want=%q", result.stdout, mode.want)
+					}
+				})
 			}
-			if !strings.Contains(result.stdout, `"name":"CI"`) {
-				t.Fatalf("stdout=%q", result.stdout)
+		})
+	}
+}
+
+func TestCLIEndToEndChecksEmptyBeforeExport(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds and executes the CLI binary")
+	}
+	bin := buildCLIBinary(t)
+	for _, mode := range []string{"human", "json", "jq-sentinel", "watch"} {
+		t.Run(mode, func(t *testing.T) {
+			fixture := newPRChecksFixture()
+			fixture.checks = []any{}
+			server := cliRelayServer(t, func(w http.ResponseWriter, r *http.Request) {
+				writeCLIEnvelope(t, w, fixture.response(t, decodeCLIRequest(t, w, r)))
+			})
+			args := []string{"gh", "pr", "checks", "7", "-R", "acme/repo"}
+			switch mode {
+			case "json":
+				args = append(args, "--json", "name")
+			case "jq-sentinel":
+				args = append(args, "--json", "name", "--jq", `"should-not-export"`)
+			case "watch":
+				args = append(args, "--watch")
+			}
+			result := runCLI(t, bin, server.URL, map[string]string{"OCTOPOOL_NO_FALLBACK": "1", "OCTOPOOL_RELAY_RETRIES": "0"}, args...)
+			if mode != "watch" && len(fixture.requests) != 3 {
+				t.Errorf("actual empty acquisition must use exactly 3 data operations: %d", len(fixture.requests))
+			}
+			var exitErr *exec.ExitError
+			if !errors.As(result.err, &exitErr) || exitErr.ExitCode() != 1 || result.stdout != "" || result.stderr != "no checks reported on the 'feature' branch\n" {
+				t.Fatalf("empty must fail before output with exact branch diagnostic once: err=%v stdout=%q stderr=%q", result.err, result.stdout, result.stderr)
 			}
 		})
 	}

--- a/cmd/octopool/gh.go
+++ b/cmd/octopool/gh.go
@@ -71,6 +71,13 @@ func runGH(ctx context.Context, args []string, stdout io.Writer, stderr io.Write
 		case ghComplete:
 			return nil
 		case ghFail:
+			var empty prChecksEmptyError
+			if errors.As(result.err, &empty) {
+				if _, err := fmt.Fprintln(stderr, empty.Error()); err != nil {
+					return err
+				}
+				return exitCodeError{Code: 1}
+			}
 			if shouldRunRealGH(result.err) {
 				return execRealGHAfterLocalFallback(ctx, floorGHWatchDelegateArgs(args), stdout, stderr, result.err)
 			}

--- a/cmd/octopool/gh_pagination_test.go
+++ b/cmd/octopool/gh_pagination_test.go
@@ -663,6 +663,7 @@ func paginationItems(start int, count int) []int {
 }
 
 func TestRunGHPRChecksFallsBackWhenPaginationIsExhausted(t *testing.T) {
+	checkCalls := 0
 	checkRuns := make([]map[string]any, relayPageSize)
 	for index := range checkRuns {
 		checkRuns[index] = map[string]any{
@@ -674,8 +675,9 @@ func TestRunGHPRChecksFallsBackWhenPaginationIsExhausted(t *testing.T) {
 	relayTestServer(t, func(body map[string]any) any {
 		switch body["path"] {
 		case "/repos/openclaw/octopool/pulls/7":
-			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+			return map[string]any{"head": map[string]any{"sha": "abc1234", "ref": "feature"}}
 		case "/repos/openclaw/octopool/commits/abc1234/check-runs":
+			checkCalls++
 			return map[string]any{"total_count": maxRelayPages*relayPageSize + 1, "check_runs": checkRuns}
 		default:
 			return nil
@@ -688,6 +690,9 @@ func TestRunGHPRChecksFallsBackWhenPaginationIsExhausted(t *testing.T) {
 	}, &out)
 	if result.action != ghFail || !isLocalFallback(result.err) {
 		t.Fatalf("action=%v err=%v", result.action, result.err)
+	}
+	if checkCalls != 1 || out.Len() != 0 {
+		t.Fatalf("pagination guard was not reached before output: calls=%d output=%q", checkCalls, out.String())
 	}
 }
 

--- a/cmd/octopool/gh_test_helpers_test.go
+++ b/cmd/octopool/gh_test_helpers_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -92,4 +94,96 @@ func serveEmptyRewritePolicy(t *testing.T, w http.ResponseWriter, r *http.Reques
 func emptyRewriteTestServer(t *testing.T) {
 	t.Helper()
 	relayTestServer(t, func(map[string]any) any { t.Error("unexpected relay request"); return nil })
+}
+
+// REST fixtures for the shared checks/rollup owners; no production hooks.
+type prChecksFixture struct {
+	checks, statuses, runs, workflows []any
+	requests                          []map[string]any
+	head                              map[string]any
+}
+
+func newPRChecksFixture() *prChecksFixture {
+	return &prChecksFixture{
+		head:     map[string]any{"sha": metadataHead, "ref": "feature"},
+		checks:   []any{prChecksCheck(1, "unit", "completed", "success")},
+		statuses: []any{},
+		runs: []any{map[string]any{
+			"id": 301, "head_sha": metadataHead, "check_suite_id": 201, "workflow_id": 401,
+			"name": "misleading run title", "display_title": "Not the workflow", "event": "pull_request",
+			"head_repository": map[string]any{"id": 12, "full_name": "contributor/repo"},
+			"repository":      map[string]any{"id": 11, "full_name": "acme/repo"},
+		}},
+		workflows: []any{map[string]any{"id": 401, "name": "CI", "path": ".github/workflows/ci.yml", "state": "disabled_manually"}},
+	}
+}
+
+func prChecksCheck(id int64, name, status, conclusion string) map[string]any {
+	var result any = conclusion
+	if conclusion == "" {
+		result = nil
+	}
+	item := map[string]any{
+		"id": id, "name": name, "status": status, "conclusion": result, "head_sha": metadataHead,
+		"app": map[string]any{"id": 15368, "slug": "github-actions"}, "check_suite": map[string]any{"id": 201},
+		"started_at": "2026-09-01T01:00:00Z", "completed_at": "2026-09-01T01:01:00Z",
+		"details_url": "https://github.com/acme/repo/actions/runs/301/job/1",
+	}
+	if status != "completed" {
+		item["completed_at"] = nil
+	}
+	return item
+}
+
+func (f *prChecksFixture) response(t *testing.T, request map[string]any) any {
+	t.Helper()
+	f.requests = append(f.requests, request)
+	path, _ := request["path"].(string)
+	if path == "/repos/acme/repo/pulls/7" {
+		return map[string]any{"number": 7, "head": f.head}
+	}
+	var key string
+	var items []any
+	switch path {
+	case "/repos/acme/repo/commits/" + metadataHead + "/check-runs":
+		key, items = "check_runs", f.checks
+	case "/repos/acme/repo/commits/" + metadataHead + "/status":
+		key, items = "statuses", f.statuses
+	case "/repos/acme/repo/actions/runs":
+		key, items = "workflow_runs", f.runs
+		query, _ := request["query"].(map[string]any)
+		if query["head_sha"] != metadataHead {
+			t.Errorf("runs must be head-filtered: %v", query)
+		}
+	case "/repos/acme/repo/actions/workflows":
+		key, items = "workflows", f.workflows
+	default:
+		t.Errorf("unexpected data route (no per-check/suite/detail fanout): %s", path)
+		return nil
+	}
+	query, _ := request["query"].(map[string]any)
+	pageText, _ := query["page"].(string)
+	page, err := strconv.Atoi(pageText)
+	if err != nil || page < 1 || page > 10 || query["per_page"] != "100" {
+		t.Errorf("invalid bounded collection query: %v", query)
+		return nil
+	}
+	if strings.Contains(path, "/actions/") {
+		headers, _ := request["headers"].(map[string]any)
+		if headers["x-octopool-public-shape"] != nil {
+			t.Error("metadata must use raw REST collections")
+		}
+	}
+	start := min((page-1)*100, len(items))
+	return map[string]any{"total_count": len(items), key: items[start:min(start+100, len(items))]}
+}
+
+func (f *prChecksFixture) calls(suffix string) int {
+	n := 0
+	for _, request := range f.requests {
+		if strings.HasSuffix(request["path"].(string), suffix) {
+			n++
+		}
+	}
+	return n
 }

--- a/cmd/octopool/gh_top_checks.go
+++ b/cmd/octopool/gh_top_checks.go
@@ -4,119 +4,174 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
 
-// prChecksMaxPRAgeSeconds bounds how old a relay-cached PR record may be when
-// resolving the head SHA for `gh pr checks`.
+// prChecksMaxPRAgeSeconds bounds the shared PR head lookup's staleness.
 const prChecksMaxPRAgeSeconds = 60
 
-func relayPRChecks(ctx context.Context, stdout io.Writer, repo string, number string, opts ghTopOptions) error {
+type prCheckHead struct {
+	SHA string `json:"sha"`
+	Ref string `json:"ref"`
+}
+
+type prChecksEmptyError struct{ head prCheckHead }
+
+func (err prChecksEmptyError) Error() string {
+	return fmt.Sprintf("no checks reported on the '%s' branch", watchSafeText(err.head.Ref))
+}
+
+// Keep the REST source discriminator until each consumer projects its own shape.
+// In particular, status created_at is not a check's startedAt.
+type prCheckContext struct {
+	raw      map[string]any
+	isStatus bool
+}
+
+type prCheckRow struct {
+	Name, State, Link, Bucket, Event, Workflow, Description string
+	StartedAt, CompletedAt                                  time.Time
+	isStatus                                                bool
+}
+
+func relayPRChecks(ctx context.Context, stdout io.Writer, repo, number string, opts ghTopOptions) error {
 	client, err := newGHRelayClient()
 	if err != nil {
 		return err
 	}
-	items, err := relayPRCheckItems(ctx, client, repo, number)
+	items, head, err := relayPRCheckItemsWithHead(ctx, client, repo, number)
 	if err != nil {
 		return err
+	}
+	if len(items) == 0 {
+		return prChecksEmptyError{head: head}
 	}
 	if len(opts.json) == 0 {
 		if err := renderHumanPRChecks(stdout, items); err != nil {
 			return err
 		}
-	} else {
-		raw, err := json.Marshal(items)
-		if err != nil {
-			return err
-		}
-		raw, err = filterJSONFields(raw, opts.json, fieldMapCheckRun)
-		if err != nil {
-			return err
-		}
-		if err := writeBytes(ctx, stdout, raw, opts.jq); err != nil {
-			return err
-		}
+		return checkExitCode(items)
 	}
-	return checkExitCode(items)
+	rows := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		rows = append(rows, item.export(opts.json))
+	}
+	raw, err := json.Marshal(rows)
+	if err != nil {
+		return err
+	}
+	// Export success is independent of check outcomes. Include the terminator in
+	// the write so a writer failure cannot be lost on a second newline write.
+	return writeBytes(ctx, stdout, append(raw, '\n'), opts.jq)
 }
 
-func relayPRCheckItems(ctx context.Context, client ghRelayClient, repo string, number string) ([]any, error) {
-	items, _, err := relayPRCheckItemsWithSHA(ctx, client, repo, number)
-	return items, err
+func (row prCheckRow) export(fields []string) map[string]any {
+	values := map[string]any{
+		"name": row.Name, "state": row.State, "link": row.Link, "bucket": row.Bucket,
+		"event": row.Event, "workflow": row.Workflow, "description": row.Description,
+		"startedAt": row.StartedAt, "completedAt": row.CompletedAt,
+	}
+	out := make(map[string]any, len(fields))
+	for _, field := range fields {
+		out[field] = values[field]
+	}
+	return out
 }
 
-func relayPRHeadSHA(ctx context.Context, client ghRelayClient, repo string, number string, maxAgeSeconds int) (string, error) {
-	prEnvelope, err := client.do(ctx, ghAPIRequest{
-		method: "GET",
-		path:   repoPath(repo, "pulls", number),
+func relayPRHead(ctx context.Context, client ghRelayClient, repo, number string, maxAgeSeconds int) (prCheckHead, error) {
+	envelope, err := client.do(ctx, ghAPIRequest{
+		method: "GET", path: repoPath(repo, "pulls", number),
 		headers: map[string]string{
 			"cache-control":           "max-age=" + strconv.Itoa(maxAgeSeconds),
 			"x-octopool-public-shape": publicShapePullRequestSummary,
 		},
 	})
 	if err != nil {
-		return "", err
+		return prCheckHead{}, err
 	}
-	prBody, err := envelopeBodyBytes(prEnvelope)
+	body, err := envelopeBodyBytes(envelope)
+	if err != nil {
+		return prCheckHead{}, err
+	}
+	var pr struct {
+		Head map[string]json.RawMessage `json:"head"`
+	}
+	if err := json.Unmarshal(body, &pr); err != nil {
+		return prCheckHead{}, err
+	}
+	var head prCheckHead
+	// Each caller validates the identity it needs; an unrelated PR-view SHA
+	// verification must not acquire the checks-only branch requirement.
+	_ = json.Unmarshal(pr.Head["sha"], &head.SHA)
+	_ = json.Unmarshal(pr.Head["ref"], &head.Ref)
+	return head, nil
+}
+
+// PR-view's final SHA verification does not need checks' branch diagnostic.
+func relayPRHeadSHA(ctx context.Context, client ghRelayClient, repo, number string, maxAgeSeconds int) (string, error) {
+	head, err := relayPRHead(ctx, client, repo, number, maxAgeSeconds)
 	if err != nil {
 		return "", err
 	}
-	var pr map[string]any
-	if err := json.Unmarshal(prBody, &pr); err != nil {
-		return "", err
-	}
-	sha, ok := nestedString(pr, "head", "sha")
-	if !ok || sha == "" {
+	if head.SHA == "" {
 		return "", errors.New("pull request response did not include head.sha")
 	}
-	return sha, nil
+	return head.SHA, nil
 }
 
-func relayPRCheckItemsWithSHA(ctx context.Context, client ghRelayClient, repo string, number string) ([]any, string, error) {
-	// Bound the PR lookup's staleness instead of forcing a live read: concurrent
-	// CI-polling sessions coalesce onto one shared-cache fill while the head SHA
-	// stays at most a few seconds behind a push.
-	sha, err := relayPRHeadSHA(ctx, client, repo, number, prChecksMaxPRAgeSeconds)
+func relayPRChecksHead(ctx context.Context, client ghRelayClient, repo, number string, maxAgeSeconds int) (prCheckHead, error) {
+	head, err := relayPRHead(ctx, client, repo, number, maxAgeSeconds)
 	if err != nil {
-		return nil, "", err
+		return prCheckHead{}, err
 	}
-	items, err := prCheckItemsForSHA(ctx, client, repo, sha)
+	if head.SHA == "" || head.Ref == "" {
+		return prCheckHead{}, localFallbackError{Reason: "pull request response did not include checks head identity"}
+	}
+	return head, nil
+}
+
+func relayPRCheckItemsWithHead(ctx context.Context, client ghRelayClient, repo, number string) ([]prCheckRow, prCheckHead, error) {
+	head, err := relayPRChecksHead(ctx, client, repo, number, prChecksMaxPRAgeSeconds)
 	if err != nil {
-		return nil, "", err
+		return nil, prCheckHead{}, err
 	}
-	return items, sha, nil
+	items, err := prCheckItemsForSHAWithHeaders(ctx, client, repo, head.SHA, nil)
+	return items, head, err
 }
 
-func prCheckItemsForSHA(ctx context.Context, client ghRelayClient, repo string, sha string) ([]any, error) {
-	return prCheckItemsForSHAWithHeaders(ctx, client, repo, sha, nil)
+// Every page, including Actions metadata, bypasses cached staleness in a fresh
+// sweep. Each acquisition builds its own associations, including same-SHA reruns.
+func prCheckItemsForSHAFresh(ctx context.Context, client ghRelayClient, repo, sha string) ([]prCheckRow, error) {
+	return prCheckItemsForSHAWithHeaders(ctx, client, repo, sha, watchFreshHeaders())
 }
 
-// prCheckItemsForSHAFresh bypasses cached staleness so a terminal watch
-// snapshot cannot be confirmed by an obsolete cached payload after a rerun.
-func prCheckItemsForSHAFresh(ctx context.Context, client ghRelayClient, repo string, sha string) ([]any, error) {
-	return prCheckItemsForSHAWithHeaders(ctx, client, repo, sha, map[string]string{"cache-control": "max-age=0"})
-}
-
-func prCheckItemsForSHAWithHeaders(
-	ctx context.Context,
-	client ghRelayClient,
-	repo string,
-	sha string,
-	headers map[string]string,
-) ([]any, error) {
-	items, err := prCheckContextsForSHA(ctx, client, repo, sha, headers)
+func prCheckItemsForSHAWithHeaders(ctx context.Context, client ghRelayClient, repo, sha string, headers map[string]string) ([]prCheckRow, error) {
+	contexts, err := prCheckContextsForSHA(ctx, client, repo, sha, headers)
 	if err != nil {
 		return nil, err
 	}
-	return ghCheckItems(items), nil
+	metadata, err := verifiedPRCheckMetadata(ctx, client, repo, sha, headers, contexts)
+	if err != nil {
+		return nil, err
+	}
+	rows := make([]prCheckRow, 0, len(contexts))
+	for _, item := range contexts {
+		row, err := normalizePRCheck(item, metadata)
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, row)
+	}
+	return deduplicatePRChecks(rows), nil
 }
 
-// Preserve the context discriminator and source fields until each gh export
-// projects them; pr checks and pr view expose different public JSON contracts.
-func prCheckContextsForSHA(ctx context.Context, client ghRelayClient, repo, sha string, headers map[string]string) ([]any, error) {
-	checkRuns, err := relayCompleteCollection(ctx, client, ghAPIRequest{
+func prCheckContextsForSHA(ctx context.Context, client ghRelayClient, repo, sha string, headers map[string]string) ([]prCheckContext, error) {
+	checks, err := relayCompleteCollection(ctx, client, ghAPIRequest{
 		method: "GET", path: repoPath(repo, "commits", sha, "check-runs"), headers: headers,
 	}, "check_runs")
 	if err != nil {
@@ -128,125 +183,114 @@ func prCheckContextsForSHA(ctx context.Context, client ghRelayClient, repo, sha 
 	if err != nil {
 		return nil, err
 	}
-	return append(checkRuns, statusItems(statuses)...), nil
-}
-
-func statusItems(rawItems []any) []any {
-	items := make([]any, 0, len(rawItems))
-	for _, raw := range rawItems {
-		status, ok := raw.(map[string]any)
-		if !ok {
-			continue
-		}
-		state, _ := status["state"].(string)
-		displayStatus := "completed"
-		if strings.EqualFold(state, "pending") {
-			displayStatus = "pending"
-		}
-		item := map[string]any{
-			"name":         status["context"],
-			"context":      status["context"],
-			"status":       displayStatus,
-			"conclusion":   status["state"],
-			"details_url":  status["target_url"],
-			"started_at":   status["created_at"],
-			"completed_at": status["updated_at"],
-		}
-		items = append(items, item)
+	items := make([]prCheckContext, 0, len(checks)+len(statuses))
+	for _, raw := range checks {
+		items = append(items, prCheckContext{raw: raw.(map[string]any)})
 	}
-	return items
+	return append(items, statusItems(statuses)...), nil
 }
 
-func ghCheckItems(items []any) []any {
-	out := make([]any, 0, len(items))
+func statusItems(items []any) []prCheckContext {
+	out := make([]prCheckContext, 0, len(items))
 	for _, raw := range items {
-		item, ok := raw.(map[string]any)
-		if !ok {
-			continue
-		}
-		state := ghCheckState(item)
-		out = append(out, map[string]any{
-			"bucket":      ghCheckBucket(state),
-			"completedAt": firstString(item, "completed_at", "completedAt"),
-			"description": ghCheckDescription(item),
-			"event":       nestedStringValue(item, "check_suite", "event"),
-			"link":        firstString(item, "details_url", "target_url", "link"),
-			"name":        firstString(item, "name", "context"),
-			"startedAt":   firstString(item, "started_at", "created_at", "startedAt"),
-			"state":       state,
-			"workflow":    ghCheckWorkflow(item),
-		})
+		out = append(out, prCheckContext{raw: raw.(map[string]any), isStatus: true})
 	}
 	return out
 }
 
-func ghCheckState(item map[string]any) string {
-	status := strings.ToLower(firstString(item, "status"))
-	conclusion := strings.ToLower(firstString(item, "conclusion"))
-	if status != "" && status != "completed" {
-		return strings.ToUpper(status)
+func normalizePRCheck(context prCheckContext, metadata map[int64]prCheckMetadata) (prCheckRow, error) {
+	item := context.raw
+	row := prCheckRow{isStatus: context.isStatus}
+	if context.isStatus {
+		row.Name = firstString(item, "context")
+		row.State = strings.ToUpper(firstString(item, "state"))
+		row.Link = firstString(item, "target_url")
+		row.Description = firstString(item, "description")
+	} else {
+		row.Name = firstString(item, "name")
+		row.State = strings.ToUpper(firstString(item, "status"))
+		if row.State == "COMPLETED" {
+			row.State = strings.ToUpper(firstString(item, "conclusion"))
+		}
+		row.Link = firstString(item, "details_url")
+		var err error
+		row.StartedAt, err = prCheckTime(item["started_at"])
+		if err != nil {
+			return prCheckRow{}, err
+		}
+		row.CompletedAt, err = prCheckTime(item["completed_at"])
+		if err != nil {
+			return prCheckRow{}, err
+		}
+		if nestedStringValue(item, "app", "slug") == "github-actions" {
+			suite, _ := valueAtPath(item, "check_suite", "id")
+			id, _ := prCheckID(suite)
+			association := metadata[id]
+			row.Workflow, row.Event = association.workflowName, association.event
+		}
 	}
-	if conclusion == "" {
-		return strings.ToUpper(status)
+	row.Bucket = ghCheckBucket(row.State)
+	return row, nil
+}
+
+func prCheckTime(raw any) (time.Time, error) {
+	if raw == nil || raw == "" {
+		return time.Time{}, nil
 	}
-	return strings.ToUpper(conclusion)
+	if value, ok := raw.(string); ok {
+		if parsed, err := time.Parse(time.RFC3339Nano, value); err == nil {
+			return parsed, nil
+		}
+	}
+	return time.Time{}, localFallbackError{Reason: "invalid check timestamp"}
+}
+
+func deduplicatePRChecks(rows []prCheckRow) []prCheckRow {
+	// Literal native aggregation: unstable descending start time, with no
+	// created_at/ID tiebreaker and separate status and slash-joined check keys.
+	sort.Slice(rows, func(i, j int) bool { return rows[i].StartedAt.After(rows[j].StartedAt) })
+	checks, statuses := map[string]bool{}, map[string]bool{}
+	out := make([]prCheckRow, 0, len(rows))
+	for _, row := range rows {
+		seen, key := checks, row.Name+"/"+row.Workflow+"/"+row.Event
+		if row.isStatus {
+			seen, key = statuses, row.Name
+		}
+		if !seen[key] {
+			seen[key] = true
+			out = append(out, row)
+		}
+	}
+	return out
 }
 
 func ghCheckBucket(state string) string {
 	switch strings.ToLower(state) {
-	case "success", "neutral":
+	case "success":
 		return "pass"
 	case "failure", "error", "timed_out", "action_required":
 		return "fail"
 	case "cancelled":
 		return "cancel"
-	case "skipped":
+	case "skipped", "neutral":
 		return "skipping"
 	default:
 		return "pending"
 	}
 }
 
-func ghCheckDescription(item map[string]any) string {
-	if description := firstString(item, "description"); description != "" {
-		return description
-	}
-	return nestedStringValue(item, "output", "summary")
-}
-
-func ghCheckWorkflow(item map[string]any) string {
-	if workflow := firstString(item, "workflow"); workflow != "" {
-		return workflow
-	}
-	return nestedStringValue(item, "check_suite", "workflow_name")
-}
-
-func checkExitCode(items []any) error {
-	exitCode := 0
-	for _, raw := range items {
-		item, ok := raw.(map[string]any)
-		if !ok {
-			continue
-		}
-		bucket, _ := item["bucket"].(string)
-		state, _ := item["state"].(string)
-		switch strings.ToLower(bucket) {
+func checkExitCode(items []prCheckRow) error {
+	code := 0
+	for _, item := range items {
+		switch item.Bucket {
 		case "fail":
-			exitCode = 1
-		case "cancel":
-			// real gh exits by Failed then Pending counts only; cancelled
-			// checks are terminal and do not fail the command.
+			return exitCodeError{Code: 1}
 		case "pending":
-			if exitCode == 0 {
-				exitCode = 8
-			}
-		}
-		if bucket == "" && strings.ToLower(state) != "success" && strings.ToLower(state) != "neutral" && exitCode == 0 {
-			exitCode = 8
+			code = 8
 		}
 	}
-	if exitCode != 0 {
-		return exitCodeError{Code: exitCode}
+	if code != 0 {
+		return exitCodeError{Code: code}
 	}
 	return nil
 }

--- a/cmd/octopool/gh_top_checks_metadata.go
+++ b/cmd/octopool/gh_top_checks_metadata.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type prCheckMetadata struct {
+	runID, workflowID   int64
+	workflowName, event string
+}
+
+func prCheckID(raw any) (int64, bool) {
+	number, ok := raw.(json.Number)
+	id, err := number.Int64()
+	return id, ok && err == nil && id > 0
+}
+
+// Both checks and the PR-view rollup use verified workflow names. Never use a
+// run's display title/name or follow URLs from response bodies to hydrate them.
+func verifiedPRCheckMetadata(ctx context.Context, client ghRelayClient, repo, sha string, headers map[string]string, contexts []prCheckContext) (map[int64]prCheckMetadata, error) {
+	needed := map[int64]bool{}
+	for _, context := range contexts {
+		if context.isStatus {
+			continue
+		}
+		check := context.raw
+		if firstString(check, "head_sha") != sha {
+			return nil, localFallbackError{Reason: "check response did not match pull request head"}
+		}
+		app, _ := check["app"].(map[string]any)
+		_, appOK := prCheckID(app["id"])
+		slug := firstString(app, "slug")
+		suite, _ := valueAtPath(check, "check_suite", "id")
+		suiteID, suiteOK := prCheckID(suite)
+		if !appOK || slug == "" || !suiteOK {
+			return nil, localFallbackError{Reason: "check response did not include app and suite identity"}
+		}
+		if slug == "github-actions" {
+			needed[suiteID] = true
+		}
+	}
+	metadata := map[int64]prCheckMetadata{}
+	if len(needed) == 0 {
+		return metadata, nil
+	}
+	runs, err := relayCompleteCollection(ctx, client, ghAPIRequest{
+		method: "GET", path: repoPath(repo, "actions", "runs"), headers: headers,
+		query: map[string]any{"head_sha": sha},
+	}, "workflow_runs")
+	if err != nil {
+		return nil, err
+	}
+	for _, raw := range runs {
+		run := raw.(map[string]any)
+		if firstString(run, "head_sha") != sha {
+			return nil, localFallbackError{Reason: "workflow run response did not match pull request head"}
+		}
+		runID, _ := prCheckID(run["id"]) // Already validated by the raw collector.
+		suiteID, suiteOK := prCheckID(run["check_suite_id"])
+		workflowID, workflowOK := prCheckID(run["workflow_id"])
+		if !suiteOK || !workflowOK {
+			return nil, localFallbackError{Reason: "workflow run response did not include suite and workflow identity"}
+		}
+		if _, exists := metadata[suiteID]; exists {
+			return nil, localFallbackError{Reason: "ambiguous workflow runs for check suite"}
+		}
+		metadata[suiteID] = prCheckMetadata{runID: runID, workflowID: workflowID, event: firstString(run, "event")}
+	}
+	// The raw catalogue includes inactive workflows; the public workflow-list
+	// projection is incomplete and cannot establish these associations.
+	workflows, err := relayCompleteCollection(ctx, client, ghAPIRequest{
+		method: "GET", path: repoPath(repo, "actions", "workflows"), headers: headers,
+	}, "workflows")
+	if err != nil {
+		return nil, err
+	}
+	names := make(map[int64]string, len(workflows))
+	for _, raw := range workflows {
+		workflow := raw.(map[string]any)
+		id, _ := prCheckID(workflow["id"])
+		names[id] = firstString(workflow, "name")
+	}
+	for suiteID := range needed {
+		association, found := metadata[suiteID]
+		association.workflowName = names[association.workflowID]
+		if !found || association.workflowName == "" || association.event == "" {
+			return nil, localFallbackError{Reason: "missing workflow association for GitHub Actions check suite"}
+		}
+		metadata[suiteID] = association
+	}
+	return metadata, nil
+}

--- a/cmd/octopool/gh_top_collection_test.go
+++ b/cmd/octopool/gh_top_collection_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,6 +18,7 @@ func TestRelayCompleteCollection(t *testing.T) {
 		{"commits/" + metadataHead + "/check-runs", "check_runs"},
 		{"commits/" + metadataHead + "/status", "statuses"},
 		{"actions/runs", "workflow_runs"},
+		{"actions/workflows", "workflows"},
 	} {
 		for _, scenario := range []string{
 			"empty", "full", "boundary", "large-identities", "growing", "shrinking",
@@ -130,7 +132,7 @@ func TestPRChecksGrowingCollectionsUseGuardedFallback(t *testing.T) {
 						request := decodeCLIRequest(t, w, r)
 						path := request["path"].(string)
 						if strings.HasSuffix(path, "/pulls/1") {
-							writeCLIEnvelope(t, w, map[string]any{"head": map[string]any{"sha": metadataHead}})
+							writeCLIEnvelope(t, w, map[string]any{"head": map[string]any{"sha": metadataHead, "ref": "feature"}})
 							return
 						}
 						collection := "check_runs"
@@ -207,7 +209,7 @@ func TestGHPRChecksWatchRejectsRepeatedCollectionIDs(t *testing.T) {
 	relayTestServer(t, func(request map[string]any) any {
 		path := request["path"].(string)
 		if strings.HasSuffix(path, "/pulls/1") {
-			return map[string]any{"head": map[string]any{"sha": metadataHead}}
+			return map[string]any{"head": map[string]any{"sha": metadataHead, "ref": "feature"}}
 		}
 		if !strings.HasSuffix(path, "/check-runs") {
 			t.Fatalf("unexpected path %s", path)
@@ -227,5 +229,203 @@ func TestGHPRChecksWatchRejectsRepeatedCollectionIDs(t *testing.T) {
 	result := handleGHPR(t.Context(), []string{"checks", "1", "-R", "acme/repo", "--watch"}, &out)
 	if result.action != ghFail || !isLocalFallback(result.err) || out.Len() != 0 || calls != 2 {
 		t.Fatalf("watch accepted incomplete snapshot: result=%+v output=%q calls=%d", result, out.String(), calls)
+	}
+}
+
+func TestPRChecksMetadataCollectionBudgets(t *testing.T) {
+	for _, scenario := range []string{"match-page-2", "match-page-10", "41-operations", "21-without-actions", "1001-workflows", "1001-runs", "late-duplicate", "late-short", "late-total-change"} {
+		t.Run(scenario, func(t *testing.T) {
+			f := newPRChecksFixture()
+			count := 101
+			if scenario == "match-page-10" || scenario == "41-operations" || scenario == "21-without-actions" {
+				count = 1000
+			}
+			if scenario == "1001-workflows" || scenario == "1001-runs" {
+				count = 1001
+			}
+			f.runs, f.workflows = []any{}, []any{}
+			for i := 0; i < count; i++ {
+				suite := 10000 + i
+				if i == count-1 {
+					suite = 201
+				}
+				f.runs = append(f.runs, map[string]any{"id": 3000 + i, "head_sha": metadataHead, "check_suite_id": suite, "workflow_id": 4000 + count - 1, "event": "pull_request", "name": "not CI"})
+				f.workflows = append(f.workflows, map[string]any{"id": 4000 + i, "name": "CI", "state": "disabled_manually", "path": fmt.Sprintf(".github/workflows/%d.yml", i)})
+			}
+			if scenario == "1001-workflows" {
+				f.runs = f.runs[count-1:]
+			}
+			if scenario == "41-operations" || scenario == "21-without-actions" {
+				f.checks, f.statuses = []any{}, []any{}
+				for i := 0; i < 1000; i++ {
+					c := prChecksCheck(int64(i+1), fmt.Sprintf("job-%04d", i), "completed", "success")
+					if scenario == "21-without-actions" {
+						c["app"] = map[string]any{"id": 999, "slug": "third-party"}
+					}
+					f.checks = append(f.checks, c)
+					f.statuses = append(f.statuses, map[string]any{"id": i + 1, "context": fmt.Sprintf("status-%04d", i), "state": "success", "target_url": "https://example.test/status", "description": "external", "created_at": "2026-09-01T00:00:00Z", "updated_at": "2026-09-01T00:00:00Z"})
+				}
+			}
+			if strings.HasPrefix(scenario, "late-") {
+				// The needed match is already on page 1. Completeness still requires page 2.
+				f.runs[0].(map[string]any)["check_suite_id"] = 201
+				f.runs[count-1].(map[string]any)["check_suite_id"] = 99999
+				for _, r := range f.runs {
+					r.(map[string]any)["workflow_id"] = 4000
+				}
+			}
+			_, policies := rewriteTestServer(t, rewriteEmptyTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+				req := decodeCLIRequest(t, w, r)
+				body := f.response(t, req)
+				if req["path"] == "/repos/acme/repo/actions/workflows" && f.calls("/actions/workflows") == 2 {
+					page := body.(map[string]any)
+					switch scenario {
+					case "late-duplicate":
+						page["workflows"] = []any{f.workflows[0]}
+					case "late-short":
+						page["workflows"] = []any{}
+					case "late-total-change":
+						page["total_count"] = 102
+					}
+				}
+				writeCLIEnvelope(t, w, body)
+			})
+			var out bytes.Buffer
+			err := relayPRChecks(t.Context(), &out, "acme/repo", "7", ghTopOptions{json: []string{"name", "workflow", "event"}})
+			invalid := strings.HasPrefix(scenario, "late-") || strings.HasPrefix(scenario, "1001-")
+			if invalid {
+				if !isLocalFallback(err) || out.Len() != 0 {
+					t.Errorf("incomplete metadata escaped before output: err=%v bytes=%d", err, out.Len())
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				var rows []map[string]any
+				if e := json.Unmarshal(out.Bytes(), &rows); e != nil {
+					t.Fatal(e)
+				}
+				if len(rows) != len(f.checks)+len(f.statuses) {
+					t.Errorf("complete output rows=%d", len(rows))
+				}
+				if scenario != "21-without-actions" && rows[0]["workflow"] != "CI" {
+					t.Errorf("late-page association missing: %v", rows[0])
+				}
+			}
+			wantRuns, wantCatalogue := (count+99)/100, (count+99)/100
+			if scenario == "1001-runs" {
+				wantRuns, wantCatalogue = 1, 0
+			}
+			if scenario == "1001-workflows" {
+				wantRuns, wantCatalogue = 1, 1
+			}
+			if scenario == "21-without-actions" {
+				wantRuns, wantCatalogue = 0, 0
+			}
+			if f.calls("/actions/runs") != wantRuns || f.calls("/actions/workflows") != wantCatalogue {
+				t.Errorf("complete bounded joins: runs=%d want=%d catalogue=%d want=%d", f.calls("/actions/runs"), wantRuns, f.calls("/actions/workflows"), wantCatalogue)
+			}
+			if policies.Load() != int64(len(f.requests)) {
+				t.Errorf("policy/data split: policies=%d data=%d", policies.Load(), len(f.requests))
+			}
+			if scenario == "41-operations" && len(f.requests) != 41 || scenario == "21-without-actions" && len(f.requests) != 21 {
+				t.Errorf("logical data budget=%d", len(f.requests))
+			}
+		})
+	}
+}
+
+func TestPRChecksLogicalDedupAcrossPages(t *testing.T) {
+	for _, mode := range []string{"json", "human", "watch"} {
+		t.Run(mode, func(t *testing.T) {
+			f := newPRChecksFixture()
+			f.checks = []any{}
+			for i := 0; i < 100; i++ {
+				c := prChecksCheck(int64(i+1), "unit", "completed", "failure")
+				c["started_at"] = "2026-09-01T00:00:00Z"
+				f.checks = append(f.checks, c)
+			}
+			f.checks = append(f.checks, prChecksCheck(101, "unit", "completed", "success"))
+			relayTestServer(t, func(r map[string]any) any { return f.response(t, r) })
+			sleeps := recordWatchSleeps(t)
+			var out bytes.Buffer
+			args := []string{"checks", "7", "-R", "acme/repo"}
+			if mode == "json" {
+				args = append(args, "--json", "name,state")
+			}
+			if mode == "watch" {
+				args = append(args, "--watch")
+			}
+			result := handleGHPR(t.Context(), args, &out)
+			if result.err != nil || result.action != ghComplete {
+				t.Errorf("obsolete failure survived logical dedup: action=%v err=%v", result.action, result.err)
+			}
+			if mode == "json" {
+				if out.String() != "[{\"name\":\"unit\",\"state\":\"SUCCESS\"}]\n" {
+					t.Errorf("expected only newest successful check, bytes=%d", out.Len())
+				}
+			} else {
+				if strings.Count(out.String(), "unit\t") != 1 {
+					t.Errorf("obsolete rows printed: %d", strings.Count(out.String(), "unit\t"))
+				}
+				if mode == "watch" && !strings.Contains(out.String(), "checks: 0 pending, 1 pass, 0 fail, 0 cancel\n") {
+					t.Errorf("watch counts not deduped")
+				}
+			}
+			if len(*sleeps) != 0 {
+				t.Errorf("terminal checks slept: %v", *sleeps)
+			}
+		})
+	}
+}
+
+func TestPRChecksDedupNamespacesAndLiteralKey(t *testing.T) {
+	for _, scenario := range []string{"workflow-event-status", "slash-key", "equal-start-no-invented-winner"} {
+		t.Run(scenario, func(t *testing.T) {
+			f := newPRChecksFixture()
+			f.checks, f.runs, f.workflows = []any{}, []any{}, []any{}
+			for i := 0; i < 3; i++ {
+				c := prChecksCheck(int64(i+1), "unit", "completed", "success")
+				c["check_suite"] = map[string]any{"id": 201 + i}
+				c["started_at"] = fmt.Sprintf("2026-09-01T0%d:00:00Z", i)
+				workflow, event := "CI", "push"
+				if i == 1 {
+					workflow = "Other"
+				}
+				if i == 2 {
+					event = "pull_request"
+				}
+				if scenario == "slash-key" {
+					if i == 0 {
+						c["name"], workflow, event = "a/b", "c", "push"
+					} else if i == 1 {
+						c["name"], workflow, event = "a", "b/c", "push"
+					}
+				}
+				if scenario == "equal-start-no-invented-winner" {
+					workflow, event = "CI", "push"
+					c["started_at"] = "2026-09-01T00:00:00Z"
+				}
+				f.checks = append(f.checks, c)
+				f.runs = append(f.runs, map[string]any{"id": 301 + i, "head_sha": metadataHead, "check_suite_id": 201 + i, "workflow_id": 401 + i, "name": "wrong", "event": event})
+				f.workflows = append(f.workflows, map[string]any{"id": 401 + i, "name": workflow, "state": "active", "path": fmt.Sprintf(".github/workflows/%d.yml", i)})
+			}
+			if scenario == "workflow-event-status" {
+				f.statuses = []any{map[string]any{"id": 10, "context": "unit", "state": "success", "created_at": "2026-09-01T00:00:00Z"}, map[string]any{"id": 11, "context": "unit", "state": "success", "created_at": "2026-09-01T01:00:00Z"}}
+			}
+			relayTestServer(t, func(r map[string]any) any { return f.response(t, r) })
+			var out bytes.Buffer
+			if err := relayPRChecks(t.Context(), &out, "acme/repo", "7", ghTopOptions{json: []string{"name", "state"}}); err != nil {
+				t.Fatal(err)
+			}
+			var got []map[string]any
+			if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			want := map[string]int{"workflow-event-status": 4, "slash-key": 2, "equal-start-no-invented-winner": 1}[scenario]
+			if len(got) != want {
+				t.Fatalf("native logical namespaces/key rows=%d want=%d output=%s", len(got), want, out.String())
+			}
+		})
 	}
 }

--- a/cmd/octopool/gh_top_human.go
+++ b/cmd/octopool/gh_top_human.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -132,18 +133,34 @@ func relayHumanPRList(ctx context.Context, stdout io.Writer, request ghAPIReques
 	return nil
 }
 
-func renderHumanPRChecks(stdout io.Writer, items []any) error {
-	for _, raw := range items {
-		item, ok := raw.(map[string]any)
-		if !ok {
-			continue
+func renderHumanPRChecks(stdout io.Writer, items []prCheckRow) error {
+	items = append([]prCheckRow(nil), items...)
+	// Keep gh's literal comparator, including "success" (not "pass"). This
+	// presentation sort must never reorder the JSON aggregation result.
+	sort.Slice(items, func(i, j int) bool {
+		a, b := items[i], items[j]
+		if a.Bucket == b.Bucket {
+			if a.Name == b.Name {
+				return a.Link < b.Link
+			}
+			return a.Name < b.Name
+		}
+		return a.Bucket == "fail" || (a.Bucket == "pending" && b.Bucket == "success")
+	})
+	for _, item := range items {
+		bucket := item.Bucket
+		if bucket == "cancel" {
+			bucket = "fail"
+		}
+		elapsed := "0"
+		if !item.StartedAt.IsZero() && !item.CompletedAt.IsZero() {
+			if duration := item.CompletedAt.Sub(item.StartedAt); duration > 0 {
+				elapsed = duration.String()
+			}
 		}
 		if _, err := fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\n",
-			watchSafeText(firstString(item, "name")),
-			watchSafeText(firstString(item, "bucket")),
-			humanDuration(firstString(item, "startedAt"), firstString(item, "completedAt")),
-			watchSafeText(firstString(item, "link")),
-			watchSafeText(firstString(item, "description")),
+			watchSafeText(item.Name), bucket, elapsed,
+			watchSafeText(item.Link), watchSafeText(item.Description),
 		); err != nil {
 			return err
 		}

--- a/cmd/octopool/gh_top_human_test.go
+++ b/cmd/octopool/gh_top_human_test.go
@@ -132,10 +132,10 @@ func TestHumanPRChecksExactOutputAndSanitizesName(t *testing.T) {
 	relayTestServer(t, func(body map[string]any) any {
 		switch body["path"] {
 		case "/repos/openclaw/octopool/pulls/25":
-			return map[string]any{"head": map[string]any{"sha": "abc123"}}
+			return map[string]any{"head": map[string]any{"sha": "abc123", "ref": "feature"}}
 		case "/repos/openclaw/octopool/commits/abc123/check-runs":
 			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{
-				"id": 1, "name": "Check\x1b[31m", "status": "completed", "conclusion": "success",
+				"id": 1, "head_sha": "abc123", "app": map[string]any{"id": 999, "slug": "third-party"}, "check_suite": map[string]any{"id": 201}, "name": "Check\x1b[31m", "status": "completed", "conclusion": "success",
 				"started_at": "2026-07-17T21:00:00Z", "completed_at": "2026-07-17T21:03:12Z",
 				"details_url": "https://github.com/openclaw/octopool/actions/runs/29614118703/job/87995297404",
 			}}}
@@ -353,10 +353,10 @@ func TestHumanPRChecksPendingExitsEight(t *testing.T) {
 	relayTestServer(t, func(body map[string]any) any {
 		switch body["path"] {
 		case "/repos/openclaw/octopool/pulls/25":
-			return map[string]any{"head": map[string]any{"sha": "abc123"}}
+			return map[string]any{"head": map[string]any{"sha": "abc123", "ref": "feature"}}
 		case "/repos/openclaw/octopool/commits/abc123/check-runs":
 			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{
-				"id": 1, "name": "Check", "status": "in_progress", "started_at": "2026-07-17T21:00:00Z",
+				"id": 1, "head_sha": "abc123", "app": map[string]any{"id": 999, "slug": "third-party"}, "check_suite": map[string]any{"id": 201}, "name": "Check", "status": "in_progress", "started_at": "2026-07-17T21:00:00Z",
 			}}}
 		case "/repos/openclaw/octopool/commits/abc123/status":
 			return map[string]any{"total_count": 0, "statuses": []map[string]any{}}
@@ -371,7 +371,7 @@ func TestHumanPRChecksPendingExitsEight(t *testing.T) {
 	if result.action != ghFail || !errors.As(result.err, &exitErr) || exitErr.Code != 8 {
 		t.Fatalf("action=%v err=%v", result.action, result.err)
 	}
-	if got, want := out.String(), "Check\tpending\t\t\t\n"; got != want {
+	if got, want := out.String(), "Check\tpending\t0\t\t\n"; got != want {
 		t.Fatalf("output = %q, want %q", got, want)
 	}
 }
@@ -535,5 +535,83 @@ func assertGHComplete(t *testing.T, result ghResult) {
 	t.Helper()
 	if result.action != ghComplete || result.err != nil {
 		t.Fatalf("action=%v err=%v", result.action, result.err)
+	}
+}
+
+func TestPRChecksNativeHumanPresentation(t *testing.T) {
+	for _, row := range []struct {
+		name, conclusion string
+		start, end       any
+		elapsed, bucket  string
+	}{
+		{"cancelled", "cancelled", nil, nil, "0", "fail"},
+		{"missing", "success", nil, nil, "0", "pass"},
+		{"equal", "success", "2026-09-01T00:00:00Z", "2026-09-01T00:00:00Z", "0", "pass"},
+		{"negative", "success", "2026-09-01T00:00:01Z", "2026-09-01T00:00:00Z", "0", "pass"},
+		{"fractional", "success", "2026-09-01T00:00:00.12+02:30", "2026-09-01T00:00:01.62+02:30", "1.5s", "pass"},
+	} {
+		t.Run(row.name, func(t *testing.T) {
+			f := newPRChecksFixture()
+			c := f.checks[0].(map[string]any)
+			c["conclusion"], c["started_at"], c["completed_at"] = row.conclusion, row.start, row.end
+			c["name"], c["details_url"] = "unit\x1b[31m", "https://example.test/job"
+			relayTestServer(t, func(r map[string]any) any { return f.response(t, r) })
+			var out bytes.Buffer
+			err := relayPRChecks(t.Context(), &out, "acme/repo", "7", ghTopOptions{})
+			want := "unit[31m\t" + row.bucket + "\t" + row.elapsed + "\thttps://example.test/job\t\n"
+			if err != nil || out.String() != want {
+				t.Fatalf("checks-local native row: err=%v got=%q want=%q", err, out.String(), want)
+			}
+		})
+	}
+}
+
+func TestPRChecksHumanSortSeparateFromJSON(t *testing.T) {
+	for _, mode := range []string{"human", "json"} {
+		t.Run(mode, func(t *testing.T) {
+			f := newPRChecksFixture()
+			f.checks = []any{}
+			// Native comparator leaves pass before pending (it tests "success", not "pass").
+			for i, row := range []struct{ name, status, conclusion, link string }{
+				{"z", "completed", "success", "https://example.test/z"},
+				{"a", "completed", "success", "https://example.test/b"},
+				{"a", "completed", "success", "https://example.test/a"},
+				{"pending", "queued", "", "https://example.test/p"},
+				{"failed", "completed", "failure", "https://example.test/f"},
+			} {
+				c := prChecksCheck(int64(i+1), row.name, row.status, row.conclusion)
+				c["details_url"] = row.link
+				c["started_at"] = time.Date(2026, 9, 1, 5-i, 0, 0, 0, time.UTC).Format(time.RFC3339)
+				c["completed_at"] = nil
+				c["check_suite"] = map[string]any{"id": 201 + i}
+				f.checks = append(f.checks, c)
+				if i > 0 {
+					f.runs = append(f.runs, map[string]any{"id": 301 + i, "head_sha": metadataHead, "check_suite_id": 201 + i, "workflow_id": 401 + i, "name": "wrong", "event": "push"})
+					f.workflows = append(f.workflows, map[string]any{"id": 401 + i, "name": row.link, "state": "active", "path": ".github/workflows/other.yml"})
+				}
+			}
+			relayTestServer(t, func(r map[string]any) any { return f.response(t, r) })
+			var out bytes.Buffer
+			opts := ghTopOptions{}
+			if mode == "json" {
+				opts.json = []string{"name", "link"}
+			}
+			err := relayPRChecks(t.Context(), &out, "acme/repo", "7", opts)
+			if mode == "human" {
+				assertExitCode(t, err, 1)
+				want := "failed\tfail\t0\thttps://example.test/f\t\na\tpass\t0\thttps://example.test/a\t\na\tpass\t0\thttps://example.test/b\t\nz\tpass\t0\thttps://example.test/z\t\npending\tpending\t0\thttps://example.test/p\t\n"
+				if out.String() != want {
+					t.Fatalf("literal native presentation comparator: got=%q want=%q", out.String(), want)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("export exit=%v", err)
+				}
+				want := "[{\"link\":\"https://example.test/z\",\"name\":\"z\"},{\"link\":\"https://example.test/b\",\"name\":\"a\"},{\"link\":\"https://example.test/a\",\"name\":\"a\"},{\"link\":\"https://example.test/p\",\"name\":\"pending\"},{\"link\":\"https://example.test/f\",\"name\":\"failed\"}]\n"
+				if out.String() != want {
+					t.Fatalf("JSON must retain aggregation rather than presentation order: %s", out.String())
+				}
+			}
+		})
 	}
 }

--- a/cmd/octopool/gh_top_pr_metadata.go
+++ b/cmd/octopool/gh_top_pr_metadata.go
@@ -50,39 +50,26 @@ func relayPRStatusCheckRollup(ctx context.Context, client ghRelayClient, repo, s
 	if err != nil {
 		return nil, err
 	}
-	workflows := map[json.Number]string{}
-	for _, raw := range items {
-		item, _ := raw.(map[string]any)
-		if nestedStringValue(item, "app", "slug") == "github-actions" {
-			if err := hydratePRCheckWorkflows(ctx, client, repo, sha, headers, workflows); err != nil {
-				return nil, err
-			}
-			break
-		}
+	metadata, err := verifiedPRCheckMetadata(ctx, client, repo, sha, headers, items)
+	if err != nil {
+		return nil, err
 	}
 	rollup := make([]any, 0, len(items))
-	for _, raw := range items {
-		item, ok := raw.(map[string]any)
-		if !ok {
-			return nil, errors.New("invalid check context")
-		}
-		if _, status := item["context"]; status {
+	for _, context := range items {
+		item := context.raw
+		if context.isStatus {
 			rollup = append(rollup, map[string]any{
 				"__typename": "StatusContext", "context": firstString(item, "context"),
-				"state":     strings.ToUpper(firstString(item, "conclusion")),
-				"targetUrl": firstString(item, "details_url"), "startedAt": ghCheckTimestamp(item, "started_at"),
+				"state":     strings.ToUpper(firstString(item, "state")),
+				"targetUrl": firstString(item, "target_url"), "startedAt": ghCheckTimestamp(item, "created_at"),
 			})
 			continue
 		}
 		workflow := ""
 		if nestedStringValue(item, "app", "slug") == "github-actions" {
 			suite, _ := valueAtPath(item, "check_suite", "id")
-			id, _ := suite.(json.Number)
-			var found bool
-			workflow, found = workflows[id]
-			if !found {
-				return nil, errors.New("workflow run response did not include GitHub Actions check suite")
-			}
+			id, _ := prCheckID(suite)
+			workflow = metadata[id].workflowName
 		}
 		rollup = append(rollup, map[string]any{
 			"__typename": "CheckRun", "name": firstString(item, "name"), "workflowName": workflow,
@@ -101,36 +88,4 @@ func ghCheckTimestamp(item map[string]any, field string) string {
 		return value
 	}
 	return time.Time{}.Format(time.RFC3339)
-}
-
-func hydratePRCheckWorkflows(ctx context.Context, client ghRelayClient, repo, sha string, headers map[string]string, workflows map[json.Number]string) error {
-	request := ghAPIRequest{
-		method: "GET", path: repoPath(repo, "actions", "runs"), headers: headers,
-		query: map[string]any{"head_sha": sha},
-	}
-	if !safeRelayRequest(request) {
-		return errors.New("unsupported workflow run lookup")
-	}
-	// Filtered workflow queries and the shared collector are bounded to 1,000
-	// items. Never fabricate an empty name from an incomplete workflow lookup.
-	items, err := relayCompleteCollection(ctx, client, request, "workflow_runs")
-	if err != nil {
-		return err
-	}
-	for _, raw := range items {
-		run := raw.(map[string]any)
-		if firstString(run, "head_sha") != sha {
-			return errors.New("workflow run response did not match pull request head")
-		}
-		id, ok := run["check_suite_id"].(json.Number)
-		if !ok {
-			return errors.New("workflow run response did not include check_suite_id")
-		}
-		name, ok := run["name"].(string)
-		if !ok {
-			return errors.New("workflow run response did not include name")
-		}
-		workflows[id] = name
-	}
-	return nil
 }

--- a/cmd/octopool/gh_top_pr_metadata_test.go
+++ b/cmd/octopool/gh_top_pr_metadata_test.go
@@ -58,8 +58,8 @@ func TestRunGHPRViewMetadataUnderActivePolicy(t *testing.T) {
 					writeCLIEnvelope(t, w, []any{map[string]any{"filename": "fixed.go", "additions": 2, "deletions": 1, "status": "modified"}})
 				case "/repos/acme/repo/commits/" + metadataHead + "/check-runs":
 					writeCLIEnvelope(t, w, map[string]any{"total_count": 2, "check_runs": []any{
-						map[string]any{"id": 1, "name": "unit", "status": "completed", "conclusion": "success", "started_at": "2026-08-29T01:00:00Z", "completed_at": "2026-08-29T01:01:00Z", "details_url": "https://example.test/unit", "check_suite": map[string]any{"id": 42}, "app": map[string]any{"slug": "github-actions"}},
-						map[string]any{"id": 2, "name": "external", "status": "queued", "conclusion": nil, "started_at": nil, "completed_at": nil, "details_url": nil, "check_suite": map[string]any{"id": 43}, "app": map[string]any{"slug": "third-party"}},
+						map[string]any{"id": 1, "head_sha": metadataHead, "name": "unit", "status": "completed", "conclusion": "success", "started_at": "2026-08-29T01:00:00Z", "completed_at": "2026-08-29T01:01:00Z", "details_url": "https://example.test/unit", "check_suite": map[string]any{"id": 42}, "app": map[string]any{"id": 15368, "slug": "github-actions"}},
+						map[string]any{"id": 2, "head_sha": metadataHead, "name": "external", "status": "queued", "conclusion": nil, "started_at": nil, "completed_at": nil, "details_url": nil, "check_suite": map[string]any{"id": 43}, "app": map[string]any{"id": 999, "slug": "third-party"}},
 					}})
 				case "/repos/acme/repo/commits/" + metadataHead + "/status":
 					writeCLIEnvelope(t, w, map[string]any{"total_count": 1, "statuses": []any{map[string]any{"id": 1, "context": "ci/external", "state": "pending", "target_url": "https://example.test/status", "created_at": "2026-08-29T01:02:00Z"}}})
@@ -70,7 +70,9 @@ func TestRunGHPRViewMetadataUnderActivePolicy(t *testing.T) {
 					if query["head_sha"] != metadataHead {
 						t.Errorf("workflow query = %#v", query)
 					}
-					writeCLIEnvelope(t, w, map[string]any{"total_count": 1, "workflow_runs": []any{map[string]any{"id": 1, "head_sha": metadataHead, "check_suite_id": 42, "name": "CI"}}})
+					writeCLIEnvelope(t, w, map[string]any{"total_count": 1, "workflow_runs": []any{map[string]any{"id": 1, "head_sha": metadataHead, "check_suite_id": 42, "workflow_id": 401, "name": "CI", "event": "pull_request"}}})
+				case "/repos/acme/repo/actions/workflows":
+					writeCLIEnvelope(t, w, map[string]any{"total_count": 1, "workflows": []any{map[string]any{"id": 401, "name": "CI", "state": "active", "path": ".github/workflows/ci.yml"}}})
 				default:
 					t.Errorf("unexpected metadata path %q", path)
 					w.WriteHeader(400)
@@ -105,7 +107,7 @@ func TestRunGHPRViewMetadataUnderActivePolicy(t *testing.T) {
 			if !reflect.DeepEqual(got, want) {
 				t.Errorf("metadata = %s, want %#v", out.String(), want)
 			}
-			if prCalls != 2 || len(paths) != 7 || paths[len(paths)-1] != "/repos/acme/repo/pulls/1" {
+			if prCalls != 2 || len(paths) != 8 || paths[len(paths)-1] != "/repos/acme/repo/pulls/1" {
 				t.Errorf("hydration must finish with head verification: %v", paths)
 			}
 			if _, err := os.Stat(capture); !os.IsNotExist(err) {
@@ -184,13 +186,16 @@ func TestRunGHPRViewRollupPaginates(t *testing.T) {
 			suite := (page-1)*100 + i + 1
 			switch {
 			case strings.HasSuffix(path, "/check-runs"):
-				items[i] = map[string]any{"id": suite, "name": fmt.Sprintf("job-%d", suite), "status": "completed", "conclusion": "success", "check_suite": map[string]any{"id": suite}, "app": map[string]any{"slug": "github-actions"}}
+				items[i] = map[string]any{"id": suite, "head_sha": metadataHead, "name": fmt.Sprintf("job-%d", suite), "status": "completed", "conclusion": "success", "check_suite": map[string]any{"id": suite}, "app": map[string]any{"id": 15368, "slug": "github-actions"}}
 			case strings.HasSuffix(path, "/status"):
 				key = "statuses"
 				items[i] = map[string]any{"id": suite, "context": fmt.Sprintf("status-%d", suite), "state": "success"}
 			case strings.HasSuffix(path, "/actions/runs"):
 				key = "workflow_runs"
-				items[i] = map[string]any{"id": suite, "head_sha": metadataHead, "check_suite_id": suite, "name": fmt.Sprintf("workflow-%d", suite)}
+				items[i] = map[string]any{"id": suite, "head_sha": metadataHead, "check_suite_id": suite, "workflow_id": suite, "event": "push", "name": "run title"}
+			case strings.HasSuffix(path, "/actions/workflows"):
+				key = "workflows"
+				items[i] = map[string]any{"id": suite, "name": fmt.Sprintf("workflow-%d", suite), "state": "active", "path": fmt.Sprintf(".github/workflows/%d.yml", suite)}
 			default:
 				t.Fatalf("unexpected path %q", path)
 			}
@@ -283,7 +288,7 @@ func TestRunGHPRViewMetadataFailsClosedDuringHydration(t *testing.T) {
 				case path == "/users/user":
 					writeCLIEnvelope(t, w, map[string]any{"node_id": "U_different", "id": 12, "login": "user", "name": "User", "type": "User"})
 				case strings.HasSuffix(path, "/check-runs"):
-					writeCLIEnvelope(t, w, map[string]any{"total_count": 1, "check_runs": []any{map[string]any{"id": 1, "name": "unit", "check_suite": map[string]any{"id": 42}, "app": map[string]any{"slug": "github-actions"}}}})
+					writeCLIEnvelope(t, w, map[string]any{"total_count": 1, "check_runs": []any{map[string]any{"id": 1, "head_sha": metadataHead, "name": "unit", "check_suite": map[string]any{"id": 42}, "app": map[string]any{"id": 15368, "slug": "github-actions"}}}})
 				case strings.HasSuffix(path, "/status"):
 					if scenario == "policy-change" {
 						setPolicy()
@@ -301,6 +306,8 @@ func TestRunGHPRViewMetadataFailsClosedDuringHydration(t *testing.T) {
 						runs = []any{}
 					}
 					writeCLIEnvelope(t, w, map[string]any{"total_count": total, "workflow_runs": runs})
+				case strings.HasSuffix(path, "/actions/workflows"):
+					writeCLIEnvelope(t, w, map[string]any{"total_count": 0, "workflows": []any{}})
 				default:
 					t.Errorf("unexpected path %s", path)
 					w.WriteHeader(400)
@@ -353,7 +360,7 @@ func TestRunGHPRViewMetadataTypedFallback(t *testing.T) {
 					}
 					writeCLIEnvelope(t, w, map[string]any{"head": map[string]any{"sha": sha}})
 				case strings.HasSuffix(path, "/check-runs"):
-					writeCLIEnvelope(t, w, map[string]any{"total_count": 1, "check_runs": []any{map[string]any{"id": 1, "status": "completed", "conclusion": "success", "app": map[string]any{"slug": "github-actions"}, "check_suite": map[string]any{"id": 42}}}})
+					writeCLIEnvelope(t, w, map[string]any{"total_count": 1, "check_runs": []any{map[string]any{"id": 1, "head_sha": metadataHead, "status": "completed", "conclusion": "success", "app": map[string]any{"id": 15368, "slug": "github-actions"}, "check_suite": map[string]any{"id": 42}}}})
 				case strings.HasSuffix(path, "/status"):
 					writeCLIEnvelope(t, w, map[string]any{"total_count": 0, "statuses": []any{}})
 				case strings.HasSuffix(path, "/actions/runs"):
@@ -361,7 +368,9 @@ func TestRunGHPRViewMetadataTypedFallback(t *testing.T) {
 					if scenario == "workflow-limit" {
 						total = 1001
 					}
-					writeCLIEnvelope(t, w, map[string]any{"total_count": total, "workflow_runs": []any{map[string]any{"id": 1, "head_sha": metadataHead, "check_suite_id": 42, "name": "CI"}}})
+					writeCLIEnvelope(t, w, map[string]any{"total_count": total, "workflow_runs": []any{map[string]any{"id": 1, "head_sha": metadataHead, "check_suite_id": 42, "workflow_id": 401, "event": "push", "name": "run title"}}})
+				case strings.HasSuffix(path, "/actions/workflows"):
+					writeCLIEnvelope(t, w, map[string]any{"total_count": 1, "workflows": []any{map[string]any{"id": 401, "name": "CI", "state": "active", "path": ".github/workflows/ci.yml"}}})
 				default:
 					t.Errorf("unexpected path %s", path)
 					w.WriteHeader(400)
@@ -390,6 +399,7 @@ func TestRunGHPRViewMetadataUpstreamFailuresStayClosed(t *testing.T) {
 			t.Run(fmt.Sprintf("%s/%d", phase, upstream), func(t *testing.T) {
 				t.Setenv("OCTOPOOL_NO_FALLBACK", "")
 				prCalls := 0
+				upstreamReached := false
 				rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
 					req := decodeCLIRequest(t, w, r)
 					path := req["path"].(string)
@@ -407,19 +417,22 @@ func TestRunGHPRViewMetadataUpstreamFailuresStayClosed(t *testing.T) {
 						data = map[string]any{"login": "alice", "node_id": "U_alice", "id": 12, "type": "User", "name": nil}
 					case strings.HasSuffix(path, "/check-runs"):
 						current = "checks"
-						data = map[string]any{"total_count": 1, "check_runs": []any{map[string]any{"id": 1, "name": "unit", "status": "completed", "conclusion": "success", "check_suite": map[string]any{"id": 42}, "app": map[string]any{"slug": "github-actions"}}}}
+						data = map[string]any{"total_count": 1, "check_runs": []any{map[string]any{"id": 1, "head_sha": metadataHead, "name": "unit", "status": "completed", "conclusion": "success", "check_suite": map[string]any{"id": 42}, "app": map[string]any{"id": 15368, "slug": "github-actions"}}}}
 					case strings.HasSuffix(path, "/status"):
 						current = "statuses"
 						data = map[string]any{"total_count": 0, "statuses": []any{}}
 					case strings.HasSuffix(path, "/actions/runs"):
 						current = "workflows"
-						data = map[string]any{"total_count": 1, "workflow_runs": []any{map[string]any{"id": 1, "check_suite_id": 42, "head_sha": metadataHead, "name": "CI"}}}
+						data = map[string]any{"total_count": 1, "workflow_runs": []any{map[string]any{"id": 1, "check_suite_id": 42, "head_sha": metadataHead, "workflow_id": 401, "event": "push", "name": "run title"}}}
+					case strings.HasSuffix(path, "/actions/workflows"):
+						data = map[string]any{"total_count": 1, "workflows": []any{map[string]any{"id": 401, "name": "CI", "state": "active", "path": ".github/workflows/ci.yml"}}}
 					default:
 						t.Errorf("unexpected request: %s", path)
 						w.WriteHeader(400)
 						return
 					}
 					if current == phase {
+						upstreamReached = true
 						_ = json.NewEncoder(w).Encode(map[string]any{"status": upstream, "body_encoding": "json", "body": map[string]any{"message": "upstream failure"}})
 						return
 					}
@@ -428,6 +441,9 @@ func TestRunGHPRViewMetadataUpstreamFailuresStayClosed(t *testing.T) {
 				capture := captureRewriteGH(t)
 				var out bytes.Buffer
 				err := runGH(t.Context(), []string{"pr", "view", "1", "-R", "acme/repo", "--json", "headRepositoryOwner,statusCheckRollup"}, &out, io.Discard)
+				if !upstreamReached {
+					t.Fatal("intended upstream failure was not reached")
+				}
 				if err == nil || out.Len() != 0 {
 					t.Fatalf("upstream failure: err=%v out=%q", err, out.String())
 				}
@@ -436,5 +452,239 @@ func TestRunGHPRViewMetadataUpstreamFailuresStayClosed(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestPRChecksVerifiedWorkflowMetadata(t *testing.T) {
+	for _, scenario := range []string{"shared-inactive-fork", "large-identities", "rollup"} {
+		t.Run(scenario, func(t *testing.T) {
+			f := newPRChecksFixture()
+			f.checks = append(f.checks, prChecksCheck(2, "lint", "completed", "success"))
+			if scenario == "large-identities" {
+				f.runs, f.workflows = []any{}, []any{}
+				for i, raw := range f.checks {
+					id := int64(1<<53) + int64(i)
+					check := raw.(map[string]any)
+					check["id"], check["check_suite"] = id, map[string]any{"id": id}
+					f.runs = append(f.runs, map[string]any{"id": id, "head_sha": metadataHead, "check_suite_id": id, "workflow_id": id, "event": "push", "name": "wrong"})
+					f.workflows = append(f.workflows, map[string]any{"id": id, "name": fmt.Sprint("workflow-", i), "state": "active", "path": fmt.Sprint(".github/workflows/", i, ".yml")})
+				}
+			}
+			_, policies := rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+				writeCLIEnvelope(t, w, f.response(t, decodeCLIRequest(t, w, r)))
+			})
+			var out bytes.Buffer
+			args := []string{"pr", "checks", "7", "-R", "acme/repo", "--json", "name,workflow,event"}
+			if scenario == "rollup" {
+				args[1], args[6] = "view", "statusCheckRollup"
+			}
+			if err := runGH(t.Context(), args, &out, io.Discard); err != nil {
+				t.Fatal(err)
+			}
+			if scenario == "rollup" {
+				var got map[string][]map[string]any
+				if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+					t.Fatal(err)
+				}
+				rows := got["statusCheckRollup"]
+				if len(rows) != 2 || rows[0]["name"] != "unit" || rows[1]["name"] != "lint" {
+					t.Fatalf("rollup order/shape=%s", out.String())
+				}
+				for _, row := range rows {
+					if len(row) != 8 || row["workflowName"] != "CI" || row["__typename"] != "CheckRun" || row["status"] != "COMPLETED" || row["conclusion"] != "SUCCESS" || row["startedAt"] != "2026-09-01T01:00:00Z" || row["completedAt"] != "2026-09-01T01:01:00Z" {
+						t.Errorf("verified rollup projection=%v", row)
+					}
+				}
+				if f.calls("/pulls/7") != 2 || f.requests[len(f.requests)-1]["path"] != "/repos/acme/repo/pulls/7" {
+					t.Errorf("rollup final-head contract=%v", f.requests)
+				}
+			} else {
+				var got []map[string]any
+				if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+					t.Fatal(err)
+				}
+				if len(got) != 2 {
+					t.Fatalf("checks row count=%d want=2: %s", len(got), out.String())
+				}
+				seen := map[string]bool{}
+				for _, row := range got {
+					checkName, ok := row["name"].(string)
+					if !ok || (checkName != "unit" && checkName != "lint") || seen[checkName] {
+						t.Fatalf("unexpected or duplicate check identity: %v", row)
+					}
+					seen[checkName] = true
+					name, event := "CI", "pull_request"
+					if scenario == "large-identities" {
+						name, event = "workflow-0", "push"
+						if checkName == "lint" {
+							name = "workflow-1"
+						}
+					}
+					if row["workflow"] != name || row["event"] != event {
+						t.Errorf("suite/run/workflow association: row=%v want=%s/%s", row, name, event)
+					}
+				}
+				if f.calls("/pulls/7") != 1 {
+					t.Errorf("ordinary read must not add a live head check")
+				}
+			}
+			if f.calls("/actions/runs") != 1 || f.calls("/actions/workflows") != 1 {
+				t.Errorf("shared raw joins missing or repeated: runs=%d catalogue=%d", f.calls("/actions/runs"), f.calls("/actions/workflows"))
+			}
+			if policies.Load() != int64(1+len(f.requests)) {
+				t.Errorf("authoritative policy read per data operation: policies=%d data=%d", policies.Load(), len(f.requests))
+			}
+		})
+	}
+}
+
+func TestPRChecksRejectsUnverifiedMetadata(t *testing.T) {
+	for _, scenario := range []string{
+		"check-wrong-head", "check-missing-head", "missing-app", "missing-app-slug", "missing-suite", "zero-suite", "string-suite",
+		"run-wrong-head", "missing-run", "missing-run-suite", "wrong-run-suite", "ambiguous-suite", "missing-workflow-id", "negative-workflow-id",
+		"missing-workflow", "wrong-workflow-id", "duplicate-workflow-id", "missing-workflow-name", "missing-event", "missing-head-ref", "invalid-date",
+	} {
+		t.Run(scenario, func(t *testing.T) {
+			f := newPRChecksFixture()
+			check := f.checks[0].(map[string]any)
+			run := f.runs[0].(map[string]any)
+			workflow := f.workflows[0].(map[string]any)
+			switch scenario {
+			case "check-wrong-head":
+				check["head_sha"] = strings.Repeat("f", 40)
+			case "check-missing-head":
+				delete(check, "head_sha")
+			case "missing-app":
+				delete(check, "app")
+			case "missing-app-slug":
+				check["app"] = map[string]any{"id": 15368}
+			case "missing-suite":
+				delete(check, "check_suite")
+			case "zero-suite":
+				check["check_suite"] = map[string]any{"id": 0}
+			case "string-suite":
+				check["check_suite"] = map[string]any{"id": "201"}
+			case "run-wrong-head":
+				run["head_sha"] = strings.Repeat("f", 40)
+			case "missing-run":
+				f.runs = []any{}
+			case "missing-run-suite":
+				delete(run, "check_suite_id")
+			case "wrong-run-suite":
+				run["check_suite_id"] = 202
+			case "ambiguous-suite":
+				f.runs = append(f.runs, map[string]any{"id": 302, "check_suite_id": 201, "workflow_id": 402, "head_sha": metadataHead, "name": "conflict", "event": "push"})
+				f.workflows = append(f.workflows, map[string]any{"id": 402, "name": "Other", "state": "active", "path": ".github/workflows/other.yml"})
+			case "missing-workflow-id":
+				delete(run, "workflow_id")
+			case "negative-workflow-id":
+				run["workflow_id"] = -1
+			case "missing-workflow":
+				f.workflows = []any{}
+			case "wrong-workflow-id":
+				workflow["id"] = 402
+			case "duplicate-workflow-id":
+				f.workflows = append(f.workflows, workflow)
+			case "missing-workflow-name":
+				delete(workflow, "name")
+			case "missing-event":
+				delete(run, "event")
+			case "missing-head-ref":
+				delete(f.head, "ref")
+			case "invalid-date":
+				check["started_at"] = "not-a-timestamp"
+			}
+			relayTestServer(t, func(r map[string]any) any { return f.response(t, r) })
+			var out bytes.Buffer
+			err := relayPRChecks(t.Context(), &out, "acme/repo", "7", ghTopOptions{json: []string{"name", "workflow"}})
+			if !isLocalFallback(err) || out.Len() != 0 {
+				t.Fatalf("unverified metadata must refuse projection via typed fallback: err=%v output=%q", err, out.String())
+			}
+		})
+	}
+}
+
+func TestPRChecksMetadataGuardedFallback(t *testing.T) {
+	for _, policy := range []string{rewriteEmptyTestPolicy, rewriteActiveTestPolicy} {
+		for _, noFallback := range []string{"", "1"} {
+			t.Run(fmt.Sprintf("active=%t/no-fallback=%s", policy == rewriteActiveTestPolicy, noFallback), func(t *testing.T) {
+				f := newPRChecksFixture()
+				f.workflows = []any{}
+				_, policies := rewriteTestServer(t, policy, func(w http.ResponseWriter, r *http.Request) {
+					writeCLIEnvelope(t, w, f.response(t, decodeCLIRequest(t, w, r)))
+				})
+				t.Setenv("OCTOPOOL_NO_FALLBACK", noFallback)
+				capture := captureRewriteGH(t)
+				var out, stderr bytes.Buffer
+				err := runGH(t.Context(), []string{"pr", "checks", "7", "-R", "acme/repo", "--json", "name"}, &out, &stderr)
+				if noFallback != "" {
+					if !isLocalFallback(err) || out.Len() != 0 {
+						t.Errorf("NO_FALLBACK lost: err=%v output=%q", err, out.String())
+					}
+					if _, e := os.Stat(capture); !os.IsNotExist(e) {
+						t.Error("forbidden child ran")
+					}
+				} else {
+					if err != nil || out.String() != "child stdout\n" {
+						t.Fatalf("fallback must precede all projected output: err=%v output=%q", err, out.String())
+					}
+					child := readRewriteCapture(t, capture)
+					if policy == rewriteActiveTestPolicy && (child.Env["GH_HOST"] != "github.com" || !strings.Contains(strings.Join(child.Args, " "), "--repo=acme/repo")) {
+						t.Errorf("guarded child lost host/repo pin: %+v", child)
+					}
+					if policies.Load() != int64(2+len(f.requests)) {
+						t.Errorf("fallback must reread policy: policies=%d data=%d", policies.Load(), len(f.requests))
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestPRChecksMetadataPolicyRefresh(t *testing.T) {
+	for _, stage := range []string{"before-runs", "before-catalogue", "before-catalogue-page-2", "before-fallback"} {
+		t.Run(stage, func(t *testing.T) {
+			f := newPRChecksFixture()
+			if stage == "before-catalogue-page-2" {
+				for i := 0; i < 100; i++ {
+					f.workflows = append(f.workflows, map[string]any{"id": 500 + i, "name": "other", "state": "active", "path": ".github/workflows/other.yml"})
+				}
+			}
+			var replacePolicy func()
+			policy, _ := rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+				req := decodeCLIRequest(t, w, r)
+				path := req["path"].(string)
+				body := f.response(t, req)
+				if stage == "before-runs" && strings.HasSuffix(path, "/status") || stage == "before-catalogue" && strings.HasSuffix(path, "/actions/runs") || stage == "before-catalogue-page-2" && strings.HasSuffix(path, "/actions/workflows") && f.calls("/actions/workflows") == 1 || stage == "before-fallback" && strings.HasSuffix(path, "/actions/workflows") {
+					replacePolicy()
+					if stage == "before-fallback" {
+						body = map[string]any{"total_count": 0, "workflows": []any{}}
+					}
+				}
+				writeCLIEnvelope(t, w, body)
+			})
+			replacePolicy = func() {
+				policy.Store(`{"schema_version":1,"revision":2,"updated_at":"2026-09-01T00:00:00Z","rules":[{"pattern":"acme","replacement":"blocked"}]}`)
+			}
+			capture := captureRewriteGH(t)
+			var out bytes.Buffer
+			err := runGH(t.Context(), []string{"pr", "checks", "7", "-R", "acme/repo", "--json", "name"}, &out, io.Discard)
+			if err == nil || out.Len() != 0 {
+				t.Errorf("new authoritative policy must block next lookup/child: err=%v output=%q", err, out.String())
+			}
+			if _, e := os.Stat(capture); !os.IsNotExist(e) {
+				t.Error("forbidden native child ran")
+			}
+			wantRuns, wantCatalogue := 1, 0
+			if stage == "before-runs" {
+				wantRuns = 0
+			}
+			if stage == "before-catalogue-page-2" || stage == "before-fallback" {
+				wantCatalogue = 1
+			}
+			if f.calls("/actions/runs") != wantRuns || f.calls("/actions/workflows") != wantCatalogue {
+				t.Errorf("policy-boundary requests runs=%d catalogue=%d", f.calls("/actions/runs"), f.calls("/actions/workflows"))
+			}
+		})
 	}
 }

--- a/cmd/octopool/gh_top_pr_test.go
+++ b/cmd/octopool/gh_top_pr_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"io"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -65,6 +68,183 @@ func TestRunGHPRViewHydratesDetails(t *testing.T) {
 	}
 }
 
+func TestPRChecksNativeStatesAndPrecedence(t *testing.T) {
+	t.Run("native-expected-bucket", func(t *testing.T) {
+		// EXPECTED is a native GraphQL state, not a REST status fixture.
+		if got := ghCheckBucket("EXPECTED"); got != "pending" {
+			t.Fatalf("native EXPECTED bucket=%q, want pending", got)
+		}
+	})
+	for _, row := range []struct{ status, conclusion, bucket string }{
+		{"completed", "success", "pass"}, {"completed", "neutral", "skipping"},
+		{"completed", "skipped", "skipping"}, {"completed", "cancelled", "cancel"},
+		{"completed", "failure", "fail"}, {"completed", "error", "fail"},
+		{"completed", "timed_out", "fail"}, {"completed", "action_required", "fail"},
+		{"queued", "", "pending"}, {"in_progress", "", "pending"}, {"pending", "", "pending"},
+		{"requested", "", "pending"}, {"waiting", "", "pending"},
+		{"completed", "stale", "pending"}, {"completed", "startup_failure", "pending"},
+	} {
+		t.Run(row.status+"/"+row.conclusion, func(t *testing.T) {
+			f := newPRChecksFixture()
+			f.checks = []any{prChecksCheck(1, "unit", row.status, row.conclusion)}
+			if row.conclusion == "error" {
+				f.checks = []any{}
+				f.statuses = []any{map[string]any{"id": 1, "context": "unit", "state": "error", "target_url": "https://example.test/status", "created_at": "2026-09-01T00:00:00Z", "description": "legacy"}}
+			}
+			relayTestServer(t, func(r map[string]any) any { return f.response(t, r) })
+			var out bytes.Buffer
+			err := relayPRChecks(t.Context(), &out, "acme/repo", "7", ghTopOptions{json: []string{"state", "bucket"}})
+			var got []map[string]any
+			if e := json.Unmarshal(out.Bytes(), &got); e != nil {
+				t.Fatal(e)
+			}
+			state := row.conclusion
+			if row.status != "completed" {
+				state = row.status
+			}
+			want := []map[string]any{{"state": strings.ToUpper(state), "bucket": row.bucket}}
+			if err != nil || !reflect.DeepEqual(got, want) {
+				t.Fatalf("native state/export: err=%v got=%v want=%v", err, got, want)
+			}
+		})
+	}
+	for _, row := range []struct {
+		name        string
+		conclusions []string
+		exit        int
+	}{
+		{"failure-before-pending", []string{"failure", "stale"}, 1},
+		{"failure-after-pending", []string{"stale", "failure"}, 1},
+		{"cancel-and-pending", []string{"cancelled", "stale"}, 8},
+		{"cancel-and-skipping", []string{"cancelled", "neutral", "skipped"}, 0},
+	} {
+		t.Run(row.name, func(t *testing.T) {
+			f := newPRChecksFixture()
+			f.checks = []any{}
+			for i, conclusion := range row.conclusions {
+				f.checks = append(f.checks, prChecksCheck(int64(i+1), conclusion, "completed", conclusion))
+			}
+			relayTestServer(t, func(r map[string]any) any { return f.response(t, r) })
+			var out bytes.Buffer
+			err := relayPRChecks(t.Context(), &out, "acme/repo", "7", ghTopOptions{})
+			if row.exit == 0 {
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				assertExitCode(t, err, row.exit)
+			}
+		})
+	}
+}
+
+func TestPRChecksNativeTypedFields(t *testing.T) {
+	f := newPRChecksFixture()
+	check := prChecksCheck(1, "unit", "completed", "success")
+	check["app"] = map[string]any{"id": 999, "slug": "third-party"}
+	check["started_at"], check["completed_at"] = nil, nil
+	check["output"] = map[string]any{"title": "job", "summary": "must not become a description"}
+	f.checks = []any{check}
+	f.statuses = []any{map[string]any{"id": 2, "context": "external", "state": "success", "description": "external result", "target_url": "https://example.test/status", "created_at": "2026-08-31T01:00:00Z", "updated_at": "2026-09-01T02:00:00Z"}}
+	for _, mode := range []string{"all-fields", "subset", "jq", "raw-control"} {
+		t.Run(mode, func(t *testing.T) {
+			relayTestServer(t, func(r map[string]any) any { return f.response(t, r) })
+			var out bytes.Buffer
+			fields := "name,state,bucket,startedAt,completedAt,description,link,event,workflow"
+			args := []string{"pr", "checks", "7", "-R", "acme/repo", "--json", fields}
+			if mode == "subset" {
+				args[6] = "name,description,startedAt"
+			}
+			if mode == "jq" {
+				args = append(args, "--jq", `map(.description) | join("|")`)
+			}
+			if mode == "raw-control" {
+				args = []string{"api", "repos/acme/repo/commits/" + metadataHead + "/check-runs?per_page=100&page=1"}
+			}
+			err := runGH(t.Context(), args, &out, io.Discard)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if mode == "raw-control" {
+				if !strings.Contains(out.String(), "must not become a description") || !strings.Contains(out.String(), `"started_at":null`) {
+					t.Fatalf("raw API changed: %s", out.String())
+				}
+				return
+			}
+			if mode == "jq" {
+				if out.String() != "|external result\n" {
+					t.Fatalf("descriptions=%q", out.String())
+				}
+				return
+			}
+			var got []map[string]any
+			if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			want := []map[string]any{
+				{"name": "unit", "state": "SUCCESS", "bucket": "pass", "startedAt": "0001-01-01T00:00:00Z", "completedAt": "0001-01-01T00:00:00Z", "description": "", "link": check["details_url"], "event": "", "workflow": ""},
+				{"name": "external", "state": "SUCCESS", "bucket": "pass", "startedAt": "0001-01-01T00:00:00Z", "completedAt": "0001-01-01T00:00:00Z", "description": "external result", "link": "https://example.test/status", "event": "", "workflow": ""},
+			}
+			if mode == "subset" {
+				for _, item := range want {
+					for key := range item {
+						if key != "name" && key != "description" && key != "startedAt" {
+							delete(item, key)
+						}
+					}
+				}
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("typed check/status fields: got=%s want=%v", out.String(), want)
+			}
+		})
+	}
+	for _, row := range []struct {
+		name               string
+		start, end         any
+		wantStart, wantEnd string
+	}{
+		{"offset-fraction", "2026-09-01T01:00:00.1200+02:30", "2026-09-01T01:00:01.6200+02:30", "2026-09-01T01:00:00.12+02:30", "2026-09-01T01:00:01.62+02:30"},
+		{"null-strings", nil, nil, "0001-01-01T00:00:00Z", "0001-01-01T00:00:00Z"},
+	} {
+		t.Run(row.name, func(t *testing.T) {
+			f := newPRChecksFixture()
+			c := f.checks[0].(map[string]any)
+			c["app"] = map[string]any{"id": 999, "slug": "third-party"}
+			c["started_at"], c["completed_at"] = row.start, row.end
+			c["details_url"] = nil
+			relayTestServer(t, func(r map[string]any) any { return f.response(t, r) })
+			var out bytes.Buffer
+			if err := relayPRChecks(t.Context(), &out, "acme/repo", "7", ghTopOptions{json: []string{"startedAt", "completedAt", "description", "link", "event", "workflow"}}); err != nil {
+				t.Fatal(err)
+			}
+			var got []map[string]any
+			if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			want := []map[string]any{{"startedAt": row.wantStart, "completedAt": row.wantEnd, "description": "", "link": "", "event": "", "workflow": ""}}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("typed times/null strings got=%s want=%v", out.String(), want)
+			}
+		})
+	}
+}
+
+type prChecksBrokenWriter struct{ err error }
+
+func (w prChecksBrokenWriter) Write([]byte) (int, error) { return 0, w.err }
+
+func TestPRChecksOutputWriteFailure(t *testing.T) {
+	f := newPRChecksFixture()
+	relayTestServer(t, func(r map[string]any) any { return f.response(t, r) })
+	want := errors.New("synthetic output closed")
+	for _, fields := range [][]string{nil, {"name"}} {
+		if err := relayPRChecks(t.Context(), prChecksBrokenWriter{want}, "acme/repo", "7", ghTopOptions{json: fields}); !errors.Is(err, want) {
+			t.Fatalf("write failure=%v", err)
+		}
+	}
+}
+
 func TestRunGHPRViewFilesFallsBackWhenHeadMoves(t *testing.T) {
 	prCalls := 0
 	relayTestServer(t, func(body map[string]any) any {
@@ -113,9 +293,9 @@ func TestRunGHPRChecksUsesCacheableRequests(t *testing.T) {
 		}
 		switch body["path"] {
 		case "/repos/openclaw/octopool/pulls/7":
-			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+			return map[string]any{"head": map[string]any{"sha": "abc1234", "ref": "feature"}}
 		case "/repos/openclaw/octopool/commits/abc1234/check-runs":
-			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "name": "CI", "status": "completed", "conclusion": "success"}}}
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "head_sha": "abc1234", "app": map[string]any{"id": 999, "slug": "third-party"}, "check_suite": map[string]any{"id": 201}, "name": "CI", "status": "completed", "conclusion": "success"}}}
 		case "/repos/openclaw/octopool/commits/abc1234/status":
 			return map[string]any{"total_count": 0, "statuses": []map[string]any{}}
 		default:
@@ -147,8 +327,47 @@ func TestStatusItemsMapLegacyContexts(t *testing.T) {
 	if len(items) != 1 {
 		t.Fatalf("items = %#v", items)
 	}
-	item := items[0].(map[string]any)
-	if item["name"] != "ci/external" || item["conclusion"] != "success" || item["details_url"] != "https://example.test" {
+	item, err := normalizePRCheck(items[0], nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if item.Name != "ci/external" || item.State != "SUCCESS" || item.Link != "https://example.test" {
 		t.Fatalf("item = %#v", item)
+	}
+}
+
+func TestPRChecksEligibilityControls(t *testing.T) {
+	for _, row := range []struct {
+		name string
+		args []string
+	}{
+		{"required", []string{"checks", "7", "-R", "acme/repo", "--required", "--json", "name"}},
+		{"unsupported-field", []string{"checks", "7", "-R", "acme/repo", "--json", "name,databaseId"}},
+		{"template", []string{"checks", "7", "-R", "acme/repo", "--template", "{{.}}"}},
+		{"watch-json", []string{"checks", "7", "-R", "acme/repo", "--watch", "--json", "name"}},
+		{"missing-jq", []string{"checks", "7", "-R", "acme/repo", "--json", "name", "--jq", "."}},
+	} {
+		t.Run(row.name, func(t *testing.T) {
+			relayTestServer(t, func(map[string]any) any { t.Error("delegated shape contacted data relay"); return nil })
+			if row.name == "missing-jq" {
+				t.Setenv("PATH", t.TempDir())
+			}
+			var out bytes.Buffer
+			result := handleGHPR(t.Context(), row.args, &out)
+			if result.action != ghDelegate || result.err != nil || out.Len() != 0 {
+				t.Fatalf("eligibility widened: result=%+v output=%q", result, out.String())
+			}
+		})
+	}
+	for _, selector := range []string{"7", "https://github.com/acme/repo/pull/7", "acme/repo#7"} {
+		t.Run(selector, func(t *testing.T) {
+			f := newPRChecksFixture()
+			relayTestServer(t, func(r map[string]any) any { return f.response(t, r) })
+			var out bytes.Buffer
+			result := handleGHPR(t.Context(), []string{"checks", selector, "-R", "acme/repo", "--json", "name"}, &out)
+			if result.action != ghComplete || result.err != nil || out.String() != "[{\"name\":\"unit\"}]\n" {
+				t.Fatalf("selector changed: %+v output=%q", result, out.String())
+			}
+		})
 	}
 }

--- a/cmd/octopool/gh_top_watch.go
+++ b/cmd/octopool/gh_top_watch.go
@@ -436,11 +436,11 @@ func relayPRChecksWatch(ctx context.Context, stdout io.Writer, opts ghPRChecksWa
 	previousCounts := ""
 	progressPrinted := false
 	for {
-		var items []any
-		var sha string
+		var items []prCheckRow
+		var head prCheckHead
 		err := retryWatchTick(ctx, &backoff, func() error {
 			var pollErr error
-			items, sha, pollErr = relayPRCheckItemsWithSHA(ctx, client, opts.repo, opts.number)
+			items, head, pollErr = relayPRCheckItemsWithHead(ctx, client, opts.repo, opts.number)
 			return pollErr
 		})
 		if err != nil {
@@ -451,22 +451,22 @@ func relayPRChecksWatch(ctx context.Context, stdout io.Writer, opts ghPRChecksWa
 		// fresh sweep first; genuinely empty results error like real gh.
 		if len(items) == 0 {
 			err := retryWatchTick(ctx, &backoff, func() error {
-				current, freshErr := relayPRHeadSHA(ctx, client, opts.repo, opts.number, 0)
+				current, freshErr := relayPRChecksHead(ctx, client, opts.repo, opts.number, 0)
 				if freshErr != nil {
 					return freshErr
 				}
-				freshItems, freshErr := prCheckItemsForSHAFresh(ctx, client, opts.repo, current)
+				freshItems, freshErr := prCheckItemsForSHAFresh(ctx, client, opts.repo, current.SHA)
 				if freshErr != nil {
 					return freshErr
 				}
-				items, sha = freshItems, current
+				items, head = freshItems, current
 				return nil
 			})
 			if err != nil {
 				return watchError(err, progressPrinted)
 			}
 			if len(items) == 0 {
-				return fmt.Errorf("no checks reported on pull request #%s", opts.number)
+				return prChecksEmptyError{head: head}
 			}
 		}
 		pending, passing, failing, cancelled := checkWatchCounts(items)
@@ -485,11 +485,11 @@ func relayPRChecksWatch(ctx context.Context, stdout io.Writer, opts ghPRChecksWa
 			// before the watch (new head SHA) or a check rerun (same SHA, cached
 			// terminal payloads) could otherwise finalize on obsolete results.
 			// One fresh sweep per exit attempt.
-			var final []any
+			var final []prCheckRow
 			var confirmed bool
 			err := retryWatchTick(ctx, &backoff, func() error {
 				var confirmErr error
-				final, confirmed, confirmErr = confirmPRChecksTerminal(ctx, client, opts, sha)
+				final, confirmed, confirmErr = confirmPRChecksTerminal(ctx, client, opts, head.SHA)
 				return confirmErr
 			})
 			if err != nil {
@@ -513,37 +513,42 @@ func confirmPRChecksTerminal(
 	client ghRelayClient,
 	opts ghPRChecksWatchOptions,
 	sha string,
-) ([]any, bool, error) {
-	current, err := relayPRHeadSHA(ctx, client, opts.repo, opts.number, 0)
+) ([]prCheckRow, bool, error) {
+	current, err := relayPRChecksHead(ctx, client, opts.repo, opts.number, 0)
 	if err != nil {
 		return nil, false, err
 	}
-	if current != sha {
+	if current.SHA != sha {
 		return nil, false, nil
 	}
-	items, err := prCheckItemsForSHAFresh(ctx, client, opts.repo, current)
+	items, err := prCheckItemsForSHAFresh(ctx, client, opts.repo, current.SHA)
 	if err != nil {
 		return nil, false, err
 	}
 	// A fresh empty set after a terminal-looking cached snapshot is an
 	// anomaly (rerun re-registration, data lag) — never confirm it as green.
 	if len(items) == 0 {
-		return nil, false, fmt.Errorf("no checks reported on pull request #%s", opts.number)
+		return nil, false, prChecksEmptyError{head: current}
 	}
 	pending, _, failing, _ := checkWatchCounts(items)
-	if pending == 0 || opts.failFast && failing > 0 {
-		return items, true, nil
+	if pending != 0 && !(opts.failFast && failing > 0) {
+		return nil, false, nil
 	}
-	return nil, false, nil
+	// The head can move while context or workflow pages are being hydrated.
+	// A matching head closes that window, not same-commit status races.
+	finalHead, err := relayPRChecksHead(ctx, client, opts.repo, opts.number, 0)
+	if err != nil {
+		return nil, false, err
+	}
+	if finalHead.SHA != current.SHA {
+		return nil, false, nil
+	}
+	return items, true, nil
 }
 
-func checkWatchCounts(items []any) (pending int, passing int, failing int, cancelled int) {
-	for _, raw := range items {
-		item, ok := raw.(map[string]any)
-		if !ok {
-			continue
-		}
-		switch watchCheckBucket(item) {
+func checkWatchCounts(items []prCheckRow) (pending int, passing int, failing int, cancelled int) {
+	for _, item := range items {
+		switch item.Bucket {
 		case "pass", "skipping":
 			passing++
 		case "fail":
@@ -557,25 +562,9 @@ func checkWatchCounts(items []any) (pending int, passing int, failing int, cance
 	return pending, passing, failing, cancelled
 }
 
-func watchCheckBucket(item map[string]any) string {
-	bucket := strings.ToLower(firstString(item, "bucket"))
-	if bucket != "" {
-		return bucket
-	}
-	state := strings.ToLower(firstString(item, "state"))
-	if state == "success" || state == "neutral" {
-		return "pass"
-	}
-	return "pending"
-}
-
-func printPRChecksWatchFinal(stdout io.Writer, items []any) error {
-	for _, raw := range items {
-		item, ok := raw.(map[string]any)
-		if !ok {
-			continue
-		}
-		if _, err := fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\n", watchSafeText(firstString(item, "name")), firstString(item, "bucket"), watchSafeText(firstString(item, "state")), watchSafeText(firstString(item, "link"))); err != nil {
+func printPRChecksWatchFinal(stdout io.Writer, items []prCheckRow) error {
+	for _, item := range items {
+		if _, err := fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\n", watchSafeText(item.Name), item.Bucket, watchSafeText(item.State), watchSafeText(item.Link)); err != nil {
 			return err
 		}
 	}

--- a/cmd/octopool/gh_top_watch_test.go
+++ b/cmd/octopool/gh_top_watch_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -138,7 +139,7 @@ func TestGHPRChecksWatchPendingToDone(t *testing.T) {
 	relayTestServer(t, func(body map[string]any) any {
 		switch body["path"] {
 		case "/repos/openclaw/octopool/pulls/7":
-			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+			return map[string]any{"head": map[string]any{"sha": "abc1234", "ref": "feature"}}
 		case "/repos/openclaw/octopool/commits/abc1234/check-runs":
 			checkCalls++
 			status := "in_progress"
@@ -150,8 +151,8 @@ func TestGHPRChecksWatchPendingToDone(t *testing.T) {
 			return map[string]any{
 				"total_count": 2,
 				"check_runs": []map[string]any{
-					{"id": 1, "name": "CI", "status": status, "conclusion": conclusion, "details_url": "https://example.test/ci"},
-					{"id": 2, "name": "Lint", "status": "completed", "conclusion": "success", "details_url": "https://example.test/lint"},
+					{"id": 1, "head_sha": "abc1234", "app": map[string]any{"id": 999, "slug": "third-party"}, "check_suite": map[string]any{"id": 201}, "name": "CI", "status": status, "conclusion": conclusion, "details_url": "https://example.test/ci"},
+					{"id": 2, "head_sha": "abc1234", "app": map[string]any{"id": 999, "slug": "third-party"}, "check_suite": map[string]any{"id": 202}, "name": "Lint", "status": "completed", "conclusion": "success", "details_url": "https://example.test/lint"},
 				},
 			}
 		case "/repos/openclaw/octopool/commits/abc1234/status":
@@ -186,12 +187,12 @@ func TestGHPRChecksWatchFailFast(t *testing.T) {
 	relayTestServer(t, func(body map[string]any) any {
 		switch body["path"] {
 		case "/repos/openclaw/octopool/pulls/7":
-			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+			return map[string]any{"head": map[string]any{"sha": "abc1234", "ref": "feature"}}
 		case "/repos/openclaw/octopool/commits/abc1234/check-runs":
 			checkCalls++
 			return map[string]any{"total_count": 2, "check_runs": []map[string]any{
-				{"id": 1, "name": "CI", "status": "completed", "conclusion": "failure"},
-				{"id": 2, "name": "Integration", "status": "queued"},
+				{"id": 1, "head_sha": "abc1234", "app": map[string]any{"id": 999, "slug": "third-party"}, "check_suite": map[string]any{"id": 201}, "name": "CI", "status": "completed", "conclusion": "failure"},
+				{"id": 2, "head_sha": "abc1234", "app": map[string]any{"id": 999, "slug": "third-party"}, "check_suite": map[string]any{"id": 202}, "name": "Integration", "status": "queued"},
 			}}
 		case "/repos/openclaw/octopool/commits/abc1234/status":
 			return map[string]any{"total_count": 0, "statuses": []any{}}
@@ -218,7 +219,7 @@ func TestGHPRChecksWatchFailFastIgnoresCancelled(t *testing.T) {
 	relayTestServer(t, func(body map[string]any) any {
 		switch body["path"] {
 		case "/repos/openclaw/octopool/pulls/7":
-			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+			return map[string]any{"head": map[string]any{"sha": "abc1234", "ref": "feature"}}
 		case "/repos/openclaw/octopool/commits/abc1234/check-runs":
 			checkCalls++
 			pendingStatus := "queued"
@@ -227,8 +228,8 @@ func TestGHPRChecksWatchFailFastIgnoresCancelled(t *testing.T) {
 				pendingStatus, pendingConclusion = "completed", "success"
 			}
 			return map[string]any{"total_count": 2, "check_runs": []map[string]any{
-				{"id": 1, "name": "CI", "status": "completed", "conclusion": "cancelled"},
-				{"id": 2, "name": "Integration", "status": pendingStatus, "conclusion": pendingConclusion},
+				{"id": 1, "head_sha": "abc1234", "app": map[string]any{"id": 999, "slug": "third-party"}, "check_suite": map[string]any{"id": 201}, "name": "CI", "status": "completed", "conclusion": "cancelled"},
+				{"id": 2, "head_sha": "abc1234", "app": map[string]any{"id": 999, "slug": "third-party"}, "check_suite": map[string]any{"id": 202}, "name": "Integration", "status": pendingStatus, "conclusion": pendingConclusion},
 			}}
 		case "/repos/openclaw/octopool/commits/abc1234/status":
 			return map[string]any{"total_count": 0, "statuses": []any{}}
@@ -255,7 +256,7 @@ func TestGHPRChecksWatchErrorsOnNoChecks(t *testing.T) {
 	relayTestServer(t, func(body map[string]any) any {
 		switch body["path"] {
 		case "/repos/openclaw/octopool/pulls/7":
-			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+			return map[string]any{"head": map[string]any{"sha": "abc1234", "ref": "feature"}}
 		case "/repos/openclaw/octopool/commits/abc1234/check-runs":
 			return map[string]any{"total_count": 0, "check_runs": []any{}}
 		case "/repos/openclaw/octopool/commits/abc1234/status":
@@ -277,14 +278,14 @@ func TestGHPRChecksWatchCachedEmptyRevalidatesFresh(t *testing.T) {
 	relayTestServer(t, func(body map[string]any) any {
 		switch path := body["path"].(string); {
 		case path == "/repos/openclaw/octopool/pulls/7":
-			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+			return map[string]any{"head": map[string]any{"sha": "abc1234", "ref": "feature"}}
 		case strings.HasSuffix(path, "/check-runs"):
 			h, _ := body["headers"].(map[string]any)
 			if h["cache-control"] != "max-age=0" {
 				// Stale shared-cache entry from before checks registered.
 				return map[string]any{"total_count": 0, "check_runs": []any{}}
 			}
-			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "name": "CI", "status": "completed", "conclusion": "success"}}}
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "head_sha": "abc1234", "app": map[string]any{"id": 999, "slug": "third-party"}, "check_suite": map[string]any{"id": 201}, "name": "CI", "status": "completed", "conclusion": "success"}}}
 		case strings.HasSuffix(path, "/status"):
 			return map[string]any{"total_count": 0, "statuses": []any{}}
 		default:
@@ -307,14 +308,14 @@ func TestGHPRChecksWatchFreshEmptyTerminalIsNotGreen(t *testing.T) {
 	relayTestServer(t, func(body map[string]any) any {
 		switch path := body["path"].(string); {
 		case path == "/repos/openclaw/octopool/pulls/7":
-			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+			return map[string]any{"head": map[string]any{"sha": "abc1234", "ref": "feature"}}
 		case strings.HasSuffix(path, "/check-runs"):
 			h, _ := body["headers"].(map[string]any)
 			if h["cache-control"] == "max-age=0" {
 				// Terminal confirmation sees the checks vanish (rerun lag).
 				return map[string]any{"total_count": 0, "check_runs": []any{}}
 			}
-			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "name": "CI", "status": "completed", "conclusion": "success"}}}
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "head_sha": "abc1234", "app": map[string]any{"id": 999, "slug": "third-party"}, "check_suite": map[string]any{"id": 201}, "name": "CI", "status": "completed", "conclusion": "success"}}}
 		case strings.HasSuffix(path, "/status"):
 			return map[string]any{"total_count": 0, "statuses": []any{}}
 		default:
@@ -361,9 +362,9 @@ func TestGHPRChecksWatchEqualsTrueSpelling(t *testing.T) {
 	relayTestServer(t, func(body map[string]any) any {
 		switch body["path"] {
 		case "/repos/openclaw/octopool/pulls/7":
-			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+			return map[string]any{"head": map[string]any{"sha": "abc1234", "ref": "feature"}}
 		case "/repos/openclaw/octopool/commits/abc1234/check-runs":
-			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "name": "CI", "status": "completed", "conclusion": "success"}}}
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "head_sha": "abc1234", "app": map[string]any{"id": 999, "slug": "third-party"}, "check_suite": map[string]any{"id": 201}, "name": "CI", "status": "completed", "conclusion": "success"}}}
 		case "/repos/openclaw/octopool/commits/abc1234/status":
 			return map[string]any{"total_count": 0, "statuses": []any{}}
 		default:
@@ -415,17 +416,17 @@ func TestGHPRChecksWatchRevalidatesHeadBeforeTerminal(t *testing.T) {
 		case path == "/repos/openclaw/octopool/pulls/7":
 			headers, _ := body["headers"].(map[string]any)
 			if headers["cache-control"] == "max-age=0" {
-				return map[string]any{"head": map[string]any{"sha": "newsha"}}
+				return map[string]any{"head": map[string]any{"sha": "newsha", "ref": "feature"}}
 			}
 			sha := "oldsha"
 			if len(checkFetches) > 0 {
 				sha = "newsha"
 			}
-			return map[string]any{"head": map[string]any{"sha": sha}}
+			return map[string]any{"head": map[string]any{"sha": sha, "ref": "feature"}}
 		case strings.HasSuffix(path, "/check-runs"):
 			sha := strings.Split(path, "/")[5]
 			checkFetches = append(checkFetches, sha)
-			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "name": "CI", "status": "completed", "conclusion": "success"}}}
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "head_sha": sha, "app": map[string]any{"id": 999, "slug": "third-party"}, "check_suite": map[string]any{"id": 201}, "name": "CI", "status": "completed", "conclusion": "success"}}}
 		case strings.HasSuffix(path, "/status"):
 			return map[string]any{"total_count": 0, "statuses": []any{}}
 		default:
@@ -493,16 +494,16 @@ func TestGHPRChecksWatchConfirmsRerunSameHead(t *testing.T) {
 	relayTestServer(t, func(body map[string]any) any {
 		switch path := body["path"].(string); {
 		case path == "/repos/openclaw/octopool/pulls/7":
-			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+			return map[string]any{"head": map[string]any{"sha": "abc1234", "ref": "feature"}}
 		case strings.HasSuffix(path, "/check-runs"):
 			if h, _ := body["headers"].(map[string]any); h["cache-control"] == "max-age=0" {
 				freshCheckReads++
 				if freshCheckReads == 1 {
 					// Rerun in flight: same head SHA, cached payload obsolete.
-					return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "name": "CI", "status": "in_progress"}}}
+					return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "head_sha": "abc1234", "app": map[string]any{"id": 999, "slug": "third-party"}, "check_suite": map[string]any{"id": 201}, "name": "CI", "status": "in_progress"}}}
 				}
 			}
-			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "name": "CI", "status": "completed", "conclusion": "success"}}}
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "head_sha": "abc1234", "app": map[string]any{"id": 999, "slug": "third-party"}, "check_suite": map[string]any{"id": 201}, "name": "CI", "status": "completed", "conclusion": "success"}}}
 		case strings.HasSuffix(path, "/status"):
 			return map[string]any{"total_count": 0, "statuses": []any{}}
 		default:
@@ -775,9 +776,9 @@ func TestGHPRChecksWatchAuthFailureDoesNotHandoff(t *testing.T) {
 					Code: "invalid_auth", Message: "Invalid caller token",
 				})
 			}
-			return map[string]any{"head": map[string]any{"sha": "abc1234"}}
+			return map[string]any{"head": map[string]any{"sha": "abc1234", "ref": "feature"}}
 		case strings.HasSuffix(path, "/check-runs"):
-			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "name": "CI", "status": "completed", "conclusion": "success"}}}
+			return map[string]any{"total_count": 1, "check_runs": []map[string]any{{"id": 1, "head_sha": "abc1234", "app": map[string]any{"id": 999, "slug": "third-party"}, "check_suite": map[string]any{"id": 201}, "name": "CI", "status": "completed", "conclusion": "success"}}}
 		case strings.HasSuffix(path, "/status"):
 			return map[string]any{"total_count": 0, "statuses": []any{}}
 		default:
@@ -822,5 +823,170 @@ func assertExitCode(t *testing.T, err error, code int) {
 	var exit exitCodeError
 	if !errors.As(err, &exit) || exit.Code != code {
 		t.Fatalf("err=%v, want exit code %d", err, code)
+	}
+}
+
+func TestPRChecksFreshMetadataPagesAndMaps(t *testing.T) {
+	f := newPRChecksFixture()
+	for i := 0; i < 100; i++ {
+		f.runs = append(f.runs, map[string]any{"id": 1000 + i, "head_sha": metadataHead, "check_suite_id": 1000 + i, "workflow_id": 401, "name": "wrong", "event": "push"})
+		f.workflows = append(f.workflows, map[string]any{"id": 1000 + i, "name": "unrelated", "state": "active", "path": ".github/workflows/other.yml"})
+	}
+	generation := 0
+	relayTestServer(t, func(r map[string]any) any {
+		headers, _ := r["headers"].(map[string]any)
+		if headers["cache-control"] != "max-age=0" {
+			t.Errorf("fresh acquisition page must bypass cache: %v", r)
+		}
+		f.runs[0].(map[string]any)["event"] = []string{"push", "pull_request"}[generation]
+		f.workflows[0].(map[string]any)["name"] = []string{"Old CI", "New CI"}[generation]
+		return f.response(t, r)
+	})
+	client, err := newGHRelayClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for generation = 0; generation < 2; generation++ {
+		items, err := prCheckItemsForSHAFresh(t.Context(), client, "acme/repo", metadataHead)
+		if err != nil {
+			t.Fatal(err)
+		}
+		row := items[0]
+		if row.Workflow != []string{"Old CI", "New CI"}[generation] || row.Event != []string{"push", "pull_request"}[generation] {
+			t.Errorf("fresh maps must be acquisition-owned: %v", row)
+		}
+	}
+	if f.calls("/actions/runs") != 4 || f.calls("/actions/workflows") != 4 {
+		t.Errorf("all metadata pages must be reacquired: runs=%d catalogue=%d", f.calls("/actions/runs"), f.calls("/actions/workflows"))
+	}
+}
+
+func TestPRChecksWatchHeadChangesDuringHydration(t *testing.T) {
+	for _, stage := range []string{"contexts", "catalogue"} {
+		t.Run(stage, func(t *testing.T) {
+			f := newPRChecksFixture()
+			relayTestServer(t, func(r map[string]any) any {
+				body := f.response(t, r)
+				path := r["path"].(string)
+				if stage == "contexts" && strings.HasSuffix(path, "/status") || stage == "catalogue" && strings.HasSuffix(path, "/actions/workflows") {
+					f.head = map[string]any{"sha": strings.Repeat("f", 40), "ref": "feature"}
+				}
+				return body
+			})
+			client, err := newGHRelayClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			items, confirmed, err := confirmPRChecksTerminal(t.Context(), client, ghPRChecksWatchOptions{repo: "acme/repo", number: "7"}, metadataHead)
+			if err != nil || confirmed || len(items) != 0 {
+				t.Errorf("head moved during terminal hydration: confirmed=%v items=%d err=%v", confirmed, len(items), err)
+			}
+			if f.calls("/pulls/7") != 2 || f.requests[len(f.requests)-1]["path"] != "/repos/acme/repo/pulls/7" {
+				t.Errorf("terminal hydration needs final live head read: %v", f.requests)
+			}
+			for _, r := range f.requests {
+				h, _ := r["headers"].(map[string]any)
+				if h["cache-control"] != "max-age=0" {
+					t.Errorf("non-fresh confirmation read: %v", r)
+				}
+			}
+		})
+	}
+}
+
+func TestPRChecksWatchMetadataFailureOwnership(t *testing.T) {
+	for _, scenario := range []string{"typed-before", "typed-after", "relay-before", "relay-after", "no-fallback-before", "no-fallback-after"} {
+		t.Run(scenario, func(t *testing.T) {
+			f := newPRChecksFixture()
+			after := strings.HasSuffix(scenario, "after")
+			rewriteTestServer(t, rewriteEmptyTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+				req := decodeCLIRequest(t, w, r)
+				body := f.response(t, req)
+				headers, _ := req["headers"].(map[string]any)
+				if req["path"] == "/repos/acme/repo/actions/workflows" && (!after || headers["cache-control"] == "max-age=0") {
+					if strings.HasPrefix(scenario, "typed") {
+						body = map[string]any{"total_count": 0, "workflows": []any{}}
+					} else {
+						writeCLIFallback(t, w, "repo_not_public")
+						return
+					}
+				}
+				writeCLIEnvelope(t, w, body)
+			})
+			capture := captureRewriteGH(t)
+			t.Setenv("OCTOPOOL_NO_FALLBACK", "")
+			if strings.HasPrefix(scenario, "no-fallback") {
+				t.Setenv("OCTOPOOL_NO_FALLBACK", "1")
+			}
+			var out, stderr bytes.Buffer
+			err := runGH(t.Context(), []string{"pr", "checks", "7", "-R", "acme/repo", "--watch"}, &out, &stderr)
+			childAllowed := scenario == "typed-before" || strings.HasPrefix(scenario, "relay")
+			if childAllowed {
+				if err != nil || strings.Count(out.String(), "child stdout\n") != 1 {
+					t.Fatalf("one guarded child expected: err=%v out=%q stderr=%q", err, out.String(), stderr.String())
+				}
+				if _, e := os.Stat(capture); e != nil {
+					t.Error("missing child capture")
+				}
+				boundary := "falling back to real gh"
+				if after {
+					boundary = "continuing watch with real gh"
+				}
+				if strings.Count(stderr.String(), boundary) != 1 {
+					t.Errorf("one fallback boundary: %q", stderr.String())
+				}
+			} else {
+				if err == nil || strings.Contains(out.String(), "child stdout") || strings.Contains(out.String(), "unit\t") || strings.Contains(stderr.String(), "real gh") {
+					t.Errorf("no final output/handoff after client failure or NO_FALLBACK: err=%v out=%q stderr=%q", err, out.String(), stderr.String())
+				}
+				if _, e := os.Stat(capture); !os.IsNotExist(e) {
+					t.Error("forbidden native child ran")
+				}
+				if after && isLocalFallback(err) && !strings.HasPrefix(scenario, "no-fallback") {
+					t.Errorf("client failure after progress retained fallback type: %v", err)
+				}
+			}
+			if after != strings.Contains(out.String(), "checks:") {
+				t.Errorf("progress ownership: after=%v out=%q", after, out.String())
+			}
+		})
+	}
+}
+
+func TestPRChecksWatchActivePolicyDelegatesBeforeHandler(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("active-policy watch must retain pre-handler delegation")
+		w.WriteHeader(400)
+	})
+	capture := captureRewriteGH(t)
+	var out, stderr bytes.Buffer
+	if err := runGH(t.Context(), []string{"pr", "checks", "7", "-R", "acme/repo", "--watch", "--interval", "1"}, &out, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	if out.String() != "child stdout\n" {
+		t.Fatalf("output=%q", out.String())
+	}
+	if _, err := os.Stat(capture); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPRChecksWatchStaleRemainsPending(t *testing.T) {
+	f := newPRChecksFixture()
+	relayTestServer(t, func(r map[string]any) any {
+		if r["path"] == "/repos/acme/repo/commits/"+metadataHead+"/check-runs" {
+			conclusion := "success"
+			if f.calls("/check-runs") == 0 {
+				conclusion = "stale"
+			}
+			f.checks[0].(map[string]any)["conclusion"] = conclusion
+		}
+		return f.response(t, r)
+	})
+	sleeps := recordWatchSleeps(t)
+	var out bytes.Buffer
+	result := handleGHPR(t.Context(), []string{"checks", "7", "-R", "acme/repo", "--watch"}, &out)
+	if result.err != nil || result.action != ghComplete || !reflect.DeepEqual(*sleeps, []time.Duration{30 * time.Second}) || !strings.Contains(out.String(), "checks: 1 pending, 0 pass, 0 fail, 0 cancel") || !strings.Contains(out.String(), "unit\tpass\tSUCCESS") {
+		t.Fatalf("stale must remain pending until next completion: result=%+v sleeps=%v out=%q", result, *sleeps, out.String())
 	}
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -241,12 +241,16 @@ eligible caching, including under active string rewrite protection. Fork metadat
 uses GitHub node IDs; a deleted head repository is `null`. Requested author, owner, and assignee
 names use a shared per-command profile lookup. The rollup preserves native `gh`
 `CheckRun` and `StatusContext` fields and resolves workflow names by check-suite ID
-from head-filtered Actions runs, without guessing from job names or URLs. Check/status
+through head-filtered Actions runs and the complete raw workflow catalogue, including
+inactive workflows. It shares this verified association with `pr checks`, without using
+run names, display titles, or body-supplied URLs. Check/status
 pages and workflow lookups read live; after all hydration, a final live PR head check
 rejects a moving head before any JSON is printed. A matching SHA is not an atomic
 snapshot: checks can change on the same commit. Both `pr checks` and the rollup require
 consistent page totals, unique upstream IDs, and complete pages, bounded to 1,000 items
-per collection. The workflow lookup uses the same completeness checks. Inconsistent
+per collection, including both Actions runs and the workflow catalogue. Missing or
+ambiguous workflow associations and mismatched check/run heads also refuse projection.
+Fork head repositories are supported. Inconsistent
 or incomplete collections emit no partial JSON and follow the existing typed native
 fallback, including fresh policy checks and host pinning under active rewrite rules.
 `OCTOPOOL_NO_FALLBACK=1` keeps these cases as failures. Repeated JSON fields are accepted
@@ -276,10 +280,29 @@ such as `author:` or custom sort/match flags falls through to the real `gh`. PR 
 supports the issue-like fields returned by GitHub Search; PR-list-only fields such as
 `headRefName` fall through. Hydrated `gh pr view --json files,...` requests send the
 verified PR head SHA, allowing file pages to share a five-minute state-scoped cache.
-`gh pr checks` uses the shared cache throughout: its PR
+`gh pr checks` uses the shared cache throughout ordinary acquisition: its PR
 head-SHA lookup sends `cache-control: max-age=60` so concurrent CI-polling sessions share
 one upstream PR read at most 60 seconds old, and the check/status reads for that SHA use
-the normal cache TTLs. Native `gh run watch` and `gh pr checks --watch` polling also stays
+the normal cache TTLs, as do its raw Actions metadata reads. Each collection is bounded
+to 10 pages of 100 entries. Ordinary acquisition uses at most 41 logical data operations,
+or 21 without Actions associations; an actual empty result takes 3. These are not limits
+on policy reads, transport attempts, retries, or an entire watch session. Every data
+operation retains authoritative policy checks through the relay client.
+
+Successful nonempty `pr checks --json` / `--jq` exports return 0 regardless of check
+outcomes; export or writer errors still fail. An empty result fails before any JSON or
+jq output, with `no checks reported on the '<head branch>' branch` on stderr and exit 1.
+Human and watch output instead return 1 for failed checks, otherwise 8 for pending
+checks, otherwise 0; cancellation and skipping alone do not fail. `NEUTRAL` maps to
+`skipping`. Legacy status descriptions are preserved; check summaries are not descriptions.
+Legacy statuses and missing/null check timestamps export zero times. Malformed nonempty
+check timestamps use guarded fallback before output.
+
+Checks are deduplicated before field selection by descending start time, using the native
+slash-joined check name/workflow/event key and a separate status-context namespace.
+Equal starts have no promised winner; creation time and numeric ID are not tiebreakers.
+JSON retains that aggregation order, not human-table presentation order.
+Native `gh run watch` and `gh pr checks --watch` polling also stays
 on the relay, floors intervals at 30 seconds, and backs off to 120 seconds.
 
 Supported `gh run watch` commands keep polling on the relay, including under active rewrite
@@ -300,7 +323,13 @@ For `gh pr checks --watch`, an explicit relay `fallback_local` after progress st
 handoff boundary and continues the command with real `gh`, which owns output and exit status.
 Its first snapshot may repeat the last relay-rendered state. Client-side incompleteness,
 auth, transport/decode failures, and ordinary relay service errors remain terminal after
-progress and do not spend local GitHub quota. Ask for raw `gh api`
+progress and do not spend local GitHub quota. Cached empty checks are revalidated live.
+Terminal confirmation reacquires every check, status, run, and workflow page with
+`max-age=0`, builds fresh associations, then reads the PR head live again after hydration.
+A changed head cannot confirm completion; a matching head still does not make same-commit
+check changes atomic. This extra live read is part of each terminal confirmation attempt,
+not the ordinary 41-operation bound. Active rewrite policy retains the existing
+pre-handler delegation of checks-watch commands. Ask for raw `gh api`
 conditional requests only when instant freshness matters more than quota.
 `--jq` runs after `--json` filtering, matching the usual agent workflow for small
 machine-readable reads.
@@ -334,6 +363,11 @@ differences:
 All relay-controlled single-line text has terminal control characters removed. PR and
 issue bodies preserve newlines and tabs while removing other control characters and
 invalid UTF-8.
+
+Non-TTY `pr checks` uses the native checks-only table comparator, separately from JSON.
+Cancellation displays as `fail` while retaining its successful cancellation-only exit.
+Elapsed values display `0` when absent or nonpositive, and Go durations (including
+fractional seconds) otherwise. Watch retains Octopool's terse transition/final output.
 
 After successfully fetching an explicit empty string rewrite policy (and finding no
 local rules), the command retains its existing real-`gh` delegation when any of these hold:


### PR DESCRIPTION
## Summary

`gh pr checks` was applying human/watch outcome exits even after successfully exporting JSON or jq output. Empty results could be exported, duplicate checks could retain obsolete failures, legacy status fields were normalized incorrectly, and workflow metadata was missing or guessed from a run name.

Use one checks-owned pipeline: acquire complete collections, verify workflow associations, normalize typed rows, deduplicate, then apply the output mode. Successful nonempty JSON/jq exports return 0; human/watch retain their outcome-based exits. Empty results fail before export with the native head-branch diagnostic. Check states, zero times, descriptions, cancellation display and elapsed values follow the native checks contract without changing general run output.

Workflow names now come from the workflow catalogue through verified head/suite/run/workflow identities, with events from their matched runs. The PR-view rollup shares this owner instead of guessing from run names. Collections retain their 10-page/1,000-entry bounds, including inactive workflows, with no per-check detail fanout. Missing or ambiguous associations use the existing guarded fallback before output. Policy reads, `OCTOPOOL_NO_FALLBACK`, command eligibility and external jq behavior remain intact.

Terminal watch confirmation reacquires every metadata page live and checks the PR head again after hydration. A changed head cannot be reported as completed; ordinary cached reads keep their existing 60-second head bound. Documentation records the output, freshness and logical request-budget contracts.

## Validation

- Before implementation, the regression matrix demonstrated 103 intended failing cases with 159 passing controls. Corrected fixtures and focused reproofs were retained rather than counted twice.
- Final focused proof: 262 cases passed; affected siblings: 117 cases passed.
- The full Go suite passed: 4,057 leaf cases, zero failures or skips. Existing short-test behavior remains intact.
- Go vet, route/SQL generation checks, formatting, lint, build/type checks and the 13-page docs build passed.
- Independent review of the complete patch found no actionable P0–P2 findings.

The native reference is tagged GitHub CLI 2.98 source and tests; process regressions execute Octopool against synthetic servers and guarded child fixtures, not live GitHub accounts. Full exact-head Linux and Windows CI plus CodeQL are required before merge. No Worker cache generation, schema, dependency or release change is included.
