### PR TITLE
fix: apply native watch floors after policy preparation

### DIFF
--- a/cmd/octopool/gh.go
+++ b/cmd/octopool/gh.go
@@ -79,11 +79,11 @@ func runGH(ctx context.Context, args []string, stdout io.Writer, stderr io.Write
 				return exitCodeError{Code: 1}
 			}
 			if shouldRunRealGH(result.err) {
-				return execRealGHAfterLocalFallback(ctx, floorGHWatchDelegateArgs(args), stdout, stderr, result.err)
+				return execRealGHAfterLocalFallback(ctx, args, stdout, stderr, result.err)
 			}
 			return result.err
 		case ghDelegate:
-			return execRealGH(ctx, floorGHWatchDelegateArgs(args), stdout, stderr)
+			return execRealGH(ctx, args, stdout, stderr)
 		case ghHandoffAfterOutput:
 			var handoff watchFallbackHandoffError
 			if !errors.As(result.err, &handoff) {
@@ -97,7 +97,7 @@ func runGH(ctx context.Context, args []string, stdout io.Writer, stderr io.Write
 				"octopool: relay requested local fallback (%s); continuing watch with real gh\n",
 				watchSafeText(handoff.fallback.Reason),
 			)
-			return execRealGH(ctx, floorGHWatchDelegateArgs(args), stdout, stderr)
+			return execRealGH(ctx, args, stdout, stderr)
 		default:
 			return errors.New("invalid gh dispatch outcome")
 		}

--- a/cmd/octopool/gh_top_watch.go
+++ b/cmd/octopool/gh_top_watch.go
@@ -628,6 +628,32 @@ func floorGHWatchDelegateArgs(args []string) []string {
 	return append(out, args[2+parsed.delimiter:]...)
 }
 
+func nativeWatchArgumentRoles(parsed readOptions) []string {
+	var roles []string
+	occurrenceIndex := 0
+	for i := 0; i < len(parsed.argv); {
+		if occurrenceIndex < len(parsed.ordered) && parsed.ordered[occurrenceIndex].start == i {
+			occurrence := parsed.ordered[occurrenceIndex]
+			if occurrence.name != "--repo" {
+				roles = append(roles, occurrence.name)
+				if occurrence.valueIndex != occurrence.start {
+					roles = append(roles, "value:"+occurrence.name)
+				}
+			}
+			i = occurrence.end
+			occurrenceIndex++
+			continue
+		}
+		if i == parsed.delimiter {
+			roles = append(roles, "delimiter")
+		} else {
+			roles = append(roles, "positional")
+		}
+		i++
+	}
+	return roles
+}
+
 func isGHWatchShape(args []string) bool {
 	if len(args) < 2 {
 		return false

--- a/cmd/octopool/string_rewrites_guard.go
+++ b/cmd/octopool/string_rewrites_guard.go
@@ -436,6 +436,7 @@ func prepareProtectedGH(ctx context.Context, args []string, stdin io.Reader) (*r
 		return nil, err
 	}
 	if len(policy.Rules) == 0 {
+		prepared.args = floorGHWatchDelegateArgs(args)
 		return prepared, nil
 	}
 	prepared.forceGitHubHost = true
@@ -464,9 +465,68 @@ func prepareProtectedGH(ctx context.Context, args []string, stdin io.Reader) (*r
 			err = prepareRewriteBestEffort(policy, args, stdin, prepared)
 		}
 	}
+	if err == nil {
+		err = prepared.finalizeNativeWatch(policy, args)
+	}
 	if err != nil {
 		prepared.cleanup()
 		return nil, errRewriteBlocked
 	}
 	return prepared, nil
+}
+
+func (prepared *rewritePreparation) finalizeNativeWatch(policy stringRewritePolicy, original []string) error {
+	// Original material has already passed this final policy. Only corresponding,
+	// recognized watch grammar may acquire a floor; checked repo pins may differ.
+	if !isGHWatchShape(original) || !isGHWatchShape(prepared.args) ||
+		original[0] != prepared.args[0] || original[1] != prepared.args[1] {
+		return nil
+	}
+	specs := nativeWatchReadSpecs(original[0] + " " + original[1])
+	before, unsupported, err := parseReadOptions(original[2:], specs)
+	if err != nil || unsupported {
+		return nil
+	}
+	if _, ok := readWatchInterval(before); !ok {
+		return nil
+	}
+	after, unsupported, err := parseReadOptions(prepared.args[2:], specs)
+	if err != nil || unsupported || !slices.Equal(nativeWatchArgumentRoles(before), nativeWatchArgumentRoles(after)) {
+		return nil
+	}
+	floored := floorGHWatchDelegateArgs(prepared.args)
+	if slices.Equal(floored, prepared.args) {
+		return nil
+	}
+	// Check both the semantic value and emitted spelling: attached aliases must
+	// not hide a forbidden 30. Generated material is never rewritten below floor.
+	if err := policy.checkStructural("30"); err != nil {
+		return err
+	}
+	if len(floored) == len(prepared.args) {
+		for i, arg := range floored {
+			if arg != prepared.args[i] {
+				if err := policy.checkStructural(arg); err != nil {
+					return err
+				}
+			}
+		}
+	} else if err := policy.checkStructural("--interval"); err != nil {
+		return err
+	}
+	oldBytes, newBytes := 0, 0
+	for _, arg := range prepared.args {
+		oldBytes += len(arg)
+	}
+	for _, arg := range floored {
+		newBytes += len(arg)
+	}
+	// Charge only generated growth, without replaying original content or sources.
+	growth := max(0, newBytes-oldBytes)
+	if newBytes > rewriteMaxContent || prepared.outputBytes+growth > rewriteMaxContent {
+		return errRewriteBlocked
+	}
+	prepared.outputBytes += growth
+	prepared.args = floored
+	return nil
 }

--- a/cmd/octopool/string_rewrites_process_test.go
+++ b/cmd/octopool/string_rewrites_process_test.go
@@ -183,6 +183,14 @@ func rewriteTestServer(t *testing.T, policyBody string, relay http.HandlerFunc) 
 	t.Helper()
 	body := &atomic.Value{}
 	body.Store(policyBody)
+	calls := rewriteTestServerPolicySequence(t, func(int64) (string, int) {
+		return body.Load().(string), http.StatusOK
+	}, relay)
+	return body, calls
+}
+
+func rewriteTestServerPolicySequence(t *testing.T, policy func(int64) (string, int), relay http.HandlerFunc) *atomic.Int64 {
+	t.Helper()
 	calls := &atomic.Int64{}
 	isolateTestConfig(t)
 	t.Setenv("OCTOPOOL_STRING_REWRITE_FILE", "")
@@ -193,13 +201,14 @@ func rewriteTestServer(t *testing.T, policyBody string, relay http.HandlerFunc) 
 			return
 		}
 		if r.URL.Path == "/v1/pools/maintainers/string-rewrites" {
-			calls.Add(1)
+			body, code := policy(calls.Add(1))
 			if r.Method != "GET" || r.Header.Get("Cache-Control") != "no-cache, no-store" {
 				t.Error("incorrect policy method/cache")
 			}
 			w.Header().Set("Cache-Control", "no-store")
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = io.WriteString(w, body.Load().(string))
+			w.WriteHeader(code)
+			_, _ = io.WriteString(w, body)
 			return
 		}
 		if r.URL.Path != "/v1/github/request" || r.Method != "POST" || relay == nil {
@@ -214,7 +223,7 @@ func rewriteTestServer(t *testing.T, policyBody string, relay http.HandlerFunc) 
 	t.Setenv("OCTOPOOL_TOKEN", "test-token")
 	t.Setenv("OCTOPOOL_POOL", "maintainers")
 	t.Setenv("OCTOPOOL_RELAY_RETRIES", "0")
-	return body, calls
+	return calls
 }
 
 const rewriteActiveTestPolicy = `{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"internal-model","replacement":"public"}]}`
@@ -2491,31 +2500,323 @@ func TestStringRewriteOptionStrictControls(t *testing.T) {
 	}
 }
 
+func TestStringRewritePRWatchPolicyFloor(t *testing.T) {
+	const active = `{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"watch-policy-canary","replacement":"safe"}]}`
+	const residualFive = `{"schema_version":1,"revision":2,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"^5$","replacement":"5"}]}`
+	const forbiddenThirty = `{"schema_version":1,"revision":2,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"^30$","replacement":"5"}]}`
+	const material = `{"pattern":"watch-policy-canary","replacement":"safe"}`
+	for _, test := range []struct {
+		name       string
+		flags      []string
+		want       []string
+		first      string
+		final      string
+		finalCode  int
+		wantErr    error
+		noFallback bool
+	}{
+		{
+			name:  "active_nonmatching_floor",
+			flags: []string{"--watch", "--interval", "5"},
+			want:  []string{"pr", "checks", "7", "-R", "github.com/acme/repo", "--watch", "--interval", "30"},
+		},
+		{
+			name: "direct_no_fallback_still_floors", noFallback: true,
+			flags: []string{"--watch", "--interval", "5"},
+			want:  []string{"pr", "checks", "7", "-R", "github.com/acme/repo", "--watch", "--interval", "30"},
+		},
+		{
+			name:  "default_interval",
+			flags: []string{"--watch"},
+			want:  []string{"pr", "checks", "7", "-R", "github.com/acme/repo", "--watch", "--interval", "30"},
+		},
+		{
+			name:  "default_before_real_terminator",
+			flags: []string{"--watch", "--", "-i5"},
+			want:  []string{"pr", "checks", "7", "-R", "github.com/acme/repo", "--watch", "--interval", "30", "--", "-i5"},
+		},
+		{
+			name:  "only_final_interval_changes",
+			flags: []string{"--watch", "--interval", "5", "-i6"},
+			want:  []string{"pr", "checks", "7", "-R", "github.com/acme/repo", "--watch", "--interval", "5", "-i30"},
+		},
+		{
+			name:  "native_only_short_web_false",
+			flags: []string{"--watch", "-w=false", "--interval", "5"},
+			want:  []string{"pr", "checks", "7", "-R", "github.com/acme/repo", "--watch", "-w=false", "--interval", "30"},
+		},
+		{
+			name: "original_residual_blocks", first: residualFive, final: residualFive, wantErr: errRewriteBlocked,
+			flags: []string{"--watch", "--interval", "5"},
+		},
+		{
+			name: "fresh_final_residual_blocks", final: residualFive, wantErr: errRewriteBlocked,
+			flags: []string{"--watch", "--interval", "5"},
+		},
+		{
+			name: "final_policy_unavailable", finalCode: http.StatusServiceUnavailable, wantErr: errRewritePolicy,
+			flags: []string{"--watch", "--interval", "5"},
+		},
+		{
+			name: "overwritten_original_residual_blocks", first: residualFive, final: residualFive, wantErr: errRewriteBlocked,
+			flags: []string{"--watch", "--interval", "5", "-i6"},
+		},
+		{
+			name: "original_owned_rule_material_blocks", wantErr: errRewriteBlocked,
+			flags: []string{"--watch", "--interval", "5", "--template", material},
+		},
+		{
+			name: "generated_floor_policy_conflict", final: forbiddenThirty, wantErr: errRewriteBlocked,
+			flags: []string{"--watch", "--interval", "5"},
+		},
+		{
+			name: "generated_attached_short_floor_policy_conflict", final: forbiddenThirty, wantErr: errRewriteBlocked,
+			flags: []string{"--watch", "-i5"},
+		},
+		{
+			name: "generated_attached_long_floor_policy_conflict", final: forbiddenThirty, wantErr: errRewriteBlocked,
+			flags: []string{"--watch", "--interval=5"},
+		},
+		{
+			name:    "generated_default_flag_policy_conflict",
+			final:   `{"schema_version":1,"revision":2,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"^--interval$","replacement":"--template"}]}`,
+			wantErr: errRewriteBlocked,
+			flags:   []string{"--watch"},
+		},
+		{
+			name:  "rewritten_valid_interval_stays_above_floor",
+			final: `{"schema_version":1,"revision":2,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"^5$","replacement":"40"}]}`,
+			flags: []string{"--watch", "--interval", "5"},
+			want:  []string{"pr", "checks", "7", "-R", "github.com/acme/repo", "--watch", "--interval", "40"},
+		},
+		{
+			name:  "rewritten_interval_option_does_not_gain_default",
+			final: `{"schema_version":1,"revision":2,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"^--interval$","replacement":"--template"}]}`,
+			flags: []string{"--watch", "--interval", "5"},
+			want:  []string{"pr", "checks", "7", "-R", "github.com/acme/repo", "--watch", "--template", "5"},
+		},
+		{
+			// Empty P1 reaches ghDelegate; final P2 must still see the original 5.
+			name: "lower_handoff_fresh_final_residual", first: rewriteEmptyTestPolicy, final: residualFive, wantErr: errRewriteBlocked,
+			flags: []string{"--watch", "--required", "--interval", "5"},
+		},
+		{
+			name: "lower_handoff_nonmatching_control", first: rewriteEmptyTestPolicy,
+			flags: []string{"--watch", "--required", "--interval", "5"},
+			want:  []string{"pr", "checks", "7", "-R", "github.com/acme/repo", "--watch", "--required", "--interval", "30"},
+		},
+		{
+			name: "empty_policy_control", first: rewriteEmptyTestPolicy, final: rewriteEmptyTestPolicy,
+			flags: []string{"--watch", "--required", "--interval", "5"},
+			want:  []string{"pr", "checks", "7", "-R", "acme/repo", "--watch", "--required", "--interval", "30"},
+		},
+		{
+			name:  "invalid_earlier_integer_not_repaired",
+			flags: []string{"--watch", "--interval", "08", "-i5"},
+			want:  []string{"pr", "checks", "7", "-R", "github.com/acme/repo", "--watch", "--interval", "08", "-i5"},
+		},
+		{
+			name:  "final_duration_overflow_not_repaired",
+			flags: []string{"--watch", "--interval", "9223372037"},
+			want:  []string{"pr", "checks", "7", "-R", "github.com/acme/repo", "--watch", "--interval", "9223372037"},
+		},
+		{
+			name:  "unknown_grammar_not_repaired",
+			flags: []string{"--watch", "--future", "-i5"},
+			want:  []string{"pr", "checks", "7", "-R", "github.com/acme/repo", "--watch", "--future", "-i5"},
+		},
+		{
+			name:  "short_cluster_not_repaired",
+			flags: []string{"--watch", "-wf", "-i5"},
+			want:  []string{"pr", "checks", "7", "-R", "github.com/acme/repo", "--watch", "-wf", "-i5"},
+		},
+		{
+			name:  "false_watch_not_repaired",
+			flags: []string{"--watch=false", "-i5"},
+			want:  []string{"pr", "checks", "7", "-R", "github.com/acme/repo", "--watch=false", "-i5"},
+		},
+		{
+			name:  "owned_watch_value_not_repaired",
+			flags: []string{"--template", "--watch", "--interval", "5"},
+			want:  []string{"pr", "checks", "7", "-R", "github.com/acme/repo", "--template", "--watch", "--interval", "5"},
+		},
+		{
+			name:  "terminator_watch_text_not_repaired",
+			flags: []string{"--watch=false", "--", "--watch", "-i5"},
+			want:  []string{"pr", "checks", "7", "-R", "github.com/acme/repo", "--watch=false", "--", "--watch", "-i5"},
+		},
+		{
+			name:  "rewritten_invalid_original_does_not_gain_floor",
+			final: `{"schema_version":1,"revision":2,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"^08$","replacement":"5"}]}`,
+			flags: []string{"--watch", "--interval", "08"},
+			want:  []string{"pr", "checks", "7", "-R", "github.com/acme/repo", "--watch", "--interval", "5"},
+		},
+		{
+			name:  "rewritten_command_does_not_gain_floor",
+			final: `{"schema_version":1,"revision":2,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"^checks$","replacement":"view"}]}`,
+			flags: []string{"--watch", "--interval", "5"},
+			want:  []string{"pr", "view", "7", "-R", "github.com/acme/repo", "--watch", "--interval", "5"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			first, final := test.first, test.final
+			if first == "" {
+				first = active
+			}
+			if final == "" {
+				final = active
+			}
+			var data atomic.Int64
+			policies := rewriteTestServerPolicySequence(t, func(ordinal int64) (string, int) {
+				if ordinal == 1 {
+					return first, http.StatusOK
+				}
+				if ordinal != 2 {
+					t.Error("unexpected extra policy read")
+					return "", http.StatusServiceUnavailable
+				}
+				if test.finalCode != 0 {
+					return "", test.finalCode
+				}
+				return final, http.StatusOK
+			}, func(w http.ResponseWriter, r *http.Request) {
+				data.Add(1)
+				t.Error("native watch unexpectedly dispatched relay data")
+				w.WriteHeader(http.StatusBadRequest)
+			})
+			t.Setenv("OCTOPOOL_NO_FALLBACK", "")
+			if test.noFallback {
+				t.Setenv("OCTOPOOL_NO_FALLBACK", "1")
+			}
+			t.Setenv("GH_HOST", "github.com")
+			t.Setenv("GH_REPO", "acme/inherited")
+			capturePath := captureRewriteGH(t)
+			input, err := os.Open(os.DevNull)
+			if err != nil {
+				t.Fatal(err)
+			}
+			saved := os.Stdin
+			os.Stdin = input
+			defer func() { os.Stdin = saved; input.Close() }()
+			args := append([]string{"pr", "checks", "7", "-R", "acme/repo"}, test.flags...)
+			original := append([]string(nil), args...)
+			var stdout, stderr bytes.Buffer
+			err = runGH(t.Context(), args, &stdout, &stderr)
+			_, childErr := os.Stat(capturePath)
+			childCount := strings.Count(stdout.String(), "child stdout\n")
+			t.Logf("boundary: policies=%d data=%d child=%d err=%v stdout=%q stderr=%q", policies.Load(), data.Load(), childCount, err, stdout.String(), stderr.String())
+			if !slices.Equal(args, original) {
+				t.Error("caller argv mutated")
+			}
+			if policies.Load() != 2 || data.Load() != 0 {
+				t.Errorf("policy/data counts=%d/%d, want 2/0", policies.Load(), data.Load())
+			}
+			if test.wantErr != nil {
+				if childErr == nil {
+					t.Logf("unexpected child argv=%q", readRewriteCapture(t, capturePath).Args)
+				}
+				if !errors.Is(err, test.wantErr) || !os.IsNotExist(childErr) || stdout.Len() != 0 || stderr.Len() != 0 {
+					t.Errorf("policy must stop native child: want err=%v and no child/output", test.wantErr)
+				}
+				if strings.Contains(stdout.String()+stderr.String(), material) || (err != nil && strings.Contains(err.Error(), material)) {
+					t.Error("rejected policy material echoed")
+				}
+				return
+			}
+			if err != nil || childCount != 1 || stdout.String() != "child stdout\n" || stderr.String() != "child stderr\n" {
+				t.Fatalf("native child markers/result changed: err=%v", err)
+			}
+			capture := readRewriteCapture(t, capturePath)
+			wantRepo := ""
+			if final == rewriteEmptyTestPolicy {
+				wantRepo = "acme/inherited"
+			}
+			if capture.Env["GH_HOST"] != "github.com" || capture.Env["GH_REPO"] != wantRepo || capture.Stdin != "" || len(capture.Files) != 0 || len(capture.FileData) != 0 {
+				t.Errorf("native environment/stdin/snapshots changed: %+v", capture)
+			}
+			if !slices.Equal(capture.Args, test.want) {
+				t.Errorf("watch floor/value ownership: native argv=%q, want=%q", capture.Args, test.want)
+			}
+		})
+	}
+}
+
 func TestStringRewritePrivateRunWatchFallback(t *testing.T) {
-	recordWatchSleeps(t)
-	relayCalls := 0
-	rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
-		relayCalls++
-		var request map[string]any
-		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
-			t.Error(err)
-		}
-		if request["path"] != "/repos/acme/repo/actions/runs/42" {
-			t.Error("unexpected watch path")
-		}
-		writeCLIFallback(t, w, "repo_not_public")
-	})
-	capture := captureRewriteGH(t)
-	args := []string{"run", "watch", "42", "-Racme/repo", "-i5", "--exit-status"}
-	if err := runGH(t.Context(), args, io.Discard, io.Discard); err != nil {
-		t.Fatalf("private watch fallback failed: %v", err)
-	}
-	if relayCalls != 1 {
-		t.Fatalf("relay calls=%d, want initial lookup before private fallback", relayCalls)
-	}
-	want := []string{"run", "watch", "42", "--repo=acme/repo", "-i30", "--exit-status"}
-	if got := readRewriteCapture(t, capture); !slices.Equal(got.Args, want) || got.Env["GH_HOST"] != "github.com" {
-		t.Fatalf("native watch args=%v env=%v", got.Args, got.Env)
+	for _, test := range []struct {
+		name, reason string
+		noFallback   bool
+		inferredRepo bool
+	}{
+		{name: "private_repo_handoff", reason: "repo_not_public"},
+		{name: "typed_no_fallback", reason: "repo_not_public", noFallback: true},
+		{name: "other_refusal_stays_on_relay", reason: "pagination_exhausted"},
+		{name: "inferred_repo_survives_context_change", reason: "repo_not_public", inferredRepo: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			sleeps := recordWatchSleeps(t)
+			relayCalls := 0
+			_, policies := rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+				relayCalls++
+				request := decodeCLIRequest(t, w, r)
+				if request["path"] != "/repos/acme/repo/actions/runs/42" {
+					t.Error("unexpected watch path")
+				}
+				if test.inferredRepo {
+					// The initial t.Setenv owns cleanup of this synthetic context.
+					if err := os.Setenv("GH_REPO", "acme/changed"); err != nil {
+						t.Error(err)
+					}
+				}
+				writeCLIFallback(t, w, test.reason)
+			})
+			t.Setenv("OCTOPOOL_NO_FALLBACK", "")
+			if test.noFallback {
+				t.Setenv("OCTOPOOL_NO_FALLBACK", "1")
+			}
+			t.Setenv("GH_HOST", "github.com")
+			t.Setenv("GH_REPO", "acme/inherited")
+			capture := captureRewriteGH(t)
+			input, err := os.Open(os.DevNull)
+			if err != nil {
+				t.Fatal(err)
+			}
+			saved := os.Stdin
+			os.Stdin = input
+			defer func() { os.Stdin = saved; input.Close() }()
+			args := []string{"run", "watch", "42", "-Racme/repo", "-i5", "--exit-status"}
+			if test.inferredRepo {
+				t.Setenv("GH_REPO", "acme/repo")
+				args = []string{"run", "watch", "42", "-i5", "--exit-status"}
+			}
+			original := append([]string(nil), args...)
+			var stdout, stderr bytes.Buffer
+			err = runGH(t.Context(), args, &stdout, &stderr)
+			t.Logf("boundary: policies=%d data=%d child=%d err=%v stdout=%q stderr=%q", policies.Load(), relayCalls, strings.Count(stdout.String(), "child stdout\n"), err, stdout.String(), stderr.String())
+			if relayCalls != 1 || len(*sleeps) != 0 || !slices.Equal(args, original) {
+				t.Fatalf("initial lookup ownership changed: data=%d sleeps=%v caller=%q", relayCalls, *sleeps, args)
+			}
+			if test.noFallback || test.reason != "repo_not_public" {
+				_, childErr := os.Stat(capture)
+				if err == nil || isLocalFallback(err) != test.noFallback || policies.Load() != 2 || !os.IsNotExist(childErr) || stdout.Len() != 0 || stderr.Len() != 0 {
+					t.Fatalf("run-watch refusal ownership changed: err=%v policies=%d child=%v stdout=%q stderr=%q", err, policies.Load(), childErr, stdout.String(), stderr.String())
+				}
+				return
+			}
+			if err != nil || policies.Load() != 3 || stdout.String() != "child stdout\n" || stderr.String() != "octopool: octopool requested local gh fallback: repo_not_public; falling back to real gh\nchild stderr\n" {
+				t.Fatalf("private watch handoff changed: err=%v policies=%d stdout=%q stderr=%q", err, policies.Load(), stdout.String(), stderr.String())
+			}
+			want := []string{"run", "watch", "42", "--repo=acme/repo", "-i30", "--exit-status"}
+			if test.inferredRepo {
+				want = []string{"run", "watch", "42", "-i30", "--exit-status", "--repo=acme/repo"}
+				if os.Getenv("GH_REPO") != "acme/changed" {
+					t.Error("synthetic repository context did not change")
+				}
+			}
+			got := readRewriteCapture(t, capture)
+			if !slices.Equal(got.Args, want) || got.Env["GH_HOST"] != "github.com" || got.Env["GH_REPO"] != "" || got.Stdin != "" || len(got.Files) != 0 {
+				t.Fatalf("native watch args=%q env=%v stdin=%q files=%v", got.Args, got.Env, got.Stdin, got.Files)
+			}
+		})
 	}
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -384,6 +384,17 @@ With no active rewrite rules, native PR-checks watch handoff recognizes `-w=fals
 and `-w=0` as disabled web mode and keeps the watch floor. The `-w` spelling remains
 native-only; short clusters and invalid Boolean assignments are left intact.
 
+Protected native watches apply that floor only after fresh final-policy preparation
+has inspected the original interval occurrences, retaining any repository already
+pinned before a relay handoff. Active-policy PR checks-watch still delegates before
+the handler. Both the input and prepared command must be recognized watches with
+corresponding option/value, positional, and terminator ownership, apart from checked
+repository pins. A valid policy rewrite from interval 5 to 40 stays 40; invalid
+input rewritten into valid grammar, changed commands or option ownership, and unknown
+grammar retain their policy-prepared argv without a guessed floor. Generated interval
+values and emitted tokens must also satisfy that final policy; a conflict blocks the
+child rather than bypassing policy or rewriting the floor below 30 seconds.
+
 These parsers run after the existing policy check. Active rules still inspect
 original occurrences and structural material, even overwritten scalars or CSV
 records ignored by decoding. Native argv retains spelling and order except for


### PR DESCRIPTION
## Summary

Native watch handoffs applied the polling floor at inconsistent points. Active-policy PR checks-watch delegation bypassed it, while lower fallback paths could replace an original interval before the freshly acquired final policy inspected it. That could hide a value the final policy should reject.

Move native flooring into final protected preparation and remove the three earlier floor calls. Existing repository pins, policy acquisition, native delegation, output/exit ownership, and typed versus direct `OCTOPOOL_NO_FALLBACK` behavior stay intact. The command is prepared once; no approval cache or second snapshot/preparation pass is added.

Both input and prepared arguments must retain recognized watch grammar and corresponding non-repository option/value, positional, and terminator ownership. Unknown, invalid, or ownership-changing policy transformations keep their prepared arguments without a guessed floor. Valid rewrites above the floor remain unchanged. Generated interval values and emitted tokens must also satisfy the final policy and existing byte ceilings; attached aliases cannot hide a forbidden value, and conflicts block the child rather than rewriting the floor below 30 seconds.

Active-policy PR checks-watch remains native-only. No new flags, short clusters, relay eligibility, dependencies, configuration, or Worker changes are included.

## Validation

- Tests first on unchanged production: 11 intended failures and 22 passing controls; the identical 33 cases pass after the fix.
- Broader sibling/protocol coverage: 2,701 passing cases, including all 127 retained watch/policy controls and compiled-CLI coverage.
- Full Go suite: 4,499 passing leaf cases. The prior single private-run-watch case is preserved in a stronger table; its name change is explicitly accounted for rather than counted as unchanged coverage.
- Added controls prove generated-token policy checks for attached and default intervals, valid policy rewrites, changed option ownership, and preservation of an initially inferred repository after context changes.
- Go vet, route/SQL generation, formatting, lint, build/types, and docs checks passed. No test deadlines, dependencies, runtime configuration, or policy restrictions were relaxed.

The evidence uses synthetic policy/data servers and captured native-child arguments; it does not claim real native polling, production quota impact, or incident attribution. Required merge gates are full independent P2 review and exact-head Linux/Windows CI, CodeQL analyses, and the separate CodeQL security summary.
