### PR TITLE
fix: add safe string rewrite policy diagnostics

### DIFF
--- a/cmd/octopool/cli_protocol_e2e_test.go
+++ b/cmd/octopool/cli_protocol_e2e_test.go
@@ -3,16 +3,20 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestCLIEndToEndRelayProtocol(t *testing.T) {
@@ -332,4 +336,75 @@ func fakeGHWithExit(t *testing.T, code int) string {
 		t.Fatal(err)
 	}
 	return path
+}
+
+func TestGHShimProtocolRewritePolicyDiagnostics(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds and executes the CLI binary")
+	}
+	bin := buildCLIBinary(t)
+	wrapper := filepath.Join(t.TempDir(), executableName("gh"))
+	binary, err := os.ReadFile(bin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(wrapper, binary, 0755); err != nil {
+		t.Fatal(err)
+	}
+	for _, local := range []bool{false, true} {
+		name, class, code := "HTTP403", "http_status", 403
+		if local {
+			name, class, code = "local validation", "local_validation", 200
+		}
+		t.Run(name, func(t *testing.T) {
+			var calls atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				if r.URL.Path != "/v1/pools/maintainers/string-rewrites" || r.Method != "GET" || r.Header.Get("Authorization") != "Bearer synthetic-token-secret" {
+					t.Error("unexpected dispatch")
+				}
+				w.Header().Set("CF-Ray", "0123456789abcdef-SJC")
+				w.Header().Set("X-Private", "synthetic-header-secret")
+				w.WriteHeader(code)
+				if local {
+					_, _ = io.WriteString(w, rewriteEmptyTestPolicy)
+				} else {
+					_, _ = io.WriteString(w, "synthetic-response-secret")
+				}
+			}))
+			t.Cleanup(server.Close)
+			extra := map[string]string{"OCTOPOOL_TOKEN": "synthetic-token-secret", "OCTOPOOL_RELAY_RETRIES": "2"}
+			path := filepath.Join(t.TempDir(), "synthetic-path-secret.json")
+			if local {
+				if err := os.WriteFile(path, []byte(`{"schema_version":1,"rules":[{"pattern":"[synthetic-pattern-secret","replacement":"synthetic-value-secret"}]}`), 0600); err != nil {
+					t.Fatal(err)
+				}
+				extra["OCTOPOOL_STRING_REWRITE_FILE"] = path
+			}
+			capture := captureRewriteGH(t)
+			started := time.Now()
+			result := runCLI(t, wrapper, server.URL, extra, "pr", "view", "7", "-R", "acme/repo", "--json=number")
+			var exit *exec.ExitError
+			if !errors.As(result.err, &exit) || exit.ExitCode() != 1 || result.stdout != "" || calls.Load() != 1 {
+				t.Fatalf("policy error protocol: %+v calls=%d", result, calls.Load())
+			}
+			pattern := `\Aerror: string rewrite policy unavailable or invalid \(class=` + class + ` attempt_utc=([^ ]+Z) elapsed_ms=([0-9]+) http_status=` + strconv.Itoa(code) + ` cf_ray=0123456789abcdef-SJC\)\n\z`
+			matches := regexp.MustCompile(pattern).FindStringSubmatch(result.stderr)
+			if matches == nil {
+				t.Fatalf("unexpected stderr: %q", result.stderr)
+			}
+			attempt, err := time.Parse(time.RFC3339Nano, matches[1])
+			if err != nil || attempt.Before(started) || attempt.After(time.Now()) {
+				t.Fatal("invalid UTC attempt")
+			}
+			for _, secret := range []string{path, server.URL, "synthetic-token-secret", "synthetic-header-secret", "synthetic-response-secret", "synthetic-pattern-secret", "synthetic-value-secret"} {
+				if strings.Contains(result.stderr, secret) {
+					t.Fatal("shim exposed sensitive fixture")
+				}
+			}
+			if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Fatal("policy failure reached native gh")
+			}
+		})
+	}
 }

--- a/cmd/octopool/command_admin_string_rewrites.go
+++ b/cmd/octopool/command_admin_string_rewrites.go
@@ -67,11 +67,11 @@ func runAdminStringRewrites(ctx context.Context, args []string, stdout io.Writer
 	if err != nil {
 		return errRewritePolicy
 	}
-	data, err := rewritePolicyHTTP(ctx, *baseURL, "/v1/admin/string-rewrites", token, http.MethodGet, nil)
+	result, err := rewritePolicyHTTP(ctx, *baseURL, "/v1/admin/string-rewrites", token, http.MethodGet, nil)
 	if err != nil {
 		return err
 	}
-	current, err := parseStringRewritePolicy(data, true)
+	current, err := parseStringRewritePolicy(result.data, true)
 	if err != nil {
 		return err
 	}
@@ -87,11 +87,11 @@ func runAdminStringRewrites(ctx context.Context, args []string, stdout io.Writer
 		rules = append(rules, rule.stringRewriteRule)
 	}
 	body, _ := json.Marshal(map[string]any{"schema_version": 1, "expected_revision": current.Revision, "rules": rules})
-	data, err = rewritePolicyHTTP(ctx, *baseURL, "/v1/admin/string-rewrites", token, http.MethodPut, body)
+	result, err = rewritePolicyHTTP(ctx, *baseURL, "/v1/admin/string-rewrites", token, http.MethodPut, body)
 	if err != nil {
 		return err
 	}
-	value, err := strictRewriteJSON(data, rewriteMaxDocument)
+	value, err := strictRewriteJSON(result.data, rewriteMaxDocument)
 	if err != nil {
 		return err
 	}

--- a/cmd/octopool/protection_reads_test.go
+++ b/cmd/octopool/protection_reads_test.go
@@ -302,7 +302,7 @@ func TestProtectionReadsFreshPolicyBeforeFallback(t *testing.T) {
 			if err == nil || relays.Load() != 1 {
 				t.Fatalf("err=%v relay=%d", err, relays.Load())
 			}
-			if (scenario == "changed" && err != errRewriteBlocked) || (scenario == "missing" && err != errRewritePolicy) {
+			if (scenario == "changed" && err != errRewriteBlocked) || (scenario == "missing" && !errors.Is(err, errRewritePolicy)) {
 				t.Fatalf("wrong final policy failure: %v", err)
 			}
 			wantPolicies := int64(2)

--- a/cmd/octopool/string_rewrites_diagnostic.go
+++ b/cmd/octopool/string_rewrites_diagnostic.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"regexp"
+	"time"
+)
+
+type rewritePolicyClass uint8
+
+const (
+	rewritePolicySetup rewritePolicyClass = iota
+	rewritePolicyRequest
+	rewritePolicyTransport
+	rewritePolicyTimeoutClass
+	rewritePolicyCanceled
+	rewritePolicyHTTPStatus
+	rewritePolicyResponseRead
+	rewritePolicyResponseSize
+	rewritePolicyServerValidation
+	rewritePolicyLocalRead
+	rewritePolicyLocalValidation
+	rewritePolicyMerge
+)
+
+func (class rewritePolicyClass) String() string {
+	switch class {
+	case rewritePolicySetup:
+		return "setup"
+	case rewritePolicyRequest:
+		return "request"
+	case rewritePolicyTransport:
+		return "transport"
+	case rewritePolicyTimeoutClass:
+		return "timeout"
+	case rewritePolicyCanceled:
+		return "canceled"
+	case rewritePolicyHTTPStatus:
+		return "http_status"
+	case rewritePolicyResponseRead:
+		return "response_read"
+	case rewritePolicyResponseSize:
+		return "response_size"
+	case rewritePolicyServerValidation:
+		return "server_validation"
+	case rewritePolicyLocalRead:
+		return "local_read"
+	case rewritePolicyLocalValidation:
+		return "local_validation"
+	case rewritePolicyMerge:
+		return "merge"
+	default:
+		return "unknown"
+	}
+}
+
+// The attempt starts before HTTP validation and continues through local/merge
+// checks. Setup failures instead start before client setup; no request occurred.
+type rewritePolicyAttempt struct {
+	started time.Time
+	status  int
+	ray     string
+}
+
+// Retain only safe metadata, never an underlying error or response document.
+type rewritePolicyError struct {
+	class rewritePolicyClass
+	rewritePolicyAttempt
+	elapsed time.Duration
+}
+
+func (attempt rewritePolicyAttempt) failure(class rewritePolicyClass) error {
+	return &rewritePolicyError{class: class, rewritePolicyAttempt: attempt, elapsed: time.Since(attempt.started)}
+}
+
+func (err *rewritePolicyError) Is(target error) bool { return target == errRewritePolicy }
+
+func (err *rewritePolicyError) Error() string {
+	text := fmt.Sprintf("%s (class=%s attempt_utc=%s elapsed_ms=%d", errRewritePolicy,
+		err.class, err.started.UTC().Format(time.RFC3339Nano), max(0, err.elapsed.Milliseconds()))
+	if err.status != 0 {
+		text += fmt.Sprintf(" http_status=%d", err.status)
+	}
+	if err.ray != "" {
+		text += " cf_ray=" + err.ray
+	}
+	return text + ")"
+}
+
+func rewritePolicyTransportClass(err error) rewritePolicyClass {
+	if errors.Is(err, context.Canceled) {
+		return rewritePolicyCanceled
+	}
+	var network net.Error
+	if errors.Is(err, context.DeadlineExceeded) || errors.As(err, &network) && network.Timeout() {
+		return rewritePolicyTimeoutClass
+	}
+	return rewritePolicyTransport
+}
+
+var rewritePolicyRayPattern = regexp.MustCompile(`\A[0-9a-fA-F]{16}(-[A-Z]{3})?\z`)
+
+func safeRewritePolicyRay(header http.Header) string {
+	values := header.Values("CF-Ray")
+	if len(values) != 1 || (len(values[0]) != 16 && len(values[0]) != 20) || !rewritePolicyRayPattern.MatchString(values[0]) {
+		return ""
+	}
+	return values[0]
+}

--- a/cmd/octopool/string_rewrites_policy.go
+++ b/cmd/octopool/string_rewrites_policy.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -49,22 +50,28 @@ func readRewriteFile(path string, stdin io.Reader, limit int) ([]byte, error) {
 	return boundedRewriteRead(file, limit)
 }
 
-func rewritePolicyHTTP(ctx context.Context, baseURL, path, token, method string, body []byte) ([]byte, error) {
+type rewritePolicyHTTPResult struct {
+	data    []byte
+	attempt rewritePolicyAttempt
+}
+
+func rewritePolicyHTTP(ctx context.Context, baseURL, path, token, method string, body []byte) (rewritePolicyHTTPResult, error) {
+	result := rewritePolicyHTTPResult{attempt: rewritePolicyAttempt{started: time.Now()}}
 	parsed, err := url.Parse(baseURL)
 	if err != nil || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
-		return nil, errRewritePolicy
+		return result, result.attempt.failure(rewritePolicyRequest)
 	}
 	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && (parsed.Hostname() == "localhost" || parsed.Hostname() == "127.0.0.1" || parsed.Hostname() == "::1")) {
-		return nil, errRewritePolicy
+		return result, result.attempt.failure(rewritePolicyRequest)
 	}
 	if strings.TrimSpace(token) == "" {
-		return nil, errRewritePolicy
+		return result, result.attempt.failure(rewritePolicyRequest)
 	}
 	child, cancel := context.WithTimeout(ctx, rewritePolicyTimeout)
 	defer cancel()
 	request, err := http.NewRequestWithContext(child, method, apiURL(baseURL, path), bytes.NewReader(body))
 	if err != nil {
-		return nil, errRewritePolicy
+		return result, result.attempt.failure(rewritePolicyRequest)
 	}
 	request.Header.Set("Authorization", "Bearer "+token)
 	request.Header.Set("Cache-Control", "no-cache, no-store")
@@ -75,29 +82,35 @@ func rewritePolicyHTTP(ctx context.Context, baseURL, path, token, method string,
 	client := &http.Client{Timeout: rewritePolicyTimeout, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
 	response, err := client.Do(request)
 	if err != nil {
-		return nil, errRewritePolicy
+		return result, result.attempt.failure(rewritePolicyTransportClass(err))
 	}
 	defer response.Body.Close()
+	result.attempt.status = response.StatusCode
+	result.attempt.ray = safeRewritePolicyRay(response.Header)
 	if response.StatusCode == http.StatusConflict {
-		return nil, errRewriteConflict
+		return result, errRewriteConflict
 	}
 	if response.StatusCode != http.StatusOK {
-		return nil, errRewritePolicy
+		return result, result.attempt.failure(rewritePolicyHTTPStatus)
 	}
-	data, err := boundedRewriteRead(response.Body, rewriteMaxDocument)
+	data, err := io.ReadAll(io.LimitReader(response.Body, rewriteMaxDocument+1))
 	if err != nil {
-		return nil, errRewritePolicy
+		return result, result.attempt.failure(rewritePolicyResponseRead)
 	}
-	return data, nil
+	if len(data) > rewriteMaxDocument {
+		return result, result.attempt.failure(rewritePolicyResponseSize)
+	}
+	result.data = data
+	return result, nil
 }
 
-func loadLocalStringRewritePolicy() (stringRewritePolicy, error) {
+func loadLocalStringRewritePolicy(attempt rewritePolicyAttempt) (stringRewritePolicy, error) {
 	path := os.Getenv("OCTOPOOL_STRING_REWRITE_FILE")
 	explicit := path != ""
 	if !explicit {
 		auth, err := authPath()
 		if err != nil {
-			return stringRewritePolicy{}, errRewritePolicy
+			return stringRewritePolicy{}, attempt.failure(rewritePolicyLocalRead)
 		}
 		path = filepath.Join(filepath.Dir(auth), "string-rewrites.json")
 		if _, err := os.Lstat(path); os.IsNotExist(err) {
@@ -106,30 +119,42 @@ func loadLocalStringRewritePolicy() (stringRewritePolicy, error) {
 	}
 	data, err := readRewriteFile(path, nil, rewriteMaxDocument)
 	if err != nil {
-		return stringRewritePolicy{}, errRewritePolicy
+		return stringRewritePolicy{}, attempt.failure(rewritePolicyLocalRead)
 	}
-	return parseStringRewritePolicy(data, false)
+	policy, err := parseStringRewritePolicy(data, false)
+	if err != nil {
+		return stringRewritePolicy{}, attempt.failure(rewritePolicyLocalValidation)
+	}
+	return policy, nil
 }
 
 func (client ghRelayClient) stringRewritePolicy(ctx context.Context) (stringRewritePolicy, error) {
-	data, err := rewritePolicyHTTP(ctx, client.baseURL, "/v1/pools/"+url.PathEscape(client.pool)+"/string-rewrites", client.token, http.MethodGet, nil)
-	if err != nil {
-		return stringRewritePolicy{}, errRewritePolicy
+	result, err := rewritePolicyHTTP(ctx, client.baseURL, "/v1/pools/"+url.PathEscape(client.pool)+"/string-rewrites", client.token, http.MethodGet, nil)
+	if errors.Is(err, errRewriteConflict) {
+		return stringRewritePolicy{}, result.attempt.failure(rewritePolicyHTTPStatus)
 	}
-	server, err := parseStringRewritePolicy(data, true)
-	if err != nil {
-		return stringRewritePolicy{}, err
-	}
-	local, err := loadLocalStringRewritePolicy()
 	if err != nil {
 		return stringRewritePolicy{}, err
 	}
-	return mergeStringRewritePolicies(server, local)
+	server, err := parseStringRewritePolicy(result.data, true)
+	if err != nil {
+		return stringRewritePolicy{}, result.attempt.failure(rewritePolicyServerValidation)
+	}
+	local, err := loadLocalStringRewritePolicy(result.attempt)
+	if err != nil {
+		return stringRewritePolicy{}, err
+	}
+	merged, err := mergeStringRewritePolicies(server, local)
+	if err != nil {
+		return stringRewritePolicy{}, result.attempt.failure(rewritePolicyMerge)
+	}
+	return merged, nil
 }
 func currentStringRewritePolicy(ctx context.Context) (stringRewritePolicy, error) {
+	attempt := rewritePolicyAttempt{started: time.Now()}
 	client, err := newGHRelayClient()
 	if err != nil {
-		return stringRewritePolicy{}, errRewritePolicy
+		return stringRewritePolicy{}, attempt.failure(rewritePolicySetup)
 	}
 	return client.stringRewritePolicy(ctx)
 }

--- a/cmd/octopool/string_rewrites_policy_test.go
+++ b/cmd/octopool/string_rewrites_policy_test.go
@@ -4,16 +4,21 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -23,7 +28,9 @@ func TestStringRewritePolicyFailuresNeverRunChild(t *testing.T) {
 		code int
 		body string
 	}{
-		{"unauthorized", 401, `internal-model`}, {"forbidden", 403, `internal-model`}, {"missing", 404, `internal-model`}, {"outage", 503, `internal-model`},
+		{"unauthorized", 401, `internal-model`}, {"forbidden", 403, `internal-model`}, {"missing", 404, `internal-model`},
+		{"conflict", 409, `internal-model`}, {"limited", 429, `internal-model`}, {"internal", 500, `internal-model`}, {"gateway", 502, `internal-model`}, {"outage", 503, `internal-model`}, {"gateway timeout", 504, `internal-model`},
+		{"no content", 204, ""}, {"partial", 206, rewriteEmptyTestPolicy},
 		{"invalid JSON", 200, `internal-model`}, {"missing fields", 200, `{"rules":[]}`}, {"duplicate keys", 200, `{"schema_version":1,"schema_version":1,"rules":[]}`},
 		{"oversized", 200, strings.Repeat(" ", rewriteMaxDocument) + rewriteEmptyTestPolicy},
 		{"invalid UTF8", 200, strings.Replace(rewriteActiveTestPolicy, "public", string([]byte{255}), 1)},
@@ -38,6 +45,8 @@ func TestStringRewritePolicyFailuresNeverRunChild(t *testing.T) {
 				if r.URL.Path != "/v1/pools/selected/string-rewrites" || r.Method != "GET" || r.Header.Get("Authorization") != "Bearer configured-token" {
 					t.Error("incorrect policy request")
 				}
+				w.Header().Set("CF-Ray", "0123456789abcdef-SJC")
+				w.Header().Set("X-Private", "synthetic-header-secret")
 				w.WriteHeader(test.code)
 				_, _ = io.WriteString(w, test.body)
 			}))
@@ -45,14 +54,32 @@ func TestStringRewritePolicyFailuresNeverRunChild(t *testing.T) {
 			t.Setenv("OCTOPOOL_URL", server.URL)
 			t.Setenv("OCTOPOOL_POOL", "selected")
 			t.Setenv("OCTOPOOL_TOKEN", "configured-token")
+			t.Setenv("OCTOPOOL_RELAY_RETRIES", "2")
 			capture := captureRewriteGH(t)
 			var out, stderr bytes.Buffer
+			started := time.Now()
 			err := runGH(t.Context(), []string{"issue", "edit", "1", "--body=internal-model", "-Racme/repo"}, &out, &stderr)
-			if err != errRewritePolicy || out.Len() != 0 || stderr.Len() != 0 {
+			if !errors.Is(err, errRewritePolicy) || out.Len() != 0 || stderr.Len() != 0 {
 				t.Fatalf("failure output=%q %q error=%v", out.String(), stderr.String(), err)
 			}
 			if shouldRunRealGH(err) || calls.Load() != 1 {
 				t.Fatal("policy failure was retryable/fallback eligible")
+			}
+			class := rewritePolicyHTTPStatus
+			if test.code == 200 {
+				class = rewritePolicyServerValidation
+				if test.name == "oversized" {
+					class = rewritePolicyResponseSize
+				}
+			}
+			requireRewritePolicyDiagnostic(t, err, class, test.code, "0123456789abcdef-SJC", started,
+				"internal-model", "configured-token", "synthetic-header-secret", server.URL)
+			client, err := newGHRelayClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := client.do(t.Context(), ghAPIRequest{method: "GET", path: "/repos/acme/repo"}); !errors.Is(err, errRewritePolicy) || calls.Load() != 2 {
+				t.Fatal("relay boundary retried or dispatched on policy failure")
 			}
 			if _, err := os.Stat(capture); !os.IsNotExist(err) {
 				t.Fatal("policy failure reached child")
@@ -76,7 +103,7 @@ func TestStringRewritePolicyBeforeMalformedReadOptions(t *testing.T) {
 				capture := captureRewriteGH(t)
 				var out, stderr bytes.Buffer
 				err := runGH(t.Context(), append([]string{"pr", "list", "-R", "acme/repo"}, flags...), &out, &stderr)
-				if err != errRewritePolicy || out.Len() != 0 || stderr.Len() != 0 || !slices.Equal(paths, []string{"/v1/pools/maintainers/string-rewrites"}) {
+				if !errors.Is(err, errRewritePolicy) || out.Len() != 0 || stderr.Len() != 0 || !slices.Equal(paths, []string{"/v1/pools/maintainers/string-rewrites"}) {
 					t.Fatalf("policy precedence err=%v paths=%v out=%q stderr=%q", err, paths, out.String(), stderr.String())
 				}
 				if _, err := os.Stat(capture); !os.IsNotExist(err) {
@@ -95,7 +122,7 @@ func TestStringRewritePolicyRedirectsAndTimeout(t *testing.T) {
 	defer destination.Close()
 	for _, code := range []int{301, 302, 303, 307, 308} {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { http.Redirect(w, r, destination.URL, code) }))
-		if _, err := rewritePolicyHTTP(t.Context(), server.URL, "/policy", "test-token", "GET", nil); err != errRewritePolicy {
+		if _, err := rewritePolicyHTTP(t.Context(), server.URL, "/policy", "test-token", "GET", nil); !errors.Is(err, errRewritePolicy) {
 			t.Fatalf("redirect error=%v", err)
 		}
 		server.Close()
@@ -108,14 +135,14 @@ func TestStringRewritePolicyRedirectsAndTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Millisecond)
 	defer cancel()
 	start := time.Now()
-	if _, err := rewritePolicyHTTP(ctx, slow.URL, "/policy", "test-token", "GET", nil); err != errRewritePolicy {
+	if _, err := rewritePolicyHTTP(ctx, slow.URL, "/policy", "test-token", "GET", nil); !errors.Is(err, errRewritePolicy) {
 		t.Fatal(err)
 	}
 	if time.Since(start) > time.Second {
 		t.Fatal("policy ignored context deadline")
 	}
 	for _, base := range []string{"http://example.com", "https://user:pass@example.com", "https://example.com?x=y", "https://example.com#fragment"} {
-		if _, err := rewritePolicyHTTP(t.Context(), base, "/policy", "synthetic", "GET", nil); err != errRewritePolicy {
+		if _, err := rewritePolicyHTTP(t.Context(), base, "/policy", "synthetic", "GET", nil); !errors.Is(err, errRewritePolicy) {
 			t.Fatal("unsafe policy URL accepted")
 		}
 	}
@@ -124,7 +151,7 @@ func TestStringRewriteMissingLoginAndLocalFile(t *testing.T) {
 	_, calls := rewriteTestServer(t, rewriteEmptyTestPolicy, nil)
 	capture := captureRewriteGH(t)
 	t.Setenv("OCTOPOOL_TOKEN", "")
-	if err := runGH(t.Context(), []string{"alias", "list"}, io.Discard, io.Discard); err != errRewritePolicy {
+	if err := runGH(t.Context(), []string{"alias", "list"}, io.Discard, io.Discard); !errors.Is(err, errRewritePolicy) {
 		t.Fatalf("no-login error=%v", err)
 	}
 	if calls.Load() != 0 {
@@ -138,7 +165,7 @@ func TestStringRewriteMissingLoginAndLocalFile(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("OCTOPOOL_STRING_REWRITE_FILE", filepath.Join(t.TempDir(), "missing.json"))
-	if err := execRealGH(t.Context(), []string{"alias", "list"}, io.Discard, io.Discard); err != errRewritePolicy {
+	if err := execRealGH(t.Context(), []string{"alias", "list"}, io.Discard, io.Discard); !errors.Is(err, errRewritePolicy) {
 		t.Fatalf("explicit missing local error=%v", err)
 	}
 	if _, err := os.Stat(capture); !os.IsNotExist(err) {
@@ -169,7 +196,7 @@ func TestStringRewriteSavedURLBinding(t *testing.T) {
 	if err := saveAuth(authFile{URL: "https://saved.example", Token: "saved-token", Pool: "maintainers"}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := currentStringRewritePolicy(t.Context()); err != errRewritePolicy {
+	if _, err := currentStringRewritePolicy(t.Context()); !errors.Is(err, errRewritePolicy) {
 		t.Fatal("saved token was not bound to saved URL")
 	}
 }
@@ -253,7 +280,7 @@ func TestStringRewriteLocalConflictAndImmediateChange(t *testing.T) {
 		}
 	}
 	write(`{"schema_version":1,"rules":[{"pattern":"internal-model","replacement":"other"}]}`)
-	if _, err := currentStringRewritePolicy(t.Context()); err != errRewritePolicy {
+	if _, err := currentStringRewritePolicy(t.Context()); !errors.Is(err, errRewritePolicy) {
 		t.Fatal("conflict accepted")
 	}
 	write(`{"schema_version":1,"rules":[{"pattern":"internal-model","replacement":"public"}]}`)
@@ -270,7 +297,7 @@ func TestStringRewriteLocalConflictAndImmediateChange(t *testing.T) {
 		t.Fatalf("stale local policy: %q %v", out, err)
 	}
 	write(`{"schema_version":1,"rules":null}`)
-	if _, err := currentStringRewritePolicy(t.Context()); err != errRewritePolicy {
+	if _, err := currentStringRewritePolicy(t.Context()); !errors.Is(err, errRewritePolicy) {
 		t.Fatal("corrupt local policy reused last good value")
 	}
 }
@@ -296,5 +323,477 @@ func TestStringRewriteWatchPolicyErrorsAreTerminal(t *testing.T) {
 		if err != failure || calls != 1 || len(*sleeps) != 0 {
 			t.Fatalf("policy failure retried: %v calls=%d sleeps=%v", err, calls, *sleeps)
 		}
+	}
+}
+
+func requireRewritePolicyDiagnostic(t *testing.T, err error, class rewritePolicyClass, code int, ray string, started time.Time, secrets ...string) *rewritePolicyError {
+	t.Helper()
+	var diagnostic *rewritePolicyError
+	if !errors.Is(err, errRewritePolicy) || !errors.As(err, &diagnostic) {
+		t.Fatalf("expected typed policy failure: %v", err)
+	}
+	if diagnostic.class != class || diagnostic.status != code || diagnostic.ray != ray {
+		t.Fatalf("wrong diagnostic: %v", err)
+	}
+	if diagnostic.started.Before(started) || diagnostic.started.After(time.Now()) || diagnostic.elapsed < 0 || diagnostic.elapsed > time.Since(diagnostic.started) {
+		t.Fatalf("invalid attempt timing: %v", err)
+	}
+	if !strings.HasPrefix(err.Error(), errRewritePolicy.Error()+" (class="+class.String()+" attempt_utc=") || !strings.Contains(err.Error(), "Z elapsed_ms=") || strings.ContainsAny(err.Error(), "\n\r\x1b") {
+		t.Fatalf("invalid diagnostic format: %q", err)
+	}
+	if (code == 0 && strings.Contains(err.Error(), "http_status=")) || (code != 0 && !strings.Contains(err.Error(), fmt.Sprintf(" http_status=%d", code))) {
+		t.Fatalf("incorrect HTTP status output: %v", err)
+	}
+	if (ray == "" && strings.Contains(err.Error(), "cf_ray=")) || (ray != "" && !strings.Contains(err.Error(), " cf_ray="+ray)) {
+		t.Fatalf("incorrect correlation output: %v", err)
+	}
+	for _, secret := range secrets {
+		if strings.Contains(fmt.Sprintf("%v\n%+v\n%#v", err, err, err), secret) {
+			t.Fatal("diagnostic retained synthetic sensitive input")
+		}
+	}
+	var relay *relayResponseError
+	var network *url.Error
+	if errors.Unwrap(err) != nil || errors.As(err, &relay) || errors.As(err, &network) || errors.Is(err, errRewriteConflict) || shouldRunRealGH(err) || transientRelayFailure(err) {
+		t.Fatal("policy failure exposed a cause or allowed fallback/retry")
+	}
+	sleeps := recordWatchSleeps(t)
+	calls := 0
+	backoff := newWatchBackoff(time.Second)
+	if got := retryWatchTick(t.Context(), &backoff, func() error { calls++; return err }); got != err || calls != 1 || len(*sleeps) != 0 {
+		t.Fatal("typed policy failure did not stop watch immediately")
+	}
+	return diagnostic
+}
+
+type rewritePolicyTestTransport func(*http.Request) (*http.Response, error)
+
+func (transport rewritePolicyTestTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	return transport(request)
+}
+
+func useRewritePolicyTestTransport(t *testing.T, transport rewritePolicyTestTransport) {
+	t.Helper()
+	// The policy client uses the standard default transport, not httpClient.
+	// Replace it only in nonparallel synthetic tests; no production hook.
+	original := http.DefaultTransport
+	http.DefaultTransport = transport
+	t.Cleanup(func() { http.DefaultTransport = original })
+}
+
+func TestRewritePolicySetupDiagnostics(t *testing.T) {
+	for _, scenario := range []string{"missing login", "saved binding", "auth parse", "auth read"} {
+		t.Run(scenario, func(t *testing.T) {
+			isolateTestConfig(t)
+			t.Setenv("OCTOPOOL_TOKEN", "")
+			t.Setenv("OCTOPOOL_URL", "https://synthetic-target.invalid")
+			t.Setenv("OCTOPOOL_STRING_REWRITE_FILE", "")
+			path, err := authPath()
+			if err != nil {
+				t.Fatal(err)
+			}
+			switch scenario {
+			case "saved binding":
+				if err := saveAuth(authFile{URL: "https://synthetic-saved.invalid", Token: "synthetic-secret-token"}); err != nil {
+					t.Fatal(err)
+				}
+			case "auth parse", "auth read":
+				t.Setenv("OCTOPOOL_TOKEN", "synthetic-secret-token")
+				if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+					t.Fatal(err)
+				}
+				if scenario == "auth read" {
+					err = os.Mkdir(path, 0700)
+				} else {
+					err = os.WriteFile(path, []byte(`{"created_at":"synthetic-parser-secret"}`), 0600)
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			useRewritePolicyTestTransport(t, func(*http.Request) (*http.Response, error) {
+				t.Error("setup failure reached transport")
+				return nil, errors.New("synthetic-network-secret")
+			})
+			capture := captureRewriteGH(t)
+			started := time.Now()
+			var out, stderr bytes.Buffer
+			err = runGH(t.Context(), []string{"alias", "list"}, &out, &stderr)
+			requireRewritePolicyDiagnostic(t, err, rewritePolicySetup, 0, "", started, path,
+				"synthetic-secret-token", "synthetic-parser-secret", "synthetic-saved", "synthetic-target")
+			if _, err := os.Stat(capture); !os.IsNotExist(err) || out.Len() != 0 || stderr.Len() != 0 {
+				t.Fatal("setup failure dispatched or emitted output")
+			}
+		})
+	}
+}
+
+func TestRewritePolicyRequestDiagnostics(t *testing.T) {
+	for _, test := range []struct{ name, base, token, method, path string }{
+		{"malformed URL", "https://synthetic-url-secret.invalid/%zz", "synthetic-token-secret", "GET", "/policy"},
+		{"insecure URL", "http://synthetic-url-secret.invalid", "synthetic-token-secret", "GET", "/policy"},
+		{"userinfo", "https://synthetic-token-secret@synthetic-url-secret.invalid", "synthetic-token-secret", "GET", "/policy"},
+		{"query", "https://synthetic-url-secret.invalid?query=synthetic-secret", "synthetic-token-secret", "GET", "/policy"},
+		{"fragment", "https://synthetic-url-secret.invalid#synthetic-secret", "synthetic-token-secret", "GET", "/policy"},
+		{"missing URL", "", "synthetic-token-secret", "GET", "/policy"},
+		{"blank token", "https://synthetic-url-secret.invalid", " \t", "GET", "/policy"},
+		{"invalid method", "https://synthetic-url-secret.invalid", "synthetic-token-secret", "synthetic\nmethod-secret", "/policy"},
+		{"invalid path", "https://synthetic-url-secret.invalid", "synthetic-token-secret", "GET", "/%zz/synthetic-path-secret"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			useRewritePolicyTestTransport(t, func(*http.Request) (*http.Response, error) {
+				t.Error("invalid request reached transport")
+				return nil, errors.New("synthetic-network-secret")
+			})
+			started := time.Now()
+			_, err := rewritePolicyHTTP(t.Context(), test.base, test.path, test.token, test.method, nil)
+			requireRewritePolicyDiagnostic(t, err, rewritePolicyRequest, 0, "", started,
+				"synthetic-url-secret", "synthetic-token-secret", "synthetic-path-secret", "method-secret")
+		})
+	}
+}
+
+func TestRewritePolicyTransportDiagnostics(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		err   error
+		class rewritePolicyClass
+	}{
+		{"dns", &net.DNSError{Err: "synthetic-dns-secret", Name: "synthetic-host-secret"}, rewritePolicyTransport},
+		{"network", &net.OpError{Op: "synthetic-operation-secret", Net: "tcp", Err: errors.New("synthetic-network-secret")}, rewritePolicyTransport},
+		{"timeout", &net.DNSError{Err: "synthetic-dns-secret", IsTimeout: true}, rewritePolicyTimeoutClass},
+		{"deadline", fmt.Errorf("synthetic-wrapper-secret: %w", context.DeadlineExceeded), rewritePolicyTimeoutClass},
+		{"canceled", fmt.Errorf("synthetic-wrapper-secret: %w", context.Canceled), rewritePolicyCanceled},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			isolateTestConfig(t)
+			t.Setenv("OCTOPOOL_STRING_REWRITE_FILE", "")
+			capture := captureRewriteGH(t)
+			t.Setenv("OCTOPOOL_RELAY_RETRIES", "2")
+			calls := 0
+			useRewritePolicyTestTransport(t, func(r *http.Request) (*http.Response, error) {
+				calls++
+				if r.Method != "GET" || !strings.HasSuffix(r.URL.Path, "/string-rewrites") {
+					t.Error("policy failure reached relay")
+				}
+				return nil, test.err
+			})
+			client := ghRelayClient{baseURL: "https://synthetic-url-secret.invalid", token: "synthetic-token-secret", pool: "synthetic-pool-secret"}
+			started := time.Now()
+			_, err := client.do(t.Context(), ghAPIRequest{method: "GET", path: "/repos/acme/repo"})
+			requireRewritePolicyDiagnostic(t, err, test.class, 0, "", started, "synthetic-dns-secret", "synthetic-host-secret",
+				"synthetic-operation-secret", "synthetic-network-secret", "synthetic-wrapper-secret", "synthetic-url-secret", "synthetic-token-secret", "synthetic-pool-secret")
+			if errors.Is(err, test.err) || calls != 1 {
+				t.Fatal("transport cause retained or policy retried")
+			}
+			if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Fatal("transport failure ran child")
+			}
+		})
+	}
+}
+
+func TestRewritePolicyControlledTiming(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		duration time.Duration
+		class    rewritePolicyClass
+	}{
+		{"five second deadline", 5 * time.Second, rewritePolicyTimeoutClass},
+		{"parent deadline", 23 * time.Millisecond, rewritePolicyTimeoutClass},
+		{"parent cancellation", 17 * time.Millisecond, rewritePolicyCanceled},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				if test.name == "parent deadline" {
+					var deadlineCancel context.CancelFunc
+					ctx, deadlineCancel = context.WithTimeout(ctx, test.duration)
+					defer deadlineCancel()
+				} else if test.name == "parent cancellation" {
+					go func() { time.Sleep(test.duration); cancel() }()
+				}
+				calls := 0
+				useRewritePolicyTestTransport(t, func(r *http.Request) (*http.Response, error) {
+					calls++
+					deadline, ok := r.Context().Deadline()
+					want := rewritePolicyTimeout
+					if test.name == "parent deadline" {
+						want = test.duration
+					}
+					if !ok || deadline.Sub(time.Now()) != want || rewritePolicyTimeout != 5*time.Second {
+						t.Error("policy context deadline changed")
+					}
+					<-r.Context().Done()
+					return nil, r.Context().Err()
+				})
+				started := time.Now()
+				_, err := rewritePolicyHTTP(ctx, "https://synthetic.invalid", "/policy", "synthetic-token", "GET", nil)
+				diagnostic := requireRewritePolicyDiagnostic(t, err, test.class, 0, "", started, "synthetic-token")
+				if diagnostic.elapsed != test.duration || calls != 1 {
+					t.Fatalf("elapsed=%s calls=%d", diagnostic.elapsed, calls)
+				}
+				line := err.Error()
+				time.Sleep(time.Second) // Virtual time; formatting must not move the failure timestamp/duration.
+				if err.Error() != line {
+					t.Fatal("diagnostic timing changed after return")
+				}
+			})
+		})
+	}
+}
+
+type rewritePolicyFailingBody struct{ closed bool }
+
+func (*rewritePolicyFailingBody) Read([]byte) (int, error) {
+	return 0, errors.New("synthetic-body-read-secret")
+}
+func (body *rewritePolicyFailingBody) Close() error { body.closed = true; return nil }
+
+func TestRewritePolicyResponseReadDiagnostic(t *testing.T) {
+	body := &rewritePolicyFailingBody{}
+	useRewritePolicyTestTransport(t, func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: http.Header{"Cf-Ray": {"0123456789abcdef-SJC"}}, Body: body}, nil
+	})
+	started := time.Now()
+	result, err := rewritePolicyHTTP(t.Context(), "https://synthetic.invalid", "/policy", "synthetic-token", "GET", nil)
+	requireRewritePolicyDiagnostic(t, err, rewritePolicyResponseRead, 200, "0123456789abcdef-SJC", started, "synthetic-body-read-secret")
+	if !body.closed || result.data != nil {
+		t.Fatal("failed body retained or not closed")
+	}
+}
+
+func TestRewritePolicyRayValidation(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		values []string
+		want   string
+	}{
+		{"absent", nil, ""}, {"id", []string{"0123456789abcdef"}, "0123456789abcdef"},
+		{"pop", []string{"0123456789ABCDEF-SJC"}, "0123456789ABCDEF-SJC"},
+		{"short", []string{"1234-SJC"}, ""}, {"long", []string{strings.Repeat("a", 10000)}, ""},
+		{"nonhex", []string{"0123456789abcdeg-SJC"}, ""}, {"lowercase pop", []string{"0123456789abcdef-sjc"}, ""},
+		{"long pop", []string{"0123456789abcdef-SJCA"}, ""}, {"empty pop", []string{"0123456789abcdef-"}, ""},
+		{"space", []string{" 0123456789abcdef-SJC"}, ""}, {"newline", []string{"0123456789abcdef-SJC\n"}, ""},
+		{"multiple", []string{"0123456789abcdef-SJC", "0123456789abcdef-SJC"}, ""},
+		{"joined", []string{"0123456789abcdef-SJC,0123456789abcdef-SJC"}, ""},
+		{"arbitrary", []string{"synthetic-header-secret\x1b[31m"}, ""},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			useRewritePolicyTestTransport(t, func(*http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: 403, Header: http.Header{"Cf-Ray": test.values, "X-Private": {"synthetic-other-header-secret"}}, Body: io.NopCloser(strings.NewReader("synthetic-body-secret"))}, nil
+			})
+			started := time.Now()
+			_, err := rewritePolicyHTTP(t.Context(), "https://synthetic.invalid", "/policy", "synthetic-token", "GET", nil)
+			requireRewritePolicyDiagnostic(t, err, rewritePolicyHTTPStatus, 403, test.want, started,
+				"synthetic-header-secret", "synthetic-other-header-secret", "synthetic-body-secret")
+		})
+	}
+}
+
+func TestRewritePolicyLocalAndMergeDiagnostics(t *testing.T) {
+	for _, scenario := range []string{"missing", "directory", "unreadable", "oversized", "malformed", "invalid", "conflict", "rule limit", "document limit"} {
+		t.Run(scenario, func(t *testing.T) {
+			isolateTestConfig(t)
+			serverPolicy := rewriteActiveTestPolicy
+			localBody := `{"schema_version":1,"rules":[{"pattern":"synthetic-local-pattern","replacement":"synthetic-local-value"}]}`
+			class := rewritePolicyLocalRead
+			switch scenario {
+			case "malformed":
+				class, localBody = rewritePolicyLocalValidation, "synthetic-file-secret"
+			case "invalid":
+				class, localBody = rewritePolicyLocalValidation, `{"schema_version":1,"rules":[{"pattern":"[synthetic-local-pattern","replacement":"synthetic-local-value"}]}`
+			case "conflict":
+				class, localBody = rewritePolicyMerge, `{"schema_version":1,"rules":[{"pattern":"internal-model","replacement":"synthetic-local-value"}]}`
+			case "oversized":
+				localBody = strings.Repeat("x", rewriteMaxDocument+1)
+			case "rule limit", "document limit":
+				class = rewritePolicyMerge
+				count, replacement := 65, "synthetic-local-value"
+				if scenario == "document limit" {
+					count, replacement = 40, strings.Repeat("x", rewriteMaxReplacement)
+				}
+				makePolicy := func(prefix string, server bool) string {
+					rules := make([]stringRewriteRule, count)
+					for i := range rules {
+						rules[i] = stringRewriteRule{fmt.Sprintf("%s-%d", prefix, i), replacement}
+					}
+					value := map[string]any{"schema_version": 1, "rules": rules}
+					if server {
+						value["revision"], value["updated_at"] = 1, "2026-09-01T00:00:00Z"
+					}
+					data, err := json.Marshal(value)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if _, err := parseStringRewritePolicy(data, server); err != nil {
+						t.Fatal("invalid individual limit fixture", err)
+					}
+					return string(data)
+				}
+				serverPolicy, localBody = makePolicy("synthetic-server-pattern", true), makePolicy("synthetic-local-pattern", false)
+			}
+			path := filepath.Join(t.TempDir(), "synthetic-path-secret.json")
+			if scenario == "directory" {
+				if err := os.Mkdir(path, 0700); err != nil {
+					t.Fatal(err)
+				}
+			} else if scenario != "missing" {
+				if err := os.WriteFile(path, []byte(localBody), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if scenario == "unreadable" {
+				if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+					t.Skip("permission fixture requires a non-root Unix user")
+				}
+				if err := os.Chmod(path, 0000); err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { _ = os.Chmod(path, 0600) })
+			}
+			t.Setenv("OCTOPOOL_STRING_REWRITE_FILE", path)
+			var calls atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				if r.Method != "GET" || r.URL.Path != "/v1/pools/maintainers/string-rewrites" || r.ContentLength > 0 {
+					t.Error("local policy uploaded or failure dispatched")
+				}
+				w.Header().Set("CF-Ray", "0123456789abcdef-SJC")
+				_, _ = io.WriteString(w, serverPolicy)
+			}))
+			t.Cleanup(server.Close)
+			t.Setenv("OCTOPOOL_URL", server.URL)
+			t.Setenv("OCTOPOOL_TOKEN", "synthetic-token-secret")
+			t.Setenv("OCTOPOOL_POOL", "maintainers")
+			capture := captureRewriteGH(t)
+			started := time.Now()
+			var out, stderr bytes.Buffer
+			err := runGH(t.Context(), []string{"alias", "list"}, &out, &stderr)
+			requireRewritePolicyDiagnostic(t, err, class, 200, "0123456789abcdef-SJC", started, path,
+				"synthetic-token-secret", "synthetic-file-secret", "synthetic-local-pattern", "synthetic-local-value", "internal-model", server.URL)
+			if _, err := os.Stat(capture); !os.IsNotExist(err) || out.Len() != 0 || stderr.Len() != 0 || calls.Load() != 1 {
+				t.Fatal("local/merge failure emitted output, dispatched or retried")
+			}
+			if scenario != "missing" && scenario != "directory" && scenario != "unreadable" {
+				data, err := os.ReadFile(path)
+				if err != nil || string(data) != localBody {
+					t.Fatal("local policy changed")
+				}
+			}
+		})
+	}
+}
+
+func TestRewritePolicyHTTPMetadataThroughLocalTiming(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		isolateTestConfig(t)
+		path := filepath.Join(t.TempDir(), "missing.json")
+		t.Setenv("OCTOPOOL_STRING_REWRITE_FILE", path)
+		useRewritePolicyTestTransport(t, func(*http.Request) (*http.Response, error) {
+			time.Sleep(31 * time.Millisecond) // Virtual transport time, not a wall-clock sleep.
+			return &http.Response{StatusCode: 200, Header: http.Header{"Cf-Ray": {"0123456789abcdef-SJC"}}, Body: io.NopCloser(strings.NewReader(rewriteEmptyTestPolicy))}, nil
+		})
+		started := time.Now()
+		client := ghRelayClient{baseURL: "https://synthetic.invalid", token: "synthetic-token", pool: "maintainers"}
+		_, err := client.stringRewritePolicy(t.Context())
+		diagnostic := requireRewritePolicyDiagnostic(t, err, rewritePolicyLocalRead, 200, "0123456789abcdef-SJC", started, path)
+		if !diagnostic.started.Equal(started) || diagnostic.elapsed != 31*time.Millisecond {
+			t.Fatal("local failure lost HTTP timing")
+		}
+	})
+}
+
+func TestRewritePolicyFailureIsNotCached(t *testing.T) {
+	calls := rewriteTestServerPolicySequence(t, func(call int64) (string, int) {
+		if call == 1 {
+			return "synthetic-failure-secret", 403
+		}
+		return rewriteEmptyTestPolicy, 200
+	}, nil)
+	capture := captureRewriteGH(t)
+	args := []string{"alias", "list"}
+	var out, stderr bytes.Buffer
+	started := time.Now()
+	err := runGH(t.Context(), args, &out, &stderr)
+	requireRewritePolicyDiagnostic(t, err, rewritePolicyHTTPStatus, 403, "", started, "synthetic-failure-secret")
+	if calls.Load() != 1 || out.Len() != 0 || stderr.Len() != 0 {
+		t.Fatal("failure retried or emitted output")
+	}
+	if _, err := os.Stat(capture); !os.IsNotExist(err) {
+		t.Fatal("failed attempt ran child")
+	}
+	// No config, arguments, binary or local policy changes between attempts.
+	if err := runGH(t.Context(), args, &out, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	if calls.Load() != 3 || !slices.Equal(readRewriteCapture(t, capture).Args, args) || stderr.String() != "child stderr\n" {
+		t.Fatalf("fresh preflight/final policy or silent success changed: calls=%d stderr=%q", calls.Load(), stderr.String())
+	}
+}
+
+func TestRewritePolicySameOriginRedirects(t *testing.T) {
+	for _, code := range []int{301, 302, 303, 307, 308} {
+		t.Run(fmt.Sprint(code), func(t *testing.T) {
+			var calls atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				if r.URL.Path != "/policy" {
+					t.Error("redirect forwarded credentials to destination")
+				}
+				w.Header().Set("CF-Ray", "0123456789abcdef-SJC")
+				http.Redirect(w, r, "/synthetic-redirect-secret", code)
+			}))
+			t.Cleanup(server.Close)
+			started := time.Now()
+			_, err := rewritePolicyHTTP(t.Context(), server.URL, "/policy", "synthetic-token-secret", "GET", nil)
+			requireRewritePolicyDiagnostic(t, err, rewritePolicyHTTPStatus, code, "0123456789abcdef-SJC", started,
+				"synthetic-redirect-secret", "synthetic-token-secret", server.URL)
+			if calls.Load() != 1 {
+				t.Fatal("same-origin redirect followed")
+			}
+		})
+	}
+}
+
+func TestRewritePolicyAdminHTTPConflict(t *testing.T) {
+	for _, method := range []string{"GET", "PUT"} {
+		t.Run(method, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(409)
+				_, _ = io.WriteString(w, "synthetic-conflict-secret")
+			}))
+			t.Cleanup(server.Close)
+			result, err := rewritePolicyHTTP(t.Context(), server.URL, "/v1/admin/string-rewrites", "synthetic-token", method, nil)
+			if err != errRewriteConflict || errors.Is(err, errRewritePolicy) || result.attempt.status != 409 || result.data != nil {
+				t.Fatalf("admin conflict contract changed: %v", err)
+			}
+		})
+	}
+}
+
+func TestRewritePolicyExactResponseBound(t *testing.T) {
+	for _, size := range []int{rewriteMaxDocument, rewriteMaxDocument + 1} {
+		t.Run(fmt.Sprint(size), func(t *testing.T) {
+			data := rewriteEmptyTestPolicy + strings.Repeat(" ", size-len(rewriteEmptyTestPolicy))
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = io.WriteString(w, data) }))
+			t.Cleanup(server.Close)
+			started := time.Now()
+			result, err := rewritePolicyHTTP(t.Context(), server.URL, "/policy", "synthetic-token", "GET", nil)
+			if size == rewriteMaxDocument {
+				if err != nil || len(result.data) != size {
+					t.Fatalf("exact bound rejected: %v", err)
+				}
+				if _, err := parseStringRewritePolicy(result.data, true); err != nil {
+					t.Fatal("valid padded policy rejected", err)
+				}
+			} else {
+				requireRewritePolicyDiagnostic(t, err, rewritePolicyResponseSize, 200, "", started)
+				if result.data != nil {
+					t.Fatal("oversized body retained")
+				}
+			}
+		})
 	}
 }

--- a/cmd/octopool/string_rewrites_process_test.go
+++ b/cmd/octopool/string_rewrites_process_test.go
@@ -2069,7 +2069,7 @@ func TestStringRewriteProcessBlocks(t *testing.T) {
 	}
 	policy.Store(`{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"a*","replacement":"b"}]}`)
 	capture := captureRewriteGH(t)
-	if err := execRealGH(t.Context(), []string{"alias", "list"}, io.Discard, io.Discard); err != errRewritePolicy {
+	if err := execRealGH(t.Context(), []string{"alias", "list"}, io.Discard, io.Discard); !errors.Is(err, errRewritePolicy) {
 		t.Fatalf("invalid policy: %v", err)
 	}
 	if _, err := os.Stat(capture); !os.IsNotExist(err) {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -638,6 +638,49 @@ an explicitly configured missing or unreadable file fails closed. The local file
 uploaded. Server rules run first, then local rules; identical entries are deduplicated,
 conflicting replacements are rejected, and combined limits still apply.
 
+Policy-load failures keep the existing message prefix and add bounded diagnostics to the
+normal stderr error line. There is no success diagnostic, stdout change, persistent log,
+automatic policy retry, or cached-policy fallback. A synthetic example:
+
+```text
+error: string rewrite policy unavailable or invalid (class=http_status attempt_utc=2026-09-01T12:34:56.123Z elapsed_ms=42 http_status=403 cf_ray=0123456789abcdef-SJC)
+```
+
+The fixed `class` identifies the failing check, not its underlying cause:
+
+| Class                  | Meaning                                                                                                                                                                     |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `setup`                | Caller client setup failed, including saved-auth loading, missing login, or saved-token URL binding. No policy request occurred.                                            |
+| `request`              | Policy URL, blank token, or HTTP request construction failed validation.                                                                                                    |
+| `transport`            | HTTP execution failed without a response, including DNS/network errors not classified below.                                                                                |
+| `timeout` / `canceled` | HTTP execution reported a deadline/network timeout or context cancellation, respectively.                                                                                   |
+| `http_status`          | The policy HTTP response was not exactly 200; redirects, including same-origin redirects, are refused.                                                                      |
+| `response_read`        | Reading the 200 response body failed (including a timeout/cancellation while reading it).                                                                                   |
+| `response_size`        | The 200 response exceeded the 65,536-byte document limit.                                                                                                                   |
+| `server_validation`    | The 200 document failed JSON/schema/rule validation.                                                                                                                        |
+| `local_read`           | Local path resolution or bounded file reading failed, including an explicit missing, unreadable, nonregular, or oversized file. An absent optional default remains allowed. |
+| `local_validation`     | Local JSON/schema/rule validation failed.                                                                                                                                   |
+| `merge`                | Combining individually valid server/local policies failed conflict or combined-limit checks.                                                                                |
+
+`attempt_utc` is the client clock's UTC start time, before policy HTTP validation.
+`elapsed_ms` is monotonic elapsed time from that start to failure construction, truncated
+to whole milliseconds. It includes GET/body reading and any subsequent server/local/merge
+checks reached, but excludes caller client setup and final stderr formatting. For `setup`
+only, both fields instead cover client setup. They do not measure a whole `gh` invocation;
+each guarded boundary reloads policy and starts another attempt. The existing five-second
+context and HTTP-client deadlines are unchanged, and do not bound later local/merge work.
+
+`http_status` is omitted without an observed response. For `server_validation`, `local_read`,
+`local_validation`, or `merge`, `http_status=200` belongs to the preceding policy **GET**,
+not to local validation. Its correlation metadata survives those later failures. Optional
+`cf_ray` accepts only one value with exactly 16 ASCII hex digits, optionally followed by
+`-` and three uppercase ASCII POP letters. Missing, malformed, overlong, or multiple values
+are dropped, never truncated. It is an unauthenticated correlation hint, not proof of origin.
+No raw error strings, URLs, paths, bodies, arbitrary headers, tokens, or rule content are
+included. Admin HTTP 409 remains a revision conflict; guarded caller GET 409 is a terminal
+policy failure. See [policy-failure correlation](operations.md#correlating-policy-load-failures)
+before drawing conclusions from a later successful probe.
+
 Rules use a portable RE2 subset: literal Unicode, captures/noncapturing groups, alternation,
 greedy/lazy repetition, bracket classes, dot, anchors, ASCII `\b`, `\w`, `\d`, `\s`
 and their uppercase complements, escaped punctuation, and `\n`, `\r`, `\t`, `\f`,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -409,6 +409,12 @@ and do not log patterns, matched text, or backend exception messages. API respon
 including errors, are `no-store`. Protect policy GET access and D1 backups: rules can
 contain private names even though error responses and normal import output do not.
 
+CLI policy-load failures return only bounded metadata on the existing stderr error line;
+they do not change protection, retry policy, or stdout. The [CLI diagnostic contract](cli.md#outbound-string-rewrite-protection)
+defines every class, timestamp, elapsed scope, HTTP status, and validated CF-Ray field.
+Use the [correlation procedure](#correlating-policy-load-failures) below to investigate the
+exact failed attempt without exposing policy material or changing authentication.
+
 If policy storage is missing or corrupt, restore the migration/schema and last reviewed
 valid singleton row through the operator's controlled D1 recovery process. PUT cannot
 repair an unreadable current policy, and a deleted row is not a supported way to clear
@@ -560,11 +566,50 @@ Override the host/resolver with `OCTOPOOL_E2E_HOST` / `OCTOPOOL_E2E_RESOLVER`.
 
 ## Observability
 
-Observability is enabled at full sampling. Every validated request from an authenticated
+Both authoritative and public-proxy Worker source configurations enable observability at
+full sampling (`head_sampling_rate: 1`). Every validated relay request from an authenticated
 caller to an existing pool writes an `audit_events` row (caller, client, pool, route key/kind,
 identity, status, error/fallback classification, duration, cache hit/miss/bypass status,
 and coalesced-fill marker); parse, authentication, string-protection, and pool-lookup
 failures occur before that boundary. Secrets and request bodies are never recorded.
+
+### Correlating policy-load failures
+
+Preserve the exact safe failure line, its `attempt_utc` and `elapsed_ms`, and the binary
+version/revision in the external incident record. The CLI does not persist them. The
+timestamp uses the client's clock; allow for known clock skew when bounding the search
+window from start through elapsed time. `setup` and `request` failures do not establish
+any HTTP response. A local/merge failure with `http_status=200` describes a successful
+GET followed by a failing client check, not an HTTP outage.
+
+In authorized Cloudflare edge/Worker observability, filter by method `GET`, the expected
+`/v1/pools/<pool>/string-rewrites` path, that UTC window, and observed status. Add `cf_ray`
+when present and supported by the deployed log fields; it is only a strictly validated,
+unauthenticated correlation hint. Inspect each relevant layer separately: the public
+proxy's edge/security events, the public-proxy Worker invocation/upstream outcome, the
+authoritative Worker invocation/authentication/policy outcome, and authorized D1 health
+or query-failure telemetry. Direct authoritative URLs skip the public-proxy hop. A 403
+alone does not identify which layer refused the request; a 503 alone does not identify
+D1 as the cause. Correlate observed events before assigning a source.
+
+Full-sampling settings in source do not prove deployed log availability or reliable Ray-ID
+joins across proxy and authoritative hops. Verify those deployed fields and joins before
+using them for attribution. Missing logs or IDs are not proof of where a failure arose:
+an edge rejection can occur before Worker execution, expected policy errors do not emit
+the unexpected-exception console event, and retention/access/field coverage may differ.
+Policy GETs and authentication/protection failures bypass relay `audit_events` and stats;
+their absence there is expected, not evidence that no request occurred.
+
+`whoami` reads saved metadata, `health` uses another caller endpoint, and admin
+`string-rewrites status` uses separate admin authentication and does not merge local rules.
+They test different boundaries. A later unchanged guarded invocation can succeed because
+each attempt reloads policy and failures are not cached; that recovery does not establish
+the historical failure's cause. A separate Cloudflare-shaped 403 likewise cannot attribute
+an earlier generic failure. These diagnostics improve evidence, not resolve an outage.
+Never dump policy files, error response bodies, arbitrary headers, tokens, or debug traces,
+and never reconfigure authentication as a diagnostic shortcut.
+
+### Relay retention and stats
 
 The main Worker has an hourly cron trigger at minute 17. It deletes bounded batches of
 cache entries after each entry's route-specific stale deadline and audit rows older than


### PR DESCRIPTION
## Summary

Protected `gh` commands previously reduced client setup, policy transport/status, remote-document validation, local-file validation, and merge failures to the same generic error. Intermittent failures could therefore disappear on a later unchanged invocation without leaving enough evidence to identify the failed boundary. This change improves diagnosis; it does not claim to establish or resolve a particular outage's cause.

The loader now returns a typed, terminal policy error through the existing stderr surface. It includes a fixed failure class, UTC attempt time, elapsed milliseconds, the observed HTTP status when available, and an optional strictly validated CF-Ray. Successful GET metadata survives later local/merge failures. Raw errors, URLs, local paths, credentials, response bodies, arbitrary headers, and rule content are not retained in the diagnostic.

The five-second HTTP/context deadline, redirect rejection, exact-200 and response-size checks, saved-token URL binding, admin revision-conflict semantics, and fresh policy checks remain unchanged. There is no new configuration, success output, retry, persistent policy cache, or empty-policy fallback. Operational documentation explains exact-attempt edge/Worker correlation, the relay-audit visibility gap, and why a healthy endpoint or later successful probe cannot attribute an earlier failure.

## Validation

- Focused policy-loader, guarded fallback, admin, and compiled-shim tests passed.
- Three race-detector repetitions of the synthetic failure matrix passed.
- The new compiled-shim tests fail against the original source as expected for both HTTP 403 and local validation.
- Go static analysis, Go/docs formatting, diff checks, and the docs-site build passed.
- The full local Go suite exhausted a twenty-minute timeout while executing help-bootstrap tests, with no assertion failure reported before the deadline. That verification gap is now closed by [CI run 33561414125](https://github.com/openclaw/octopool/actions/runs/33561414125) on head `149653aa838a7cd41fd6dd502d664356f14700a8`: full Linux checks, full native Windows Go tests/vet, docs build, and snapshot build all passed. CodeQL checks also passed.

Tests use synthetic policies and controlled transport/server/file failures, including setup and URL validation, HTTP errors, timeout/cancellation, malformed and oversized responses, local policy failures, merge conflicts/limits, redaction, redirect refusal, and an unchanged invocation succeeding after a failed attempt.

No application installation, Worker deployment, configuration/authentication change, or release is part of this PR.

## Error-contract decision

Adopt the documented generic prefix plus bounded diagnostic suffix as the intended policy-error contract. The suffix is the requested user-visible enhancement, not a promise of compatibility with exact full-line stderr comparisons. Consumers making those comparisons must accommodate the suffix; exit status and terminal fail-closed semantics remain unchanged. No exact-full-line compatibility requirement has been identified for this project.

## Captured compiled-CLI behavior

Built the actual CLI at head `149653aa838a7cd41fd6dd502d664356f14700a8` and invoked it as `gh` through a scratch process PATH, not through an internal function or a unit-test entrypoint. HOME/config and all credentials/policy inputs were isolated synthetic fixtures. A loopback HTTP server supplied controlled responses; a native-child marker stub established whether guarded dispatch occurred. The successful case intentionally serves a valid explicit empty synthetic policy; it is not an empty-policy fallback.

The following is captured terminal output. The CF-Ray is synthetic and establishes no Cloudflare attribution. Canary assertions verified that response/header/token/local-file sentinels and scratch paths were absent from stdout/stderr.

```text
Controlled HTTP 403
$ gh alias list
stdout: (empty)
stderr: error: string rewrite policy unavailable or invalid (class=http_status attempt_utc=2026-09-01T21:40:46.044859Z elapsed_ms=2 http_status=403 cf_ray=0123456789abcdef-SJC)
exit=1; policy_requests=1; native_child_started=false

Same invocation, binary, environment and local policy; server now returns valid policy
$ gh alias list
stdout: native-stub-ok
stderr: (empty)
exit=0; policy_requests=2; native_child_started=true

Independent case: HTTP 200 followed by invalid synthetic local policy
$ gh alias list
stdout: (empty)
stderr: error: string rewrite policy unavailable or invalid (class=local_validation attempt_utc=2026-09-01T21:40:46.86521Z elapsed_ms=1 http_status=200 cf_ray=0123456789abcdef-SJC)
exit=1; policy_requests=1; native_child_started=false
```

This demonstrates the normal CLI-entrypoint behavior of the compiled candidate, not a live-production reproduction or a claim that the original intermittent failure has been diagnosed. No live credentials/policy, global configuration, or installed binary was changed.
