### PR TITLE
chore(release): prepare Octopool 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,43 @@
 # Changelog
 
-## 0.5.18 - Unreleased
+## 0.6.0 - 2026-09-01
 
-### Fixes
+### Highlights
 
-- Unblock the standard `gh pr create` shape under active rewrite rules: pin a missing `--head` to the current branch (fail closed on detached HEAD or non-git directories), make `--base` optional, and accept `--dry-run`.
-- Allow typed attachments on protected `gh issue edit` and `gh issue comment` through existing strict snapshots and inline-reference rewriting, requiring explicit complete bodies for attachment edits.
-- Fence cache bodies and public-repository proofs with committed D1 ownership, isolate old writers across upgrades, and reclaim abandoned owners without adding authority calls to hot cache hits.
-- Honor native input declarations and reject malformed nonempty declared JSON before dispatch, preserving explicit UTF-8 text, zero-byte best-effort compatibility, and existing interactive-input limits.
-- Normalize compound client-name aliases consistently across CLI, login and stats, safely rotate historical singletons in place, and refuse ambiguous legacy families without changing credentials; apply the schema write guards before rollout.
-- Include eligible wildcard PATs for explicitly allowed owners and fail over selected local credential errors with bounded shared cooldowns, preserving cache authorization, valid credential continuations, and hard aggregate egress denials.
-- Keep persisted identity quota and cooldown feedback monotonic across delayed responses, reject invalid numeric observations, and atomically preserve rate/cooldown state on storage failure.
-- Keep `--jq` expressions literal, preserve native `gh` output bytes with native jq 1.7+ on Windows, and recognize `octopool.exe` when resolving the shim target without requiring Unix execute bits.
-- Reject malformed stored pool policies before cache reuse or pooled GitHub access with a typed configuration-unavailable error, preserving valid partial-policy defaults.
-- Reject extra or malformed repository qualifiers and negated scope in issue, code, and commit searches before relay dispatch or cache reuse, preserving typed local fallback for unsupported queries.
-- Make active caller enrollment and named-client token rotation atomic across CLI, admin, and browser login, preserving existing access and history while refusing ambiguous upgrades.
-- Bind org membership checks to the enrolled GitHub account on every page, isolate verification timestamps across rolling upgrades, and preserve safe legacy re-login and typed upstream errors.
-- Validate protected `gh repo clone` repository inputs according to native argument ownership, preserving destination paths and Git flags while retaining visible-argument filtering and GitHub.com-only source checks.
-- Keep issue timelines and issue-event reads anonymous-only, retiring cached private cross-references and preserving safe conditional and native fallback behavior.
-- Preserve contributor credit in protected exact-head squash merges by accepting merge body files through the existing text rewriting and private snapshot checks.
-- Keep supported `gh run watch` on the relay when pagination or relay requests fail, rejecting incomplete job summaries without spending personal GitHub quota.
-- Keep CLI caller tokens bound to the loaded server URL when another login replaces saved auth during request setup.
-- Pin CLI login credential lookup to GitHub.com so Enterprise host settings cannot select an Enterprise token.
-- Block cross-origin redirects and HTTPS downgrades for CLI login and authenticated JSON requests to prevent credential replay.
-- Preserve exact raw Markdown in release-view JSON via the anonymous API and retire cached HTML-derived release summaries for existing clients.
-- Return native uppercase PR-list lifecycle states and lowercase merged PR-search states from nested merge metadata before `--jq`, preserving raw API and cache payloads.
-- Cache page-derived closed issues for one hour, matching REST closed issues while preserving response state casing and cached bodies.
+- **Protected draft releases with binary assets.** `gh release create --draft --verify-tag` now snapshots local release assets into private staging before native GitHub CLI execution, preserving filenames, order, notes, and bytes on macOS, Linux, and Windows.
+- **Smoother everyday maintainer workflows.** Create PRs from the current branch without spelling out `--head` or `--base`, attach files to protected issue edits and comments, preserve contributor credit with squash-merge body files, and clone into nested destinations while retaining native Git flags.
+- **More dependable scripts and exports.** Restore native PR, checks, and workflow-run JSON semantics, delegate detail exports that cannot be reconstructed completely, and preserve raw release Markdown, diffs, response bodies, and job-log bytes.
+- **Stronger shared-cache and sign-in safety.** Fence superseded cache publishers and repository-visibility proofs, bind membership checks to immutable GitHub accounts, and make enrollment and named-client rotation atomic without silently merging ambiguous accounts.
+
+### CLI and workflow fixes
+
+- Match native PR-list and PR-search lifecycle states, checks deduplication/order/timestamps and JSON exit codes, and workflow-run field defaults, historical attempts, workflow names, and nested job exports.
+- Delegate PR selections containing `commits`, `comments`, or `reviews` as a whole instead of returning partial approximations; reject incomplete or inconsistent workflow-job exports before emitting JSON.
+- Preserve native repeated-option ownership, CSV fields and labels, signed integer syntax, Boolean assignments, literal jq programs, and unsupported-option delegation. Respect declared JSON versus text input and reject malformed nonempty JSON before dispatch.
+- Keep supported `gh run watch` on the relay when reads or pagination fail, without starting a personal-token watcher or printing an incomplete final summary. Reject duplicate job IDs and contradictory run/head metadata across watch, human-view, and machine-export paths. Apply native watch polling floors only after final policy preparation, preserving valid rewritten intervals.
+- Explain policy-loader failures with bounded failure classes, observed HTTP status, UTC attempt time, elapsed milliseconds, and an optional validated CF-Ray; never expose credentials, rule content, raw errors, response bodies, or local paths.
+- Restrict policy-free help to complete built-in native command paths while preserving authentication hostname shorthand. Protected PR creation accepts `--dry-run` and refuses an inferred head outside a Git branch.
+- Preserve exact stdout bytes with native jq 1.7+ on Windows and recognize `octopool.exe` without Unix executable-bit assumptions.
+
+### Cache, authentication, and routing fixes
+
+- Prevent expired or superseded writers from publishing shared cache bodies or public-repository proofs across Worker upgrades. Preserve committed publication ownership and reclaim abandoned owners without adding authority reads to hot cache hits.
+- Keep credentials on their intended origin: bind each caller request to one loaded auth snapshot, reject cross-origin redirects and HTTPS downgrades, and select login credentials explicitly for GitHub.com rather than an Enterprise host.
+- Verify org membership against the enrolled immutable GitHub account on every page. Reconcile repeated `.local` client-name suffixes without losing token/audit history, and refuse ambiguous account or client families unchanged.
+- Route around selected unavailable pooled credentials, include eligible wildcard PATs for explicitly allowed owners, and retain conservative quota/cooldown observations despite delayed responses or storage failures.
+- Keep issue events and timelines anonymous-only, reject broadened or malformed repository search scopes, and fail closed on malformed stored pool policies before cache reuse or pooled GitHub access.
+- Preserve opaque response, diff, and log bytes, including invalid UTF-8 and leading BOMs. Derive Actions status/trigger metadata from the owning page elements, not arbitrary titles or branch prose.
+- Encode generated contents self-links exactly once, require complete Git ref advertisements, and bound PR-state metadata before parsing or caching its proof.
+- Cache page-derived closed issues for one hour, keep pending repository statistics uncached, and attribute anonymous replacements and conditional revalidations to the correct backend.
+- Reclaim expired coordinator leases and cooldowns in bounded indexed batches. Repair Worker-test isolation after storage eviction and isolate platform auth stores in cross-platform tests.
+
+### Upgrade notes
+
+- **Self-hosters:** apply and verify migrations `0017`–`0020` before deploying the Worker; follow the duplicate-account, client-alias, and publication-owner preflights in [Deployment & Operations](docs/operations.md). Preserve the publication allocator's high-water mark and the new schema guards on rollback. Do not resolve ambiguous accounts by guessing or discarding credentials.
+- Cache/public-proof generations and first-use immutable membership verification can increase upstream traffic after rollout. Drain old Worker instances before treating the changes as fully deployed; an in-flight request retains its already-checked policy snapshot.
+- **Script authors:** successful nonempty `pr checks --json`/`--jq` exports return 0 regardless of check outcomes; empty checks return 1 without JSON. PR-list states are uppercase and search states remain lowercase. Policy errors retain their generic prefix but append diagnostic fields, so exact full-line stderr comparisons must allow the suffix.
+- Release-view cache misses use the anonymous GitHub API to preserve raw Markdown. Unsupported/incomplete native exports still follow guarded delegation, and `OCTOPOOL_NO_FALLBACK=1` rejects typed fallback requests.
+- Protected release assets require an existing verified tag and explicit draft creation, with at most 16 files, 1 GiB per file, and 4 GiB total. Assets are opaque, not scanned or certified secret-free; failed uploads can leave a partial remote draft. This does not add automatic publication, rollback, or modeled standalone `release upload` support.
 
 ## 0.5.17 - 2026-08-30
 

--- a/cmd/octopool/gh_run_export.go
+++ b/cmd/octopool/gh_run_export.go
@@ -44,34 +44,14 @@ type machineRun struct {
 	jobs         []machineJobExport
 }
 
-// Null is a no-op for native primitive fields, including after a duplicate
-// non-null assignment. A pointer would incorrectly erase association evidence.
-type runAssociation[T int64 | string] struct {
-	value   T
-	present bool
-}
-
-func (a *runAssociation[T]) UnmarshalJSON(raw []byte) error {
-	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
-		return nil
-	}
-	if err := json.Unmarshal(raw, &a.value); err != nil {
-		return err
-	}
-	a.present = true
-	return nil
-}
-
 type machineJob struct {
-	ID          int64
+	runJobIdentity
 	Name        string
 	Status      string
 	Conclusion  string
-	StartedAt   time.Time              `json:"started_at"`
-	CompletedAt time.Time              `json:"completed_at"`
-	URL         string                 `json:"html_url"`
-	RunID       runAssociation[int64]  `json:"run_id"`
-	HeadSha     runAssociation[string] `json:"head_sha"`
+	StartedAt   time.Time `json:"started_at"`
+	CompletedAt time.Time `json:"completed_at"`
+	URL         string    `json:"html_url"`
 	Steps       []machineStep
 }
 
@@ -280,6 +260,7 @@ func machineRunJobs(envelope relayEnvelope, run machineRun) ([]machineJobExport,
 	}
 	jobs := make([]machineJobExport, 0, len(records))
 	seen := map[int64]bool{}
+	owner := runJobOwner{id: strconv.FormatInt(run.ID, 10), headSHA: run.HeadSha}
 	for _, record := range records {
 		if bytes.TrimSpace(record)[0] != '{' {
 			return nil, unsupportedRunExport()
@@ -288,20 +269,11 @@ func machineRunJobs(envelope relayEnvelope, run machineRun) ([]machineJobExport,
 		if err := json.Unmarshal(record, &job); err != nil {
 			return nil, err
 		}
-		if job.ID <= 0 || !safeRunExportInteger(job.ID) || seen[job.ID] || !safeRunExportInteger(job.RunID.value) {
-			return nil, unsupportedRunExport()
-		}
-		seen[job.ID] = true
-		if job.RunID.present && job.RunID.value != run.ID {
-			return nil, errors.New("workflow job did not match owned run")
-		}
-		if job.HeadSha.present && job.HeadSha.value != "" {
-			if run.HeadSha == "" {
+		if err := job.runJobIdentity.validate(owner, seen); err != nil {
+			if errors.Is(err, errInvalidRunJobIdentity) || errors.Is(err, errUnprovedRunJobHead) {
 				return nil, unsupportedRunExport()
 			}
-			if job.HeadSha.value != run.HeadSha {
-				return nil, errors.New("workflow job did not match historical run head")
-			}
+			return nil, err
 		}
 		steps := make([]machineStepExport, 0, len(job.Steps))
 		for _, step := range job.Steps {

--- a/cmd/octopool/gh_run_jobs.go
+++ b/cmd/octopool/gh_run_jobs.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"strings"
+)
+
+// Null is a no-op for native primitive fields, including after a duplicate
+// non-null assignment. A pointer would incorrectly erase association evidence.
+type runAssociation[T int64 | string] struct {
+	value   T
+	present bool
+}
+
+func (a *runAssociation[T]) UnmarshalJSON(raw []byte) error {
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil
+	}
+	if err := json.Unmarshal(raw, &a.value); err != nil {
+		return err
+	}
+	a.present = true
+	return nil
+}
+
+type runJobIdentity struct {
+	ID      int64
+	RunID   runAssociation[int64]  `json:"run_id"`
+	HeadSha runAssociation[string] `json:"head_sha"`
+}
+
+type runJobOwner struct {
+	id      string
+	headSHA string
+}
+
+var (
+	errInvalidRunJobIdentity = errors.New("workflow jobs response included invalid or duplicate job IDs")
+	errUnprovedRunJobHead    = errors.New("workflow job head could not be verified against owned run")
+)
+
+// The seen set belongs to the entire collection, not a page. Attempts are not
+// identity evidence: GitHub may return successful jobs reused from an older one.
+func (job runJobIdentity) validate(owner runJobOwner, seen map[int64]bool) error {
+	if job.ID <= 0 || !safeRunExportInteger(job.ID) || seen[job.ID] || !safeRunExportInteger(job.RunID.value) {
+		return errInvalidRunJobIdentity
+	}
+	if job.RunID.present && strconv.FormatInt(job.RunID.value, 10) != strings.TrimLeft(owner.id, "0") {
+		return errors.New("workflow job did not match owned run")
+	}
+	if job.HeadSha.present && job.HeadSha.value != "" {
+		if owner.headSHA == "" {
+			return errUnprovedRunJobHead
+		}
+		if job.HeadSha.value != owner.headSHA {
+			return errors.New("workflow job did not match historical run head")
+		}
+	}
+	seen[job.ID] = true
+	return nil
+}

--- a/cmd/octopool/gh_run_watch_ownership_test.go
+++ b/cmd/octopool/gh_run_watch_ownership_test.go
@@ -2,12 +2,75 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestGHRunWatchRejectsInvalidJobIdentity(t *testing.T) {
+	for _, variant := range []string{"duplicate within page", "duplicate across pages", "foreign run", "foreign head", "missing id", "null id", "zero id", "negative id", "fractional id", "string id", "unsafe id", "overflow id"} {
+		t.Run(variant, func(t *testing.T) {
+			t.Setenv("OCTOPOOL_GH_PATH", fakeGHExit(t, 0))
+			t.Setenv("OCTOPOOL_NO_FALLBACK", "")
+			recordWatchSleeps(t)
+			jobCalls := 0
+			relayTestServer(t, func(body map[string]any) any {
+				if !strings.HasSuffix(body["path"].(string), "/jobs") {
+					return map[string]any{"id": 42, "status": "completed", "conclusion": "success", "run_attempt": 2, "head_sha": "owned-head"}
+				}
+				jobCalls++
+				job := map[string]any{"id": 7, "name": "Check", "conclusion": "success", "run_id": 42, "head_sha": "owned-head"}
+				jobs, total := []map[string]any{job}, 1
+				switch variant {
+				case "duplicate within page":
+					jobs, total = append(jobs, job), 2
+				case "duplicate across pages":
+					total = relayPageSize + 1
+					if body["query"].(map[string]any)["page"] == "1" {
+						jobs = nil
+						for id := 1; id <= relayPageSize; id++ {
+							jobs = append(jobs, map[string]any{"id": id, "name": "Check", "conclusion": "success"})
+						}
+					}
+				case "foreign run":
+					job["run_id"] = 43
+				case "foreign head":
+					job["head_sha"] = "foreign-head"
+				case "missing id":
+					delete(job, "id")
+				case "null id":
+					job["id"] = nil
+				case "zero id":
+					job["id"] = 0
+				case "negative id":
+					job["id"] = -7
+				case "fractional id":
+					job["id"] = 7.5
+				case "string id":
+					job["id"] = "7"
+				case "unsafe id":
+					job["id"] = json.RawMessage(`9007199254740993`)
+				case "overflow id":
+					job["id"] = json.RawMessage(`9223372036854775808`)
+				}
+				return map[string]any{"total_count": total, "jobs": jobs}
+			})
+			var stdout, stderr bytes.Buffer
+			err := runGH(t.Context(), []string{"run", "watch", "42", "-R", "acme/repo"}, &stdout, &stderr)
+			wantCalls := 1
+			if variant == "duplicate across pages" {
+				wantCalls = 2
+			}
+			if err == nil || jobCalls != wantCalls || shouldRunRealGH(err) || strings.Contains(stdout.String(), fakeGHArgvPrefix) ||
+				strings.Contains(stdout.String(), "job ") || strings.Contains(stdout.String(), "completed with") {
+				t.Fatalf("job calls=%d err=%v stdout=%q stderr=%q", jobCalls, err, stdout.String(), stderr.String())
+			}
+		})
+	}
+}
 
 func TestGHRunWatchKeepsRelayOwnership(t *testing.T) {
 	for _, phase := range []string{"initial", "poll", "confirmation", "jobs"} {
@@ -66,7 +129,7 @@ func TestGHRunWatchKeepsRelayOwnership(t *testing.T) {
 }
 
 func TestGHRunWatchRejectsIncompleteJobs(t *testing.T) {
-	for _, variant := range []string{"rerun count mismatch", "missing count", "fractional count", "changed count", "next link", "short next page", "cap"} {
+	for _, variant := range []string{"rerun count mismatch", "missing count", "fractional count", "changed count", "next link", "short next page", "oversized page", "cap"} {
 		t.Run(variant, func(t *testing.T) {
 			t.Setenv("OCTOPOOL_GH_PATH", fakeGHExit(t, 0))
 			t.Setenv("OCTOPOOL_NO_FALLBACK", "")
@@ -97,6 +160,8 @@ func TestGHRunWatchRejectsIncompleteJobs(t *testing.T) {
 					if jobCalls == 2 {
 						count = 1
 					}
+				case "oversized page":
+					count, total = relayPageSize+1, relayPageSize+1
 				case "cap":
 					count, total = relayPageSize, maxRelayPages*relayPageSize+1
 				}
@@ -124,6 +189,36 @@ func TestGHRunWatchRejectsIncompleteJobs(t *testing.T) {
 	}
 }
 
+func TestGHRunWatchJobsRetryClearsCollection(t *testing.T) {
+	var pages []string
+	sleeps := recordWatchSleeps(t)
+	relayTestServer(t, func(request map[string]any) any {
+		page := request["query"].(map[string]any)["page"].(string)
+		pages = append(pages, page)
+		if len(pages) == 2 {
+			return "invalid jobs response" // Synthetic decode failure after a valid page.
+		}
+		count, offset := relayPageSize, 0
+		if page == "2" {
+			count, offset = 1, relayPageSize
+		}
+		jobs := make([]map[string]any, count)
+		for index := range jobs {
+			jobs[index] = map[string]any{"id": offset + index + 1, "run_id": 42}
+		}
+		return map[string]any{"total_count": relayPageSize + 1, "jobs": jobs}
+	})
+	client, err := newGHRelayClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	backoff := newWatchBackoff(watchMinInterval)
+	jobs, err := relayWatchRunJobs(t.Context(), client, "acme/repo", runJobOwner{id: "42"}, 2, &backoff)
+	if err != nil || len(jobs) != relayPageSize+1 || strings.Join(pages, ",") != "1,2,1,2" || len(*sleeps) != 1 {
+		t.Fatalf("err=%v jobs=%d pages=%v sleeps=%v", err, len(jobs), pages, *sleeps)
+	}
+}
+
 func TestGHRunWatchRerunAttemptAndExitStatus(t *testing.T) {
 	for _, conclusion := range []string{"success", "failure", "cancelled", "timed_out"} {
 		for _, exitStatus := range []bool{false, true} {
@@ -135,18 +230,18 @@ func TestGHRunWatchRerunAttemptAndExitStatus(t *testing.T) {
 					case "/repos/openclaw/octopool/actions/runs/42":
 						runCalls++
 						if runCalls == 1 {
-							return map[string]any{"status": "completed", "conclusion": "failure", "run_attempt": 1}
+							return map[string]any{"status": "completed", "conclusion": "failure", "run_attempt": 1, "head_sha": "old-head"}
 						}
 						if body["headers"].(map[string]any)["cache-control"] != "max-age=0" {
 							t.Error("confirmation must be fresh")
 						}
-						return map[string]any{"status": "completed", "conclusion": conclusion, "run_attempt": 2}
+						return map[string]any{"status": "completed", "conclusion": conclusion, "run_attempt": 2, "head_sha": "confirmed-head"}
 					case "/repos/openclaw/octopool/actions/runs/42/attempts/2/jobs":
 						jobCalls++
 						// Preserve reused successes if the attempt endpoint returns them;
 						// never fetch attempt 1 to reconstruct or replace this snapshot.
 						return map[string]any{"total_count": 3, "jobs": []map[string]any{
-							{"id": 1, "name": "actions", "run_attempt": 1, "conclusion": "success"},
+							{"id": 1, "name": "actions", "run_attempt": 1, "conclusion": "success", "run_id": 42, "head_sha": "confirmed-head"},
 							{"id": 2, "name": "JavaScript", "run_attempt": 1, "conclusion": "success"},
 							{"id": 3, "name": "Swift", "run_attempt": 2, "conclusion": conclusion},
 						}}
@@ -199,6 +294,60 @@ func TestCLIRunWatchPaginationFailureDoesNotLaunchNative(t *testing.T) {
 				t.Fatalf("calls=%d err=%v stdout=%q stderr=%q", calls, result.err, result.stdout, result.stderr)
 			}
 		})
+	}
+}
+
+func TestCLIRunWatchInvalidJobsDoesNotLaunchNative(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds and executes the CLI binary")
+	}
+	bin := buildCLIBinary(t)
+	for _, variant := range []string{"duplicate", "foreign run", "foreign head"} {
+		for _, exitStatus := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/exit-status=%t", variant, exitStatus), func(t *testing.T) {
+				calls := 0
+				server := cliRelayServer(t, func(w http.ResponseWriter, r *http.Request) {
+					request := decodeCLIRequest(t, w, r)
+					calls++
+					if calls <= 2 {
+						if request["path"] != "/repos/acme/repo/actions/runs/42" {
+							t.Errorf("unexpected run path: %v", request["path"])
+						}
+						if calls == 2 && request["headers"].(map[string]any)["cache-control"] != "max-age=0" {
+							t.Error("completion confirmation must be fresh")
+						}
+						writeCLIEnvelope(t, w, map[string]any{"id": 42, "status": "completed", "conclusion": "success", "run_attempt": 2, "head_sha": "owned"})
+						return
+					}
+					if request["path"] != "/repos/acme/repo/actions/runs/42/attempts/2/jobs" || request["headers"].(map[string]any)["cache-control"] != "max-age=0" {
+						t.Error("jobs must belong to the confirmed attempt and be fresh")
+					}
+					job := map[string]any{"id": 7, "name": "Check", "conclusion": "success"}
+					jobs := []map[string]any{job}
+					switch variant {
+					case "duplicate":
+						jobs = append(jobs, job)
+					case "foreign run":
+						job["run_id"] = 43
+					case "foreign head":
+						job["head_sha"] = "foreign"
+					}
+					writeCLIEnvelope(t, w, map[string]any{"total_count": len(jobs), "jobs": jobs})
+				})
+				args := []string{"gh", "run", "watch", "42", "-R", "acme/repo"}
+				if exitStatus {
+					args = append(args, "--exit-status")
+				}
+				result := runCLI(t, bin, server.URL, map[string]string{
+					"OCTOPOOL_GH_PATH": fakeGHExit(t, 0), "OCTOPOOL_NO_FALLBACK": "", "OCTOPOOL_RELAY_RETRIES": "0",
+				}, args...)
+				if result.err == nil || calls != 3 || strings.Contains(result.stdout, fakeGHArgvPrefix) ||
+					strings.Contains(result.stdout, "job ") || strings.Contains(result.stdout, "completed with") ||
+					!strings.Contains(result.stdout, "Watching run 42") || !strings.Contains(result.stderr, "run watch stopped without local gh fallback") {
+					t.Fatalf("calls=%d err=%v stdout=%q stderr=%q", calls, result.err, result.stdout, result.stderr)
+				}
+			})
+		}
 	}
 }
 

--- a/cmd/octopool/gh_top_run.go
+++ b/cmd/octopool/gh_top_run.go
@@ -118,7 +118,7 @@ func relayHumanRunView(ctx context.Context, stdout io.Writer, repo string, id st
 	if err != nil {
 		return err
 	}
-	jobs, err := runJobs(envelope)
+	jobs, err := runJobs(envelope, runJobOwner{id: id, headSHA: firstString(run, "head_sha")})
 	if err != nil {
 		return err
 	}
@@ -134,43 +134,56 @@ func positiveJSONInt(value any) (int, bool) {
 	return int(parsed), true
 }
 
-func runJobs(envelope relayEnvelope) ([]any, error) {
-	jobs, total, err := runJobsPage(envelope)
+func runJobs(envelope relayEnvelope, owner runJobOwner) ([]any, error) {
+	jobs, total, err := runJobsPage(envelope, owner, map[int64]bool{})
 	if err != nil {
 		return nil, err
 	}
-	if total > len(jobs) {
+	link, _ := relayResponseHeader(envelope.Headers, "link")
+	_, next := relayNextLink(link)
+	if total > len(jobs) || next {
 		return nil, localFallbackError{Reason: "workflow jobs response requires pagination"}
 	}
 	return jobs, nil
 }
 
-func runJobsPage(envelope relayEnvelope) ([]any, int, error) {
+func runJobsPage(envelope relayEnvelope, owner runJobOwner, seen map[int64]bool) ([]any, int, error) {
 	body, err := envelopeBodyBytes(envelope)
 	if err != nil {
 		return nil, 0, err
 	}
-	var response map[string]any
+	var response struct {
+		Total any               `json:"total_count"`
+		Jobs  []json.RawMessage `json:"jobs"`
+	}
 	if err := json.Unmarshal(body, &response); err != nil {
 		return nil, 0, err
 	}
-	rawJobs, ok := response["jobs"].([]any)
-	if !ok {
+	if response.Jobs == nil {
 		return nil, 0, errors.New("workflow jobs response did not include jobs")
 	}
-	total, ok := jsonNumericInt(response["total_count"])
+	total, ok := jsonNumericInt(response.Total)
 	if !ok {
 		return nil, 0, localFallbackError{Reason: "workflow jobs response did not include a valid total_count"}
 	}
-	jobs := make([]any, 0, len(rawJobs))
-	for _, rawJob := range rawJobs {
-		job, ok := rawJob.(map[string]any)
-		if !ok {
-			return nil, 0, errors.New("workflow jobs response included an invalid job")
+	if len(response.Jobs) > relayPageSize || len(response.Jobs) > total {
+		return nil, 0, localFallbackError{Reason: "workflow jobs pagination contradicts total_count or page size"}
+	}
+	jobs := make([]any, 0, len(response.Jobs))
+	for _, rawJob := range response.Jobs {
+		var identity runJobIdentity
+		if err := json.Unmarshal(rawJob, &identity); err != nil {
+			return nil, 0, localFallbackError{Reason: "workflow jobs response included invalid identity metadata"}
 		}
-		mapped := map[string]any{}
+		if err := identity.validate(owner, seen); err != nil {
+			return nil, 0, localFallbackError{Reason: err.Error()}
+		}
+		var job map[string]any
+		if err := json.Unmarshal(rawJob, &job); err != nil {
+			return nil, 0, err
+		}
+		mapped := map[string]any{"databaseId": float64(identity.ID)}
 		for field, path := range map[string][]string{
-			"databaseId":  {"id"},
 			"name":        {"name"},
 			"status":      {"status"},
 			"conclusion":  {"conclusion"},

--- a/cmd/octopool/gh_top_run_test.go
+++ b/cmd/octopool/gh_top_run_test.go
@@ -220,13 +220,110 @@ func TestRunGHRunListMapsDisplayTitle(t *testing.T) {
 }
 
 func TestRunJobsFallsBackWhenPaginationIsRequired(t *testing.T) {
-	_, err := runJobs(relayEnvelope{
-		Status:       200,
-		BodyEncoding: "json",
-		Body:         []byte(`{"total_count":101,"jobs":[{"id":1}]}`),
-	})
-	if !isLocalFallback(err) {
-		t.Fatalf("err = %v", err)
+	for _, variant := range []string{"missing jobs", "excess jobs", "next link", "oversized page"} {
+		t.Run(variant, func(t *testing.T) {
+			body := `{"total_count":101,"jobs":[{"id":1}]}`
+			headers := map[string]string{}
+			switch variant {
+			case "excess jobs":
+				body = `{"total_count":0,"jobs":[{"id":1}]}`
+			case "next link":
+				body = `{"total_count":1,"jobs":[{"id":1}]}`
+				headers["Link"] = `<https://api.github.com/repos/acme/repo/actions/runs/42/attempts/2/jobs?page=2>; rel="next"`
+			case "oversized page":
+				var jobs []string
+				for id := 1; id <= relayPageSize+1; id++ {
+					jobs = append(jobs, fmt.Sprintf(`{"id":%d}`, id))
+				}
+				body = fmt.Sprintf(`{"total_count":%d,"jobs":[%s]}`, len(jobs), strings.Join(jobs, ","))
+			}
+			jobs, err := runJobs(relayEnvelope{Status: 200, BodyEncoding: "json", Body: []byte(body), Headers: headers}, runJobOwner{id: "42"})
+			if !isLocalFallback(err) || jobs != nil {
+				t.Fatalf("err=%v jobs=%v", err, jobs)
+			}
+		})
+	}
+}
+
+func TestRunJobsIdentityAndOwnership(t *testing.T) {
+	for _, test := range []struct {
+		name, jobs, head string
+		valid            bool
+	}{
+		{"optional metadata", `[{"id":7}]`, "", true},
+		{"null metadata", `[{"id":7,"run_id":null,"head_sha":null}]`, "", true},
+		{"empty head", `[{"id":7,"run_id":42,"head_sha":""}]`, "", true},
+		{"reused job", `[{"id":7,"run_id":42,"head_sha":"owned","run_attempt":1}]`, "owned", true},
+		{"safe id", `[{"id":9007199254740991}]`, "", true},
+		{"id then null", `[{"id":7,"id":null}]`, "", true},
+		{"duplicate ids", `[{"id":7},{"id":7}]`, "", false},
+		{"missing id", `[{}]`, "", false},
+		{"null id", `[{"id":null}]`, "", false},
+		{"zero id", `[{"id":0}]`, "", false},
+		{"negative id", `[{"id":-7}]`, "", false},
+		{"fractional id", `[{"id":7.5}]`, "", false},
+		{"string id", `[{"id":"7"}]`, "", false},
+		{"bool id", `[{"id":true}]`, "", false},
+		{"unsafe id", `[{"id":9007199254740992}]`, "", false},
+		{"overflow id", `[{"id":9223372036854775808}]`, "", false},
+		{"foreign run", `[{"id":7,"run_id":43}]`, "", false},
+		{"foreign head", `[{"id":7,"head_sha":"foreign"}]`, "owned", false},
+		{"unproved head", `[{"id":7,"head_sha":"foreign"}]`, "", false},
+		{"malformed run", `[{"id":7,"run_id":"42"}]`, "", false},
+		{"unsafe run", `[{"id":7,"run_id":9007199254740993}]`, "", false},
+		{"nonpositive run", `[{"id":7,"run_id":0}]`, "", false},
+		{"malformed head", `[{"id":7,"head_sha":42}]`, "owned", false},
+		{"run then null", `[{"id":7,"run_id":43,"run_id":null}]`, "", false},
+		{"head then null", `[{"id":7,"head_sha":"foreign","head_sha":null}]`, "owned", false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var records []json.RawMessage
+			if err := json.Unmarshal([]byte(test.jobs), &records); err != nil {
+				t.Fatal(err)
+			}
+			envelope := relayEnvelope{BodyEncoding: "json", Body: []byte(fmt.Sprintf(`{"total_count":%d,"jobs":%s}`, len(records), test.jobs))}
+			jobs, humanErr := runJobs(envelope, runJobOwner{id: "00042", headSHA: test.head})
+			machineJobs, machineErr := machineRunJobs(envelope, machineRun{ID: 42, HeadSha: test.head, Attempt: 2})
+			if (humanErr == nil) != test.valid || (machineErr == nil) != test.valid {
+				t.Fatalf("valid=%t human=%v machine=%v", test.valid, humanErr, machineErr)
+			}
+			if !test.valid {
+				if jobs != nil || machineJobs != nil {
+					t.Fatal("invalid identity returned a partial collection")
+				}
+				return
+			}
+			if len(jobs) != len(machineJobs) || len(jobs) != len(records) {
+				t.Fatal("valid collection lost jobs")
+			}
+			for index, job := range jobs {
+				if job.(map[string]any)["databaseId"] != float64(machineJobs[index].DatabaseID) {
+					t.Fatal("human and machine identity projections disagree")
+				}
+			}
+		})
+	}
+}
+
+func TestHumanRunViewRejectsContradictoryJobs(t *testing.T) {
+	for _, jobs := range []string{`[{"id":7},{"id":7}]`, `[{"id":7,"run_id":43}]`, `[{"id":7,"head_sha":"foreign"}]`} {
+		t.Run(jobs, func(t *testing.T) {
+			relayTestServer(t, func(request map[string]any) any {
+				if strings.HasSuffix(request["path"].(string), "/jobs") {
+					var records []json.RawMessage
+					if err := json.Unmarshal([]byte(jobs), &records); err != nil {
+						t.Fatal(err)
+					}
+					return map[string]any{"total_count": len(records), "jobs": records}
+				}
+				return map[string]any{"id": 42, "status": "completed", "conclusion": "success", "run_attempt": 2, "head_sha": "owned"}
+			})
+			var out bytes.Buffer
+			result := handleGHRun(t.Context(), []string{"view", "42", "-R", "acme/repo"}, &out)
+			if !isLocalFallback(result.err) || out.Len() != 0 {
+				t.Fatalf("human view must fail before output with ordinary fallback available: err=%v stdout=%q", result.err, out.String())
+			}
+		})
 	}
 }
 

--- a/cmd/octopool/gh_top_watch.go
+++ b/cmd/octopool/gh_top_watch.go
@@ -240,7 +240,8 @@ func relayRunWatch(ctx context.Context, stdout io.Writer, opts ghRunWatchOptions
 			if conclusion == "" {
 				return errors.New("workflow run confirmation did not include conclusion")
 			}
-			jobs, err := relayWatchRunJobs(ctx, client, opts.repo, opts.id, attempt, &backoff)
+			owner := runJobOwner{id: opts.id, headSHA: firstString(confirmed, "head_sha")}
+			jobs, err := relayWatchRunJobs(ctx, client, opts.repo, owner, attempt, &backoff)
 			if err != nil {
 				return runWatchError(err, true)
 			}
@@ -289,15 +290,16 @@ func relayWatchRun(ctx context.Context, client ghRelayClient, repo string, id st
 	return run, nil
 }
 
-func relayWatchRunJobs(ctx context.Context, client ghRelayClient, repo string, id string, attempt int, backoff *watchBackoff) ([]any, error) {
+func relayWatchRunJobs(ctx context.Context, client ghRelayClient, repo string, owner runJobOwner, attempt int, backoff *watchBackoff) ([]any, error) {
 	var jobs []any
 	err := retryWatchTick(ctx, backoff, func() error {
 		jobs = jobs[:0]
+		seen := map[int64]bool{}
 		total := 0
 		for page := 1; page <= maxRelayPages; page++ {
 			envelope, err := client.do(ctx, ghAPIRequest{
 				method: "GET",
-				path:   repoPath(repo, "actions", "runs", id, "attempts", strconv.Itoa(attempt), "jobs"),
+				path:   repoPath(repo, "actions", "runs", owner.id, "attempts", strconv.Itoa(attempt), "jobs"),
 				query:  map[string]any{"per_page": strconv.Itoa(relayPageSize), "page": strconv.Itoa(page)},
 				headers: map[string]string{
 					"x-octopool-public-shape": publicShapeActionsJobs,
@@ -309,7 +311,7 @@ func relayWatchRunJobs(ctx context.Context, client ghRelayClient, repo string, i
 			if err != nil {
 				return err
 			}
-			pageJobs, pageTotal, err := runJobsPage(envelope)
+			pageJobs, pageTotal, err := runJobsPage(envelope, owner, seen)
 			if err != nil {
 				return err
 			}

--- a/cmd/octopool/gh_top_watch_test.go
+++ b/cmd/octopool/gh_top_watch_test.go
@@ -37,7 +37,7 @@ func TestGHRunWatchPrintsTransitionsAndFetchesJobsOnce(t *testing.T) {
 			return map[string]any{
 				"total_count": 1,
 				"jobs": []map[string]any{{
-					"name": "Test", "status": "completed", "conclusion": "failure",
+					"id": 7, "name": "Test", "status": "completed", "conclusion": "failure",
 					"steps": []map[string]any{
 						{"name": "Compile", "status": "completed", "conclusion": "success"},
 						{"name": "Unit tests", "status": "completed", "conclusion": "failure"},
@@ -732,8 +732,8 @@ func TestGHRunWatchPaginatesCompletedRunJobs(t *testing.T) {
 	relayTestServer(t, func(body map[string]any) any {
 		switch body["path"] {
 		case "/repos/openclaw/octopool/actions/runs/42":
-			return map[string]any{"id": 42, "status": "completed", "conclusion": "success", "run_attempt": 1}
-		case "/repos/openclaw/octopool/actions/runs/42/attempts/1/jobs":
+			return map[string]any{"id": 42, "status": "completed", "conclusion": "success", "run_attempt": 2, "head_sha": "owned-head"}
+		case "/repos/openclaw/octopool/actions/runs/42/attempts/2/jobs":
 			page := body["query"].(map[string]any)["page"].(string)
 			jobsRequests = append(jobsRequests, page)
 			jobs := []map[string]any{}
@@ -744,7 +744,7 @@ func TestGHRunWatchPaginatesCompletedRunJobs(t *testing.T) {
 				offset = relayPageSize
 			}
 			for index := 0; index < count; index++ {
-				jobs = append(jobs, map[string]any{"id": offset + index, "name": "job", "status": "completed", "conclusion": "success"})
+				jobs = append(jobs, map[string]any{"id": offset + index + 1, "name": "job", "status": "completed", "conclusion": "success", "run_id": 42, "head_sha": "owned-head", "run_attempt": 1})
 			}
 			return map[string]any{"total_count": 150, "jobs": jobs}
 		default:

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -156,7 +156,7 @@ token still returns `503 org_verification_unavailable` when a refresh is require
 
 ### Immutable membership upgrade
 
-The 0.5.18 migration `0017_org_identity_verification.sql` adds nullable
+The 0.6.0 migration `0017_org_identity_verification.sql` adds nullable
 `callers.org_identity_verified_at` without backfilling it. Only successful identity-bound
 verification writes this column, including CLI/OAuth login, admin provisioning, and caller/session
 refresh. New auth TTL decisions use only this proof. A verified login stores it immediately, so the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -358,6 +358,10 @@ they never start a personal-token watcher. This applies to the initial read, lat
 fresh completion confirmation, and final job hydration. Jobs are fetched only after a fresh
 completed run response, using its exact `run_attempt`. Missing or inconsistent job metadata
 fails explicitly without printing a partial job summary or a successful completion message.
+Job IDs must be positive, unique across all pages, and within the relay's safe-integer
+range. Supplied `run_id` and nonempty `head_sha` must match the owning run; optional
+ownership fields may be absent from public-page-derived jobs. Human run views validate
+the same job identities before rendering, retaining their guarded fallback on invalid data.
 Octopool preserves the job set returned for that attempt, including reused successes when
 present, and does not reconstruct missing jobs from earlier attempts. With complete data,
 `--exit-status` returns 1 for a non-successful run; without it, a completed run returns 0.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -16,8 +16,8 @@ durable release evidence; signing uses the OpenClaw Foundation Developer ID.
    below): download both darwin tarballs, sign the `octopool` binary with
    `Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)` using
    `codesign --force --options runtime --timestamp`, notarize a zip of each
-   binary with `xcrun notarytool submit --wait` (App Store Connect key
-   `op://Molty/API Key - App Store Connect - Personal - Release`), verify
+   binary with `xcrun notarytool submit --wait` using the canonical release
+   App Store Connect key from the approved private credential workflow, verify
    `spctl -a -t install` reports `Notarized Developer ID`, repackage the
    tarballs, rewrite the two darwin lines in `checksums.txt`, and
    `gh release upload vX.Y.Z --clobber` the three files.
@@ -42,7 +42,9 @@ durable release evidence; signing uses the OpenClaw Foundation Developer ID.
    push token is unavailable, generate locally with
    `node scripts/openclaw-release-evidence.mjs` and commit the evidence
    directory directly (precedent: `evidence/octopool-0.5.0`).
-8. Reopen the changelog: add `## X.Y.(Z+1) - Unreleased`, commit, push.
+8. Verify the published release body exactly matches the finalized dated changelog section,
+   the final assets/checksums match the Homebrew formula, and the working tree is clean.
+   Do not prefill another `Unreleased` section; write the next version's notes at release time.
 
 ## Future: CI-hosted signing
 


### PR DESCRIPTION
## Release scope

Prepare Octopool 0.6.0 rather than a fixes-only patch release: the post-0.5.17 changes add protected draft-release asset snapshots across macOS, Linux, and Windows. The changelog now leads with user-facing highlights, groups the remaining fixes by impact, and separates migration and scripting compatibility notes. Historical release entries are unchanged.

Extensive release validation also reproduced a remaining workflow-job integrity bug: duplicate or foreign-job records could satisfy the advertised total and let `run watch` print a successful completion. The fix shares identity validation across watch, human view, and machine export, tracks uniqueness across all pages, and rejects contradictory supplied run/head metadata. Optional absent ownership fields and legitimate jobs reused from earlier attempts remain supported. Failures do not emit a partial final summary or start a native fallback watcher.

Release instructions now point to the approved credential workflow instead of a stale locator, require final notes/checksum verification, and no longer prefill the next unreleased changelog. The membership-upgrade documentation names 0.6.0.

## Validation

- All twelve new synthetic job-identity regression cases failed against the original code and pass with the fix.
- Focused watch, human-view, machine-export, and compiled-CLI tests passed in the isolated fix checkout and again in the release branch.
- Go static analysis, scoped formatting, historical-changelog preservation, and the mandatory isolated review passed.
- A read-only production CLI matrix validated PR gate fields/checks, workflow exports, issue-list shape, and cold/warm/fresh consistency. The existing deployed release-view formatting still needs the already-implemented Worker fix and rollout verification; it is not claimed fixed in production yet.
- [Full PR CI](https://github.com/openclaw/octopool/actions/runs/33568590029) passed on exact head `1cc83aca526b9ebc5a451b794be9054ca2cd2989`, including Linux checks, native Windows Go tests/vet, docs, and snapshot builds.
- The non-root clean Linux baseline passed 983 unit tests, 958 native Workerd integration tests, the full Go suite, and the existing compiled CLI → Worker → real GitHub gate.
- The expanded exact-head live matrix passed its positive cases and a separately selected continuation: real miss/hit/304/restart behavior; PR/issue/run parity; two jobs and 26 steps; exact 999-byte release Markdown; four-way immutable-content reads with three observed coalesced calls, one retained payload and no live owners; raw diff parity; typed missing-resource refusal; local/modeled-native boundaries; and active-policy asset preparation/cleanup. Generated harness assumptions about pnpm context and the no-identity 424 audit outcome were corrected against source, without changing product code or rerunning already-proved public reads.
- A production-boundary run of the compiled candidate watched a real completed GitHub run successfully with native fallback forbidden and two job summaries. The malformed-job regression was separately exercised through actual CLI processes and loopback relay sockets, as captured below.

## Captured runtime regression proof

The same controlled relay fixtures were supplied to the compiled pre-fix baseline and exact-head candidate. These are real CLI processes, not calls to internal test functions. All inputs, credentials, and malformed jobs are synthetic; no malformed data was injected into a production service.

| Fixture | Baseline exit / successful completion / job summaries | Candidate exit / successful completion / job summaries | Native child |
| --- | --- | --- | --- |
| Duplicate job ID | 0 / yes / 2 | 1 / no / 0 | Not started |
| Foreign run ID | 0 / yes / 1 | 1 / no / 0 | Not started |
| Foreign head SHA | 0 / yes / 1 | 1 / no / 0 | Not started |

Captured candidate stderr for the duplicate-ID case:

```text
error: run watch stopped without local gh fallback: octopool requested local gh fallback: workflow jobs response included invalid or duplicate job IDs
```

The asset phase ran the actual compiled CLI against a local Worker serving an active synthetic policy and a capture-only native child. Four opaque files retained their names, order and digests; notes, empty child stdin, private modes and cleanup were verified. Unsafe filenames never reached the child, and a child exit of 23 was preserved with cleanup. This is preparation proof, not a claim of real GitHub upload or native server-side tag verification.

No version tag or GitHub Release has been published by this PR. Pre-tag validation is complete; release completion additionally requires the authorized schema-first Worker rollout and final artifact/signing/checksum verification. Tests do not upload synthetic release content to an unapproved GitHub destination or change users' policy/authentication configuration.
