### PR TITLE
chore(release): prepare Octopool 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
-## Unreleased
+## 0.6.1 - 2026-09-02
 
 ### Fixes
 
 - Accept explicit `github.com/OWNER/REPO` selectors in protected releases and shared repository parsing while preserving GitHub.com host pinning and outbound rewrite checks.
+- Allow protected PR branch and current-branch reads through checked native fallback, preserving GitHub CLI lookup, output, and exit semantics without loosening numeric relay or lifecycle-write rules.
+- Support `gh pr merge --subject` / `-t` with bounded text rewriting and private snapshots while retaining exact-head, immediate squash-only merge restrictions.
+
+### Upgrade notes
+
+- This is a CLI-only patch release; no Worker deployment or database migration is required.
 
 ## 0.6.0 - 2026-09-01
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -45,7 +45,8 @@ durable release evidence; signing uses the OpenClaw Foundation Developer ID.
    directory directly (precedent: `evidence/octopool-0.5.0`).
 8. Verify the published release body exactly matches the finalized dated changelog section,
    the final assets/checksums match the Homebrew formula, and the working tree is clean.
-   Do not prefill another `Unreleased` section; write the next version's notes at release time.
+   Resume an `Unreleased` section when the next user-visible changes land; keep their notes
+   current as work lands rather than deferring changelog maintenance to release time.
 
 ## Future: CI-hosted signing
 


### PR DESCRIPTION
Finalize the 0.6.1 changelog dated 2026-09-02, covering explicit GitHub.com repository selectors, protected PR branch/current-branch reads, and protected merge subjects. Record that this is a CLI-only patch with no Worker deployment or database/schema migration required.

Correct the release guide so future user-visible changes maintain an Unreleased section as they land, instead of deferring changelog updates until release time. This PR changes only CHANGELOG.md and docs/releasing.md; it contains no source, Worker, or schema changes.

Validation: scoped Codex review found no actionable findings; `go test ./cmd/octopool -run 'HostQualified|PRRead|MergeSubject' -count=1` passed (46.202s); `go vet ./...`, documentation formatting, the 13-page docs site build, and `git diff --check` passed.
