### PR TITLE
fix: delegate unprovable PR detail exports

### DIFF
--- a/cmd/octopool/gh_api_test.go
+++ b/cmd/octopool/gh_api_test.go
@@ -2,10 +2,49 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
+	"net/http"
+	"os"
 	"strings"
 	"testing"
 )
+
+func TestRunGHAPIPRDetailRESTControls(t *testing.T) {
+	for _, test := range []struct{ field, path string }{
+		{"commits", "/repos/acme/repo/pulls/7/commits"},
+		{"comments", "/repos/acme/repo/issues/7/comments"},
+		{"reviews", "/repos/acme/repo/pulls/7/reviews"},
+	} {
+		t.Run(test.field, func(t *testing.T) {
+			body := prDetailRESTFixture(test.field)
+			data := 0
+			_, policies := rewriteTestServer(t, rewriteActiveTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+				data++
+				req := decodeCLIRequest(t, w, r)
+				headers, _ := req["headers"].(map[string]any)
+				if req["method"] != "GET" || req["path"] != test.path || req["route_hint"] != nil || headers["x-octopool-public-shape"] != nil {
+					t.Errorf("raw REST must use existing unprojected route: %v", req)
+				}
+				writeCLIEnvelope(t, w, body)
+			})
+			t.Setenv("OCTOPOOL_NO_FALLBACK", "1")
+			capture := captureRewriteGH(t)
+			var out, stderr bytes.Buffer
+			err := runGH(t.Context(), []string{"api", strings.TrimPrefix(test.path, "/")}, &out, &stderr)
+			want, marshalErr := json.Marshal(body)
+			if marshalErr != nil {
+				t.Fatal(marshalErr)
+			}
+			if err != nil || !bytes.Equal(bytes.TrimSpace(out.Bytes()), want) || stderr.Len() != 0 || data != 1 || policies.Load() != 2 {
+				t.Fatalf("raw REST changed: err=%v data=%d policies=%d out=%q want=%q stderr=%q", err, data, policies.Load(), out.String(), want, stderr.String())
+			}
+			if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Fatal("raw detail GET must still relay, not use native GraphQL export")
+			}
+		})
+	}
+}
 
 func TestParseGHAPIArgs(t *testing.T) {
 	request, fallback, err := parseGHAPIArgs([]string{

--- a/cmd/octopool/gh_pagination_test.go
+++ b/cmd/octopool/gh_pagination_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"strconv"
 	"strings"
@@ -696,18 +697,32 @@ func TestRunGHPRChecksFallsBackWhenPaginationIsExhausted(t *testing.T) {
 	}
 }
 
-func TestRunGHPRViewFallsBackWhenDetailPaginationIsExhausted(t *testing.T) {
-	files := make([]map[string]any, relayPageSize)
-	for index := range files {
-		files[index] = map[string]any{"filename": "file-" + strconv.Itoa(index)}
-	}
+func TestRunGHPRViewFallsBackWhenFilePaginationIsExhausted(t *testing.T) {
+	prCalls, fileCalls := 0, 0
 	relayTestServer(t, func(body map[string]any) any {
 		switch body["path"] {
 		case "/repos/openclaw/octopool/pulls/7":
-			return map[string]any{"number": 7}
+			prCalls++
+			if prCalls != 1 || fileCalls != 0 {
+				t.Fatalf("unexpected head read: PR calls=%d file calls=%d", prCalls, fileCalls)
+			}
+			return map[string]any{"number": 7, "head": map[string]any{"sha": "0123456789abcdef0123456789abcdef01234567"}}
 		case "/repos/openclaw/octopool/pulls/7/files":
+			fileCalls++
+			query := body["query"].(map[string]any)
+			if prCalls != 1 || query["page"] != strconv.Itoa(fileCalls) || query["per_page"] != "100" {
+				t.Fatalf("file call %d: PR calls=%d query=%#v", fileCalls, prCalls, query)
+			}
+			files := make([]map[string]any, relayPageSize)
+			for index := range files {
+				files[index] = map[string]any{
+					"filename": "file-" + strconv.Itoa((fileCalls-1)*relayPageSize+index),
+					"status":   "modified", "additions": 2, "deletions": 1,
+				}
+			}
 			return files
 		default:
+			t.Fatalf("path = %v", body["path"])
 			return nil
 		}
 	})
@@ -716,8 +731,12 @@ func TestRunGHPRViewFallsBackWhenDetailPaginationIsExhausted(t *testing.T) {
 	result := handleGHPR(t.Context(), []string{
 		"view", "7", "-R", "openclaw/octopool", "--json", "number,files",
 	}, &out)
-	if result.action != ghFail || !isLocalFallback(result.err) {
+	var fallback localFallbackError
+	if result.action != ghFail || !errors.As(result.err, &fallback) || fallback.Reason != "pagination_exhausted" || fallback.Relay != nil {
 		t.Fatalf("action=%v err=%v", result.action, result.err)
+	}
+	if fileCalls != 10 || prCalls != 1 || out.Len() != 0 {
+		t.Fatalf("pagination refusal: file calls=%d PR calls=%d output=%q", fileCalls, prCalls, out.String())
 	}
 }
 

--- a/cmd/octopool/gh_test_helpers_test.go
+++ b/cmd/octopool/gh_test_helpers_test.go
@@ -211,3 +211,47 @@ func (f *prChecksFixture) calls(suffix string) int {
 	}
 	return n
 }
+
+// These REST records exercise acquisition, not fabricated native GraphQL output.
+func prDetailRESTFixture(field string) []any {
+	user := map[string]any{"id": 12, "node_id": "U_alice", "login": "alice", "type": "User"}
+	switch field {
+	case "commits":
+		return []any{map[string]any{
+			"sha": metadataHead, "html_url": "https://github.com/acme/repo/commit/" + metadataHead, "author": user,
+			"commit": map[string]any{"message": "Subject\n\nBody", "author": map[string]any{"name": "Display name", "email": "alice@example.test", "date": "2026-09-01T00:00:00Z"}, "committer": map[string]any{"date": "2026-09-01T00:00:00Z"}},
+		}}
+	case "comments":
+		return []any{map[string]any{
+			"id": 31, "node_id": "IC_comment", "user": user, "author_association": "MEMBER", "body": "Comment body",
+			"created_at": "2026-09-01T00:00:00Z", "updated_at": "2026-09-01T01:00:00Z", "html_url": "https://github.com/acme/repo/pull/7#issuecomment-31",
+		}}
+	case "reviews":
+		return []any{map[string]any{
+			"id": 41, "node_id": "PRR_review", "user": user, "author_association": "MEMBER", "body": "Review body", "state": "APPROVED",
+			"submitted_at": "2026-09-01T00:00:00Z", "commit_id": metadataHead, "html_url": "https://github.com/acme/repo/pull/7#pullrequestreview-41",
+		}}
+	default:
+		panic("unknown PR detail fixture")
+	}
+}
+
+func prDetailExportResponse(t *testing.T, checks *prChecksFixture, request map[string]any) any {
+	t.Helper()
+	switch request["path"] {
+	case "/repos/acme/repo/pulls/7":
+		return map[string]any{"number": 7, "title": "Detail fixture", "head": checks.head, "user": map[string]any{"id": 12, "node_id": "U_alice", "login": "alice", "type": "User"}}
+	case "/users/alice":
+		return map[string]any{"id": 12, "node_id": "U_alice", "login": "alice", "type": "User", "name": "Alice"}
+	case "/repos/acme/repo/pulls/7/files":
+		return []any{map[string]any{"filename": "proof.go", "status": "added", "additions": 1, "deletions": 0}}
+	case "/repos/acme/repo/pulls/7/commits":
+		return prDetailRESTFixture("commits")
+	case "/repos/acme/repo/issues/7/comments":
+		return prDetailRESTFixture("comments")
+	case "/repos/acme/repo/pulls/7/reviews":
+		return prDetailRESTFixture("reviews")
+	default:
+		return checks.response(t, request)
+	}
+}

--- a/cmd/octopool/gh_top_pr.go
+++ b/cmd/octopool/gh_top_pr.go
@@ -146,6 +146,9 @@ func relayPRList(ctx context.Context, stdout io.Writer, request ghAPIRequest, op
 }
 
 func relayPRView(ctx context.Context, stdout io.Writer, repo string, number string, opts ghTopOptions) error {
+	if hasJSONField(opts.json, "commits") || hasJSONField(opts.json, "comments") || hasJSONField(opts.json, "reviews") {
+		return localFallbackError{Reason: "unsupported_pr_detail_export"}
+	}
 	headers := prViewHeaders(opts)
 	if hasJSONField(opts.json, "files") || needsLivePRRead(opts.json) || freshReadRequested() {
 		if headers == nil {
@@ -278,24 +281,6 @@ func relayPRView(ctx context.Context, stdout io.Writer, repo string, number stri
 			}
 			hydratedHeadSHA = sha
 			pr["files"] = mapped
-		case "commits":
-			commits, err := relayPagedArray(ctx, client, repoPath(repo, "pulls", number, "commits"), nil)
-			if err != nil {
-				return err
-			}
-			pr["commits"] = mapPRCommits(commits)
-		case "comments":
-			comments, err := relayPagedArray(ctx, client, repoPath(repo, "issues", number, "comments"), nil)
-			if err != nil {
-				return err
-			}
-			pr["comments"] = mapPRComments(comments)
-		case "reviews":
-			reviews, err := relayPagedArray(ctx, client, repoPath(repo, "pulls", number, "reviews"), nil)
-			if err != nil {
-				return err
-			}
-			pr["reviews"] = mapPRReviews(reviews)
 		}
 	}
 	if hydratedHeadSHA != "" {
@@ -354,7 +339,7 @@ func normalizePRViewMergeable(pr map[string]any) {
 func prViewHeaders(opts ghTopOptions) map[string]string {
 	for _, field := range opts.json {
 		switch field {
-		case "files", "commits", "comments", "reviews", "statusCheckRollup":
+		case "files", "statusCheckRollup":
 			continue
 		}
 		if !supportedPublicPRViewFields[field] {
@@ -430,71 +415,4 @@ func mapPRFiles(items []any) ([]any, error) {
 		})
 	}
 	return out, nil
-}
-
-func mapPRCommits(items []any) []any {
-	return mapObjects(items, func(item map[string]any) map[string]any {
-		commit, _ := item["commit"].(map[string]any)
-		message := firstString(commit, "message")
-		headline, body, _ := strings.Cut(message, "\n\n")
-		if headline == "" {
-			headline = message
-		}
-		return map[string]any{
-			"oid":             firstString(item, "sha"),
-			"messageHeadline": headline,
-			"messageBody":     body,
-			"committedDate":   nestedStringValue(item, "commit", "committer", "date"),
-			"authoredDate":    nestedStringValue(item, "commit", "author", "date"),
-			"url":             firstString(item, "html_url"),
-			"authors":         commitAuthors(item),
-		}
-	})
-}
-
-func mapPRComments(items []any) []any {
-	return mapObjects(items, func(item map[string]any) map[string]any {
-		return map[string]any{
-			"author":    item["user"],
-			"body":      item["body"],
-			"createdAt": item["created_at"],
-			"updatedAt": item["updated_at"],
-			"url":       item["html_url"],
-		}
-	})
-}
-
-func mapPRReviews(items []any) []any {
-	return mapObjects(items, func(item map[string]any) map[string]any {
-		return map[string]any{
-			"author":      item["user"],
-			"body":        item["body"],
-			"state":       item["state"],
-			"submittedAt": item["submitted_at"],
-			"url":         item["html_url"],
-		}
-	})
-}
-
-func mapObjects(items []any, mapper func(map[string]any) map[string]any) []any {
-	out := make([]any, 0, len(items))
-	for _, raw := range items {
-		item, ok := raw.(map[string]any)
-		if !ok {
-			continue
-		}
-		out = append(out, mapper(item))
-	}
-	return out
-}
-
-func commitAuthors(item map[string]any) []any {
-	login := nestedStringValue(item, "author", "login")
-	if login == "" {
-		login = nestedStringValue(item, "commit", "author", "name")
-	}
-	if login == "" {
-		return []any{}
-	}
-	return []any{map[string]any{"login": login}}
 }

--- a/cmd/octopool/gh_top_pr_export_test.go
+++ b/cmd/octopool/gh_top_pr_export_test.go
@@ -3,14 +3,261 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
+
+func prDetailSelections() []struct {
+	name  string
+	flags []string
+	jq    bool
+} {
+	return []struct {
+		name  string
+		flags []string
+		jq    bool
+	}{
+		{"commits", []string{"--json", "commits"}, false},
+		{"comments", []string{"--json", "comments"}, false},
+		{"reviews", []string{"--json", "reviews"}, false},
+		{"author_before_commits", []string{"--json", "number,author,commits"}, false},
+		{"files_before_comments", []string{"--json=files,comments,title"}, false},
+		{"rollup_before_reviews", []string{"--json", "statusCheckRollup,reviews,number"}, false},
+		{"reordered_repeated", []string{"--json", `"reviews",author`, "--json=files,commits,comments,reviews,author,statusCheckRollup", "--json="}, false},
+		{"jq_native_owns_filter", []string{"--json", "author,commits,files", "--jq", "(", "-q", `"LOCAL JQ MUST NOT RUN"`}, true},
+		{"jq_short_equals_literal", []string{"--json=comments,number", "-q="}, true},
+	}
+}
+
+func TestPRDetailExportTypedBeforeClient(t *testing.T) {
+	for _, field := range []string{"commits", "comments", "reviews"} {
+		t.Run(field, func(t *testing.T) {
+			isolateTestConfig(t)
+			t.Setenv("OCTOPOOL_TOKEN", "")
+			var out bytes.Buffer
+			result := handleGHPR(t.Context(), []string{"view", "7", "-R", "acme/repo", "--json", field}, &out)
+			var fallback localFallbackError
+			if result.action != ghFail || !errors.As(result.err, &fallback) || fallback.Reason != "unsupported_pr_detail_export" || fallback.Relay != nil || out.Len() != 0 {
+				t.Fatalf("detail must remain accepted and fail typed before relay client/auth: action=%v err=%v out=%q", result.action, result.err, out.String())
+			}
+		})
+	}
+}
+
+func TestRunGHPRDetailExportNativeBoundary(t *testing.T) {
+	for _, active := range []bool{false, true} {
+		for _, noFallback := range []bool{false, true} {
+			for _, test := range prDetailSelections() {
+				t.Run(fmt.Sprintf("active=%v/no-fallback=%v/%s", active, noFallback, test.name), func(t *testing.T) {
+					if test.jq && !jqAvailable() {
+						t.Skip("existing jq required for relay eligibility")
+					}
+					policy := rewriteEmptyTestPolicy
+					if active {
+						policy = rewriteActiveTestPolicy
+					}
+					var paths []string
+					checks := newPRChecksFixture()
+					_, policies := rewriteTestServer(t, policy, func(w http.ResponseWriter, r *http.Request) {
+						req := decodeCLIRequest(t, w, r)
+						paths = append(paths, req["path"].(string))
+						writeCLIEnvelope(t, w, prDetailExportResponse(t, checks, req))
+					})
+					t.Setenv("OCTOPOOL_NO_FALLBACK", "")
+					if noFallback {
+						t.Setenv("OCTOPOOL_NO_FALLBACK", "1")
+					}
+					t.Setenv("GH_HOST", "github.com")
+					t.Setenv("GH_REPO", "acme/inherited")
+					capture := captureRewriteGH(t)
+					t.Setenv("OCTOPOOL_TEST_REWRITE_CALLS", capture+".calls")
+					args := append([]string{"pr", "view", "7", "-Racme/repo"}, test.flags...)
+					original := append([]string(nil), args...)
+					var stdout, stderr bytes.Buffer
+					err := runGH(t.Context(), args, &stdout, &stderr)
+					calls, callErr := os.ReadFile(capture + ".calls")
+					t.Logf("boundary policies=%d data=%d paths=%v child=%d err=%v stdout=%q stderr=%q", policies.Load(), len(paths), paths, strings.Count(string(calls), "child\n"), err, stdout.String(), stderr.String())
+					if !reflect.DeepEqual(args, original) || os.Getenv("GH_HOST") != "github.com" || os.Getenv("GH_REPO") != "acme/inherited" {
+						t.Error("caller argv/environment mutated")
+					}
+					if len(paths) != 0 {
+						t.Errorf("detail preflight must do zero relay DATA, including earlier hydration: %v", paths)
+					}
+					if noFallback {
+						var fallback localFallbackError
+						if !errors.As(err, &fallback) || fallback.Reason != "unsupported_pr_detail_export" || fallback.Relay != nil {
+							t.Errorf("NO_FALLBACK must return exact local typed projection refusal, got %T: %v", err, err)
+						}
+						if policies.Load() != 1 || stdout.Len() != 0 || stderr.Len() != 0 || !os.IsNotExist(callErr) {
+							t.Error("NO_FALLBACK must stop after initial policy, without child/local JSON/jq/output")
+						}
+						if _, err := os.Stat(capture); !os.IsNotExist(err) {
+							t.Error("NO_FALLBACK ran native child")
+						}
+						return
+					}
+					if err != nil || stdout.String() != "child stdout\n" || stderr.String() != "octopool: octopool requested local gh fallback: unsupported_pr_detail_export; falling back to real gh\nchild stderr\n" || string(calls) != "child\n" || callErr != nil || policies.Load() != 2 {
+						t.Error("typed handoff must precede exactly one synthetic native child, which owns all stdout/jq; only initial and final policy reads")
+					}
+					if _, statErr := os.Stat(capture); statErr != nil {
+						t.Errorf("missing synthetic native capture: %v", statErr)
+						return
+					}
+					got := readRewriteCapture(t, capture)
+					want := original
+					wantRepo := "acme/inherited"
+					if active {
+						want = append([]string{"pr", "view", "7", "--repo=acme/repo"}, test.flags...)
+						wantRepo = ""
+					}
+					if !reflect.DeepEqual(got.Args, want) || got.Env["GH_HOST"] != "github.com" || got.Env["GH_REPO"] != wantRepo || got.Stdin != "" || len(got.Files) != 0 {
+						t.Errorf("native argv/pins/streams: got=%+v want argv=%q repo=%q", got, want, wantRepo)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestRunGHPRDetailExportPolicyBoundaries(t *testing.T) {
+	for _, field := range []string{"commits", "comments", "reviews"} {
+		for _, stage := range []string{"initial-denial", "final-denial", "final-unavailable"} {
+			t.Run(field+"/"+stage, func(t *testing.T) {
+				var data atomic.Int64
+				policies := rewriteTestServerPolicySequence(t, func(ordinal int64) (string, int) {
+					if ordinal == 1 && stage != "initial-denial" {
+						return rewriteActiveTestPolicy, http.StatusOK
+					}
+					if ordinal > 2 {
+						t.Error("unexpected extra policy read")
+					}
+					if stage == "final-unavailable" {
+						return "", http.StatusServiceUnavailable
+					}
+					return strings.ReplaceAll(rewriteActiveTestPolicy, "internal-model", "acme/repo"), http.StatusOK
+				}, func(w http.ResponseWriter, r *http.Request) {
+					data.Add(1)
+					t.Error("policy boundary must prevent data")
+					w.WriteHeader(http.StatusBadRequest)
+				})
+				t.Setenv("OCTOPOOL_NO_FALLBACK", "")
+				capture := captureRewriteGH(t)
+				var out, stderr bytes.Buffer
+				err := runGH(t.Context(), []string{"pr", "view", "7", "-R", "acme/repo", "--json", "author,files,statusCheckRollup," + field}, &out, &stderr)
+				wantErr := errRewriteBlocked
+				if stage == "final-unavailable" {
+					wantErr = errRewritePolicy
+				}
+				wantPolicies, wantStderr := int64(2), "octopool: octopool requested local gh fallback: unsupported_pr_detail_export; falling back to real gh\n"
+				if stage == "initial-denial" {
+					wantPolicies, wantStderr = 1, ""
+				}
+				t.Logf("policies=%d data=%d err=%v stdout=%q stderr=%q", policies.Load(), data.Load(), err, out.String(), stderr.String())
+				if !errors.Is(err, wantErr) || isLocalFallback(err) || policies.Load() != wantPolicies || data.Load() != 0 || out.Len() != 0 || stderr.String() != wantStderr {
+					t.Error("initial policy owns denial; final policy must freshly block the typed native handoff")
+				}
+				if _, err := os.Stat(capture); !os.IsNotExist(err) {
+					t.Error("policy refusal ran native child")
+				}
+			})
+		}
+	}
+}
+
+func TestRunGHPRDetailExportDirectDelegationControls(t *testing.T) {
+	for _, test := range []struct {
+		name, selector string
+		flags          []string
+		active, noJQ   bool
+	}{
+		{"unknown_field_before", "7", []string{"--json=unknown,commits", "--json=reviews"}, true, false},
+		{"unknown_field_after", "7", []string{"--json=comments", "--json=unknown"}, true, false},
+		{"unknown_flag_before", "7", []string{"--future", "--json=commits"}, true, false},
+		{"unknown_flag_after", "7", []string{"--json=reviews", "--future"}, true, false},
+		{"unknown_flag_owns_detail_text", "7", []string{"--future", "--json=comments", "--json=number"}, true, false},
+		{"zero_json", "7", []string{"--json="}, true, false},
+		{"missing_jq", "7", []string{"--json=commits", "--jq=.commits"}, true, true},
+		{"unmodeled_selector_empty_policy", "branch-name", []string{"--json=reviews"}, false, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			policy := rewriteEmptyTestPolicy
+			if test.active {
+				policy = rewriteActiveTestPolicy
+			}
+			var data atomic.Int64
+			_, policies := rewriteTestServer(t, policy, func(w http.ResponseWriter, r *http.Request) {
+				data.Add(1)
+				t.Error("direct delegation requested data")
+				w.WriteHeader(http.StatusBadRequest)
+			})
+			t.Setenv("OCTOPOOL_NO_FALLBACK", "1")
+			t.Setenv("GH_HOST", "github.com")
+			t.Setenv("GH_REPO", "")
+			capture := captureRewriteGH(t)
+			t.Setenv("OCTOPOOL_TEST_REWRITE_CALLS", capture+".calls")
+			if test.noJQ {
+				t.Setenv("PATH", t.TempDir())
+			}
+			args := append([]string{"pr", "view", test.selector, "-R", "acme/repo"}, test.flags...)
+			original := append([]string(nil), args...)
+			var out, stderr bytes.Buffer
+			result := handleGHPR(t.Context(), args[1:], &out)
+			if result.action != ghDelegate || result.err != nil || out.Len() != 0 || data.Load() != 0 || policies.Load() != 0 {
+				t.Fatalf("unmodeled shape must stay direct delegation: %+v out=%q", result, out.String())
+			}
+			err := runGH(t.Context(), args, &out, &stderr)
+			calls, callErr := os.ReadFile(capture + ".calls")
+			if err != nil || out.String() != "child stdout\n" || stderr.String() != "child stderr\n" || policies.Load() != 2 || data.Load() != 0 || string(calls) != "child\n" || callErr != nil || !reflect.DeepEqual(args, original) {
+				t.Fatalf("direct protected delegation must ignore typed-only NO_FALLBACK: err=%v out=%q stderr=%q policies=%d data=%d calls=%q", err, out.String(), stderr.String(), policies.Load(), data.Load(), calls)
+			}
+			want := original
+			if test.active {
+				repoArgs := []string{"pr", "view", test.selector, "--repo=acme/repo"}
+				if strings.HasPrefix(test.name, "unknown_flag") {
+					repoArgs = []string{"pr", "view", test.selector, "-R", "github.com/acme/repo"}
+				}
+				want = append(repoArgs, test.flags...)
+			}
+			got := readRewriteCapture(t, capture)
+			if !reflect.DeepEqual(got.Args, want) || got.Env["GH_HOST"] != "github.com" || got.Env["GH_REPO"] != "" || got.Stdin != "" {
+				t.Fatalf("direct argv/pin mismatch: got=%+v want=%q", got, want)
+			}
+		})
+	}
+}
+
+func TestRunGHPRDetailExportRemainingProjectionControl(t *testing.T) {
+	checks := newPRChecksFixture()
+	var paths []string
+	relayTestServer(t, func(req map[string]any) any {
+		paths = append(paths, req["path"].(string))
+		return prDetailExportResponse(t, checks, req)
+	})
+	capture := captureRewriteGH(t)
+	var out bytes.Buffer
+	err := runGH(t.Context(), []string{"pr", "view", "7", "-R", "acme/repo", "--json=number,title,author,files,statusCheckRollup"}, &out, io.Discard)
+	var got map[string]any
+	if err != nil || json.Unmarshal(out.Bytes(), &got) != nil {
+		t.Fatalf("legitimate shared fixture must fully hydrate: err=%v out=%q", err, out.String())
+	}
+	if len(got) != 5 || got["number"] != float64(7) || got["title"] != "Detail fixture" || !reflect.DeepEqual(got["author"], map[string]any{"id": "U_alice", "login": "alice", "name": "Alice", "is_bot": false}) || !reflect.DeepEqual(got["files"], []any{map[string]any{"path": "proof.go", "changeType": "ADDED", "additions": float64(1), "deletions": float64(0)}}) {
+		t.Errorf("remaining projection: %s", out.String())
+	}
+	rollup, ok := got["statusCheckRollup"].([]any)
+	if !ok || len(rollup) != 1 || rollup[0].(map[string]any)["workflowName"] != "CI" || len(paths) != 8 || paths[len(paths)-1] != "/repos/acme/repo/pulls/7" {
+		t.Errorf("rollup/head acquisition: paths=%v output=%s", paths, out.String())
+	}
+	if _, err := os.Stat(capture); !os.IsNotExist(err) {
+		t.Error("remaining projection delegated")
+	}
+}
 
 func TestRunGHPRViewAuthorNativeShape(t *testing.T) {
 	for _, test := range []struct {

--- a/cmd/octopool/gh_top_pr_state_test.go
+++ b/cmd/octopool/gh_top_pr_state_test.go
@@ -99,17 +99,28 @@ func TestRunGHPRViewLifecycleProjection(t *testing.T) {
 						"state,updatedAt", "state,headRefOid,updatedAt", "state,isDraft,updatedAt",
 						"state,headRefOid,isDraft,updatedAt", "isDraft,state,headRefOid",
 						"isDraft", "headRefOid", "headRefOid,isDraft",
-						"state,comments", "state,headRefOid,comments", "state,isDraft,comments",
-						"state,headRefOid,isDraft,comments",
+						"state,headRefOid,files", "state,headRefOid,isDraft,files",
 					} {
 						t.Run(fields, func(t *testing.T) {
 							// REST may also serve a public shape after a page parser misses.
 							wantShape := !strings.Contains(fields, "isDraft") && !strings.Contains(fields, "updatedAt")
-							prCalls, commentCalls := 0, 0
+							wantFiles := strings.Contains(fields, "files")
+							prCalls, fileCalls := 0, 0
 							relayTestServer(t, func(request map[string]any) any {
-								if request["path"] == "/repos/openclaw/clawsweeper/issues/1025/comments" {
-									commentCalls++
-									return []any{}
+								if request["path"] == "/repos/openclaw/clawsweeper/pulls/1025/files" {
+									if !wantFiles || prCalls != 1 || fileCalls != 0 {
+										t.Fatalf("unexpected file read: PR=%d files=%d", prCalls, fileCalls)
+									}
+									fileCalls++
+									headers, _ := request["headers"].(map[string]any)
+									hint, _ := request["route_hint"].(map[string]any)
+									query, _ := request["query"].(map[string]any)
+									if headers["x-octopool-public-shape"] != "pr-files-v1" || hint["pr_head_sha"] != prStateTestHead || query["page"] != "1" || query["per_page"] != "100" {
+										t.Fatalf("file request: headers=%#v hint=%#v query=%#v", headers, hint, query)
+									}
+									return []any{map[string]any{
+										"filename": "src/feature.go", "status": "modified", "additions": 7, "deletions": 2,
+									}}
 								}
 								if request["path"] != "/repos/openclaw/clawsweeper/pulls/1025" {
 									t.Fatalf("unexpected path: %v", request["path"])
@@ -117,8 +128,20 @@ func TestRunGHPRViewLifecycleProjection(t *testing.T) {
 								prCalls++
 								headers, _ := request["headers"].(map[string]any)
 								shape, _ := headers["x-octopool-public-shape"].(string)
+								if prCalls == 2 && wantFiles {
+									if fileCalls != 1 || shape != "pr-summary-v1" || headers["cache-control"] != "max-age=0" {
+										t.Fatalf("final head read: files=%d headers=%#v", fileCalls, headers)
+									}
+									return map[string]any{"head": map[string]any{"sha": prStateTestHead}}
+								}
+								if prCalls != 1 || fileCalls != 0 {
+									t.Fatalf("unexpected PR read: PR=%d files=%d", prCalls, fileCalls)
+								}
 								if (wantShape && shape != "pr-summary-v1") || (!wantShape && shape != "") {
 									t.Fatalf("shape = %q, want public shape = %v", shape, wantShape)
+								}
+								if wantFiles && headers["cache-control"] != "max-age=0" {
+									t.Fatalf("initial file-hydration PR headers = %#v", headers)
 								}
 								pr := map[string]any{
 									"state": lifecycle.restState, "draft": lifecycle.draft, "merged": lifecycle.merged,
@@ -152,7 +175,10 @@ func TestRunGHPRViewLifecycleProjection(t *testing.T) {
 							}
 							all := map[string]any{
 								"state": lifecycle.wantState, "isDraft": lifecycle.draft,
-								"headRefOid": prStateTestHead, "updatedAt": prStateTestTime, "comments": []any{},
+								"headRefOid": prStateTestHead, "updatedAt": prStateTestTime,
+								"files": []any{map[string]any{
+									"path": "src/feature.go", "changeType": "MODIFIED", "additions": float64(7), "deletions": float64(2),
+								}},
 							}
 							want := map[string]any{}
 							for _, field := range strings.Split(fields, ",") {
@@ -161,12 +187,12 @@ func TestRunGHPRViewLifecycleProjection(t *testing.T) {
 							if !reflect.DeepEqual(got, want) {
 								t.Errorf("projection = %#v, want %#v", got, want)
 							}
-							wantComments := 0
-							if strings.Contains(fields, "comments") {
-								wantComments = 1
+							wantPRCalls, wantFileCalls := 1, 0
+							if wantFiles {
+								wantPRCalls, wantFileCalls = 2, 1
 							}
-							if prCalls != 1 || commentCalls != wantComments {
-								t.Errorf("requests: PR=%d comments=%d, want 1/%d", prCalls, commentCalls, wantComments)
+							if prCalls != wantPRCalls || fileCalls != wantFileCalls {
+								t.Errorf("requests: PR=%d files=%d, want %d/%d", prCalls, fileCalls, wantPRCalls, wantFileCalls)
 							}
 						})
 					}

--- a/cmd/octopool/gh_top_pr_test.go
+++ b/cmd/octopool/gh_top_pr_test.go
@@ -10,12 +10,15 @@ import (
 	"testing"
 )
 
-func TestRunGHPRViewHydratesDetails(t *testing.T) {
-	prCalls := 0
+func TestRunGHPRViewHydratesFiles(t *testing.T) {
+	prCalls, fileCalls := 0, 0
 	relayTestServer(t, func(body map[string]any) any {
 		switch body["path"] {
 		case "/repos/openclaw/octopool/pulls/7":
 			prCalls++
+			if prCalls == 1 && fileCalls != 0 || prCalls == 2 && fileCalls != 1 {
+				t.Fatalf("head read order: PR calls=%d file calls=%d", prCalls, fileCalls)
+			}
 			headers := body["headers"].(map[string]any)
 			if headers["x-octopool-public-shape"] != "pr-summary-v1" || headers["cache-control"] != "max-age=0" {
 				t.Fatalf("PR headers = %#v", headers)
@@ -27,6 +30,10 @@ func TestRunGHPRViewHydratesDetails(t *testing.T) {
 				"head":     map[string]any{"sha": "0123456789abcdef0123456789abcdef01234567"},
 			}
 		case "/repos/openclaw/octopool/pulls/7/files":
+			fileCalls++
+			if prCalls != 1 {
+				t.Fatalf("files read before initial head or after final head: PR calls=%d", prCalls)
+			}
 			headers := body["headers"].(map[string]any)
 			if headers["x-octopool-public-shape"] != "pr-files-v1" {
 				t.Fatalf("files headers = %#v", headers)
@@ -36,12 +43,6 @@ func TestRunGHPRViewHydratesDetails(t *testing.T) {
 				t.Fatalf("route hint = %#v", hint)
 			}
 			return []map[string]any{{"filename": "cmd/octopool/gh.go", "status": "modified", "additions": 2, "deletions": 1}}
-		case "/repos/openclaw/octopool/pulls/7/commits":
-			return []map[string]any{{"sha": "abc1234"}}
-		case "/repos/openclaw/octopool/issues/7/comments":
-			return []map[string]any{{"body": "looks good"}}
-		case "/repos/openclaw/octopool/pulls/7/reviews":
-			return []map[string]any{{"state": "APPROVED"}}
 		default:
 			t.Fatalf("path = %v", body["path"])
 			return nil
@@ -52,19 +53,26 @@ func TestRunGHPRViewHydratesDetails(t *testing.T) {
 		"view",
 		"7",
 		"-R", "openclaw/octopool",
-		"--json", "number,files,commits,comments,reviews",
+		"--json", "number,files",
 	}, &out)
 	if result.err != nil || result.action != ghComplete {
 		t.Fatalf("action=%v err=%v", result.action, result.err)
 	}
-	if prCalls != 2 {
-		t.Fatalf("PR calls = %d, want initial and final head reads", prCalls)
+	if prCalls != 2 || fileCalls != 1 {
+		t.Fatalf("PR calls=%d file calls=%d, want initial head, files, final head", prCalls, fileCalls)
 	}
-	got := out.String()
-	for _, want := range []string{"cmd/octopool/gh.go", "abc1234", "looks good", "APPROVED"} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("out missing %q: %s", want, got)
-		}
+	var got map[string]any
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]any{
+		"number": float64(7),
+		"files": []any{map[string]any{
+			"path": "cmd/octopool/gh.go", "additions": float64(2), "deletions": float64(1), "changeType": "MODIFIED",
+		}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("file projection = %#v, want %#v", got, want)
 	}
 }
 

--- a/cmd/octopool/string_rewrites_process_test.go
+++ b/cmd/octopool/string_rewrites_process_test.go
@@ -87,6 +87,17 @@ func TestRewriteCaptureProcess(t *testing.T) {
 	if err := os.WriteFile(capturePath, data, 0600); err != nil {
 		os.Exit(81)
 	}
+	if path := os.Getenv("OCTOPOOL_TEST_REWRITE_CALLS"); path != "" {
+		file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+		if err != nil {
+			os.Exit(84)
+		}
+		_, err = file.WriteString("child\n")
+		closeErr := file.Close()
+		if err != nil || closeErr != nil {
+			os.Exit(84)
+		}
+	}
 	if os.Getenv("OCTOPOOL_TEST_REWRITE_WAIT") == "1" {
 		interrupt := make(chan os.Signal, 1)
 		signal.Notify(interrupt, os.Interrupt)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -182,7 +182,7 @@ safe relay routes:
 
 ```sh
 octopool gh pr view 85341 -R openclaw/openclaw --json number,title,url
-octopool gh pr view 85341 -R openclaw/openclaw --json number,files,commits,comments,reviews
+octopool gh pr view 85341 -R openclaw/openclaw --json number,files
 octopool gh pr list -R openclaw/openclaw --state open --limit 20 --json number,title,url
 octopool gh pr diff 85341 -R openclaw/openclaw --patch
 octopool gh pr checks 85341 -R openclaw/openclaw --json name,state,bucket,link,workflow
@@ -255,8 +255,22 @@ or incomplete collections emit no partial JSON and follow the existing typed nat
 fallback, including fresh policy checks and host pinning under active rewrite rules.
 `OCTOPOOL_NO_FALLBACK=1` keeps these cases as failures. Repeated JSON fields are accepted
 and hydrated once.
-PR-view `author`, `labels`, and `files` use native JSON projections regardless of the
-other requested fields. User authors export `id` (node ID), `is_bot`, `login`, and
+Otherwise eligible machine-readable `gh pr view` requests selecting any of `commits`,
+`comments`, or `reviews` hand the entire command to guarded native `gh` before any relay
+data read. Native GraphQL export fields cannot be proven from REST projections of these
+records. This includes mixed selections such as `--json number,files,commits`: native
+`gh` owns the complete export, the literal JSON and jq arguments, and stdout/stderr;
+Octopool does not hydrate a subset or run jq locally. The initial policy check and a
+fresh final native-dispatch policy check still apply. `OCTOPOOL_NO_FALLBACK=1` blocks
+this typed handoff with `unsupported_pr_detail_export`. Earlier direct-delegation cases
+(such as unknown fields or flags, empty JSON selection, missing jq, or an unmodeled
+selector) retain their existing guarded native behavior; this setting does not block
+all unsupported grammar. Raw REST `gh api` reads of `/repos/OWNER/REPO/pulls/N/commits`,
+`/repos/OWNER/REPO/issues/N/comments`, and `/repos/OWNER/REPO/pulls/N/reviews` remain
+supported shared reads with unprojected REST shapes. Human PR review rendering is
+unchanged. This boundary does not establish native parity for other nested exports.
+For relayed PR-view exports, `author`, `labels`, and `files` use native JSON projections.
+User authors export `id` (node ID), `is_bot`, `login`, and
 `name`; bot authors use native `is_bot` and `app/…` login keys. Labels export node IDs,
 names, descriptions (null becomes an empty string), and colors in upstream order.
 Files export only `path`, `additions`, `deletions`, and `changeType`, including renames.


### PR DESCRIPTION
## Summary

PR-view JSON exports of `commits`, `comments`, and `reviews` were assembled from REST records that cannot establish the full native GraphQL export contract. This could fabricate commit-author logins, omit native fields, and run local jq over an incomplete object. Mixed selections could also spend relay requests hydrating other fields before reaching the unsupported detail.

Otherwise relay-eligible requests selecting any of these three fields now hand the **whole command** to guarded native `gh` before acquiring a relay client or reading data. Native `gh` owns the complete JSON export and jq evaluation. The initial policy check, fresh final native-dispatch policy check, host/repository pinning, and typed `OCTOPOOL_NO_FALLBACK=1` behavior remain intact. Earlier direct-delegation cases retain their existing semantics; this does not make NO_FALLBACK a universal unsupported-command switch.

The obsolete detail hydration branches and five unused mapping helpers are removed. Raw REST API reads of PR commits, issue comments, and PR reviews remain supported shared reads. Human PR review rendering and the supported PR projections, file/head validation, metadata acquisition, and request bounds are unchanged. CLI documentation describes the boundary and its cache-versus-native tradeoff.

## Proof

- Tests first: 45 intended regression failures and 93 passing controls, with route-correct fixtures. The original regression oracles are unchanged and now pass.
- Final focused runs: 60 new cases, 78 selected controls, 140 lifecycle cases, and 1,321 sibling/protocol cases all pass. The sibling run includes 82 compiled-CLI cases; overlapping runs are not additive totals.
- Full Go suite: **4,539 passing leaves**, no failures or skips, using Go 1.26.7.
- Go vet, route and SQL generation checks, formatting, lint, build, types, and the 13-page docs build all pass with pinned local tooling.
- The existing file-pagination test previously returned before fetching a file page. Its repaired fixture passed on unchanged production and now proves exactly ten pages, the precise pagination refusal, and no partial output or final head read after refusal.
- An earlier sibling run exposed 40 lifecycle cases that expected the retired local comment export. Their redundant comment combinations were replaced with 20 supported-file hydration cases while preserving all 120 scalar lifecycle cases. The full baseline-to-candidate test-name mapping was verified.

Synthetic native-child tests prove literal dispatch, policy/NO_FALLBACK behavior, and stream ownership, not live GitHub GraphQL content. Raw REST controls prove payload shape after whitespace trimming, not opaque stdout-byte fidelity. No production deployment, migration, version change, or release is included.

Hosted qualification passed for `5d8a067e8a84d7d61522bfbacfc1a414d27e5654`: [CI](https://github.com/openclaw/octopool/actions/runs/33539554363) and [CodeQL analyses](https://github.com/openclaw/octopool/actions/runs/33539550116) succeeded, the tested CI merge checkout has the exact reviewed source tree, and the separately refreshed [CodeQL security summary](https://github.com/openclaw/octopool/runs/99962308274) reports no new alerts and zero annotations.
