### PR TITLE
fix(gh): accept host-qualified repository selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Accept explicit `github.com/OWNER/REPO` selectors in protected releases and shared repository parsing while preserving GitHub.com host pinning and outbound rewrite checks.
+
 ## 0.6.0 - 2026-09-01
 
 ### Highlights

--- a/cmd/octopool/gh_top_options_test.go
+++ b/cmd/octopool/gh_top_options_test.go
@@ -36,6 +36,62 @@ func TestTopLevelRepoNumber(t *testing.T) {
 	}
 }
 
+func TestNormalizeRepoHostQualified(t *testing.T) {
+	for _, test := range []struct{ raw, want string }{
+		{"github.com/Acme/Toolkit", "acme/Toolkit"},
+		{"github.com/Acme/Toolkit.git", "acme/Toolkit"},
+		{"Acme/Toolkit", "acme/Toolkit"},
+		{"https://github.com/Acme/Toolkit", "acme/Toolkit"},
+		{"git@github.com:Acme/Toolkit.git", "acme/Toolkit"},
+		{"ssh://git@github.com/Acme/Toolkit.git", "acme/Toolkit"},
+		{" /Acme/Toolkit/ ", "acme/Toolkit"},
+		// The shared normalizer also accepts this existing two-part owner/repo.
+		{"github.com/Toolkit", "github.com/Toolkit"},
+		{"other.example/Acme/Toolkit", ""},
+		{"github.com.other.example/Acme/Toolkit", ""},
+		{"github.com@other.example/Acme/Toolkit", ""},
+		{"github.com:443/Acme/Toolkit", ""},
+		{"github.com//Acme/Toolkit", ""},
+		{"github.com/Acme/Toolkit/extra", ""},
+		{"https://github.com/github.com/Acme/Toolkit", ""},
+	} {
+		t.Run(test.raw, func(t *testing.T) {
+			if got := normalizeRepo(test.raw); got != test.want {
+				t.Fatalf("normalizeRepo(%q) = %q, want %q", test.raw, got, test.want)
+			}
+		})
+	}
+}
+
+func TestTopLevelHostQualifiedRepoReads(t *testing.T) {
+	t.Setenv("GH_HOST", "other.example")
+	t.Setenv("GH_REPO", "other.example/wrong/repo")
+	for _, test := range []struct {
+		name string
+		args []string
+		path string
+	}{
+		{"issue", []string{"issue", "view", "7", "--json=number"}, "/repos/acme/repo/issues/7"},
+		{"pr", []string{"pr", "view", "7", "--json=number"}, "/repos/acme/repo/pulls/7"},
+		{"release", []string{"release", "view", "v1", "--json=name"}, "/repos/acme/repo/releases/tags/v1"},
+		{"repo", []string{"repo", "view", "--json=name"}, "/repos/acme/repo"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var paths []string
+			relayTestServer(t, func(req map[string]any) any {
+				paths = append(paths, req["path"].(string))
+				return map[string]any{"number": 7, "name": "synthetic"}
+			})
+			args := append(slices.Clone(test.args), "--repo=github.com/acme/repo")
+			var out bytes.Buffer
+			result := runGHTopLevel(t.Context(), args, &out)
+			if result.action != ghComplete || result.err != nil || !slices.Equal(paths, []string{test.path}) || out.Len() == 0 {
+				t.Fatalf("action=%v err=%v paths=%v output=%q", result.action, result.err, paths, out.String())
+			}
+		})
+	}
+}
+
 func TestGHTopReadOptionDispatch(t *testing.T) {
 	for _, test := range []struct {
 		name string

--- a/cmd/octopool/gh_top_repo.go
+++ b/cmd/octopool/gh_top_repo.go
@@ -99,6 +99,7 @@ func normalizeRepo(raw string) string {
 	if raw == "" {
 		return ""
 	}
+	hostQualified := strings.HasPrefix(raw, "github.com/")
 	raw = strings.TrimSuffix(raw, ".git")
 	if parsed, err := url.Parse(raw); err == nil && parsed.Scheme == "ssh" && parsed.Hostname() == "github.com" && parsed.RawQuery == "" && parsed.Fragment == "" {
 		hasPassword := false
@@ -112,6 +113,11 @@ func normalizeRepo(raw string) string {
 	raw = strings.TrimPrefix(raw, "git@github.com:")
 	raw = strings.TrimPrefix(raw, "https://github.com/")
 	parts := strings.Split(strings.Trim(raw, "/"), "/")
+	// Only a bare HOST/OWNER/REPO has a third component; do not strip a
+	// second host from a URL or change the existing two-part owner/repo form.
+	if hostQualified && len(parts) == 3 {
+		parts = parts[1:]
+	}
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return ""
 	}

--- a/cmd/octopool/string_rewrites_process_test.go
+++ b/cmd/octopool/string_rewrites_process_test.go
@@ -240,6 +240,107 @@ func rewriteTestServerPolicySequence(t *testing.T, policy func(int64) (string, i
 const rewriteActiveTestPolicy = `{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[{"pattern":"internal-model","replacement":"public"}]}`
 const rewriteEmptyTestPolicy = `{"schema_version":1,"revision":1,"updated_at":"2026-08-28T00:00:00Z","rules":[]}`
 
+func TestStringRewriteHostQualifiedRepoRoutes(t *testing.T) {
+	rewriteTestServer(t, prReadPolicy("private-term"), nil)
+	t.Setenv("GH_HOST", "other.example")
+	t.Setenv("GH_REPO", "other.example/wrong/repo")
+	for _, test := range []struct {
+		name, pin, body string
+		args            []string
+	}{
+		{"issue create", "--repo=acme/repo", "public", []string{"issue", "create", "-Rgithub.com/acme/repo", "--title=private-term", "--body=private-term"}},
+		{"pr comment", "--repo=acme/repo", "public", []string{"pr", "comment", "7", "-R", "github.com/acme/repo", "--body=private-term"}},
+		{"release edit", "--repo=acme/repo", "public", []string{"release", "edit", "v1", "--repo=github.com/acme/repo", "--notes=private-term"}},
+		{"pr ready", "--repo=acme/repo", "", []string{"pr", "ready", "7", "--repo=github.com/acme/repo"}},
+		{"issue read", "--repo=acme/repo", "", []string{"issue", "view", "7", "--repo=github.com/acme/repo", "--json=number"}},
+		{"pr numeric read", "--repo=acme/repo", "", []string{"pr", "view", "7", "--repo=github.com/acme/repo", "--json=number"}},
+		{"pr branch read", "--repo=https://github.com/acme/repo", "", []string{"pr", "view", "topic", "--repo=github.com/acme/repo", "--json=number"}},
+		{"release read", "--repo=acme/repo", "", []string{"release", "view", "v1", "--repo=github.com/acme/repo", "--json=name"}},
+		{"repo positional read", "acme/repo", "", []string{"repo", "view", "github.com/acme/repo", "--json=name"}},
+		{"best effort", "--repo=github.com/acme/repo", "", []string{"workflow", "run", "ci.yml", "--repo=github.com/acme/repo", "-fmessage=private-term"}},
+		{"api read", "--hostname=github.com", "", []string{"api", "repos/acme/repo/issues/7"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			capture := captureRewriteGH(t)
+			original := slices.Clone(test.args)
+			if err := execRealGHWithStdin(t.Context(), test.args, strings.NewReader(""), io.Discard, io.Discard); err != nil {
+				t.Fatal(err)
+			}
+			got := readRewriteCapture(t, capture)
+			if !slices.Contains(got.Args, test.pin) || !slices.Equal(test.args, original) || got.Env["GH_HOST"] != "github.com" || got.Env["GH_REPO"] != "" {
+				t.Fatalf("native repository boundary: %+v", got)
+			}
+			if test.body != "" && !rewriteCaptureHasContent(got, test.body) {
+				t.Fatal("rewritten body missing from native snapshot")
+			}
+			if strings.Contains(strings.Join(got.Args, " "), "private-term") {
+				t.Fatal("unrewritten argument reached native child")
+			}
+		})
+	}
+}
+
+func TestStringRewriteHostQualifiedRepoRejectsHosts(t *testing.T) {
+	rewriteTestServer(t, prReadPolicy("private-term"), nil)
+	for _, repo := range []string{
+		"other.example/acme/repo", "github.com.other.example/acme/repo",
+		"github.com@other.example/acme/repo", "github.com:443/acme/repo",
+		"www.github.com/acme/repo", "https://other.example/acme/repo",
+		"https://github.com@other.example/acme/repo", "github.com//acme/repo",
+		"github.com/acme/repo/extra", "github.com/acme/repo?query", "github.com/acme/repo#fragment",
+		"github.com/acme/../repo", "github.com/acme%2frepo/other", "github.com/acme/repo\nother",
+		"github.com/private-term/repo", "https://github.com/github.com/acme/repo",
+	} {
+		for _, command := range [][]string{
+			{"release", "create", "v1", "--verify-tag", "--title=safe", "--notes=safe"},
+			{"issue", "view", "7", "--json=number"},
+			{"workflow", "run", "ci.yml"},
+		} {
+			t.Run(command[0]+"/"+repo, func(t *testing.T) {
+				capture := captureRewriteGH(t)
+				args := append(slices.Clone(command), "--repo="+repo)
+				if err := execRealGHWithStdin(t.Context(), args, strings.NewReader(""), io.Discard, io.Discard); err != errRewriteBlocked {
+					t.Fatalf("error=%v", err)
+				}
+				if _, err := os.Stat(capture); !os.IsNotExist(err) {
+					t.Fatal("unsafe repository reached child")
+				}
+			})
+		}
+	}
+}
+
+func TestStringRewriteHostQualifiedRepoRevalidation(t *testing.T) {
+	for _, replacement := range []string{"--repo=other.example/acme/repo", "--repo=github.com/acme/repo/extra", "--repo=github.com/acme/.."} {
+		t.Run(replacement, func(t *testing.T) {
+			policy, err := compileStringRewriteRules([]stringRewriteRule{{Pattern: "repo-marker", Replacement: replacement}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			prepared := &rewritePreparation{}
+			defer prepared.cleanup()
+			// Only the final pass can see the repository declaration introduced by rewriting.
+			args := []string{"extension", "exec", "synthetic", "repo-marker"}
+			if err := prepareRewriteBestEffort(policy, args, strings.NewReader(""), prepared); err != errRewriteBlocked {
+				t.Fatalf("rewritten repository declaration accepted: %q, error=%v", prepared.args, err)
+			}
+		})
+	}
+	policy, err := compileStringRewriteRules([]stringRewriteRule{{Pattern: "acme", Replacement: "other"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	flags := rewriteFlags{values: map[string]string{"--repo": "github.com/acme/repo"}}
+	if err := rewriteRepo(&flags, policy); err != errRewriteBlocked {
+		t.Fatalf("structural identity rewrite accepted: %v", err)
+	}
+	// Best-effort's explicit-host contract stays stricter than normalizeRepo's
+	// existing two-part owner/repo contract.
+	if _, err := normalizeBestEffortRepo(policy, "github.com/repo"); err != errRewriteBlocked {
+		t.Fatalf("incomplete best-effort host accepted: %v", err)
+	}
+}
+
 func TestStringRewriteProcessSnapshots(t *testing.T) {
 	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
 	for _, test := range []struct {

--- a/cmd/octopool/string_rewrites_release_assets_test.go
+++ b/cmd/octopool/string_rewrites_release_assets_test.go
@@ -87,6 +87,114 @@ func releaseAssetArgs(paths ...string) []string {
 	return append([]string{"release", "create", "v1.2.3", "--repo=acme/toolkit", "--draft", "--verify-tag", "--title=Toolkit 1.2.3", "--notes=Reviewed notes.\n"}, paths...)
 }
 
+func TestReleaseHostQualifiedRepoSnapshots(t *testing.T) {
+	rewriteTestServer(t, prReadPolicy("private-term"), nil)
+	t.Setenv("GH_HOST", "other.example")
+	t.Setenv("GH_REPO", "other.example/wrong/repo")
+	for _, repo := range []string{"github.com/Acme/Toolkit", "https://github.com/Acme/Toolkit", "Acme/Toolkit"} {
+		for _, spelling := range []string{"--repo", "--repo=", "-R", "-Rattached"} {
+			for _, assets := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/%s/assets=%t", repo, spelling, assets), func(t *testing.T) {
+					capturePath := captureRewriteGH(t)
+					title, notes := "private-term release", "# private-term\r\n\nSynthetic notes. 🦞\n"
+					if assets {
+						title, notes = "Toolkit 1.2.3", "# Toolkit 1.2.3\r\n\nSynthetic frozen notes. 🦞\n"
+					}
+					notesPath := releaseAssetFile(t, "frozen.md", []byte(notes))
+					args := []string{"release", "create", "v1.2.3", "--draft", "--verify-tag", "--title", title, "--notes-file", notesPath}
+					switch spelling {
+					case "--repo", "-R":
+						args = append(args, spelling, repo)
+					case "--repo=":
+						args = append(args, spelling+repo)
+					case "-Rattached":
+						args = append(args, "-R"+repo)
+					}
+					payload := []byte{0, 0xff, 1, 2}
+					assetPath := ""
+					if assets {
+						assetPath = releaseAssetFile(t, "toolkit.zip", payload)
+						args = append(args, assetPath)
+					}
+					original := slices.Clone(args)
+					if err := execRealGHWithStdin(t.Context(), args, strings.NewReader("unused"), io.Discard, io.Discard); err != nil {
+						t.Fatal(err)
+					}
+					got := readRewriteCapture(t, capturePath)
+					wantTitle := strings.ReplaceAll(title, "private-term", "public")
+					wantNotes := strings.ReplaceAll(notes, "private-term", "public")
+					for _, arg := range []string{"--repo=acme/Toolkit", "--title=" + wantTitle, "--draft=true", "--verify-tag=true"} {
+						if !slices.Contains(got.Args, arg) {
+							t.Errorf("missing %q in native args %q", arg, got.Args)
+						}
+					}
+					if !slices.Equal(args, original) || !slices.Equal(got.Args[:3], args[:3]) || got.Stdin != "" || got.Env["GH_HOST"] != "github.com" || got.Env["GH_REPO"] != "" {
+						t.Fatalf("argument/host/stream boundary changed: %+v", got)
+					}
+					wantFiles := 1
+					if assets {
+						wantFiles++
+						staged := got.Args[len(got.Args)-1]
+						if staged == assetPath || filepath.Base(staged) != "toolkit.zip" || !bytes.Equal(got.FileData[staged], payload) {
+							t.Fatal("asset snapshot changed")
+						}
+						if data, err := os.ReadFile(assetPath); err != nil || !bytes.Equal(data, payload) {
+							t.Fatal("source asset changed")
+						}
+					}
+					if len(got.Files) != wantFiles || !rewriteCaptureHasContent(got, wantNotes) {
+						t.Fatal("native child did not receive expected notes/assets")
+					}
+					for path := range got.Files {
+						if path == notesPath || got.Modes[path] != 0600 || got.DirectoryModes[path] != 0700 {
+							t.Fatal("source path or nonprivate snapshot reached native child")
+						}
+						if _, err := os.Stat(path); !os.IsNotExist(err) {
+							t.Fatal("snapshot leaked")
+						}
+					}
+					if data, err := os.ReadFile(notesPath); err != nil || string(data) != notes {
+						t.Fatal("original notes changed")
+					}
+					if os.Getenv("GH_HOST") != "other.example" || os.Getenv("GH_REPO") != "other.example/wrong/repo" {
+						t.Fatal("parent environment changed")
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestReleaseHostQualifiedRepoRejectsUnsafeInputs(t *testing.T) {
+	rewriteTestServer(t, prReadPolicy("private-term"), nil)
+	safe := releaseAssetFile(t, "safe.zip", []byte("synthetic opaque bytes"))
+	for _, test := range []struct{ name, title, notes, asset string }{
+		{"changed title", "private-term", "safe", safe},
+		{"changed notes", "safe", "private-term", safe},
+		{"changed asset", "safe", "safe", releaseAssetFile(t, "private-term.zip", []byte("synthetic"))},
+		{"asset label", "safe", "safe", safe + "#label"},
+		{"policy material", "safe", prReadPolicy("private-term"), ""},
+		{"invalid title", "\xff", "safe", ""},
+		{"invalid notes", "safe", "\xff", ""},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			capture := captureRewriteGH(t)
+			temporary := releaseAssetTemp(t)
+			args := []string{"release", "create", "v1", "--repo=github.com/acme/repo", "--draft", "--verify-tag", "--title=" + test.title, "--notes=" + test.notes}
+			if test.asset != "" {
+				args = append(args, test.asset)
+			}
+			if err := execRealGHWithStdin(t.Context(), args, strings.NewReader(""), io.Discard, io.Discard); err != errRewriteBlocked {
+				t.Fatalf("error=%v", err)
+			}
+			if _, err := os.Stat(capture); !os.IsNotExist(err) {
+				t.Fatal("unsafe child executed")
+			}
+			assertReleaseAssetTempEmpty(t, temporary)
+		})
+	}
+}
+
 func releaseAssetFile(t *testing.T, name string, data []byte) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), name)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -764,14 +764,19 @@ attached values. Repeated flags/aliases and boolean clusters are rejected. Metad
 not listed by the guard are unsupported; use an allowlisted raw REST shape where applicable.
 Creation also rejects sanitized empty titles/bodies/notes to avoid implicit defaults.
 Repository context is normalized and pinned into an explicit `owner/repo` after validation;
-explicit `https://github.com/owner/repo` and GitHub SSH forms are accepted, while other hosts
-are blocked. Input files are read into bounded snapshots, never modified, and never reopened
-by the child. Sanitized snapshots use a private 0700 directory and 0600 files, removed
-after execution, including nonzero exits. These modeled commands do not retain live stdin.
+explicit `github.com/owner/repo`, `https://github.com/owner/repo`, and GitHub SSH forms are
+accepted, while other hosts are blocked. Protected native children force `GH_HOST=github.com`
+and remove inherited `GH_REPO`, so normalization cannot redirect an explicit GitHub.com
+repository to an ambient Enterprise host. Input files are read into bounded snapshots,
+never modified, and never reopened by the child. Sanitized snapshots use a private 0700
+directory and 0600 files, removed after execution, including nonzero exits. These modeled
+commands do not retain live stdin.
 
 With active rules, `gh release create TAG --repo OWNER/REPO --draft --verify-tag
 --title TITLE --notes-file NOTES FILE...` accepts up to 16 explicit local asset paths
-on macOS, Linux, and Windows. Each asset must be a nonempty regular file, at most 1 GiB;
+on macOS, Linux, and Windows. The explicit `--repo github.com/OWNER/REPO` spelling is
+also supported, including `--repo=...`, `-R ...`, and `-R...`; the same metadata and asset
+protections apply. Each asset must be a nonempty regular file, at most 1 GiB;
 the aggregate asset limit is 4 GiB. Public basenames are limited to 255 bytes and use
 only ASCII letters, digits, internal periods, underscores, and hyphens. A basename
 cannot start with a period or hyphen, or end with a period; a leading underscore is


### PR DESCRIPTION
Protected `gh release create --repo github.com/OWNER/REPO` rejected a valid explicit repository selector before processing release notes. The shared repository normalizer recognized `OWNER/REPO`, HTTPS URLs, and GitHub SSH forms, but rejected bare `HOST/OWNER/REPO` as having too many components.

Recognize a bare `github.com/OWNER/REPO` in `normalizeRepo`, where protected commands and repository reads share normalization. Capture the bare-host form before stripping URL/SSH prefixes so a URL cannot have its host stripped twice, and preserve the existing two-part owner/repository contract. Rewrite guard code is unchanged: foreign hosts remain blocked, native children stay pinned to GitHub.com, and repository identity, title/body/notes, and release asset protections retain their existing boundaries.

Regression coverage exercises all four repository flag spellings, releases with and without assets, private notes/asset snapshots and cleanup, ambient Enterprise host settings, adjacent read/write routes, unsafe selectors, and final repository revalidation. CLI documentation and the Unreleased changelog describe the accepted spelling and host pinning.

Validation on the reviewed six-file change:

- Corrected red proof produced 22 expected HOST/OWNER/REPO failures before the production fix; the same focused tests passed afterward (8.431s).
- Fresh pre-commit `go test ./cmd/octopool -run HostQualified -count=1` passed (11.901s).
- `go test ./cmd/octopool -count=1` passed (246.931s).
- `go vet ./...`, Go formatting, documentation formatting, and `git diff --check` passed.
- Codex autoreview completed scoped-clean at P0 with no accepted/actionable findings.

No live release creation was attempted. Live testing of the landed executable is reserved for post-merge verification.
