### PR TITLE
fix: preserve native read-option semantics

### DIFF
--- a/cmd/octopool/cli_protocol_e2e_test.go
+++ b/cmd/octopool/cli_protocol_e2e_test.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -18,6 +20,73 @@ func TestCLIEndToEndRelayProtocol(t *testing.T) {
 		t.Skip("builds and executes the CLI binary")
 	}
 	bin := buildCLIBinary(t)
+
+	t.Run("native_options", func(t *testing.T) {
+		for _, test := range []struct {
+			name       string
+			args       []string
+			mode, want string
+			policyCode int
+		}{
+			{"regression_json_jq", []string{"pr", "view", "7", "-R", "acme/repo", "--json", "number", "--json=title", "--jq", "(", "--jq", ".number,.title"}, "relay", "7\nsynthetic\n", 200},
+			{"regression_invalid_csv_earlier", []string{"pr", "view", "7", "-R", "acme/repo", "--json", `"unterminated`, "--json=number"}, "reject", "", 200},
+			{"regression_invalid_limit_earlier", []string{"pr", "list", "-R", "acme/repo", "--json=number", "--limit=08", "--limit=2"}, "reject", "", 200},
+			{"regression_empty_json", []string{"pr", "view", "7", "-R", "acme/repo", "--json="}, "delegate", "child stdout\n", 200},
+			{"control_cap_delegation", []string{"pr", "list", "-R", "acme/repo", "--json=number", "--limit=101"}, "delegate", "child stdout\n", 200},
+			{"control_last_jq", []string{"pr", "view", "7", "-R", "acme/repo", "--json=number,title", "--jq", "(", "--jq", ".number"}, "relay", "7\n", 200},
+			{"control_policy_precedence", []string{"pr", "list", "-R", "acme/repo", "--json", `"unterminated`, "--limit=08"}, "reject", "", 401},
+			{"regression_run_duration_delegation", []string{"run", "watch", "42", "-R", "acme/repo", "--interval=9223372037"}, "delegate", "child stdout\n", 200},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				if strings.Contains(test.name, "jq") && !jqAvailable() {
+					t.Skip("jq not installed")
+				}
+				var paths []string
+				data := 0
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					paths = append(paths, r.URL.Path)
+					if r.URL.Path == "/v1/pools/maintainers/string-rewrites" && test.policyCode != 200 {
+						w.WriteHeader(test.policyCode)
+						return
+					}
+					if serveEmptyRewritePolicy(t, w, r, "test-token", "maintainers") {
+						return
+					}
+					req := decodeCLIRequest(t, w, r)
+					data++
+					writeCLIEnvelope(t, w, nativeOptionsResponse(t, req))
+				}))
+				t.Cleanup(server.Close)
+				capture := captureRewriteGH(t)
+				result := runCLI(t, bin, server.URL, nil, append([]string{"gh"}, test.args...)...)
+				_, childErr := os.Stat(capture)
+				if test.mode == "reject" {
+					if result.err == nil || result.stdout != "" || data != 0 || !os.IsNotExist(childErr) {
+						t.Fatalf("invalid input err=%v data=%d child=%v output=%q stderr=%q", result.err, data, childErr, result.stdout, result.stderr)
+					}
+					if test.policyCode != 200 && (len(paths) != 1 || !strings.Contains(result.stderr, errRewritePolicy.Error())) {
+						t.Fatalf("policy precedence paths=%v stderr=%q", paths, result.stderr)
+					}
+					return
+				}
+				wantData := 1
+				if test.mode == "delegate" {
+					wantData = 0
+				}
+				if result.err != nil || result.stdout != test.want || data != wantData {
+					t.Fatalf("err=%v data=%d want=%d output=%q want=%q stderr=%q", result.err, data, wantData, result.stdout, test.want, result.stderr)
+				}
+				if test.mode == "delegate" {
+					got := readRewriteCapture(t, capture)
+					if !reflect.DeepEqual(got.Args, test.args) {
+						t.Fatalf("handoff argv=%q want=%q", got.Args, test.args)
+					}
+				} else if !os.IsNotExist(childErr) {
+					t.Fatal("relay output ran native child")
+				}
+			})
+		}
+	})
 
 	t.Run("direct api forwards query and headers and decodes text", func(t *testing.T) {
 		server := cliRelayServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/octopool/gh_api_test.go
+++ b/cmd/octopool/gh_api_test.go
@@ -35,6 +35,28 @@ func TestParseGHAPIArgs(t *testing.T) {
 	}
 }
 
+func TestParseGHAPIArgsOptionTypeControls(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		args       []string
+		jq, accept string
+		fallback   bool
+	}{
+		{"last_jq", []string{"--jq", "(", "--jq=.number"}, ".number", "", false},
+		{"empty_last_jq", []string{"--jq", "(", "--jq="}, "", "", false},
+		{"literal_header_comma", []string{"-H", "Accept: application/json,text/plain"}, "", "application/json,text/plain", false},
+		{"native_only_field", []string{"-f", "labels=a,b"}, "", "", true},
+		{"native_only_top_json", []string{"--json="}, "", "", true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			req, fallback, err := parseGHAPIArgs(append([]string{"repos/acme/repo"}, test.args...))
+			if err != nil || fallback != test.fallback || req.jq != test.jq || req.headers["accept"] != test.accept {
+				t.Fatalf("request=%#v fallback=%v err=%v", req, fallback, err)
+			}
+		})
+	}
+}
+
 func TestParseGHAPIArgsDecodesQueryOnce(t *testing.T) {
 	request, fallback, err := parseGHAPIArgs([]string{
 		"/repos/openclaw/openclaw/actions/runs?branch=feature%2Ffoo&label=a&label=b",

--- a/cmd/octopool/gh_read_options.go
+++ b/cmd/octopool/gh_read_options.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"encoding/csv"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type readOptionKind uint8
+
+const (
+	readString readOptionKind = iota
+	readSlice
+	readInt
+	readUint
+	readBool
+)
+
+type readOptionSpec struct {
+	name     string
+	kind     readOptionKind
+	enum     []string
+	attached bool
+}
+
+type readOptionValue struct {
+	raw     string
+	strings []string
+	integer int64
+	uint    uint64
+	boolean bool
+}
+
+type readOccurrence struct {
+	name, raw   string
+	start, end  int
+	valueIndex  int
+	valuePrefix string
+}
+
+type readOptions struct {
+	argv        []string
+	ordered     []readOccurrence
+	values      map[string]readOptionValue
+	positionals []string
+	delimiter   int
+}
+
+type readEnumError struct{ name string }
+
+func (err readEnumError) Error() string { return "invalid value for " + err.name }
+
+func (opts readOptions) has(name string) bool { _, ok := opts.values[name]; return ok }
+
+// This owner knows only the caller's vocabulary. Unknown grammar is delegated,
+// never assigned a guessed value type. Original spans remain separate from projection.
+func parseReadOptions(args []string, specs map[string]readOptionSpec) (readOptions, bool, error) {
+	out := readOptions{argv: append([]string(nil), args...), values: map[string]readOptionValue{}, delimiter: len(args)}
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			out.delimiter = i
+			out.positionals = append(out.positionals, args[i+1:]...)
+			break
+		}
+		if !strings.HasPrefix(arg, "-") || arg == "-" {
+			out.positionals = append(out.positionals, arg)
+			continue
+		}
+		name, raw, equals := strings.Cut(arg, "=")
+		prefix := name + "="
+		if !strings.HasPrefix(arg, "--") && len(arg) > 2 {
+			name = arg[:2]
+			spec, ok := specs[name]
+			if !ok || (!spec.attached && arg[2] != '=') {
+				return out, true, nil
+			}
+			// Boolean shorthand needs a nonempty '=value'; a lone '=' or
+			// an attached suffix is native cluster/error grammar, not a value.
+			if spec.kind == readBool && (arg[2] != '=' || len(arg) == 3) {
+				return out, true, nil
+			}
+			raw, equals, prefix = arg[2:], true, name
+			// pflag treats a lone '=' remainder as the value, not an empty value.
+			if len(raw) > 1 && raw[0] == '=' {
+				raw, prefix = raw[1:], name+"="
+			}
+		}
+		spec, ok := specs[name]
+		if !ok {
+			return out, true, nil
+		}
+		occurrence := readOccurrence{name: spec.name, start: i, valueIndex: i, valuePrefix: prefix}
+		if spec.kind == readBool && !equals {
+			raw = "true"
+		} else if !equals {
+			i++
+			if i == len(args) {
+				return out, false, fmt.Errorf("%s requires a value", name)
+			}
+			raw = args[i]
+			occurrence.valueIndex, occurrence.valuePrefix = i, ""
+		}
+		occurrence.raw, occurrence.end = raw, i+1
+		out.ordered = append(out.ordered, occurrence)
+		value := readOptionValue{raw: raw}
+		var err error
+		switch spec.kind {
+		case readSlice:
+			value.strings, err = readStringSlice(raw)
+			if previous, present := out.values[spec.name]; present && err == nil {
+				value.strings = append(previous.strings, value.strings...)
+			}
+		case readInt:
+			value.integer, err = strconv.ParseInt(raw, 0, 64)
+		case readUint:
+			value.uint, err = strconv.ParseUint(raw, 0, 64)
+		case readBool:
+			value.boolean, err = strconv.ParseBool(raw)
+		}
+		if err != nil {
+			return out, false, fmt.Errorf("invalid value for %s: %w", spec.name, err)
+		}
+		if len(spec.enum) != 0 {
+			valid := false
+			for _, choice := range spec.enum {
+				valid = valid || strings.EqualFold(raw, choice)
+			}
+			if !valid {
+				return out, false, readEnumError{name: spec.name}
+			}
+		}
+		out.values[spec.name] = value
+	}
+	return out, false, nil
+}
+
+func readStringSlice(raw string) ([]string, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	return csv.NewReader(strings.NewReader(raw)).Read()
+}
+
+func uniqueReadFields(fields []string) []string {
+	var out []string
+	seen := make(map[string]bool, len(fields))
+	for _, field := range fields {
+		if !seen[field] {
+			seen[field] = true
+			out = append(out, field)
+		}
+	}
+	return out
+}
+
+// Types augment an existing command-owned vocabulary, not native eligibility.
+func typedReadSpecs(command, values, booleans string) map[string]readOptionSpec {
+	out := map[string]readOptionSpec{}
+	for alias, name := range rewriteFlagNames(values) {
+		spec := readOptionSpec{name: name}
+		// These existing aliases retain their native attached-value ownership
+		// even when the read guard preserves the caller's original spelling.
+		switch alias {
+		case "-R", "-L", "-q":
+			spec.attached = true
+		}
+		switch name {
+		case "--json", "--label":
+			spec.kind = readSlice
+		case "--repo":
+			if command == "search issues" || command == "search prs" {
+				spec.kind = readSlice
+			}
+		case "--limit", "--interval":
+			spec.kind = readInt
+		case "--attempt":
+			spec.kind = readUint
+		case "--state":
+			switch command {
+			case "pr list":
+				spec.enum = []string{"open", "closed", "merged", "all"}
+			case "issue list":
+				spec.enum = []string{"open", "closed", "all"}
+			case "search issues", "search prs":
+				spec.enum = []string{"open", "closed"}
+			}
+		case "--status":
+			spec.enum = []string{"queued", "completed", "in_progress", "requested", "waiting", "pending", "action_required", "cancelled", "failure", "neutral", "skipped", "stale", "startup_failure", "success", "timed_out"}
+		}
+		out[alias] = spec
+	}
+	for alias, name := range rewriteFlagNames(booleans) {
+		out[alias] = readOptionSpec{name: name, kind: readBool}
+	}
+	return out
+}

--- a/cmd/octopool/gh_test_helpers_test.go
+++ b/cmd/octopool/gh_test_helpers_test.go
@@ -96,6 +96,30 @@ func emptyRewriteTestServer(t *testing.T) {
 	relayTestServer(t, func(map[string]any) any { t.Error("unexpected relay request"); return nil })
 }
 
+func nativeOptionsResponse(t *testing.T, request map[string]any) any {
+	t.Helper()
+	item := map[string]any{"number": 7, "title": "synthetic", "state": "open", "id": 42, "name": "synthetic", "run_attempt": 3, "status": "completed", "conclusion": "success"}
+	switch request["path"] {
+	case "/repos/acme/repo/pulls/7", "/repos/acme/repo/issues/7", "/repos/acme/repo/actions/runs/42", "/repos/acme/repo/actions/runs/42/attempts/2", "/repos/acme/repo", "/gists/abc123", "/repos/acme/repo/actions/workflows/ci.yml":
+		return item
+	case "/repos/acme/repo/pulls/7/reviews", "/repos/acme/repo/issues/7/comments":
+		return []any{}
+	case "/repos/acme/repo/pulls", "/repos/acme/repo/issues", "/repos/acme/repo/releases", "/repos/acme/repo/labels":
+		return []any{item}
+	case "/repos/acme/repo/actions/runs":
+		return map[string]any{"total_count": 1, "workflow_runs": []any{item}}
+	case "/repos/acme/repo/actions/workflows":
+		return map[string]any{"total_count": 1, "workflows": []any{map[string]any{"id": 42, "name": "synthetic", "state": "active"}}}
+	case "/repos/acme/repo/actions/runs/42/attempts/3/jobs":
+		return map[string]any{"total_count": 0, "jobs": []any{}}
+	case "/search/issues", "/search/repositories":
+		return map[string]any{"total_count": 1, "items": []any{item}}
+	default:
+		t.Errorf("unexpected synthetic option route: %v", request["path"])
+		return nil
+	}
+}
+
 // REST fixtures for the shared checks/rollup owners; no production hooks.
 type prChecksFixture struct {
 	checks, statuses, runs, workflows []any

--- a/cmd/octopool/gh_top_collection_test.go
+++ b/cmd/octopool/gh_top_collection_test.go
@@ -198,7 +198,11 @@ func TestPRChecksGrowingCollectionsUseGuardedFallback(t *testing.T) {
 }
 
 func TestSplitFieldsPreservesFirstOccurrence(t *testing.T) {
-	got := splitFields("assignees,assignees,files statusCheckRollup,files")
+	parsed, unsupported, err := parseReadOptions([]string{"--json", "assignees,assignees,files,statusCheckRollup,files"}, topReadSpecs("pr view"))
+	if err != nil || unsupported {
+		t.Fatalf("parse: unsupported=%v err=%v", unsupported, err)
+	}
+	got := uniqueReadFields(parsed.values["--json"].strings)
 	if !reflect.DeepEqual(got, []string{"assignees", "files", "statusCheckRollup"}) {
 		t.Fatalf("fields=%v", got)
 	}

--- a/cmd/octopool/gh_top_issue.go
+++ b/cmd/octopool/gh_top_issue.go
@@ -25,7 +25,7 @@ func handleGHIssue(ctx context.Context, args []string, stdout io.Writer) ghResul
 	if len(args) == 0 {
 		return ghDelegated()
 	}
-	opts, early, ok := prepareGHTopOptions(args[1:])
+	opts, early, ok := prepareGHTopOptions("issue "+args[0], args[1:])
 	if !ok {
 		return early
 	}
@@ -49,6 +49,13 @@ func handleGHIssue(ctx context.Context, args []string, stdout io.Writer) ghResul
 		}
 		if !nativeHumanFormat(opts) && (!machineReadable(opts) || !supportedJSONFields(opts, supportedIssueFields)) {
 			return ghDelegated()
+		}
+		// This REST representation limit is not a native label setter rule;
+		// unsupported search filters retain their own typed fallback boundary.
+		for _, label := range opts.labels {
+			if label == "" || strings.ContainsAny(label, ",\r\n") {
+				return ghDelegated()
+			}
 		}
 		query := listQuery(opts)
 		if opts.state != "" {

--- a/cmd/octopool/gh_top_options.go
+++ b/cmd/octopool/gh_top_options.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -114,7 +115,11 @@ func parseGHTopOptions(args []string, specs map[string]readOptionSpec) (ghTopOpt
 	opts.patch = parsed.values["--patch"].boolean
 	opts.limitSet = parsed.has("--limit")
 	if opts.limitSet {
-		opts.limit = int(parsed.values["--limit"].integer)
+		limit := parsed.values["--limit"].integer
+		if limit < math.MinInt || limit > math.MaxInt {
+			return opts, true, nil
+		}
+		opts.limit = int(limit)
 	}
 	opts.state = parsed.values["--state"].raw
 	opts.branch = parsed.values["--branch"].raw
@@ -123,7 +128,7 @@ func parseGHTopOptions(args []string, specs map[string]readOptionSpec) (ghTopOpt
 	opts.attemptSet = parsed.has("--attempt")
 	if opts.attemptSet {
 		attempt := parsed.values["--attempt"].uint
-		if attempt > uint64(^uint(0)>>1) {
+		if attempt > math.MaxInt {
 			return opts, true, nil
 		}
 		opts.attempt = int(attempt)

--- a/cmd/octopool/gh_top_options.go
+++ b/cmd/octopool/gh_top_options.go
@@ -8,6 +8,7 @@ import (
 )
 
 type ghTopOptions struct {
+	read        readOptions
 	repo        string
 	repoCount   int
 	json        []string
@@ -29,92 +30,107 @@ type ghTopOptions struct {
 
 var digitsPattern = regexp.MustCompile(`^[0-9]+$`)
 
-func prepareGHTopOptions(args []string) (ghTopOptions, ghResult, bool) {
-	opts, fallback, err := parseGHTopOptions(args)
+func topReadSpecs(command string) map[string]readOptionSpec {
+	values, booleans := "--repo,-R --json --jq,-q", ""
+	switch command {
+	case "pr view", "issue view", "repo view", "release view", "workflow view", "gist view":
+	case "pr diff":
+		values, booleans = "--repo,-R", "--patch"
+	case "pr list", "issue list":
+		values += " --limit,-L --state --author --assignee --label"
+	case "run list":
+		values += " --limit,-L --branch --workflow --status"
+	case "run view":
+		values += " --attempt"
+	case "pr checks":
+		booleans = "--watch --required --fail-fast"
+	case "release list", "workflow list", "label list":
+		values += " --limit,-L"
+	case "search issues", "search prs":
+		values += " --limit,-L --state --author --assignee --label"
+	case "search repos":
+		values = "--json --jq,-q --limit,-L"
+	default:
+		return nil
+	}
+	return typedReadSpecs(command, values, booleans)
+}
+
+func prepareGHTopOptions(command string, args []string) (ghTopOptions, ghResult, bool) {
+	opts, fallback, err := parseGHTopOptions(args, topReadSpecs(command))
+	if _, invalidEnum := err.(readEnumError); invalidEnum {
+		return opts, ghDelegated(), false
+	}
 	if err != nil {
 		return opts, ghFailed(err), false
 	}
-	if fallback || topJQFallback(opts) {
+	if fallback || topJQFallback(opts) || (opts.read.has("--json") && len(opts.json) == 0) || (opts.read.has("--jq") && !opts.read.has("--json")) {
+		return opts, ghDelegated(), false
+	}
+	if opts.limitSet && (opts.limit < 1 || (strings.HasPrefix(command, "search ") && opts.limit > 1000)) {
+		return opts, ghFailed(fmt.Errorf("--limit is outside the command range")), false
+	}
+	if command == "pr list" || command == "issue list" {
+		opts.state = strings.ToLower(opts.state)
+	}
+	if command == "run list" && opts.status != strings.ToLower(opts.status) {
+		// Native preserves status spelling; the relay's modeled status set does not.
+		return opts, ghDelegated(), false
+	}
+	if command == "pr list" {
+		if opts.read.has("--author") || opts.read.has("--assignee") || opts.read.has("--label") {
+			return opts, ghDelegated(), false
+		}
+	}
+	if command == "pr checks" && (opts.read.values["--watch"].boolean || opts.read.values["--required"].boolean || opts.read.values["--fail-fast"].boolean) {
 		return opts, ghDelegated(), false
 	}
 	return opts, ghResult{}, true
 }
 
-func parseGHTopOptions(args []string) (ghTopOptions, bool, error) {
+func parseGHTopOptions(args []string, specs map[string]readOptionSpec) (ghTopOptions, bool, error) {
 	opts := ghTopOptions{limit: 30}
-	limitRaw := ""
-	attemptRaw := ""
-	for index := 0; index < len(args); index++ {
-		arg := args[index]
-		valueFlag := func(name string) (string, bool, error) {
-			if arg == name {
-				index++
-				if index >= len(args) {
-					return "", false, fmt.Errorf("%s requires a value", name)
-				}
-				return args[index], true, nil
-			}
-			if strings.HasPrefix(arg, name+"=") {
-				return strings.TrimPrefix(arg, name+"="), true, nil
-			}
-			return "", false, nil
+	parsed, fallback, err := parseReadOptions(args, specs)
+	opts.read = parsed
+	if err != nil || fallback {
+		return opts, fallback, err
+	}
+	opts.positionals = parsed.positionals
+	opts.repo = parsed.values["--repo"].raw
+	for _, occurrence := range parsed.ordered {
+		if occurrence.name == "--repo" {
+			opts.repoCount++
 		}
-		for _, item := range []struct {
-			name string
-			set  func(string)
-		}{
-			{"-R", func(value string) { opts.repo = value; opts.repoCount++ }},
-			{"--repo", func(value string) { opts.repo = value; opts.repoCount++ }},
-			{"--json", func(value string) { opts.json = splitFields(value) }},
-			{"--jq", func(value string) { opts.jq = value }},
-			{"-q", func(value string) { opts.jq = value }},
-			{"--limit", func(value string) { limitRaw = value; opts.limitSet = true }},
-			{"-L", func(value string) { limitRaw = value; opts.limitSet = true }},
-			{"--state", func(value string) { opts.state = value }},
-			{"--branch", func(value string) { opts.branch = value }},
-			{"--workflow", func(value string) { opts.workflow = value }},
-			{"--status", func(value string) { opts.status = value }},
-			{"--attempt", func(value string) { attemptRaw = value; opts.attemptSet = true }},
-			{"--author", func(value string) { opts.author = value }},
-			{"--assignee", func(value string) { opts.assignee = value }},
-			{"--label", func(value string) { opts.labels = append(opts.labels, value) }},
-		} {
-			value, ok, err := valueFlag(item.name)
-			if err != nil {
-				return opts, false, err
-			}
-			if ok {
-				item.set(value)
-				goto nextArg
-			}
-		}
-		switch arg {
-		case "--patch":
-			opts.patch = true
-		case "--web", "--comments", "--template", "--paginate", "--slurp":
+	}
+	if spec, ok := specs["--repo"]; ok && spec.kind == readSlice && parsed.has("--repo") {
+		repos := parsed.values["--repo"].strings
+		if opts.repoCount > 1 || len(repos) != 1 {
 			return opts, true, nil
-		default:
-			if strings.HasPrefix(arg, "-") && arg != "--patch" {
-				return opts, true, nil
-			}
-			opts.positionals = append(opts.positionals, arg)
 		}
-	nextArg:
+		opts.repo = repos[0]
 	}
+	opts.json = uniqueReadFields(parsed.values["--json"].strings)
+	opts.jq = parsed.values["--jq"].raw
+	opts.patch = parsed.values["--patch"].boolean
+	opts.limitSet = parsed.has("--limit")
 	if opts.limitSet {
-		limit, err := strconv.Atoi(limitRaw)
-		if err != nil {
-			return opts, false, fmt.Errorf("--limit requires an integer: %w", err)
-		}
-		opts.limit = limit
+		opts.limit = int(parsed.values["--limit"].integer)
 	}
+	opts.state = parsed.values["--state"].raw
+	opts.branch = parsed.values["--branch"].raw
+	opts.workflow = parsed.values["--workflow"].raw
+	opts.status = parsed.values["--status"].raw
+	opts.attemptSet = parsed.has("--attempt")
 	if opts.attemptSet {
-		attempt, err := strconv.Atoi(attemptRaw)
-		if err != nil || attempt < 1 {
-			return opts, false, fmt.Errorf("--attempt requires a positive integer")
+		attempt := parsed.values["--attempt"].uint
+		if attempt > uint64(^uint(0)>>1) {
+			return opts, true, nil
 		}
-		opts.attempt = attempt
+		opts.attempt = int(attempt)
 	}
+	opts.author = parsed.values["--author"].raw
+	opts.assignee = parsed.values["--assignee"].raw
+	opts.labels = parsed.values["--label"].strings
 	return opts, false, nil
 }
 
@@ -133,9 +149,6 @@ func desiredLimit(opts ghTopOptions) int {
 func desiredLimitDefault(opts ghTopOptions, defaultLimit int) int {
 	if !opts.limitSet {
 		return defaultLimit
-	}
-	if opts.limit < 1 {
-		return 1
 	}
 	if opts.limit > 100 {
 		return 100
@@ -182,25 +195,6 @@ func hasTopModifiersExceptPatch(opts ghTopOptions) bool {
 func supportedWorkflowRef(ref string) bool {
 	lower := strings.ToLower(ref)
 	return isDigits(ref) || strings.HasSuffix(lower, ".yml") || strings.HasSuffix(lower, ".yaml")
-}
-
-func splitFields(raw string) []string {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return nil
-	}
-	parts := strings.FieldsFunc(raw, func(r rune) bool {
-		return r == ',' || r == ' '
-	})
-	out := make([]string, 0, len(parts))
-	seen := make(map[string]bool, len(parts))
-	for _, part := range parts {
-		if part != "" && !seen[part] {
-			seen[part] = true
-			out = append(out, part)
-		}
-	}
-	return out
 }
 
 func isDigits(raw string) bool {

--- a/cmd/octopool/gh_top_options_test.go
+++ b/cmd/octopool/gh_top_options_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"math"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -100,6 +102,12 @@ func TestGHTopReadOptionDispatch(t *testing.T) {
 }
 
 func TestGHTopListLimitDispatch(t *testing.T) {
+	type limitCase struct {
+		name   string
+		flags  []string
+		limit  string
+		action ghAction
+	}
 	for _, command := range []struct {
 		name         string
 		args         []string
@@ -115,21 +123,37 @@ func TestGHTopListLimitDispatch(t *testing.T) {
 		{"search_prs", []string{"search", "prs", "bug", "--json", "number"}, "30"},
 		{"search_repos", []string{"search", "repos", "bug", "--json", "name"}, "30"},
 	} {
-		for _, test := range []struct {
-			name  string
-			flags []string
-			limit string
-		}{
-			{"control_default", nil, command.defaultLimit},
-			{"regression_zero", []string{"--limit=0"}, ""},
-			{"regression_negative", []string{"--limit=-1"}, ""},
-			{"regression_octal", []string{"--limit=010"}, "8"},
-			{"regression_hex", []string{"--limit=0x10"}, "16"},
-			{"regression_invalid_earlier", []string{"--limit=08", "--limit=2"}, ""},
-			{"control_final_range", []string{"--limit=0", "--limit=2"}, "2"},
-			{"control_search_range_override", []string{"--limit=1001", "--limit=2"}, "2"},
-			{"control_relay_cap", []string{"--limit=101"}, ""},
-		} {
+		cases := []limitCase{
+			{"control_default", nil, command.defaultLimit, ghComplete},
+			{"regression_zero", []string{"--limit=0"}, "", ghFail},
+			{"regression_negative", []string{"--limit=-1"}, "", ghFail},
+			{"regression_octal", []string{"--limit=010"}, "8", ghComplete},
+			{"regression_hex", []string{"--limit=0x10"}, "16", ghComplete},
+			{"regression_invalid_earlier", []string{"--limit=08", "--limit=2"}, "", ghFail},
+			{"control_final_range", []string{"--limit=0", "--limit=2"}, "2", ghComplete},
+			{"control_search_range_override", []string{"--limit=1001", "--limit=2"}, "2", ghComplete},
+			{"control_relay_cap", []string{"--limit=101"}, "", ghDelegate},
+		}
+		if command.name == "pr" || command.name == "search_issues" {
+			positive, negative := ghDelegate, ghFail
+			if math.MaxInt == math.MaxInt32 {
+				negative = ghDelegate
+			} else if command.name == "search_issues" {
+				positive = ghFail
+			}
+			cases = append(cases,
+				limitCase{"control_positive_wrap_to_one", []string{"--limit=4294967297"}, "", positive},
+				limitCase{"control_negative_wrap_to_one", []string{"--limit=-4294967295"}, "", negative},
+				limitCase{"control_relay_endpoint", []string{"--limit=100"}, "100", ghComplete},
+			)
+		}
+		if command.name == "search_issues" {
+			cases = append(cases,
+				limitCase{"control_search_endpoint", []string{"--limit=1000"}, "", ghDelegate},
+				limitCase{"control_search_above_endpoint", []string{"--limit=1001"}, "", ghFail},
+			)
+		}
+		for _, test := range cases {
 			t.Run(command.name+"/"+test.name, func(t *testing.T) {
 				var requests []map[string]any
 				relayTestServer(t, func(req map[string]any) any { requests = append(requests, req); return nativeOptionsResponse(t, req) })
@@ -139,12 +163,12 @@ func TestGHTopListLimitDispatch(t *testing.T) {
 				}
 				var out bytes.Buffer
 				result := runGHTopLevel(t.Context(), args, &out)
+				if result.action != test.action || (result.err != nil) != (test.action == ghFail) {
+					t.Fatalf("action=%v want=%v err=%v", result.action, test.action, result.err)
+				}
 				if test.limit == "" {
-					if len(requests) != 0 || out.Len() != 0 || (result.action != ghDelegate && result.action != ghFail) {
+					if len(requests) != 0 || out.Len() != 0 {
 						t.Fatalf("invalid/unrepresentable limit relayed: action=%v err=%v data=%d output=%q", result.action, result.err, len(requests), out.String())
-					}
-					if test.name == "control_relay_cap" && result.action != ghDelegate {
-						t.Fatalf("native-valid cap must directly delegate: %+v", result)
 					}
 					return
 				}
@@ -352,19 +376,29 @@ func TestParseGHTopOptionsJSONOccurrences(t *testing.T) {
 }
 
 func TestParseGHTopOptionsLimitOccurrences(t *testing.T) {
-	for _, test := range []struct {
+	type limitCase struct {
 		raw  string
-		want int
-	}{
+		want int64
+	}
+	cases := []limitCase{
 		{"0", 0}, {"+0", 0}, {"-0", 0}, {"+16", 16}, {"-16", -16},
 		{"010", 8}, {"0o10", 8}, {"0O10", 8}, {"0b10", 2}, {"0B10", 2},
 		{"0x10", 16}, {"0X10", 16}, {"1_0", 10}, {"0x_F", 15},
 		{"-9223372036854775808", -9223372036854775808}, {"9223372036854775807", 9223372036854775807},
-	} {
+		{"4294967297", 4294967297}, {"-4294967295", -4294967295},
+	}
+	if math.MaxInt != math.MaxInt64 {
+		cases = append(cases,
+			limitCase{strconv.FormatInt(int64(math.MinInt), 10), math.MinInt},
+			limitCase{strconv.FormatInt(int64(math.MaxInt), 10), math.MaxInt},
+		)
+	}
+	for _, test := range cases {
 		t.Run("syntax/"+test.raw, func(t *testing.T) {
 			opts, fallback, err := parseGHTopOptions([]string{"--limit", test.raw}, topReadSpecs("issue list"))
-			if err != nil || fallback || opts.limit != test.want {
-				t.Fatalf("limit=%d want=%d fallback=%v err=%v", opts.limit, test.want, fallback, err)
+			wantFallback := test.want < math.MinInt || test.want > math.MaxInt
+			if err != nil || fallback != wantFallback || !opts.limitSet || (!wantFallback && int64(opts.limit) != test.want) {
+				t.Fatalf("limit=%d want=%d fallback=%v wantFallback=%v err=%v", opts.limit, test.want, fallback, wantFallback, err)
 			}
 		})
 	}
@@ -376,7 +410,7 @@ func TestParseGHTopOptionsLimitOccurrences(t *testing.T) {
 			}
 		})
 	}
-	for _, raw := range []string{"0", "-1", "1001", "9223372036854775807"} {
+	for _, raw := range []string{"0", "-1", "1001", "9223372036854775807", "4294967297", "-4294967295"} {
 		t.Run("control_final_range/"+raw, func(t *testing.T) {
 			opts, fallback, err := parseGHTopOptions([]string{"--limit", raw, "--limit=2"}, topReadSpecs("issue list"))
 			if err != nil || fallback || opts.limit != 2 {

--- a/cmd/octopool/gh_top_options_test.go
+++ b/cmd/octopool/gh_top_options_test.go
@@ -1,6 +1,13 @@
 package main
 
-import "testing"
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
 
 func TestTopLevelRepoNumber(t *testing.T) {
 	opts := ghTopOptions{repo: "openclaw/openclaw", positionals: []string{"85341"}}
@@ -27,6 +34,237 @@ func TestTopLevelRepoNumber(t *testing.T) {
 	}
 }
 
+func TestGHTopReadOptionDispatch(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args []string
+		mode string
+		want string
+	}{
+		{"control_plain", []string{"pr", "view", "7", "--json", "number,title"}, "relay", `{"number":7,"title":"synthetic"}`},
+		{"regression_append", []string{"pr", "view", "7", "--json", "number", "--json", "title"}, "relay", `{"number":7,"title":"synthetic"}`},
+		{"regression_empty_last", []string{"pr", "view", "7", "--json", "number", "--json="}, "relay", `{"number":7}`},
+		{"regression_quoted", []string{"pr", "view", "7", "--json", `"number",title`}, "relay", `{"number":7,"title":"synthetic"}`},
+		{"regression_first_record", []string{"pr", "view", "7", "--json", "number\n\"unterminated"}, "relay", `{"number":7}`},
+		{"regression_unsupported_earlier", []string{"pr", "view", "7", "--json", "bogus", "--json", "number"}, "delegate", ""},
+		{"regression_invalid_csv_earlier", []string{"pr", "view", "7", "--json", `"unterminated`, "--json", "number"}, "reject", ""},
+		{"regression_space_field", []string{"pr", "view", "7", "--json", "number title"}, "delegate", ""},
+		{"regression_empty_element", []string{"pr", "view", "7", "--json", "number,,title"}, "delegate", ""},
+		{"regression_leading_space", []string{"pr", "view", "7", "--json", "number, title"}, "delegate", ""},
+		{"regression_empty_json", []string{"pr", "view", "7", "--json="}, "delegate", ""},
+		{"regression_empty_jq_without_json", []string{"pr", "view", "7", "--jq="}, "reject", ""},
+		{"regression_short_equals_jq", []string{"pr", "view", "7", "--json", "number", "-q="}, "jqerror", ""},
+		{"control_last_jq", []string{"pr", "view", "7", "--json", "number,title", "--jq", "(", "--jq", ".number"}, "relay", "7"},
+		{"control_final_empty_jq", []string{"pr", "view", "7", "--json", "number", "--jq", "(", "--jq="}, "relay", `{"number":7}`},
+		{"regression_undeclared_empty_state", []string{"pr", "view", "7", "--state=", "--json", "number"}, "delegate", ""},
+		{"regression_undeclared_branch", []string{"pr", "list", "--branch", "main", "--json", "number"}, "delegate", ""},
+		{"regression_undeclared_attempt", []string{"issue", "list", "--attempt", "2", "--json", "number"}, "delegate", ""},
+		{"regression_empty_unsupported_author", []string{"pr", "list", "--author=", "--json", "number"}, "delegate", ""},
+		{"control_empty_unsupported_label", []string{"pr", "list", "--label=", "--json", "number"}, "delegate", ""},
+		{"regression_search_empty_author", []string{"search", "issues", "bug", "--author=", "--json", "number"}, "reject", ""},
+		{"control_search_multi_repo", []string{"search", "issues", "bug", "--repo", "acme/repo", "--json", "number"}, "delegate", ""},
+		{"control_search_duplicate_csv_repo", []string{"search", "issues", "bug", "--repo", "acme/repo,acme/repo", "--json", "number"}, "delegate", ""},
+		{"control_search_unknown_topic", []string{"search", "repos", "bug", "--topic=", "--json", "name"}, "delegate", ""},
+		{"control_workflow_json_extension", []string{"workflow", "view", "ci.yml", "--json", "id,name"}, "relay", `{"id":42,"name":"synthetic"}`},
+		{"control_gist_json_extension", []string{"gist", "view", "abc123", "--json", "id"}, "relay", `{"id":42}`},
+		{"control_final_pr_state_case", []string{"pr", "list", "--state=OPEN", "--json", "number"}, "relay", `[{"number":7}]`},
+		{"control_final_run_status_case", []string{"run", "list", "--status=COMPLETED", "--json", "databaseId"}, "delegate", ""},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if strings.Contains(test.name, "jq") && !jqAvailable() {
+				t.Skip("jq not installed")
+			}
+			var requests []map[string]any
+			relayTestServer(t, func(req map[string]any) any { requests = append(requests, req); return nativeOptionsResponse(t, req) })
+			args := append(slices.Clone(test.args), "-R", "acme/repo")
+			var out bytes.Buffer
+			result := runGHTopLevel(t.Context(), args, &out)
+			if test.mode == "jqerror" {
+				if out.Len() != 0 || (result.action != ghDelegate && (result.action != ghFail || result.err == nil)) {
+					t.Fatalf("-q= must retain '=' as the jq program or delegate: action=%v err=%v output=%q", result.action, result.err, out.String())
+				}
+				return
+			}
+			if test.mode == "relay" {
+				if result.action != ghComplete || result.err != nil || len(requests) != 1 || strings.TrimSpace(out.String()) != test.want {
+					t.Fatalf("action=%v err=%v data=%d output=%q want=%q", result.action, result.err, len(requests), out.String(), test.want)
+				}
+				return
+			}
+			// A native-invalid shape may fail here or delegate intact, but never relay partial fields.
+			if len(requests) != 0 || out.Len() != 0 || (result.action != ghDelegate && (test.mode == "delegate" || result.action != ghFail)) {
+				t.Fatalf("shape must %s without data/output: action=%v err=%v data=%d output=%q", test.mode, result.action, result.err, len(requests), out.String())
+			}
+		})
+	}
+}
+
+func TestGHTopListLimitDispatch(t *testing.T) {
+	for _, command := range []struct {
+		name         string
+		args         []string
+		defaultLimit string
+	}{
+		{"pr", []string{"pr", "list", "--json", "number"}, "30"},
+		{"issue", []string{"issue", "list", "--json", "number"}, "100"},
+		{"run", []string{"run", "list", "--json", "databaseId"}, "20"},
+		{"release", []string{"release", "list", "--json", "name"}, "30"},
+		{"workflow", []string{"workflow", "list", "--json", "id"}, "50"},
+		{"label", []string{"label", "list", "--json", "name"}, "30"},
+		{"search_issues", []string{"search", "issues", "bug", "--json", "number"}, "30"},
+		{"search_prs", []string{"search", "prs", "bug", "--json", "number"}, "30"},
+		{"search_repos", []string{"search", "repos", "bug", "--json", "name"}, "30"},
+	} {
+		for _, test := range []struct {
+			name  string
+			flags []string
+			limit string
+		}{
+			{"control_default", nil, command.defaultLimit},
+			{"regression_zero", []string{"--limit=0"}, ""},
+			{"regression_negative", []string{"--limit=-1"}, ""},
+			{"regression_octal", []string{"--limit=010"}, "8"},
+			{"regression_hex", []string{"--limit=0x10"}, "16"},
+			{"regression_invalid_earlier", []string{"--limit=08", "--limit=2"}, ""},
+			{"control_final_range", []string{"--limit=0", "--limit=2"}, "2"},
+			{"control_search_range_override", []string{"--limit=1001", "--limit=2"}, "2"},
+			{"control_relay_cap", []string{"--limit=101"}, ""},
+		} {
+			t.Run(command.name+"/"+test.name, func(t *testing.T) {
+				var requests []map[string]any
+				relayTestServer(t, func(req map[string]any) any { requests = append(requests, req); return nativeOptionsResponse(t, req) })
+				args := append(slices.Clone(command.args), test.flags...)
+				if command.name != "search_repos" {
+					args = append(args, "-R", "acme/repo")
+				}
+				var out bytes.Buffer
+				result := runGHTopLevel(t.Context(), args, &out)
+				if test.limit == "" {
+					if len(requests) != 0 || out.Len() != 0 || (result.action != ghDelegate && result.action != ghFail) {
+						t.Fatalf("invalid/unrepresentable limit relayed: action=%v err=%v data=%d output=%q", result.action, result.err, len(requests), out.String())
+					}
+					if test.name == "control_relay_cap" && result.action != ghDelegate {
+						t.Fatalf("native-valid cap must directly delegate: %+v", result)
+					}
+					return
+				}
+				if result.action != ghComplete || result.err != nil || len(requests) != 1 {
+					t.Fatalf("action=%v err=%v requests=%v", result.action, result.err, requests)
+				}
+				want := test.limit
+				if command.name == "issue" {
+					want = "100"
+				}
+				if got := requests[0]["query"].(map[string]any)["per_page"]; got != want {
+					t.Fatalf("per_page=%v want=%s", got, want)
+				}
+			})
+		}
+	}
+}
+
+func TestGHTopReadEnumOccurrences(t *testing.T) {
+	for _, command := range []struct {
+		name        string
+		args        []string
+		flag, valid string
+	}{
+		{"pr", []string{"pr", "list"}, "--state", "open"},
+		{"issue", []string{"issue", "list"}, "--state", "open"},
+		{"run", []string{"run", "list"}, "--status", "completed"},
+		{"search_issues", []string{"search", "issues", "bug"}, "--state", "open"},
+		{"search_prs", []string{"search", "prs", "bug"}, "--state", "open"},
+	} {
+		for _, first := range []string{"invalid", "", strings.ToUpper(command.valid)} {
+			t.Run(command.name+"/earlier="+first, func(t *testing.T) {
+				requests := 0
+				relayTestServer(t, func(req map[string]any) any { requests++; return nativeOptionsResponse(t, req) })
+				field := "number"
+				if command.name == "run" {
+					field = "databaseId"
+				}
+				args := append(slices.Clone(command.args), "-R", "acme/repo", "--json", field, command.flag, first, command.flag, command.valid)
+				var out bytes.Buffer
+				result := runGHTopLevel(t.Context(), args, &out)
+				if first == strings.ToUpper(command.valid) {
+					if result.action != ghComplete || result.err != nil || requests != 1 {
+						t.Fatalf("valid case-insensitive occurrence: action=%v err=%v data=%d", result.action, result.err, requests)
+					}
+				} else if requests != 0 || out.Len() != 0 || (result.action != ghFail && result.action != ghDelegate) {
+					t.Fatalf("invalid earlier enum disappeared: action=%v err=%v data=%d output=%q", result.action, result.err, requests, out.String())
+				}
+			})
+		}
+	}
+}
+
+func TestGHIssueLabelOccurrences(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		flags    []string
+		label    any
+		delegate bool
+	}{
+		{"control_plain_csv", []string{"--label", "bug,help wanted", "--label", "docs"}, "bug,help wanted,docs", false},
+		{"control_space", []string{"--label", "help wanted"}, "help wanted", false},
+		{"regression_quote", []string{"--label", `"bug"`}, "bug", false},
+		{"regression_doubled_quote", []string{"--label", `"a""b"`}, `a"b`, false},
+		{"regression_empty", []string{"--label="}, nil, false},
+		{"regression_empty_last", []string{"--label", "bug", "--label="}, "bug", false},
+		{"regression_first_record", []string{"--label", "bug\nignored"}, "bug", false},
+		{"regression_comma_label", []string{"--label", `"a,b"`}, nil, true},
+		{"regression_empty_element", []string{"--label", "a,,b"}, nil, true},
+		{"regression_quoted_empty", []string{"--label", `""`}, nil, true},
+		{"regression_multiline", []string{"--label", "\"a\r\nb\""}, nil, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var requests []map[string]any
+			relayTestServer(t, func(req map[string]any) any { requests = append(requests, req); return nativeOptionsResponse(t, req) })
+			args := append([]string{"issue", "list", "-R", "acme/repo", "--json", "number"}, test.flags...)
+			var out bytes.Buffer
+			result := runGHTopLevel(t.Context(), args, &out)
+			if test.delegate {
+				if result.action != ghDelegate || len(requests) != 0 || out.Len() != 0 {
+					t.Fatalf("unrepresentable label relayed: action=%v data=%d output=%q", result.action, len(requests), out.String())
+				}
+				return
+			}
+			if result.action != ghComplete || result.err != nil || len(requests) != 1 {
+				t.Fatalf("action=%v err=%v data=%d", result.action, result.err, len(requests))
+			}
+			query := requests[0]["query"].(map[string]any)
+			if _, present := query["labels"]; test.label == nil && present {
+				t.Fatalf("empty effective labels must omit query key: %v", query)
+			}
+			if query["labels"] != test.label || query["per_page"] != "100" {
+				t.Fatalf("labels=%#v want=%#v query=%v", query["labels"], test.label, query)
+			}
+		})
+	}
+}
+
+func TestGHIssueLimitCountsFilteredItems(t *testing.T) {
+	relayTestServer(t, func(req map[string]any) any {
+		if req["query"].(map[string]any)["per_page"] != "100" {
+			t.Error("issue filtering page size changed")
+		}
+		items := []any{map[string]any{"number": 99, "pull_request": map[string]any{}}}
+		for i := 1; i <= 12; i++ {
+			items = append(items, map[string]any{"number": i})
+		}
+		return items
+	})
+	var out bytes.Buffer
+	result := runGHTopLevel(t.Context(), []string{"issue", "list", "-R", "acme/repo", "--json", "number", "--limit=010"}, &out)
+	var got []map[string]any
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if result.action != ghComplete || len(got) != 8 || !reflect.DeepEqual(got[7], map[string]any{"number": float64(8)}) {
+		t.Fatalf("action=%v err=%v filtered=%v", result.action, result.err, got)
+	}
+}
+
 func TestParseGHTopOptions(t *testing.T) {
 	opts, fallback, err := parseGHTopOptions([]string{
 		"-R", "openclaw/openclaw",
@@ -36,7 +274,7 @@ func TestParseGHTopOptions(t *testing.T) {
 		"--state=open",
 		"--label", "bug",
 		"85341",
-	})
+	}, topReadSpecs("issue list"))
 	if err != nil || fallback {
 		t.Fatalf("parse fallback=%v err=%v", fallback, err)
 	}
@@ -55,20 +293,102 @@ func TestParseGHTopOptions(t *testing.T) {
 }
 
 func TestParseGHTopOptionsRejectsInvalidLimit(t *testing.T) {
-	_, fallback, err := parseGHTopOptions([]string{"--limit", "nope"})
+	_, fallback, err := parseGHTopOptions([]string{"--limit", "nope"}, topReadSpecs("issue list"))
 	if err == nil || fallback {
 		t.Fatalf("fallback=%v err=%v", fallback, err)
 	}
 }
 
 func TestParseGHTopOptionsValidatesAttempt(t *testing.T) {
-	opts, fallback, err := parseGHTopOptions([]string{"42", "--attempt", "2"})
+	opts, fallback, err := parseGHTopOptions([]string{"42", "--attempt", "2"}, topReadSpecs("run view"))
 	if err != nil || fallback || !opts.attemptSet || opts.attempt != 2 {
 		t.Fatalf("opts=%#v fallback=%v err=%v", opts, fallback, err)
 	}
-	for _, value := range []string{"0", "nope"} {
-		if _, _, err := parseGHTopOptions([]string{"42", "--attempt", value}); err == nil {
+	for _, value := range []string{"nope", "-1"} {
+		if _, _, err := parseGHTopOptions([]string{"42", "--attempt", value}, topReadSpecs("run view")); err == nil {
 			t.Fatalf("--attempt %s must fail", value)
 		}
+	}
+}
+
+func TestParseGHTopOptionsJSONOccurrences(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		args, want []string
+		invalid    bool
+	}{
+		{"control_plain_dedup", []string{"--json", "number,title,number"}, []string{"number", "title"}, false},
+		{"regression_append", []string{"--json", "number", "--json=title,number"}, []string{"number", "title"}, false},
+		{"regression_empty_last", []string{"--json", "number", "--json="}, []string{"number"}, false},
+		{"control_empty_first", []string{"--json=", "--json", "number"}, []string{"number"}, false},
+		{"regression_quoted_fields", []string{"--json", `"number",title`}, []string{"number", "title"}, false},
+		{"regression_significant_space", []string{"--json", "number, title"}, []string{"number", " title"}, false},
+		{"regression_not_space_separated", []string{"--json", "number title"}, []string{"number title"}, false},
+		{"regression_empty_element", []string{"--json", "number,,title"}, []string{"number", "", "title"}, false},
+		{"regression_quoted_empty", []string{"--json", `""`}, []string{""}, false},
+		{"regression_doubled_quote", []string{"--json", `"a""b"`}, []string{`a"b`}, false},
+		{"regression_first_record", []string{"--json", "number\nunknown"}, []string{"number"}, false},
+		{"regression_ignored_malformed_record", []string{"--json", "number\n\"unterminated"}, []string{"number"}, false},
+		{"regression_blank_line_crlf", []string{"--json", "\nnumber\r\nignored"}, []string{"number"}, false},
+		{"regression_quoted_multiline", []string{"--json", "\"a\r\nb\""}, []string{"a\nb"}, false},
+		{"regression_invalid_first", []string{"--json", `"unterminated`, "--json", "number"}, nil, true},
+		{"regression_bare_quote", []string{"--json", `a"b`}, nil, true},
+		{"regression_after_quote", []string{"--json", `"a"x`}, nil, true},
+		{"regression_blank_record_only", []string{"--json", "\n"}, nil, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			opts, fallback, err := parseGHTopOptions(test.args, topReadSpecs("issue list"))
+			if test.invalid {
+				if err == nil || fallback {
+					t.Fatalf("invalid CSV accepted: fields=%q fallback=%v err=%v", opts.json, fallback, err)
+				}
+				return
+			}
+			if err != nil || fallback || !slices.Equal(opts.json, test.want) {
+				t.Fatalf("fields=%q want=%q fallback=%v err=%v", opts.json, test.want, fallback, err)
+			}
+		})
+	}
+}
+
+func TestParseGHTopOptionsLimitOccurrences(t *testing.T) {
+	for _, test := range []struct {
+		raw  string
+		want int
+	}{
+		{"0", 0}, {"+0", 0}, {"-0", 0}, {"+16", 16}, {"-16", -16},
+		{"010", 8}, {"0o10", 8}, {"0O10", 8}, {"0b10", 2}, {"0B10", 2},
+		{"0x10", 16}, {"0X10", 16}, {"1_0", 10}, {"0x_F", 15},
+		{"-9223372036854775808", -9223372036854775808}, {"9223372036854775807", 9223372036854775807},
+	} {
+		t.Run("syntax/"+test.raw, func(t *testing.T) {
+			opts, fallback, err := parseGHTopOptions([]string{"--limit", test.raw}, topReadSpecs("issue list"))
+			if err != nil || fallback || opts.limit != test.want {
+				t.Fatalf("limit=%d want=%d fallback=%v err=%v", opts.limit, test.want, fallback, err)
+			}
+		})
+	}
+	for _, raw := range []string{"", " 1", "1 ", "08", "1.0", "1e2", "_1", "1_", "1__0", "0x", "+", "--1", "9223372036854775808", "-9223372036854775809"} {
+		t.Run("invalid_occurrence/"+raw, func(t *testing.T) {
+			_, fallback, err := parseGHTopOptions([]string{"--limit", raw, "-L=2"}, topReadSpecs("issue list"))
+			if err == nil || fallback {
+				t.Fatalf("invalid earlier limit erased: fallback=%v err=%v", fallback, err)
+			}
+		})
+	}
+	for _, raw := range []string{"0", "-1", "1001", "9223372036854775807"} {
+		t.Run("control_final_range/"+raw, func(t *testing.T) {
+			opts, fallback, err := parseGHTopOptions([]string{"--limit", raw, "--limit=2"}, topReadSpecs("issue list"))
+			if err != nil || fallback || opts.limit != 2 {
+				t.Fatalf("limit=%d fallback=%v err=%v", opts.limit, fallback, err)
+			}
+		})
+	}
+}
+
+func TestParseGHTopOptionsScalarOwnership(t *testing.T) {
+	opts, fallback, err := parseGHTopOptions([]string{"--repo", "acme/old", "-R=acme/repo", "--assignee", "alice", "--assignee=bob,carol", "--author", `"alice"`, "--jq", "(", "--jq=.number"}, topReadSpecs("issue list"))
+	if err != nil || fallback || opts.repo != "acme/repo" || opts.assignee != "bob,carol" || opts.author != `"alice"` || opts.jq != ".number" {
+		t.Fatalf("scalar assignment must not CSV-decode or validate discarded jq: opts=%#v fallback=%v err=%v", opts, fallback, err)
 	}
 }

--- a/cmd/octopool/gh_top_pr.go
+++ b/cmd/octopool/gh_top_pr.go
@@ -40,7 +40,7 @@ func handleGHPR(ctx context.Context, args []string, stdout io.Writer) ghResult {
 	if args[0] == "checks" && hasWatchFlag(args[1:]) {
 		return handleGHPRChecksWatch(ctx, args[1:], stdout)
 	}
-	opts, early, ok := prepareGHTopOptions(args[1:])
+	opts, early, ok := prepareGHTopOptions("pr "+args[0], args[1:])
 	if !ok {
 		return early
 	}

--- a/cmd/octopool/gh_top_pr_export_test.go
+++ b/cmd/octopool/gh_top_pr_export_test.go
@@ -74,6 +74,38 @@ func TestRunGHPRViewAuthorNativeShape(t *testing.T) {
 	}
 }
 
+func TestRunGHPRViewRepeatedOptionHydration(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		flags []string
+	}{
+		{"control_one_occurrence", []string{"--json", "number,author,author"}},
+		{"regression_across_occurrences", []string{"--json", "number,author", "--json", "author"}},
+		{"regression_quoted_occurrence", []string{"--json", `"number",author`, "--json", "author"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var paths []string
+			relayTestServer(t, func(req map[string]any) any {
+				paths = append(paths, req["path"].(string))
+				switch req["path"] {
+				case "/repos/acme/repo/pulls/7":
+					return map[string]any{"number": 7, "user": map[string]any{"node_id": "U_alice", "login": "alice", "type": "User"}}
+				case "/users/alice":
+					return map[string]any{"id": 12, "node_id": "U_alice", "login": "alice", "name": "Alice", "type": "User"}
+				default:
+					t.Errorf("unexpected hydration path %v", req["path"])
+					return nil
+				}
+			})
+			var out bytes.Buffer
+			result := runGHTopLevel(t.Context(), append([]string{"pr", "view", "7", "-R", "acme/repo"}, test.flags...), &out)
+			if result.action != ghComplete || result.err != nil || !reflect.DeepEqual(paths, []string{"/repos/acme/repo/pulls/7", "/users/alice"}) || !strings.Contains(out.String(), `"number":7`) || !strings.Contains(out.String(), `"name":"Alice"`) {
+				t.Fatalf("action=%v err=%v paths=%v output=%q", result.action, result.err, paths, out.String())
+			}
+		})
+	}
+}
+
 func TestRunGHPRViewLabelsNativeShape(t *testing.T) {
 	for _, empty := range []bool{false, true} {
 		t.Run(fmt.Sprint(empty), func(t *testing.T) {

--- a/cmd/octopool/gh_top_pr_metadata_test.go
+++ b/cmd/octopool/gh_top_pr_metadata_test.go
@@ -385,7 +385,7 @@ func TestRunGHPRViewMetadataTypedFallback(t *testing.T) {
 				t.Fatalf("partial JSON before fallback: %q", out.String())
 			}
 			got := readRewriteCapture(t, capture)
-			want := []string{"pr", "view", "1", "--repo=acme/repo", "--json=statusCheckRollup"}
+			want := []string{"pr", "view", "1", "--repo=acme/repo", "--json", "statusCheckRollup"}
 			if !reflect.DeepEqual(got.Args, want) || got.Env["GH_HOST"] != "github.com" {
 				t.Fatalf("fallback=%+v", got)
 			}

--- a/cmd/octopool/gh_top_resources.go
+++ b/cmd/octopool/gh_top_resources.go
@@ -12,7 +12,7 @@ func handleGHRepo(ctx context.Context, args []string, stdout io.Writer) ghResult
 	if len(args) == 0 {
 		return ghDelegated()
 	}
-	opts, early, ok := prepareGHTopOptions(args[1:])
+	opts, early, ok := prepareGHTopOptions("repo "+args[0], args[1:])
 	if !ok {
 		return early
 	}
@@ -41,7 +41,7 @@ func handleGHRelease(ctx context.Context, args []string, stdout io.Writer) ghRes
 	if len(args) == 0 {
 		return ghDelegated()
 	}
-	opts, early, ok := prepareGHTopOptions(args[1:])
+	opts, early, ok := prepareGHTopOptions("release "+args[0], args[1:])
 	if !ok {
 		return early
 	}
@@ -77,7 +77,7 @@ func handleGHWorkflow(ctx context.Context, args []string, stdout io.Writer) ghRe
 	if len(args) == 0 {
 		return ghDelegated()
 	}
-	opts, early, ok := prepareGHTopOptions(args[1:])
+	opts, early, ok := prepareGHTopOptions("workflow "+args[0], args[1:])
 	if !ok {
 		return early
 	}
@@ -109,7 +109,7 @@ func handleGHLabel(ctx context.Context, args []string, stdout io.Writer) ghResul
 	if len(args) == 0 {
 		return ghDelegated()
 	}
-	opts, early, ok := prepareGHTopOptions(args[1:])
+	opts, early, ok := prepareGHTopOptions("label "+args[0], args[1:])
 	if !ok {
 		return early
 	}
@@ -132,7 +132,7 @@ func handleGHGist(ctx context.Context, args []string, stdout io.Writer) ghResult
 	if len(args) == 0 {
 		return ghDelegated()
 	}
-	opts, early, ok := prepareGHTopOptions(args[1:])
+	opts, early, ok := prepareGHTopOptions("gist "+args[0], args[1:])
 	if !ok {
 		return early
 	}

--- a/cmd/octopool/gh_top_run.go
+++ b/cmd/octopool/gh_top_run.go
@@ -15,7 +15,7 @@ func handleGHRun(ctx context.Context, args []string, stdout io.Writer) ghResult 
 	if args[0] == "watch" {
 		return handleGHRunWatch(ctx, args[1:], stdout)
 	}
-	opts, early, ok := prepareGHTopOptions(args[1:])
+	opts, early, ok := prepareGHTopOptions("run "+args[0], args[1:])
 	if !ok {
 		return early
 	}
@@ -80,7 +80,7 @@ func relayRunView(ctx context.Context, stdout io.Writer, repo string, id string,
 	run := map[string]any{}
 	human := len(opts.json) == 0
 	runPath := repoPath(repo, "actions", "runs", id)
-	if opts.attemptSet {
+	if opts.attemptSet && opts.attempt != 0 {
 		runPath = repoPath(repo, "actions", "runs", id, "attempts", strconv.Itoa(opts.attempt))
 	}
 	envelope, err := client.do(ctx, ghAPIRequest{

--- a/cmd/octopool/gh_top_run_test.go
+++ b/cmd/octopool/gh_top_run_test.go
@@ -7,6 +7,44 @@ import (
 	"testing"
 )
 
+func TestRunGHRunViewAttemptOccurrences(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		flags      []string
+		mode, path string
+	}{
+		{"control_requested", []string{"--attempt=2"}, "relay", "/repos/acme/repo/actions/runs/42/attempts/2"},
+		{"regression_zero_latest", []string{"--attempt=0"}, "relay", "/repos/acme/repo/actions/runs/42"},
+		{"regression_prefix", []string{"--attempt=0x2"}, "relay", "/repos/acme/repo/actions/runs/42/attempts/2"},
+		{"regression_unsigned_plus", []string{"--attempt=+2"}, "reject", ""},
+		{"control_unsigned_minus", []string{"--attempt=-2"}, "reject", ""},
+		{"regression_earlier_plus", []string{"--attempt=+1", "--attempt=2"}, "reject", ""},
+		{"regression_earlier_octal_error", []string{"--attempt=08", "--attempt=2"}, "reject", ""},
+		{"regression_earlier_overflow", []string{"--attempt=18446744073709551616", "--attempt=2"}, "reject", ""},
+		{"regression_unsigned_max", []string{"--attempt=18446744073709551615"}, "delegate", ""},
+		{"regression_above_signed", []string{"--attempt=9223372036854775808"}, "delegate", ""},
+		{"control_overridden_large_uint64", []string{"--attempt=18446744073709551615", "--attempt=2"}, "relay", "/repos/acme/repo/actions/runs/42/attempts/2"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var paths []string
+			relayTestServer(t, func(req map[string]any) any {
+				paths = append(paths, req["path"].(string))
+				return nativeOptionsResponse(t, req)
+			})
+			args := append([]string{"run", "view", "42", "-R", "acme/repo", "--json", "databaseId,jobs"}, test.flags...)
+			var out bytes.Buffer
+			result := runGHTopLevel(t.Context(), args, &out)
+			if test.mode == "relay" {
+				if result.action != ghComplete || result.err != nil || len(paths) != 2 || paths[0] != test.path || paths[1] != "/repos/acme/repo/actions/runs/42/attempts/3/jobs" || strings.TrimSpace(out.String()) != `{"databaseId":42,"jobs":[]}` {
+					t.Fatalf("action=%v err=%v paths=%v output=%q (jobs belong to returned attempt 3)", result.action, result.err, paths, out.String())
+				}
+			} else if len(paths) != 0 || out.Len() != 0 || (result.action != ghDelegate && (test.mode == "delegate" || result.action != ghFail)) {
+				t.Fatalf("attempt must %s before data: action=%v err=%v paths=%v output=%q", test.mode, result.action, result.err, paths, out.String())
+			}
+		})
+	}
+}
+
 func TestRunGHRunViewComposesJobs(t *testing.T) {
 	relayTestServer(t, func(body map[string]any) any {
 		switch body["path"] {

--- a/cmd/octopool/gh_top_run_test.go
+++ b/cmd/octopool/gh_top_run_test.go
@@ -3,11 +3,15 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"math"
+	"strconv"
 	"strings"
 	"testing"
 )
 
 func TestRunGHRunViewAttemptOccurrences(t *testing.T) {
+	maxAttempt := strconv.FormatUint(uint64(math.MaxInt), 10)
+	aboveMaxAttempt := strconv.FormatUint(uint64(math.MaxInt)+1, 10)
 	for _, test := range []struct {
 		name       string
 		flags      []string
@@ -23,12 +27,17 @@ func TestRunGHRunViewAttemptOccurrences(t *testing.T) {
 		{"regression_earlier_overflow", []string{"--attempt=18446744073709551616", "--attempt=2"}, "reject", ""},
 		{"regression_unsigned_max", []string{"--attempt=18446744073709551615"}, "delegate", ""},
 		{"regression_above_signed", []string{"--attempt=9223372036854775808"}, "delegate", ""},
+		{"control_platform_max", []string{"--attempt=" + maxAttempt}, "relay", "/repos/acme/repo/actions/runs/42/attempts/" + maxAttempt},
+		{"control_above_platform_max", []string{"--attempt=" + aboveMaxAttempt}, "delegate", ""},
 		{"control_overridden_large_uint64", []string{"--attempt=18446744073709551615", "--attempt=2"}, "relay", "/repos/acme/repo/actions/runs/42/attempts/2"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			var paths []string
 			relayTestServer(t, func(req map[string]any) any {
 				paths = append(paths, req["path"].(string))
+				if req["path"] == "/repos/acme/repo/actions/runs/42/attempts/"+maxAttempt {
+					return map[string]any{"id": 42, "run_attempt": 3}
+				}
 				return nativeOptionsResponse(t, req)
 			})
 			args := append([]string{"run", "view", "42", "-R", "acme/repo", "--json", "databaseId,jobs"}, test.flags...)

--- a/cmd/octopool/gh_top_search.go
+++ b/cmd/octopool/gh_top_search.go
@@ -21,7 +21,7 @@ func handleGHSearch(ctx context.Context, args []string, stdout io.Writer) ghResu
 	if kind != "issues" && kind != "prs" && kind != "repos" {
 		return ghDelegated()
 	}
-	opts, early, ok := prepareGHTopOptions(args[1:])
+	opts, early, ok := prepareGHTopOptions("search "+args[0], args[1:])
 	if !ok {
 		return early
 	}
@@ -74,14 +74,14 @@ func handleGHSearch(ctx context.Context, args []string, stdout io.Writer) ghResu
 }
 
 func relaySearchIssues(ctx context.Context, stdout io.Writer, repo string, rawQuery string, opts ghTopOptions) error {
-	if opts.author != "" || opts.assignee != "" || len(opts.labels) > 0 {
+	if opts.read.has("--author") || opts.read.has("--assignee") || opts.read.has("--label") {
 		return localFallbackError{Reason: "unsupported_search_filter"}
 	}
 	return relayGitHubSearch(ctx, stdout, repo, rawQuery, "issue", opts, fieldMapIssue)
 }
 
 func relaySearchPRs(ctx context.Context, stdout io.Writer, repo string, rawQuery string, opts ghTopOptions) error {
-	if opts.author != "" || opts.assignee != "" || len(opts.labels) > 0 {
+	if opts.read.has("--author") || opts.read.has("--assignee") || opts.read.has("--label") {
 		return localFallbackError{Reason: "unsupported_pr_search_filter"}
 	}
 	return relayGitHubSearch(ctx, stdout, repo, rawQuery, "pr", opts, fieldMapPR)

--- a/cmd/octopool/gh_top_watch.go
+++ b/cmd/octopool/gh_top_watch.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -121,53 +122,52 @@ func handleGHRunWatch(ctx context.Context, args []string, stdout io.Writer) ghRe
 	return ghCompleted(relayRunWatch(ctx, stdout, opts))
 }
 
-func parseGHRunWatchOptions(args []string) (ghRunWatchOptions, bool) {
-	opts := ghRunWatchOptions{interval: watchMinInterval}
-	positionals := []string{}
-	for index := 0; index < len(args); index++ {
-		arg := args[index]
-		switch {
-		case arg == "--exit-status":
-			opts.exitStatus = true
-		case arg == "--compact":
-			// Accepted without effect: the shim's terse transition/summary output
-			// is already compact by design and does not render real gh's live table.
-		case watchFlagValue(args, &index, arg, "-R", &opts.repo):
-		case watchFlagValue(args, &index, arg, "--repo", &opts.repo):
-		case isWatchValueFlag(arg, "-i"):
-			value, valueOK := takeWatchFlagValue(args, &index, arg, "-i")
-			if !valueOK || !setWatchInterval(value, &opts.interval) {
-				return opts, false
-			}
-		case isWatchValueFlag(arg, "--interval"):
-			value, valueOK := takeWatchFlagValue(args, &index, arg, "--interval")
-			if !valueOK || !setWatchInterval(value, &opts.interval) {
-				return opts, false
-			}
-		case attachedWatchInterval(arg) != "":
-			if !setWatchInterval(attachedWatchInterval(arg), &opts.interval) {
-				return opts, false
-			}
-		case strings.HasPrefix(arg, "-"):
-			return opts, false
-		default:
-			positionals = append(positionals, arg)
-		}
+func watchReadSpecs(command string) map[string]readOptionSpec {
+	values, booleans := "--repo,-R --interval,-i", "--exit-status --compact"
+	if command == "pr checks" {
+		values += " --json --jq,-q --template"
+		booleans = "--watch --fail-fast --required --web"
 	}
-	if len(positionals) != 1 || !isDigits(positionals[0]) {
-		return opts, false
-	}
-	opts.id = positionals[0]
-	return opts, true
+	specs := typedReadSpecs(command, values, booleans)
+	interval := specs["-i"]
+	interval.attached = true
+	specs["-i"] = interval
+	return specs
 }
 
-// attachedWatchInterval handles pflag's attached shorthand form -i45.
-func attachedWatchInterval(arg string) string {
-	value, ok := strings.CutPrefix(arg, "-i")
-	if !ok || value == "" || !isDigits(value) {
-		return ""
+func nativeWatchReadSpecs(command string) map[string]readOptionSpec {
+	specs := watchReadSpecs(command)
+	if command == "pr checks" {
+		// Native web shorthand affects shape/floor ownership, not relay eligibility.
+		specs["-w"] = specs["--web"]
 	}
-	return value
+	return specs
+}
+
+func readWatchInterval(parsed readOptions) (time.Duration, bool) {
+	if !parsed.has("--interval") {
+		return watchMinInterval, true
+	}
+	seconds := parsed.values["--interval"].integer
+	// Validate before multiplication or flooring; an int-valid discarded value
+	// need not be a representable duration, but the final value must be.
+	if seconds > math.MaxInt64/int64(time.Second) || seconds < math.MinInt64/int64(time.Second) {
+		return 0, false
+	}
+	return max(time.Duration(seconds)*time.Second, watchMinInterval), true
+}
+
+func parseGHRunWatchOptions(args []string) (ghRunWatchOptions, bool) {
+	opts := ghRunWatchOptions{interval: watchMinInterval}
+	parsed, unsupported, err := parseReadOptions(args, watchReadSpecs("run watch"))
+	if err != nil || unsupported || len(parsed.positionals) != 1 || !isDigits(parsed.positionals[0]) {
+		return opts, false
+	}
+	var ok bool
+	opts.interval, ok = readWatchInterval(parsed)
+	opts.repo, opts.id = parsed.values["--repo"].raw, parsed.positionals[0]
+	opts.exitStatus = parsed.values["--exit-status"].boolean
+	return opts, ok
 }
 
 func relayRunWatch(ctx context.Context, stdout io.Writer, opts ghRunWatchOptions) error {
@@ -385,46 +385,18 @@ func handleGHPRChecksWatch(ctx context.Context, args []string, stdout io.Writer)
 
 func parseGHPRChecksWatchOptions(args []string) (ghPRChecksWatchOptions, bool) {
 	opts := ghPRChecksWatchOptions{interval: watchMinInterval}
-	positionals := []string{}
-	watch := false
-	for index := 0; index < len(args); index++ {
-		arg := args[index]
-		switch {
-		case watchFlagTrue(arg):
-			watch = true
-		case strings.HasPrefix(arg, "--watch="):
-			return opts, false
-		case arg == "--fail-fast":
-			opts.failFast = true
-		case watchFlagValue(args, &index, arg, "-R", &opts.repo):
-		case watchFlagValue(args, &index, arg, "--repo", &opts.repo):
-		case isWatchValueFlag(arg, "-i"):
-			value, valueOK := takeWatchFlagValue(args, &index, arg, "-i")
-			if !valueOK || !setWatchInterval(value, &opts.interval) {
-				return opts, false
-			}
-		case isWatchValueFlag(arg, "--interval"):
-			value, valueOK := takeWatchFlagValue(args, &index, arg, "--interval")
-			if !valueOK || !setWatchInterval(value, &opts.interval) {
-				return opts, false
-			}
-		case attachedWatchInterval(arg) != "":
-			if !setWatchInterval(attachedWatchInterval(arg), &opts.interval) {
-				return opts, false
-			}
-		case strings.HasPrefix(arg, "-"):
-			// real gh rejects --watch with --json/--jq/--template; delegating
-			// unknown flags lets it report those combinations itself.
-			return opts, false
-		default:
-			positionals = append(positionals, arg)
-		}
-	}
-	if !watch || len(positionals) != 1 || !isDigits(positionals[0]) {
+	parsed, unsupported, err := parseReadOptions(args, watchReadSpecs("pr checks"))
+	if err != nil || unsupported || !parsed.values["--watch"].boolean || len(parsed.positionals) != 1 || !isDigits(parsed.positionals[0]) {
 		return opts, false
 	}
-	opts.number = positionals[0]
-	return opts, true
+	if parsed.has("--json") || parsed.has("--jq") || parsed.has("--template") || parsed.values["--required"].boolean || parsed.values["--web"].boolean {
+		return opts, false
+	}
+	var ok bool
+	opts.interval, ok = readWatchInterval(parsed)
+	opts.repo, opts.number = parsed.values["--repo"].raw, parsed.positionals[0]
+	opts.failFast = parsed.values["--fail-fast"].boolean
+	return opts, ok
 }
 
 func relayPRChecksWatch(ctx context.Context, stdout io.Writer, opts ghPRChecksWatchOptions) error {
@@ -622,121 +594,38 @@ func watchError(err error, progressPrinted bool) error {
 }
 
 func hasWatchFlag(args []string) bool {
-	// pflag applies last-value-wins to repeated boolean flags; mirror that so
-	// `--watch --watch=false` is not treated as a watch shape.
-	watch := false
-	for _, arg := range args {
-		if arg == "--" {
-			break
-		}
-		if watchFlagTrue(arg) {
-			watch = true
-		} else if value, ok := strings.CutPrefix(arg, "--watch="); ok {
-			if parsed, err := strconv.ParseBool(value); err == nil && !parsed {
-				watch = false
-			}
-		}
-	}
-	return watch
-}
-
-// watchFlagTrue mirrors pflag bool parsing: bare --watch or any ParseBool
-// true spelling counts; false spellings stay unwatched.
-func watchFlagTrue(arg string) bool {
-	if arg == "--watch" {
-		return true
-	}
-	value, ok := strings.CutPrefix(arg, "--watch=")
-	if !ok {
-		return false
-	}
-	parsed, err := strconv.ParseBool(value)
-	return err == nil && parsed
-}
-
-func watchFlagValue(args []string, index *int, arg string, name string, target *string) bool {
-	if !isWatchValueFlag(arg, name) {
-		return false
-	}
-	value, ok := takeWatchFlagValue(args, index, arg, name)
-	if !ok {
-		return false
-	}
-	*target = value
-	return true
-}
-
-func isWatchValueFlag(arg string, name string) bool {
-	return arg == name || strings.HasPrefix(arg, name+"=")
-}
-
-func takeWatchFlagValue(args []string, index *int, arg string, name string) (string, bool) {
-	if strings.HasPrefix(arg, name+"=") {
-		value := strings.TrimPrefix(arg, name+"=")
-		return value, value != ""
-	}
-	*index = *index + 1
-	if *index >= len(args) {
-		return "", false
-	}
-	return args[*index], true
-}
-
-func setWatchInterval(raw string, interval *time.Duration) bool {
-	seconds, err := strconv.Atoi(raw)
-	if err != nil {
-		return false
-	}
-	*interval = max(time.Duration(seconds)*time.Second, watchMinInterval)
-	return true
+	parsed, unsupported, err := parseReadOptions(args, nativeWatchReadSpecs("pr checks"))
+	return err == nil && !unsupported && parsed.values["--watch"].boolean
 }
 
 func floorGHWatchDelegateArgs(args []string) []string {
 	if !isGHWatchShape(args) {
 		return args
 	}
-	out := append([]string(nil), args...)
-	found := false
-	for index := 2; index < len(out); index++ {
-		arg := out[index]
-		// Everything after the terminator is positional, never an interval flag.
-		if arg == "--" {
-			break
+	parsed, unsupported, err := parseReadOptions(args[2:], nativeWatchReadSpecs(args[0]+" "+args[1]))
+	if err != nil || unsupported {
+		return args
+	}
+	interval, ok := readWatchInterval(parsed)
+	if !ok {
+		return args
+	}
+	if parsed.has("--interval") {
+		if interval > watchMinInterval || parsed.values["--interval"].integer >= int64(watchMinInterval/time.Second) {
+			return args
 		}
-		if value := attachedWatchInterval(arg); value != "" {
-			found = true
-			out[index] = "-i" + floorWatchIntervalValue(value)
-			continue
-		}
-		for _, name := range []string{"-i", "--interval"} {
-			if arg == name {
-				found = true
-				if index+1 < len(out) {
-					out[index+1] = floorWatchIntervalValue(out[index+1])
-					index++
-				}
-				break
-			}
-			if strings.HasPrefix(arg, name+"=") {
-				found = true
-				value := strings.TrimPrefix(arg, name+"=")
-				out[index] = name + "=" + floorWatchIntervalValue(value)
-				break
+		for i := len(parsed.ordered) - 1; i >= 0; i-- {
+			occurrence := parsed.ordered[i]
+			if occurrence.name == "--interval" {
+				out := append([]string(nil), args...)
+				out[2+occurrence.valueIndex] = occurrence.valuePrefix + "30"
+				return out
 			}
 		}
 	}
-	if !found {
-		floor := []string{"--interval", "30"}
-		// Keep the injected flag ahead of any `--` terminator; after it,
-		// real gh would treat the flag as a positional and reject the command.
-		for index, arg := range out {
-			if arg == "--" {
-				return append(out[:index:index], append(floor, out[index:]...)...)
-			}
-		}
-		out = append(out, floor...)
-	}
-	return out
+	out := append([]string(nil), args[:2+parsed.delimiter]...)
+	out = append(out, "--interval", "30")
+	return append(out, args[2+parsed.delimiter:]...)
 }
 
 func isGHWatchShape(args []string) bool {
@@ -747,12 +636,4 @@ func isGHWatchShape(args []string) bool {
 		return true
 	}
 	return args[0] == "pr" && args[1] == "checks" && hasWatchFlag(args[2:])
-}
-
-func floorWatchIntervalValue(raw string) string {
-	seconds, err := strconv.Atoi(raw)
-	if err == nil && seconds < int(watchMinInterval/time.Second) {
-		return strconv.Itoa(int(watchMinInterval / time.Second))
-	}
-	return raw
 }

--- a/cmd/octopool/gh_top_watch_test.go
+++ b/cmd/octopool/gh_top_watch_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"os"
 	"reflect"
@@ -399,13 +400,205 @@ func TestGHWatchParsersHandleAttachedInterval(t *testing.T) {
 	if !ok || checkOpts.interval != watchMinInterval {
 		t.Fatalf("checks watch -i5 must floor: ok=%v interval=%v", ok, checkOpts.interval)
 	}
-	floored := floorGHWatchDelegateArgs([]string{"run", "watch", "42", "--json", "x", "-i5"})
-	if !reflect.DeepEqual(floored, []string{"run", "watch", "42", "--json", "x", "-i30"}) {
+	floored := floorGHWatchDelegateArgs([]string{"run", "watch", "42", "-i5"})
+	if !reflect.DeepEqual(floored, []string{"run", "watch", "42", "-i30"}) {
 		t.Fatalf("delegated -i5 must floor in place, got %v", floored)
+	}
+	invalid := []string{"run", "watch", "42", "--json", "x", "-i5"}
+	if got := floorGHWatchDelegateArgs(invalid); !reflect.DeepEqual(got, invalid) {
+		t.Fatalf("undeclared run-watch JSON must not be repaired: %v", got)
 	}
 	terminated := floorGHWatchDelegateArgs([]string{"run", "watch", "--", "42"})
 	if !reflect.DeepEqual(terminated, []string{"run", "watch", "--interval", "30", "--", "42"}) {
 		t.Fatalf("injected interval must precede the -- terminator, got %v", terminated)
+	}
+}
+
+func TestGHWatchIntervalOccurrences(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		flags     []string
+		seconds   int64
+		supported bool
+	}{
+		{"control_decimal", []string{"--interval=45"}, 45, true},
+		{"regression_octal", []string{"--interval=040"}, 32, true},
+		{"regression_hex", []string{"--interval=0x20"}, 32, true},
+		{"regression_binary", []string{"--interval=0b100000"}, 32, true},
+		{"regression_underscore", []string{"--interval=3_2"}, 32, true},
+		{"regression_attached_octal", []string{"-i040"}, 32, true},
+		{"regression_hex_floor", []string{"--interval=0x1"}, 30, true},
+		{"control_negative_floor", []string{"--interval=-1"}, 30, true},
+		{"control_zero_floor", []string{"--interval=0"}, 30, true},
+		{"regression_invalid_octal_earlier", []string{"--interval=08", "--interval=45"}, 0, false},
+		{"control_int_overflow_earlier", []string{"--interval=9223372036854775808", "--interval=45"}, 0, false},
+		{"regression_positive_duration_overflow", []string{"--interval=9223372037"}, 0, false},
+		{"regression_negative_duration_overflow", []string{"--interval=-9223372037"}, 0, false},
+		{"control_duration_overridden", []string{"--interval=9223372037", "--interval=45"}, 45, true},
+		{"control_duration_endpoint", []string{"--interval=9223372036"}, 9223372036, true},
+		{"control_negative_duration_endpoint", []string{"--interval=-9223372036"}, 30, true},
+	} {
+		for _, command := range []string{"run", "checks"} {
+			t.Run(command+"/"+test.name, func(t *testing.T) {
+				var interval time.Duration
+				var ok bool
+				if command == "run" {
+					opts, supported := parseGHRunWatchOptions(append([]string{"42"}, test.flags...))
+					interval, ok = opts.interval, supported
+				} else {
+					opts, supported := parseGHPRChecksWatchOptions(append([]string{"7", "--watch"}, test.flags...))
+					interval, ok = opts.interval, supported
+				}
+				if ok != test.supported || (ok && interval != time.Duration(test.seconds)*time.Second) {
+					t.Fatalf("supported=%v want=%v interval=%v wantSeconds=%d", ok, test.supported, interval, test.seconds)
+				}
+			})
+		}
+	}
+}
+
+func TestGHWatchFloorValueOwnership(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		args, want []string
+	}{
+		{"regression_hex_floor", []string{"run", "watch", "42", "--interval=0x1"}, []string{"run", "watch", "42", "--interval=30"}},
+		{"regression_attached_hex_floor", []string{"run", "watch", "42", "-i0x1"}, []string{"run", "watch", "42", "-i30"}},
+		{"regression_repo_owned_value", []string{"run", "watch", "42", "--repo", "-i1", "--compact"}, []string{"run", "watch", "42", "--repo", "-i1", "--compact", "--interval", "30"}},
+		{"regression_repo_owned_delimiter", []string{"run", "watch", "42", "--repo", "--", "--compact"}, []string{"run", "watch", "42", "--repo", "--", "--compact", "--interval", "30"}},
+		{"regression_discarded_interval", []string{"run", "watch", "42", "-i1", "--interval=45"}, []string{"run", "watch", "42", "-i1", "--interval=45"}},
+		{"regression_invalid_earlier_octal", []string{"run", "watch", "42", "-i08", "--interval=1"}, []string{"run", "watch", "42", "-i08", "--interval=1"}},
+		{"control_overridden_duration_floor", []string{"run", "watch", "42", "--interval=9223372037", "-i1"}, []string{"run", "watch", "42", "--interval=9223372037", "-i30"}},
+		{"control_final_floor", []string{"run", "watch", "42", "--interval=45", "-i1"}, []string{"run", "watch", "42", "--interval=45", "-i30"}},
+		{"control_original_large_spelling", []string{"run", "watch", "42", "--interval=0x20"}, []string{"run", "watch", "42", "--interval=0x20"}},
+		{"control_duration_overflow_untouched", []string{"run", "watch", "42", "--interval=9223372037"}, []string{"run", "watch", "42", "--interval=9223372037"}},
+		{"control_after_delimiter", []string{"run", "watch", "42", "--", "-i1"}, []string{"run", "watch", "42", "--interval", "30", "--", "-i1"}},
+		{"control_false_watch", []string{"pr", "checks", "7", "--watch=false", "-i1"}, []string{"pr", "checks", "7", "--watch=false", "-i1"}},
+		{"control_repo_owned_watch", []string{"pr", "checks", "7", "--repo", "--watch", "-i1"}, []string{"pr", "checks", "7", "--repo", "--watch", "-i1"}},
+		{"control_unknown_value_ownership", []string{"run", "watch", "42", "--unknown", "-i1"}, []string{"run", "watch", "42", "--unknown", "-i1"}},
+		{"regression_run_attached_repo", []string{"run", "watch", "42", "-Racme/repo", "-i1"}, []string{"run", "watch", "42", "-Racme/repo", "-i30"}},
+		{"regression_pr_attached_repo", []string{"pr", "checks", "7", "-Racme/repo", "--watch", "--required", "-i1"}, []string{"pr", "checks", "7", "-Racme/repo", "--watch", "--required", "-i30"}},
+		{"control_attached_repo_false_watch", []string{"pr", "checks", "7", "-Racme/repo", "--watch=false", "-i1"}, []string{"pr", "checks", "7", "-Racme/repo", "--watch=false", "-i1"}},
+		{"control_attached_repo_invalid_interval", []string{"run", "watch", "42", "-Racme/repo", "-i08", "--interval=1"}, []string{"run", "watch", "42", "-Racme/repo", "-i08", "--interval=1"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			original := append([]string(nil), test.args...)
+			got := floorGHWatchDelegateArgs(test.args)
+			if !reflect.DeepEqual(got, test.want) || !reflect.DeepEqual(test.args, original) {
+				t.Fatalf("floored=%q want=%q caller=%q", got, test.want, test.args)
+			}
+		})
+	}
+}
+
+func TestGHReadShortBoolOccurrences(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		args     []string
+		raw      string
+		web      bool
+		rejected bool
+	}{
+		{"false_assignment", []string{"-w=false"}, "false", false, false},
+		{"zero_assignment", []string{"-w=0"}, "0", false, false},
+		{"long_then_short", []string{"--web=true", "-w=false"}, "false", false, false},
+		{"short_then_long", []string{"-w=true", "--web=false"}, "false", false, false},
+		{"short_true", []string{"-w=true"}, "true", true, false},
+		{"bare_short_control", []string{"-w"}, "true", true, false},
+		{"long_false_control", []string{"--web=false"}, "false", false, false},
+		{"lone_equals_control", []string{"-w="}, "", false, true},
+		{"cluster_control", []string{"-wf"}, "", false, true},
+		{"attached_false_control", []string{"-wfalse"}, "", false, true},
+		{"invalid_bool_control", []string{"-w=no"}, "", false, true},
+		{"invalid_earlier_control", []string{"-w=no", "--web=false"}, "", false, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			original := append([]string(nil), test.args...)
+			specs := typedReadSpecs("pr checks", "", "--web,-w --watch")
+			parsed, unsupported, err := parseReadOptions(test.args, specs)
+			if !reflect.DeepEqual(test.args, original) {
+				t.Fatalf("caller argv changed: %q", test.args)
+			}
+			if test.rejected {
+				if err == nil && !unsupported {
+					t.Fatal("invalid or clustered shorthand accepted")
+				}
+				return
+			}
+			if err != nil || unsupported || !parsed.has("--web") || parsed.has("--watch") || parsed.values["--web"].boolean != test.web || parsed.values["--web"].raw != test.raw {
+				t.Fatalf("err=%v unsupported=%v values=%+v; want web=%v raw=%q and no watch", err, unsupported, parsed.values, test.web, test.raw)
+			}
+			if !reflect.DeepEqual(parsed.argv, original) || len(parsed.ordered) != len(test.args) {
+				t.Fatalf("raw ownership lost: %+v", parsed)
+			}
+			for i, occurrence := range parsed.ordered {
+				if occurrence.name != "--web" || occurrence.start != i || occurrence.end != i+1 {
+					t.Fatalf("alias occurrence lost: %+v", occurrence)
+				}
+			}
+		})
+	}
+}
+
+func TestGHWatchShortBoolFloorOwnership(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		flags, want []string
+	}{
+		{"false", []string{"--watch", "-w=false", "-i1"}, []string{"--watch", "-w=false", "-i30"}},
+		{"zero", []string{"--watch", "-w=0", "-i1"}, []string{"--watch", "-w=0", "-i30"}},
+		{"lower_f", []string{"--watch", "-w=f", "-i1"}, []string{"--watch", "-w=f", "-i30"}},
+		{"upper_f", []string{"--watch", "-w=F", "-i1"}, []string{"--watch", "-w=F", "-i30"}},
+		{"upper_false", []string{"--watch", "-w=FALSE", "-i1"}, []string{"--watch", "-w=FALSE", "-i30"}},
+		{"title_false", []string{"--watch", "-w=False", "-i1"}, []string{"--watch", "-w=False", "-i30"}},
+		{"mixed_final_short", []string{"--watch", "--web=true", "-w=false", "-i1"}, []string{"--watch", "--web=true", "-w=false", "-i30"}},
+		{"mixed_final_long", []string{"--watch", "-w=true", "--web=false", "-i1"}, []string{"--watch", "-w=true", "--web=false", "-i30"}},
+		{"effective_only", []string{"--watch", "-i1", "-w=0", "--interval=0x1"}, []string{"--watch", "-i1", "-w=0", "--interval=30"}},
+		{"default_before_terminator", []string{"--watch", "-w=false", "--", "-i1"}, []string{"--watch", "-w=false", "--interval", "30", "--", "-i1"}},
+		{"long_false_control", []string{"--watch", "--web=false", "--required", "-i1"}, []string{"--watch", "--web=false", "--required", "-i30"}},
+		{"lone_equals_control", []string{"--watch", "-w=", "-i1"}, []string{"--watch", "-w=", "-i1"}},
+		{"cluster_control", []string{"--watch", "-wf", "-i1"}, []string{"--watch", "-wf", "-i1"}},
+		{"invalid_bool_control", []string{"--watch", "-w=no", "--web=false", "-i1"}, []string{"--watch", "-w=no", "--web=false", "-i1"}},
+		{"terminator_control", []string{"--", "--watch", "-w=false", "-i1"}, []string{"--", "--watch", "-w=false", "-i1"}},
+		{"owned_web_control", []string{"--watch", "--jq", "-w=false", "-i1"}, []string{"--watch", "--jq", "-w=false", "-i30"}},
+		{"owned_watch_control", []string{"--jq", "--watch", "-w=false", "-i1"}, []string{"--jq", "--watch", "-w=false", "-i1"}},
+		{"false_watch_control", []string{"--watch", "-w=false", "--watch=false", "-i1"}, []string{"--watch", "-w=false", "--watch=false", "-i1"}},
+		{"web_is_not_watch_control", []string{"-w=true", "-i1"}, []string{"-w=true", "-i1"}},
+		{"large_raw_control", []string{"--watch", "-w=false", "-i0x20"}, []string{"--watch", "-w=false", "-i0x20"}},
+		{"invalid_interval_control", []string{"--watch", "-w=false", "-i08", "-i1"}, []string{"--watch", "-w=false", "-i08", "-i1"}},
+		{"duration_overflow_control", []string{"--watch", "-w=false", "--interval=9223372037"}, []string{"--watch", "-w=false", "--interval=9223372037"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			args := append([]string{"pr", "checks", "7", "-R", "acme/repo"}, test.flags...)
+			original := append([]string(nil), args...)
+			want := append([]string{"pr", "checks", "7", "-R", "acme/repo"}, test.want...)
+			if got := floorGHWatchDelegateArgs(args); !reflect.DeepEqual(got, want) || !reflect.DeepEqual(args, original) {
+				t.Fatalf("floored=%q want=%q caller=%q", got, want, args)
+			}
+		})
+	}
+}
+
+func TestGHRunWatchNativeIntervalSleep(t *testing.T) {
+	for _, raw := range []string{"040", "0x20"} {
+		t.Run(raw, func(t *testing.T) {
+			calls := 0
+			relayTestServer(t, func(req map[string]any) any {
+				if strings.HasSuffix(req["path"].(string), "/jobs") {
+					return map[string]any{"total_count": 0, "jobs": []any{}}
+				}
+				calls++
+				if calls == 1 {
+					return map[string]any{"status": "queued"}
+				}
+				return map[string]any{"status": "completed", "conclusion": "success", "run_attempt": 3}
+			})
+			sleeps := recordWatchSleeps(t)
+			result := handleGHRun(t.Context(), []string{"watch", "42", "-R", "acme/repo", "--interval", raw}, &bytes.Buffer{})
+			if result.action != ghComplete || result.err != nil || !reflect.DeepEqual(*sleeps, []time.Duration{32 * time.Second}) {
+				t.Fatalf("action=%v err=%v sleeps=%v", result.action, result.err, *sleeps)
+			}
+		})
 	}
 }
 
@@ -573,6 +766,76 @@ func TestGHRunWatchPaginatesCompletedRunJobs(t *testing.T) {
 	}
 }
 
+func TestGHWatchAttachedRepoNativeHandoff(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		repo []string
+	}{
+		{"attached", []string{"-Racme/repo"}},
+		{"separate_control", []string{"-R", "acme/repo"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			data := 0
+			_, policies := rewriteTestServer(t, rewriteEmptyTestPolicy, func(w http.ResponseWriter, r *http.Request) { data++ })
+			t.Setenv("GH_HOST", "github.com")
+			t.Setenv("GH_REPO", "")
+			capturePath := captureRewriteGH(t)
+			args := append([]string{"pr", "checks", "7"}, test.repo...)
+			args = append(args, "--watch", "--required", "-i1")
+			original := append([]string(nil), args...)
+			var out bytes.Buffer
+			err := runGH(t.Context(), args, &out, io.Discard)
+			if err != nil || data != 0 || policies.Load() != 2 || out.String() != "child stdout\n" {
+				t.Fatalf("watch handoff: err=%v data=%d policies=%d output=%q", err, data, policies.Load(), out.String())
+			}
+			capture := readRewriteCapture(t, capturePath)
+			want := append([]string(nil), args...)
+			want[len(want)-1] = "-i30"
+			if !reflect.DeepEqual(capture.Args, want) || !reflect.DeepEqual(args, original) {
+				t.Fatalf("native watch interval/argv: got=%q want=%q caller=%q", capture.Args, want, args)
+			}
+		})
+	}
+}
+
+func TestGHWatchShortBoolNativeHandoff(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		flags, want []string
+	}{
+		{"false", []string{"--watch", "-w=false", "-i1"}, []string{"--watch", "-w=false", "-i30"}},
+		{"zero", []string{"--watch", "-w=0", "-i1"}, []string{"--watch", "-w=0", "-i30"}},
+		{"mixed_final_short", []string{"--watch", "--web=true", "-w=false", "-i1"}, []string{"--watch", "--web=true", "-w=false", "-i30"}},
+		{"mixed_final_long", []string{"--watch", "-w=true", "--web=false", "-i1"}, []string{"--watch", "-w=true", "--web=false", "-i30"}},
+		{"long_required_control", []string{"--watch", "--web=false", "--required", "-i1"}, []string{"--watch", "--web=false", "--required", "-i30"}},
+		{"lone_equals_control", []string{"--watch", "-w=", "-i1"}, []string{"--watch", "-w=", "-i1"}},
+		{"cluster_control", []string{"--watch", "-wf", "-i1"}, []string{"--watch", "-wf", "-i1"}},
+		{"invalid_bool_control", []string{"--watch", "-w=no", "-i1"}, []string{"--watch", "-w=no", "-i1"}},
+		{"false_watch_control", []string{"--watch=false", "-w=false", "-i1"}, []string{"--watch=false", "-w=false", "-i1"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			data := 0
+			_, policies := rewriteTestServer(t, rewriteEmptyTestPolicy, func(w http.ResponseWriter, r *http.Request) { data++ })
+			t.Setenv("GH_HOST", "github.com")
+			t.Setenv("GH_REPO", "")
+			capturePath := captureRewriteGH(t)
+			args := append([]string{"pr", "checks", "7", "-R", "acme/repo"}, test.flags...)
+			original := append([]string(nil), args...)
+			var out, stderr bytes.Buffer
+			err := runGH(t.Context(), args, &out, &stderr)
+			// Each capture child emits one marker; exact output also proves one handoff.
+			if err != nil || data != 0 || policies.Load() != 2 || out.String() != "child stdout\n" || stderr.String() != "child stderr\n" {
+				t.Fatalf("handoff: err=%v data=%d policies=%d stdout=%q stderr=%q", err, data, policies.Load(), out.String(), stderr.String())
+			}
+			capture := readRewriteCapture(t, capturePath)
+			want := append([]string{"pr", "checks", "7", "-R", "acme/repo"}, test.want...)
+			if !reflect.DeepEqual(capture.Args, want) || !reflect.DeepEqual(args, original) || capture.Env["GH_HOST"] != "github.com" || capture.Stdin != "" {
+				t.Fatalf("capture=%+v want args=%q caller=%q", capture, want, args)
+			}
+		})
+	}
+}
+
 func TestGHWatchDelegatesWithFlooredInterval(t *testing.T) {
 	emptyRewriteTestServer(t)
 	tests := []struct {
@@ -593,7 +856,7 @@ func TestGHWatchDelegatesWithFlooredInterval(t *testing.T) {
 		{
 			name: "unknown run flag",
 			args: []string{"run", "watch", "42", "--web"},
-			want: "real-gh:run watch 42 --web --interval 30",
+			want: "real-gh:run watch 42 --web",
 		},
 	}
 	for _, test := range tests {

--- a/cmd/octopool/protection_reads_test.go
+++ b/cmd/octopool/protection_reads_test.go
@@ -57,7 +57,7 @@ func TestProtectionReadsStrictPreparation(t *testing.T) {
 			if err := prepareRewriteAPI(policy, args, strings.NewReader("unused stdin"), prepared); err != nil {
 				t.Fatal(err)
 			}
-			want := []string{"api", endpoint, "--method=GET", "--hostname=github.com", "--jq=type", "--paginate=true", "--slurp=true", "--include=true", "--silent=true"}
+			want := []string{"api", endpoint, "--method=GET", "--hostname=github.com", "--jq", "type", "--paginate=true", "--slurp=true", "--include=true", "--silent=true"}
 			if !slices.Equal(prepared.args, want) {
 				t.Fatalf("strict args=%v", prepared.args)
 			}
@@ -147,9 +147,14 @@ func TestProtectionReadsNativeHandoff(t *testing.T) {
 			if !slices.Contains(got.Args, "--hostname=github.com") || got.Env["GH_HOST"] != "github.com" || got.Env["GH_REPO"] != "" {
 				t.Fatal("native protection read lost GitHub.com host pinning")
 			}
-			for _, flag := range []string{"--jq=type", "--paginate=true", "--slurp=true"} {
-				if (flag == "--jq=type" && endpoint == "repos/acme/demo/rules/branches/main") ||
-					(flag != "--jq=type" && endpoint == "repos/acme/demo/rulesets") {
+			if slices.Contains(args, "--jq") {
+				index := slices.Index(got.Args, "--jq")
+				if index < 0 || index+1 >= len(got.Args) || got.Args[index+1] != "type" {
+					t.Fatalf("lost original jq occurrence: %v", got.Args)
+				}
+			}
+			for _, flag := range []string{"--paginate=true", "--slurp=true"} {
+				if endpoint == "repos/acme/demo/rulesets" {
 					if !slices.Contains(got.Args, flag) {
 						t.Fatalf("lost native flag %s", flag)
 					}

--- a/cmd/octopool/string_rewrites_api.go
+++ b/cmd/octopool/string_rewrites_api.go
@@ -22,6 +22,7 @@ type rewriteAPIOptions struct {
 func parseRewriteAPI(args []string) (rewriteAPIOptions, error) {
 	result := rewriteAPIOptions{headers: map[string]string{}}
 	seen := map[string]bool{}
+	jqCount := 0
 	values := rewriteFlagNames("--method,-X --input --field,-F --raw-field,-f --header,-H --jq,-q")
 	booleans := rewriteFlagNames("--include,-i --silent --paginate --slurp")
 	for i := 0; i < len(args); i++ {
@@ -51,9 +52,21 @@ func parseRewriteAPI(args []string) (rewriteAPIOptions, error) {
 			return result, errRewriteUnsupported
 		}
 		flag := parsed.ordered[0]
+		if flag.name == "--jq" {
+			jqCount++
+			specs := typedReadSpecs("api", "--jq,-q", "")
+			short := specs["-q"]
+			short.attached = true
+			specs["-q"] = short
+			owned, unsupported, err := parseReadOptions(args[i:i+count], specs)
+			if err != nil || unsupported {
+				return result, errRewriteUnsupported
+			}
+			flag.value = owned.values["--jq"].raw
+		}
 		i += count - 1
 		if flag.name != "--field" && flag.name != "--raw-field" && flag.name != "--header" {
-			if seen[flag.name] {
+			if seen[flag.name] && flag.name != "--jq" {
 				return result, errRewriteBlocked
 			}
 			seen[flag.name] = true
@@ -90,6 +103,10 @@ func parseRewriteAPI(args []string) (rewriteAPIOptions, error) {
 			result.headers[key] = value
 			result.output = append(result.output, "--header="+key+": "+value)
 		default:
+			if flag.name == "--jq" {
+				result.output = append(result.output, args[i-count+1:i+1]...)
+				continue
+			}
 			result.output = append(result.output, flag.name+"="+flag.value)
 		}
 	}
@@ -101,6 +118,9 @@ func parseRewriteAPI(args []string) (rewriteAPIOptions, error) {
 		if len(result.fields) > 0 || result.inputSet {
 			result.method = "POST"
 		}
+	}
+	if jqCount > 1 && result.method != "GET" {
+		return result, errRewriteBlocked
 	}
 	if result.inputSet && len(result.fields) > 0 {
 		return result, errRewriteBlocked

--- a/cmd/octopool/string_rewrites_guard.go
+++ b/cmd/octopool/string_rewrites_guard.go
@@ -178,9 +178,51 @@ func prepareRewriteRead(policy stringRewritePolicy, args []string, prepared *rew
 	default:
 		return errRewriteUnsupported
 	}
-	flags, err := parseRewriteFlags(args[2:], rewriteFlagNames(values), rewriteFlagNames(booleans))
-	if err != nil {
+	specs := typedReadSpecs(command, values, booleans)
+	// Retain the guard's existing attached aliases, including native-only filters.
+	for alias, spec := range specs {
+		spec.attached = len(alias) == 2
+		specs[alias] = spec
+	}
+	parsed, unsupported, err := parseReadOptions(args[2:], specs)
+	if unsupported {
 		return errRewriteUnsupported
+	}
+	if err != nil {
+		return errRewriteBlocked
+	}
+	flags := rewriteFlags{values: map[string]string{}, positionals: parsed.positionals}
+	for name, value := range parsed.values {
+		flags.values[name] = value.raw
+	}
+	if spec := specs["--repo"]; spec.kind == readSlice && parsed.has("--repo") {
+		repos := parsed.values["--repo"].strings
+		count := 0
+		for _, occurrence := range parsed.ordered {
+			if occurrence.name == "--repo" {
+				count++
+			}
+		}
+		if count > 1 || len(repos) != 1 {
+			return errRewriteUnsupported
+		}
+		flags.values["--repo"] = repos[0]
+	}
+	// Validate original material too: overwritten scalars and ignored CSV records
+	// do not erase structural/host policy input.
+	for _, occurrence := range parsed.ordered {
+		if occurrence.name == "--jq" {
+			continue
+		}
+		if err := policy.checkStructural(occurrence.raw); err != nil {
+			return err
+		}
+		if occurrence.name == "--repo" && specs["--repo"].kind != readSlice {
+			original := rewriteFlags{values: map[string]string{"--repo": occurrence.raw}}
+			if err := rewriteRepo(&original, policy); err != nil {
+				return err
+			}
+		}
 	}
 	if flags.has("--color") {
 		return errRewriteBlocked
@@ -258,19 +300,45 @@ func prepareRewriteRead(policy stringRewritePolicy, args []string, prepared *rew
 		if err := policy.checkStructural("github.com/" + flags.values["--repo"]); err != nil {
 			return err
 		}
+		// Native repo view owns a positional repository, not a --repo flag.
 		prepared.args = []string{"repo", "view", flags.values["--repo"]}
-	} else {
-		prepared.args = append([]string{args[0], args[1]}, flags.positionals...)
-		prepared.args = append(prepared.args, "--repo="+flags.values["--repo"])
-	}
-	for _, flag := range flags.ordered {
-		if flag.name != "--repo" {
-			if flag.boolean && flag.value == "true" {
-				prepared.args = append(prepared.args, flag.name)
-			} else {
-				prepared.args = append(prepared.args, flag.name+"="+flag.value)
+		for _, occurrence := range parsed.ordered {
+			if occurrence.name != "--repo" {
+				prepared.args = append(prepared.args, parsed.argv[occurrence.start:occurrence.end]...)
 			}
 		}
+		if parsed.delimiter < len(parsed.argv) {
+			prepared.args = append(prepared.args, "--")
+		}
+		prepared.stdin = strings.NewReader("")
+		return nil
+	}
+	prepared.args = append([]string(nil), args[:2]...)
+	occurrenceIndex := 0
+	for i := 0; i < len(parsed.argv); {
+		if occurrenceIndex < len(parsed.ordered) && parsed.ordered[occurrenceIndex].start == i {
+			occurrence := parsed.ordered[occurrenceIndex]
+			if occurrence.name == "--repo" {
+				repo := flags.values["--repo"]
+				if specs["--repo"].kind != readSlice && strings.TrimSpace(occurrence.raw) != "" {
+					repo = normalizeRepo(occurrence.raw)
+				}
+				prepared.args = append(prepared.args, "--repo="+repo)
+			} else {
+				prepared.args = append(prepared.args, parsed.argv[i:occurrence.end]...)
+			}
+			i = occurrence.end
+			occurrenceIndex++
+			continue
+		}
+		if i == parsed.delimiter && !parsed.has("--repo") {
+			prepared.args = append(prepared.args, "--repo="+flags.values["--repo"])
+		}
+		prepared.args = append(prepared.args, parsed.argv[i])
+		i++
+	}
+	if parsed.delimiter == len(parsed.argv) && !parsed.has("--repo") {
+		prepared.args = append(prepared.args, "--repo="+flags.values["--repo"])
 	}
 	prepared.stdin = strings.NewReader("")
 	return nil

--- a/cmd/octopool/string_rewrites_policy_test.go
+++ b/cmd/octopool/string_rewrites_policy_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -57,6 +58,32 @@ func TestStringRewritePolicyFailuresNeverRunChild(t *testing.T) {
 				t.Fatal("policy failure reached child")
 			}
 		})
+	}
+}
+
+func TestStringRewritePolicyBeforeMalformedReadOptions(t *testing.T) {
+	for _, code := range []int{401, 503} {
+		for _, flags := range [][]string{{"--json", `"unterminated`, "--json=number"}, {"--json=number", "--limit=08", "--limit=2"}} {
+			t.Run(fmt.Sprintf("%d/%s", code, flags[1]), func(t *testing.T) {
+				isolateTestConfig(t)
+				t.Setenv("OCTOPOOL_STRING_REWRITE_FILE", "")
+				var paths []string
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { paths = append(paths, r.URL.Path); w.WriteHeader(code) }))
+				t.Cleanup(server.Close)
+				t.Setenv("OCTOPOOL_URL", server.URL)
+				t.Setenv("OCTOPOOL_POOL", "maintainers")
+				t.Setenv("OCTOPOOL_TOKEN", "test-token")
+				capture := captureRewriteGH(t)
+				var out, stderr bytes.Buffer
+				err := runGH(t.Context(), append([]string{"pr", "list", "-R", "acme/repo"}, flags...), &out, &stderr)
+				if err != errRewritePolicy || out.Len() != 0 || stderr.Len() != 0 || !slices.Equal(paths, []string{"/v1/pools/maintainers/string-rewrites"}) {
+					t.Fatalf("policy precedence err=%v paths=%v out=%q stderr=%q", err, paths, out.String(), stderr.String())
+				}
+				if _, err := os.Stat(capture); !os.IsNotExist(err) {
+					t.Fatal("policy denial executed child")
+				}
+			})
+		}
 	}
 }
 func TestStringRewritePolicyRedirectsAndTimeout(t *testing.T) {

--- a/cmd/octopool/string_rewrites_process_test.go
+++ b/cmd/octopool/string_rewrites_process_test.go
@@ -1266,7 +1266,7 @@ func TestStringRewriteReadFallbackCompatibility(t *testing.T) {
 	}{
 		{"read readiness", []string{"pr", "view", "123", "--repo", "acme/repo", "--json", "number,headRefOid,statusCheckRollup"}, "123"},
 		{"read issue comments", []string{"issue", "view", "123", "--repo", "https://github.com/acme/repo", "--json", "number,comments"}, "comments"},
-		{"filter pull head", []string{"pr", "list", "--repo", "https://github.com/acme/repo", "--head", "safe-branch", "--json", "number"}, "--head=safe-branch"},
+		{"filter pull head", []string{"pr", "list", "--repo", "https://github.com/acme/repo", "--head", "safe-branch", "--json", "number"}, "safe-branch"},
 		{"mark ready", []string{"pr", "ready", "123", "--repo", "https://github.com/acme/repo"}, "ready"},
 		{"pinned merge", []string{"pr", "merge", "123", "--repo", "https://github.com/acme/repo", "--squash", "--match-head-commit", sha}, "repos/acme/repo/pulls/123/merge"},
 	} {
@@ -1276,6 +1276,9 @@ func TestStringRewriteReadFallbackCompatibility(t *testing.T) {
 				t.Fatal(err)
 			}
 			capture := readRewriteCapture(t, capturePath)
+			if test.args[0] == "pr" && test.args[1] == "list" && !slices.Equal(capture.Args, []string{"pr", "list", "--repo=acme/repo", "--head", "safe-branch", "--json", "number"}) {
+				t.Fatalf("read fallback changed caller spelling/order: %v", capture.Args)
+			}
 			if !slices.Contains(capture.Args, "--repo=acme/repo") && !slices.Contains(capture.Args, "repos/acme/repo/pulls/123/merge") {
 				t.Fatalf("repository was not structurally pinned: %v", capture.Args)
 			}
@@ -2201,6 +2204,293 @@ func TestStringRewriteRelayReadAndAuthFailure(t *testing.T) {
 	}
 }
 
+func TestStringRewriteReadOptionOccurrences(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		args  []string
+		want  string
+		label any
+	}{
+		{"control_single_json", []string{"pr", "view", "7", "-R", "acme/repo", "--json", "number,title"}, `{"number":7,"title":"synthetic"}`, nil},
+		{"regression_repeated_json", []string{"pr", "view", "7", "-R", "acme/repo", "--json", "number", "--json=title"}, `{"number":7,"title":"synthetic"}`, nil},
+		{"regression_repeated_labels", []string{"issue", "list", "-R", "acme/repo", "--label", `"bug"`, "--label=docs", "--json", "number"}, `[{"number":7}]`, "bug,docs"},
+		{"regression_repeated_limit", []string{"pr", "list", "-R", "acme/repo", "--limit=0", "--limit=2", "--json", "number"}, `[{"number":7}]`, nil},
+		{"regression_top_last_jq", []string{"pr", "view", "7", "-R", "acme/repo", "--json", "number,title", "--jq", "(", "--jq=.number"}, "7", nil},
+		{"regression_api_last_jq", []string{"api", "repos/acme/repo", "--jq", "(", "--jq=.number"}, "7", nil},
+		{"regression_api_empty_last_jq", []string{"api", "repos/acme/repo", "--jq", "(", "--jq="}, `{"number":7,"title":"synthetic"}`, nil},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if strings.Contains(test.name, "jq") && !jqAvailable() {
+				t.Skip("jq not installed")
+			}
+			var requests []map[string]any
+			_, policies := rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+				req := decodeCLIRequest(t, w, r)
+				requests = append(requests, req)
+				if test.args[0] == "api" {
+					writeCLIEnvelope(t, w, map[string]any{"number": 7, "title": "synthetic"})
+					return
+				}
+				writeCLIEnvelope(t, w, nativeOptionsResponse(t, req))
+			})
+			capture := captureRewriteGH(t)
+			var out bytes.Buffer
+			err := runGH(t.Context(), test.args, &out, io.Discard)
+			_, childErr := os.Stat(capture)
+			if err != nil || strings.TrimSpace(out.String()) != test.want || len(requests) != 1 || policies.Load() != 2 || !os.IsNotExist(childErr) {
+				t.Fatalf("err=%v output=%q want=%q data=%d policy=%d child=%v", err, out.String(), test.want, len(requests), policies.Load(), childErr)
+			}
+			if test.label != nil && requests[0]["query"].(map[string]any)["labels"] != test.label {
+				t.Fatalf("labels=%v", requests[0]["query"])
+			}
+		})
+	}
+}
+
+func TestStringRewriteRepoViewPositionalPin(t *testing.T) {
+	if !jqAvailable() {
+		t.Skip("jq not installed")
+	}
+	for _, test := range []struct {
+		name     string
+		repoArgs []string
+		envRepo  string
+		gitRepo  bool
+		blocked  bool
+	}{
+		{"positional", []string{"https://github.com/acme/repo"}, "", false, false},
+		{"environment", nil, "acme/repo", false, false},
+		{"current_fixture", nil, "", true, false},
+		{"shim_repo", []string{"--repo", "https://github.com/acme/repo"}, "", false, false},
+		{"shim_attached_repo", []string{"-Racme/repo"}, "", false, false},
+		{"empty_shim_repo", []string{"--repo="}, "acme/repo", false, false},
+		{"conflicting_positional", []string{"--repo=acme/other", "acme/repo"}, "", false, true},
+		{"enterprise_repo", []string{"--repo=https://other.example/acme/repo"}, "", false, true},
+		{"original_material", []string{"--repo=internal-model/repo", "--repo=acme/repo"}, "", false, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			data := 0
+			_, policies := rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+				data++
+				req := decodeCLIRequest(t, w, r)
+				if req["method"] != "GET" || req["path"] != "/repos/acme/repo" {
+					t.Errorf("wrong resolved repository: %v", req)
+				}
+				writeCLIFallback(t, w, "route_denied")
+			})
+			t.Setenv("GH_REPO", test.envRepo)
+			t.Setenv("GH_HOST", "other.example")
+			fixture := t.TempDir()
+			t.Chdir(fixture)
+			if test.gitRepo {
+				for _, args := range [][]string{{"init", "--quiet", fixture}, {"-C", fixture, "remote", "add", "origin", "https://github.com/acme/repo"}} {
+					if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+						t.Fatalf("synthetic repository setup: %v: %s", err, out)
+					}
+				}
+			}
+			capturePath := captureRewriteGH(t)
+			options := []string{"--json", `"name"`, "--json=url", "--jq", "(", "--jq=.name"}
+			args := append([]string{"repo", "view"}, test.repoArgs...)
+			args = append(args, options...)
+			var out bytes.Buffer
+			err := runGH(t.Context(), args, &out, io.Discard)
+			if test.blocked {
+				if err != errRewriteBlocked || data != 0 || policies.Load() != 1 || out.Len() != 0 {
+					t.Fatalf("strict repo boundary: err=%v data=%d policies=%d output=%q", err, data, policies.Load(), out.String())
+				}
+				if _, err := os.Stat(capturePath); !os.IsNotExist(err) {
+					t.Fatal("denied repo view ran native child")
+				}
+				return
+			}
+			if err != nil || data != 1 || policies.Load() != 3 || out.String() != "child stdout\n" {
+				t.Fatalf("repo handoff: err=%v data=%d policies=%d output=%q", err, data, policies.Load(), out.String())
+			}
+			capture := readRewriteCapture(t, capturePath)
+			want := append([]string{"repo", "view", "acme/repo"}, options...)
+			if !slices.Equal(capture.Args, want) || capture.Env["GH_HOST"] != "github.com" || capture.Env["GH_REPO"] != "" || capture.Stdin != "" {
+				t.Fatalf("native repo-view positional pin/raw options: got=%+v want=%q", capture, want)
+			}
+		})
+	}
+}
+
+func TestStringRewriteAttachedReadAliases(t *testing.T) {
+	if !jqAvailable() {
+		t.Skip("jq not installed")
+	}
+	for _, policy := range []struct{ name, body string }{{"active", rewriteActiveTestPolicy}, {"empty", rewriteEmptyTestPolicy}} {
+		for _, test := range []struct {
+			name, want, limit string
+			args              []string
+		}{
+			{"limit", `[{"number":7}]`, "5", []string{"pr", "list", "-R", "acme/repo", "-L5", "--json=number"}},
+			{"jq", "7", "", []string{"pr", "view", "7", "-R", "acme/repo", "--json=number", "-q.number"}},
+			{"repo", `{"number":7}`, "", []string{"pr", "view", "7", "-Racme/repo", "--json=number"}},
+			{"equals_control", "7", "5", []string{"pr", "list", "-R=acme/repo", "-L=5", "--json=number", "-q=.[0].number"}},
+		} {
+			t.Run(policy.name+"/"+test.name, func(t *testing.T) {
+				var requests []map[string]any
+				_, policies := rewriteTestServer(t, policy.body, func(w http.ResponseWriter, r *http.Request) {
+					req := decodeCLIRequest(t, w, r)
+					requests = append(requests, req)
+					writeCLIEnvelope(t, w, nativeOptionsResponse(t, req))
+				})
+				capture := captureRewriteGH(t)
+				var out bytes.Buffer
+				err := runGH(t.Context(), test.args, &out, io.Discard)
+				_, childErr := os.Stat(capture)
+				if err != nil || strings.TrimSpace(out.String()) != test.want || len(requests) != 1 || policies.Load() != 2 || !os.IsNotExist(childErr) {
+					t.Fatalf("attached read: err=%v output=%q data=%d policies=%d child=%v", err, out.String(), len(requests), policies.Load(), childErr)
+				}
+				if test.limit != "" && requests[0]["query"].(map[string]any)["per_page"] != test.limit {
+					t.Fatalf("attached limit lost: query=%v", requests[0]["query"])
+				}
+			})
+		}
+	}
+}
+
+func TestStringRewriteOptionNativeArgv(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		args       []string
+		active     bool
+		relay      bool
+		noFallback bool
+	}{
+		{"control_unsupported_field_original", []string{"pr", "view", "7", "-R", "acme/repo", "--json", "bogus", "--json=number"}, true, false, false},
+		{"control_active_empty_repo_pin", []string{"pr", "view", "7", "--repo=", "--json=bogus"}, true, false, false},
+		{"regression_unrepresentable_label", []string{"issue", "list", "-R", "acme/repo", "--label", `"a,b"`, "--json=number"}, false, false, false},
+		{"regression_active_unrepresentable_label", []string{"issue", "list", "-R", "acme/repo", "--label", `"a,b"`, "--json=number"}, true, false, false},
+		{"control_active_repeated_unrepresentable_label", []string{"issue", "list", "-R", "acme/repo", "--label", "bug", "--label", `"a,b"`, "--json=number"}, true, false, false},
+		{"control_direct_cap_no_fallback", []string{"pr", "list", "-R", "acme/repo", "--limit=101", "--json=number"}, false, false, true},
+		{"control_attached_cap_raw_argv", []string{"pr", "list", "-R", "acme/repo", "-L101", "--json=number", "-q.[].number"}, true, false, false},
+		{"control_search_issues_label_handoff", []string{"search", "issues", "bug", "-R", "acme/repo", "--json=number", "--label", `"a,b"`}, true, false, false},
+		{"control_search_prs_label_handoff", []string{"search", "prs", "bug", "-R", "acme/repo", "--json=number", "--label", `"a,b"`}, true, false, false},
+		{"control_issue_label_direct_no_fallback", []string{"issue", "list", "-R", "acme/repo", "--json=number", "--label", `"a,b"`}, false, false, true},
+		{"control_typed_no_fallback", []string{"pr", "view", "7", "-R", "acme/repo", "--json=number"}, false, true, true},
+		{"regression_api_jq_fallback_original", []string{"api", "repos/acme/repo", "--jq", ".title", "-q", ".number"}, true, true, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			policy := rewriteEmptyTestPolicy
+			t.Setenv("GH_REPO", "acme/repo")
+			if test.active {
+				policy = rewriteActiveTestPolicy
+			}
+			data := 0
+			_, policies := rewriteTestServer(t, policy, func(w http.ResponseWriter, r *http.Request) { data++; writeCLIFallback(t, w, "route_denied") })
+			capturePath := captureRewriteGH(t)
+			if test.noFallback {
+				t.Setenv("OCTOPOOL_NO_FALLBACK", "1")
+			}
+			var out bytes.Buffer
+			err := runGH(t.Context(), test.args, &out, io.Discard)
+			wantData := 0
+			if test.relay {
+				wantData = 1
+			}
+			if test.noFallback && test.relay {
+				if err == nil || out.Len() != 0 || data != 1 || policies.Load() != 2 {
+					t.Fatalf("typed fallback escaped: err=%v data=%d policy=%d output=%q", err, data, policies.Load(), out.String())
+				}
+				if _, err := os.Stat(capturePath); !os.IsNotExist(err) {
+					t.Fatal("typed NO_FALLBACK ran child")
+				}
+				return
+			}
+			if err != nil || data != wantData || policies.Load() != int64(2+wantData) {
+				t.Fatalf("err=%v data=%d want=%d policy=%d", err, data, wantData, policies.Load())
+			}
+			capture := readRewriteCapture(t, capturePath)
+			// Repository/hostname pins are allowed; every other original occurrence stays in order and spelling.
+			stripPins := func(args []string) []string {
+				var result []string
+				for i := 0; i < len(args); i++ {
+					arg := args[i]
+					if arg == "-R" || arg == "--repo" || arg == "--hostname" {
+						i++
+						continue
+					}
+					if strings.HasPrefix(arg, "--repo=") || strings.HasPrefix(arg, "--hostname=") || arg == "--method=GET" {
+						continue
+					}
+					result = append(result, arg)
+				}
+				return result
+			}
+			if !slices.Equal(stripPins(capture.Args), stripPins(test.args)) {
+				t.Fatalf("native argv=%q original=%q", capture.Args, test.args)
+			}
+			if test.active && (capture.Env["GH_HOST"] != "github.com" || capture.Env["GH_REPO"] != "") {
+				t.Fatalf("unpinned child env=%v", capture.Env)
+			}
+			if test.active && test.args[0] != "api" && !slices.Contains(capture.Args, "--repo=acme/repo") {
+				t.Fatalf("missing explicit repository pin: %v", capture.Args)
+			}
+		})
+	}
+}
+
+func TestStringRewriteSearchFilterNoFallback(t *testing.T) {
+	for _, kind := range []string{"issues", "prs"} {
+		for _, flag := range []string{"--author", "--assignee", "--label"} {
+			values := []string{"", "alice"}
+			if flag == "--label" {
+				values = append(values, `"a,b"`, "a,,b", `""`, "\"a\r\nb\"")
+			}
+			for _, value := range values {
+				t.Run(kind+"/"+flag+"/value="+value, func(t *testing.T) {
+					data := 0
+					_, policies := rewriteTestServer(t, rewriteEmptyTestPolicy, func(w http.ResponseWriter, r *http.Request) { data++ })
+					t.Setenv("OCTOPOOL_NO_FALLBACK", "1")
+					capture := captureRewriteGH(t)
+					var out bytes.Buffer
+					err := runGH(t.Context(), []string{"search", kind, "bug", "-R", "acme/repo", "--json=number", flag, value}, &out, io.Discard)
+					if !isLocalFallback(err) || data != 0 || policies.Load() != 1 || out.Len() != 0 {
+						t.Fatalf("typed filter fallback changed: err=%v data=%d policies=%d output=%q", err, data, policies.Load(), out.String())
+					}
+					if _, err := os.Stat(capture); !os.IsNotExist(err) {
+						t.Fatal("NO_FALLBACK filter ran native child")
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestStringRewriteOptionStrictControls(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args []string
+	}{
+		{"publication_duplicate_label", []string{"issue", "create", "-R", "acme/repo", "--title=safe", "--body=safe", "--label=bug", "--label=docs"}},
+		{"api_duplicate_method", []string{"api", "repos/acme/repo", "--method=GET", "-X", "GET"}},
+		{"api_duplicate_input", []string{"api", "repos/acme/repo/issues/7/comments", "--input=-", "--input=-"}},
+		{"api_duplicate_field", []string{"api", "repos/acme/repo/issues/7/comments", "-fbody=a,b", "-fbody=c"}},
+		{"api_credential_header", []string{"api", "repos/acme/repo", "-H", "Authorization: synthetic"}},
+		{"original_repo_host", []string{"pr", "view", "7", "--repo", "https://other.example/acme/repo", "--repo", "acme/repo", "--json=number"}},
+		{"original_csv_ignored_record", []string{"pr", "view", "7", "-R", "acme/repo", "--json", "number\nignored"}},
+		{"original_policy_material", []string{"pr", "view", "7", "-R", "acme/repo", "--json", "number\n" + `{"pattern":"internal-model","replacement":"public"}`}},
+		{"search_issues_original_label_newline", []string{"search", "issues", "bug", "-R", "acme/repo", "--json=number", "--label", "\"a\r\nb\""}},
+		{"search_prs_original_label_newline", []string{"search", "prs", "bug", "-R", "acme/repo", "--json=number", "--label", "\"a\r\nb\""}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+			capture := captureRewriteGH(t)
+			var out bytes.Buffer
+			err := runGH(t.Context(), test.args, &out, io.Discard)
+			if err != errRewriteBlocked || out.Len() != 0 {
+				t.Fatalf("strict boundary: err=%v output=%q", err, out.String())
+			}
+			if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Fatal("strict denial ran child")
+			}
+		})
+	}
+}
+
 func TestStringRewritePrivateRunWatchFallback(t *testing.T) {
 	recordWatchSleeps(t)
 	relayCalls := 0
@@ -2223,7 +2513,7 @@ func TestStringRewritePrivateRunWatchFallback(t *testing.T) {
 	if relayCalls != 1 {
 		t.Fatalf("relay calls=%d, want initial lookup before private fallback", relayCalls)
 	}
-	want := []string{"run", "watch", "42", "--repo=acme/repo", "--interval=30", "--exit-status"}
+	want := []string{"run", "watch", "42", "--repo=acme/repo", "-i30", "--exit-status"}
 	if got := readRewriteCapture(t, capture); !slices.Equal(got.Args, want) || got.Env["GH_HOST"] != "github.com" {
 		t.Fatalf("native watch args=%v env=%v", got.Args, got.Env)
 	}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -367,6 +367,7 @@ Every limit or interval assignment must pass native signed base-0 integer syntax
 including prefixes, signs, underscores, and overflow checks. Only the final limit
 gets the command range check: at least 1 for lists, and 1–1000 for search. Values
 above the relay's 100-item bound delegate rather than being clamped into eligibility.
+A final limit outside the platform's native integer representation delegates before conversion or command-range checks.
 Enum assignments are checked individually, case-insensitively; PR/issue list state
 is normalized, but run status spelling is preserved and unsupported spellings
 delegate. Run-view attempts use unsigned 64-bit syntax without signs: zero selects

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -334,6 +334,66 @@ conditional requests only when instant freshness matters more than quota.
 `--jq` runs after `--json` filtering, matching the usual agent workflow for small
 machine-readable reads.
 
+#### Read-option occurrences and delegation
+
+Modeled read flags use their command's value types. Each `--json` occurrence is a
+CSV record: quotes and doubled quotes are decoded, spaces and empty elements are
+significant, and only the first record is read (with normal CSV CRLF handling).
+An empty raw value contributes no fields. Repeated occurrences append; valid fields
+are deduplicated in first-occurrence order before hydration. Malformed or unsupported
+earlier fields cannot disappear into a partial relay request. Explicit `--json=` with
+no effective fields delegates, never selects human output. `--json number --json=`
+still selects `number`. The last `--jq` program wins, including an empty program;
+even an empty `--jq` without `--json` delegates on top-level commands. API jq needs
+no JSON flag. Short `-q=` retains the native literal `=` value or delegates intact.
+Already-declared `-R`, `-L`, and `-q` aliases accept attached values such as
+`-Rowner/repo`, `-L5`, and `-q.number`, including under active rewrite policy;
+native handoff preserves those spellings. This does not add short-flag clusters.
+
+Issue-list labels use the same CSV occurrence rules. An empty effective sequence
+omits the labels query key. Decoded labels containing commas, empty elements, or
+line breaks delegate because the existing REST query cannot preserve them. Spaces
+and literal quotes remain supported. Ordinary repo, author, assignee, and jq flags
+are scalars, not CSV. Search repo filters are slices but multiple occurrences or
+multiple decoded repositories remain native-only. Unsupported filters remain
+unsupported even when empty. Search label filters retain typed local fallback,
+including labels that the issue-list REST query cannot represent, so
+`OCTOPOOL_NO_FALLBACK` still blocks that native dispatch. API fields/headers stay
+literal repeated values;
+`workflow run --json` stays Boolean. The documented workflow/gist view JSON
+extensions are unchanged.
+
+Every limit or interval assignment must pass native signed base-0 integer syntax,
+including prefixes, signs, underscores, and overflow checks. Only the final limit
+gets the command range check: at least 1 for lists, and 1–1000 for search. Values
+above the relay's 100-item bound delegate rather than being clamped into eligibility.
+Enum assignments are checked individually, case-insensitively; PR/issue list state
+is normalized, but run status spelling is preserved and unsupported spellings
+delegate. Run-view attempts use unsigned 64-bit syntax without signs: zero selects
+the latest run path, and values beyond the CLI's signed representation delegate
+before conversion. Jobs still belong to the returned run attempt.
+
+Watch durations must be representable before multiplication and the 30-second
+floor. An earlier int-valid duration can be overridden; an invalid integer cannot.
+A final unrepresentable run-watch duration delegates so native lookup and
+early-completion timing remain native-owned. Delegation changes only the effective
+valid interval (or inserts a proved default before a real `--` terminator), never
+discarded intervals, another flag's value, or unknown grammar.
+With no active rewrite rules, native PR-checks watch handoff recognizes `-w=false`
+and `-w=0` as disabled web mode and keeps the watch floor. The `-w` spelling remains
+native-only; short clusters and invalid Boolean assignments are left intact.
+
+These parsers run after the existing policy check. Active rules still inspect
+original occurrences and structural material, even overwritten scalars or CSV
+records ignored by decoding. Native argv retains spelling and order except for
+necessary repository/host pins and the effective watch floor; decoded CSV is never
+joined back into native arguments. Relay attempts and final native dispatch acquire
+policy again. The guarded `repo view` pin is positional, including when resolved
+from context or supplied with the shim's repo option; native `repo view` has no
+`--repo` flag. Publication duplicate restrictions and typed-fallback
+`OCTOPOOL_NO_FALLBACK` behavior are unchanged; direct unsupported-shape delegation
+remains protected native dispatch, not a universal no-fallback opt-out.
+
 #### Human-format reads
 
 When stdout is not a terminal, the shim renders `pr view`, `pr checks`, `pr list`,


### PR DESCRIPTION
## Summary

Modeled read options were not consistently interpreted like native `gh`: repeated JSON flags could erase earlier fields, CSV quoting and empty values changed meaning, integer spellings and final ranges were confused, and watch-floor rewriting could modify the wrong argument. Active rewrite-policy preparation also disagreed with ordinary read parsing.

Introduce one small, standard-library read-option owner that keeps original argv and occurrence spans separate from typed values and relay projection. It preserves explicit presence, native CSV append/quoting/first-record behavior, scalar last-value semantics, signed base-0 integers, and unsigned run attempts. Every typed occurrence is validated, while command ranges apply to the final value. Zero run attempts select the existing latest path; values outside the relay's representation stay delegated.

Command-specific boundaries remain explicit: unrepresentable issue-list labels delegate intact, unsupported search filters retain their typed fallback and `OCTOPOOL_NO_FALLBACK` behavior, and zero-field JSON does not become human output. Existing attached `-R`, `-L`, and `-q` spellings work without adding short-flag clusters. Watch flooring validates duration before arithmetic and changes only the effective owned interval. Guarded `repo view` handoffs use native positional repository pins.

Parsing stays after policy acquisition. Original structural/material/host checks, per-attempt and final-dispatch policy reads, strict publication/API mutation restrictions, and native argv spelling remain intact. Documentation describes the actual parsing and delegation contracts. No dependency, Worker, schema, release or unrelated export changes are included.

## Validation

- Test-first parser proof: 170 failing regression cases with 134 controls, using corrected owner results rather than double-counted reruns.
- Review and follow-up inspection identified four handoff/coverage regressions in the unpublished candidate. Their focused before-fix proof had 21 failures and 58 controls; all 79 cases pass after correction.
- A subsequent review caught native `-w=false` web-mode assignments bypassing the watch floor. The focused proof had 19 failures and 44 controls; all 63 cases pass after a native-only grammar correction, without adding relay support or short-flag clusters.
- Initial affected sibling proof: 1,784 cases passed. After the bounded integer-projection correction, identical focused controls passed 140 cases before and after on the 64-bit host, sibling controls passed 423, and compiled-CLI option cases passed 8. These are passing controls, not a claimed runtime-red reproduction.
- Final full Go suite: 4,467 leaf cases passed, retaining all 4,453 earlier cases plus 14 endpoint controls, with zero failures or skips.
- Vet, route/SQL generation checks, formatting, lint, build/type checks and the docs build passed on the final source.
- Earlier integration failures and fixture/argv expectation corrections were retained. No deadline, dependency, credential or provider change was used to make tests pass.

Initial hosted qualification passed Linux/Windows CI, including 983 unit and 958 native Worker tests, but the separate CodeQL summary failed two integer-conversion checks. The correction uses explicit platform `math.MinInt`/`math.MaxInt` bounds before signed conversion and a direct `math.MaxInt` bound for unsigned attempts. The signed change hardens 32-bit source projection; the previous unsigned guard was already mathematically sufficient. Neither conversion could wrap on the published amd64/arm64 targets. No alert suppression or platform-support expansion was used; new exact-head security-summary acceptance is still required.

Native contracts are grounded in GitHub CLI 2.98, pflag 1.0.10 and Go 1.26.7 source. Process tests use synthetic servers and guarded child captures; they do not claim live GitHub or native-gh behavior-probe results. Fresh full independent review and exact-head Linux/Windows CI plus the CodeQL security summary are required before merge.
