### PR TITLE
fix(cli): clarify merge failure routing and quota evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Add opt-in final PR-merge route, policy, child-outcome, and bounded REST-header diagnostics without changing authentication, merge behavior, or retries or attributing historical failures.
+- Identify successful relay `/rate_limit` output as pooled-reader quota rather than native-writer quota or permission proof, preserving JSON stdout and quiet native probes.
+
 ## 0.6.1 - 2026-09-02
 
 ### Fixes

--- a/cmd/octopool/cli_protocol_e2e_test.go
+++ b/cmd/octopool/cli_protocol_e2e_test.go
@@ -408,3 +408,61 @@ func TestGHShimProtocolRewritePolicyDiagnostics(t *testing.T) {
 		})
 	}
 }
+
+func TestCLIMergeDiagnosticsProtocol(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds and executes the CLI binary")
+	}
+	bin := buildCLIBinary(t)
+	for _, enabled := range []string{"", "true", "1"} {
+		t.Run("diagnostics_"+enabled, func(t *testing.T) {
+			var policies atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/v1/pools/maintainers/string-rewrites" {
+					t.Error("merge made an unexpected relay request")
+					w.WriteHeader(400)
+					return
+				}
+				policies.Add(1)
+				_, _ = io.WriteString(w, rewriteActiveTestPolicy)
+			}))
+			defer server.Close()
+			capturePath := captureRewriteGH(t)
+			calls := filepath.Join(t.TempDir(), "child-calls")
+			frame := mergeHeaderFrame(403, 4958)
+			result := runCLI(t, bin, server.URL, map[string]string{
+				"OCTOPOOL_DIAGNOSTICS": enabled, "OCTOPOOL_TEST_REWRITE_STDOUT": frame,
+				"OCTOPOOL_TEST_REWRITE_EXIT": "17", "OCTOPOOL_TEST_REWRITE_CALLS": calls,
+			}, append([]string{"gh"}, mergeDiagnosticArgs()...)...)
+			var exit *exec.ExitError
+			if !errors.As(result.err, &exit) || exit.ExitCode() != 17 || policies.Load() != 2 {
+				t.Fatal("CLI changed native exit or policy count")
+			}
+			data, err := os.ReadFile(calls)
+			if err != nil || string(data) != "child\n" {
+				t.Fatal("CLI launched more than one fake mutation")
+			}
+			capture := readRewriteCapture(t, capturePath)
+			include := false
+			for _, arg := range capture.Args {
+				include = include || arg == ghMergeIncludeFlag
+			}
+			if enabled == "1" {
+				line := mergeDiagnosticLine(t, result.stderr)
+				if result.stdout != "" || !include || !strings.Contains(line, "child_started=true outcome=exited route=rest_put") || !strings.Contains(line, "http_status=403") || !strings.Contains(line, "remaining=4958") {
+					t.Fatal("CLI diagnostic contract changed")
+				}
+				if !strings.HasPrefix(result.stderr, "child stderr\n") {
+					t.Fatal("native stderr changed")
+				}
+			} else if result.stdout != frame || result.stderr != "child stderr\n" || include {
+				t.Fatal("disabled diagnostics changed CLI output")
+			}
+			for path := range capture.Files {
+				if _, err := os.Stat(filepath.Dir(path)); !os.IsNotExist(err) {
+					t.Fatal("CLI left snapshot behind")
+				}
+			}
+		})
+	}
+}

--- a/cmd/octopool/gh.go
+++ b/cmd/octopool/gh.go
@@ -125,10 +125,18 @@ func runGH(ctx context.Context, args []string, stdout io.Writer, stderr io.Write
 		}
 		return err
 	}
+	output := &ghQuotaOutput{Writer: stdout}
+	var relayOutput io.Writer = stdout
+	if request.path == "/rate_limit" {
+		relayOutput = output
+	}
 	if request.paginate {
-		err = relayPaginatedGHAPI(ctx, client, request, stdout)
+		err = relayPaginatedGHAPI(ctx, client, request, relayOutput)
 		if err != nil && shouldRunRealGH(err) {
 			return execRealGHAfterLocalFallback(ctx, args, stdout, stderr, err)
+		}
+		if err == nil && request.path == "/rate_limit" && !output.failed {
+			_, _ = io.WriteString(stderr, ghRelayQuotaNotice)
 		}
 		return err
 	}
@@ -139,5 +147,26 @@ func runGH(ctx context.Context, args []string, stdout io.Writer, stderr io.Write
 		}
 		return err
 	}
-	return writeGHBody(ctx, stdout, envelope, request.jq)
+	if err := writeGHBody(ctx, relayOutput, envelope, request.jq); err != nil {
+		return err
+	}
+	if request.path == "/rate_limit" && !output.failed {
+		_, _ = io.WriteString(stderr, ghRelayQuotaNotice)
+	}
+	return nil
+}
+
+const ghRelayQuotaNotice = "octopool: /rate_limit describes pooled-reader quota, not native-writer quota or permission proof.\n"
+
+// Track even a failed trailing newline or short write that the existing output
+// path ignores, without changing its result or wrapping native fallback output.
+type ghQuotaOutput struct {
+	io.Writer
+	failed bool
+}
+
+func (output *ghQuotaOutput) Write(p []byte) (int, error) {
+	n, err := output.Writer.Write(p)
+	output.failed = output.failed || err != nil || n != len(p)
+	return n, err
 }

--- a/cmd/octopool/gh_fallback.go
+++ b/cmd/octopool/gh_fallback.go
@@ -117,18 +117,30 @@ func execRealGHWithStdinAndEnv(
 	stderr io.Writer,
 	env []string,
 ) error {
+	attempt := time.Now()
 	prepared, err := prepareProtectedGH(ctx, args, stdin)
+	var diagnostic *ghMergeDiagnostic
+	if prepared != nil && prepared.mergeDiagnostics != nil {
+		diagnostic = &ghMergeDiagnostic{attempt: attempt, preparation: prepared.mergeDiagnostics}
+		defer diagnostic.writeTo(stderr)
+	}
 	if err != nil {
 		return err
 	}
 	defer prepared.cleanup()
 	if err := ctx.Err(); err != nil {
+		if diagnostic != nil {
+			diagnostic.outcome = ghMergeCanceledBeforeStart
+		}
 		return err
 	}
 	if len(prepared.preflight) != 0 {
 		if err := execRealGHWithStdinAndEnv(ctx, prepared.preflight, strings.NewReader(""), io.Discard, io.Discard, env); err != nil {
 			return errRewriteBlocked
 		}
+	}
+	if diagnostic != nil {
+		diagnostic.outcome = ghMergeStartFailed
 	}
 	path, err := resolveGHPath(envDefault("OCTOPOOL_GH_PATH", "gh"))
 	if err != nil {
@@ -138,11 +150,41 @@ func execRealGHWithStdinAndEnv(
 	cmd.Stdin = prepared.stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
+	if diagnostic != nil && prepared.mergeDiagnostics.captureHeaders {
+		diagnostic.headers = &ghMergeHeaderCollector{}
+		cmd.Stdout = diagnostic.headers
+	}
 	if prepared.forceGitHubHost {
 		env = envWithGitHubHost(env)
 	}
 	cmd.Env = env
-	if err := cmd.Run(); err != nil {
+	if diagnostic == nil {
+		err = cmd.Run()
+	} else {
+		err = cmd.Start()
+		if err == nil {
+			diagnostic.childStarted = true
+			err = cmd.Wait()
+			diagnostic.outcome = ghMergeSucceeded
+			if cmd.ProcessState != nil {
+				code := cmd.ProcessState.ExitCode()
+				diagnostic.exitCode = &code
+			}
+			if err != nil {
+				diagnostic.outcome = ghMergeWaitFailed
+				var exitErr *exec.ExitError
+				if errors.As(err, &exitErr) {
+					diagnostic.outcome = ghMergeExited
+				}
+				if ctx.Err() != nil {
+					diagnostic.outcome = ghMergeCanceled
+				}
+			}
+		} else if ctx.Err() != nil {
+			diagnostic.outcome = ghMergeCanceledBeforeStart
+		}
+	}
+	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
 			return exitCodeError{Code: exitErr.ExitCode()}

--- a/cmd/octopool/gh_merge_diagnostics.go
+++ b/cmd/octopool/gh_merge_diagnostics.go
@@ -1,0 +1,286 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type ghMergeRoute uint8
+
+const (
+	ghMergeUndetermined ghMergeRoute = iota
+	ghMergeNative
+	ghMergeREST
+)
+
+// Only final preparation owns these facts. A server revision does not identify
+// locally merged rules; captureHeaders marks our generated silent REST request.
+type ghMergePreparation struct {
+	route          ghMergeRoute
+	policyKnown    bool
+	serverRevision int64
+	effectiveRules int
+	captureHeaders bool
+}
+
+func ghMergeDiagnosticsEnabled(args []string) bool {
+	return os.Getenv("OCTOPOOL_DIAGNOSTICS") == "1" && len(args) >= 2 &&
+		args[0] == "pr" && args[1] == "merge" && !rewriteBootstrapInvocation(args)
+}
+
+const ghMergeIncludeFlag = "--include=true"
+
+func ghMergeArgBytes(args []string) int {
+	total := 0
+	for _, arg := range args {
+		total += len(arg)
+	}
+	return total
+}
+
+func ghMergeIncludeAllowed(policy stringRewritePolicy, original, generated []string) bool {
+	// Check the name, semantic value, and exact spelling emitted by the API owner.
+	for _, text := range []string{"--include", "true", ghMergeIncludeFlag} {
+		if policy.checkStructural(text) != nil {
+			return false
+		}
+	}
+	return ghMergeArgBytes(original)+len(ghMergeIncludeFlag) <= rewriteMaxContent &&
+		ghMergeArgBytes(generated)+len(ghMergeIncludeFlag) <= rewriteMaxContent
+}
+
+type ghMergeOutcome uint8
+
+const (
+	ghMergePreparationFailed ghMergeOutcome = iota
+	ghMergeStartFailed
+	ghMergeCanceledBeforeStart
+	ghMergeSucceeded
+	ghMergeExited
+	ghMergeWaitFailed
+	ghMergeCanceled
+)
+
+func (outcome ghMergeOutcome) String() string {
+	switch outcome {
+	case ghMergePreparationFailed:
+		return "preparation_failed"
+	case ghMergeStartFailed:
+		return "start_failed"
+	case ghMergeCanceledBeforeStart:
+		return "canceled_before_start"
+	case ghMergeSucceeded:
+		return "succeeded"
+	case ghMergeExited:
+		return "exited"
+	case ghMergeWaitFailed:
+		return "wait_failed"
+	case ghMergeCanceled:
+		return "canceled"
+	default:
+		return "unknown"
+	}
+}
+
+type ghMergeDiagnostic struct {
+	attempt      time.Time
+	preparation  *ghMergePreparation
+	outcome      ghMergeOutcome
+	childStarted bool
+	exitCode     *int
+	headers      *ghMergeHeaderCollector
+}
+
+func (diagnostic *ghMergeDiagnostic) writeTo(stderr io.Writer) {
+	if stderr == nil {
+		return
+	}
+	var line strings.Builder
+	fmt.Fprintf(&line, "octopool: merge_diagnostics attempt_utc=%s elapsed_ms=%d child_started=%t outcome=%s",
+		diagnostic.attempt.UTC().Format(time.RFC3339Nano), max(0, time.Since(diagnostic.attempt).Milliseconds()),
+		diagnostic.childStarted, diagnostic.outcome)
+	if prepared := diagnostic.preparation; prepared != nil {
+		switch prepared.route {
+		case ghMergeNative:
+			line.WriteString(" route=native")
+		case ghMergeREST:
+			line.WriteString(" route=rest_put")
+		}
+		if prepared.policyKnown && prepared.serverRevision >= 0 && prepared.effectiveRules >= 0 && prepared.effectiveRules <= rewriteMaxRules {
+			fmt.Fprintf(&line, " server_policy_revision=%d effective_rule_count=%d", prepared.serverRevision, prepared.effectiveRules)
+		}
+	}
+	if diagnostic.exitCode != nil {
+		fmt.Fprintf(&line, " exit_code=%d", *diagnostic.exitCode)
+	}
+	if headers, ok := diagnostic.headers.result(); ok {
+		fmt.Fprintf(&line, " headers=available http_status=%d", headers.status)
+		if headers.requestID != "" {
+			fmt.Fprintf(&line, " request_id=%s", headers.requestID)
+		}
+		if headers.resource != "" {
+			fmt.Fprintf(&line, " resource=%s", headers.resource)
+		}
+		for i, name := range ghMergeNumericFields {
+			if value := headers.numbers[i]; value != nil {
+				fmt.Fprintf(&line, " %s=%d", name, *value)
+			}
+		}
+	} else {
+		line.WriteString(" headers=unavailable")
+	}
+	line.WriteByte('\n')
+	// Observability cannot change the native result or cause a second attempt.
+	_, _ = io.WriteString(stderr, line.String())
+}
+
+const (
+	ghMergeHeaderLineLimit  = 4 * 1024
+	ghMergeHeaderBlockLimit = 32 * 1024
+)
+
+var ghMergeStatusLine = regexp.MustCompile(`^HTTP/(?:1\.[01]|2\.0) ([1-5][0-9]{2}) [\x20-\x7e]+$`)
+var ghMergeRequestID = regexp.MustCompile(`^[0-9A-Fa-f]+(?::[0-9A-Fa-f]+)+$`)
+var ghMergeHeaderName = regexp.MustCompile("^[!#$%&'*+.^_`|~0-9A-Za-z-]+$")
+var ghMergeNumericFields = [...]string{"limit", "remaining", "used", "reset", "retry_after"}
+
+// All fields are withheld on any invalid framing or selected value. Nothing in
+// this buffer ever falls through to stdout, including after overflow or EOF.
+type ghMergeHeaders struct {
+	status    int
+	requestID string
+	resource  string
+	numbers   [5]*int64
+}
+
+type ghMergeHeaderCollector struct {
+	line    [ghMergeHeaderLineLimit]byte
+	length  int
+	total   int
+	started bool
+	done    bool
+	invalid bool
+	seen    [7]bool
+	fields  ghMergeHeaders
+}
+
+func (collector *ghMergeHeaderCollector) Write(data []byte) (int, error) {
+	for _, b := range data {
+		if collector.invalid {
+			break
+		}
+		collector.total++
+		if collector.done || collector.total > ghMergeHeaderBlockLimit || collector.length == len(collector.line) {
+			collector.invalid = true
+			break
+		}
+		collector.line[collector.length] = b
+		collector.length++
+		if b == '\n' {
+			collector.readLine(string(collector.line[:collector.length]))
+			collector.length = 0
+		}
+	}
+	// Always drain, even after rejection: a pipe error must not affect a write.
+	return len(data), nil
+}
+
+func (collector *ghMergeHeaderCollector) readLine(line string) {
+	if !collector.started {
+		match := ghMergeStatusLine.FindStringSubmatch(strings.TrimSuffix(line, "\n"))
+		if match == nil {
+			collector.invalid = true
+			return
+		}
+		collector.fields.status, _ = strconv.Atoi(match[1])
+		collector.started = true
+		return
+	}
+	if !strings.HasSuffix(line, "\r\n") {
+		collector.invalid = true
+		return
+	}
+	line = strings.TrimSuffix(line, "\r\n")
+	if line == "" {
+		collector.done = true
+		return
+	}
+	name, value, ok := strings.Cut(line, ": ")
+	// Only the header-name wrapper proven by the opt-in native protocol fixture.
+	if strings.HasPrefix(name, "\x1b[1;34m") && strings.HasSuffix(name, "\x1b[m") {
+		name = strings.TrimSuffix(strings.TrimPrefix(name, "\x1b[1;34m"), "\x1b[m")
+	}
+	if !ok || !ghMergeHeaderName.MatchString(name) {
+		collector.invalid = true
+		return
+	}
+	for _, b := range []byte(value) {
+		if b < 32 || b > 126 {
+			collector.invalid = true
+			return
+		}
+	}
+	index := -1
+	switch strings.ToLower(name) {
+	case "x-ratelimit-limit":
+		index = 0
+	case "x-ratelimit-remaining":
+		index = 1
+	case "x-ratelimit-used":
+		index = 2
+	case "x-ratelimit-reset":
+		index = 3
+	case "retry-after":
+		index = 4
+	case "x-github-request-id":
+		index = 5
+	case "x-ratelimit-resource":
+		index = 6
+	}
+	if index < 0 {
+		return
+	}
+	if collector.seen[index] {
+		collector.invalid = true
+		return
+	}
+	collector.seen[index] = true
+	switch index {
+	case 5:
+		if len(value) > 128 || !ghMergeRequestID.MatchString(value) {
+			collector.invalid = true
+			return
+		}
+		collector.fields.requestID = value
+	case 6:
+		switch value {
+		case "core", "search", "graphql", "integration_manifest", "code_search":
+			collector.fields.resource = value
+		default:
+			collector.invalid = true
+		}
+	default:
+		if len(value) == 0 || len(value) > 19 || !isDigits(value) {
+			collector.invalid = true
+			return
+		}
+		number, err := strconv.ParseInt(value, 10, 64)
+		if err != nil || number < 0 {
+			collector.invalid = true
+			return
+		}
+		collector.fields.numbers[index] = &number
+	}
+}
+
+func (collector *ghMergeHeaderCollector) result() (ghMergeHeaders, bool) {
+	if collector == nil || collector.invalid || !collector.done || collector.length != 0 {
+		return ghMergeHeaders{}, false
+	}
+	return collector.fields, true
+}

--- a/cmd/octopool/gh_merge_diagnostics_process_test.go
+++ b/cmd/octopool/gh_merge_diagnostics_process_test.go
@@ -1,0 +1,509 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func mergeDiagnosticArgs() []string {
+	return []string{"pr", "merge", "7", "--repo=acme/repo", "--squash", "--match-head-commit=" + strings.Repeat("a", 40)}
+}
+
+func mergeDiagnosticLine(t *testing.T, stderr string) string {
+	t.Helper()
+	var found string
+	for _, line := range strings.Split(stderr, "\n") {
+		if strings.HasPrefix(line, "octopool: merge_diagnostics ") {
+			if found != "" {
+				t.Fatal("multiple diagnostics for one child")
+			}
+			found = line
+		}
+	}
+	if found == "" {
+		t.Fatal("missing merge diagnostic")
+	}
+	allowed := strings.Fields("attempt_utc elapsed_ms child_started outcome route server_policy_revision effective_rule_count exit_code headers http_status request_id resource limit remaining used reset retry_after")
+	for _, field := range strings.Fields(found)[2:] {
+		key, value, ok := strings.Cut(field, "=")
+		if !ok || value == "" || !slices.Contains(allowed, key) {
+			t.Fatalf("unexpected diagnostic field %q", field)
+		}
+		if key == "attempt_utc" {
+			if stamp, err := time.Parse(time.RFC3339Nano, value); err != nil || stamp.Location() != time.UTC {
+				t.Fatal("attempt timestamp is not UTC")
+			}
+		}
+	}
+	return found
+}
+
+func assertMergeSnapshot(t *testing.T, capture rewriteCapture, include bool, title, body string) {
+	t.Helper()
+	if len(capture.Files) != 1 || capture.Stdin != "" || capture.Env["GH_HOST"] != "github.com" || capture.Env["GH_REPO"] != "" {
+		t.Fatal("snapshot, stdin, or host pin changed")
+	}
+	for path, data := range capture.Files {
+		want := []string{"api", "repos/acme/repo/pulls/7/merge", "--method=PUT", "--hostname=github.com", "--input=" + path, "--silent=true"}
+		if include {
+			want = append(want, ghMergeIncludeFlag)
+		}
+		if !slices.Equal(capture.Args, want) {
+			t.Fatalf("unexpected generated argv: %q", capture.Args)
+		}
+		var payload map[string]string
+		if err := json.Unmarshal([]byte(data), &payload); err != nil || len(payload) != 4 || payload["sha"] != strings.Repeat("a", 40) || payload["merge_method"] != "squash" || payload["commit_title"] != title || payload["commit_message"] != body {
+			t.Fatal("exact-head squash payload changed")
+		}
+		if capture.Modes[path] != 0600 || capture.DirectoryModes[path] != 0700 {
+			t.Fatal("snapshot privacy changed")
+		}
+		if _, err := os.Stat(filepath.Dir(path)); !os.IsNotExist(err) {
+			t.Fatal("snapshot survived completion")
+		}
+	}
+}
+
+func TestGHMergeDiagnosticsOff(t *testing.T) {
+	for _, enabled := range []string{"", "0", "true", "01", "1 ", " 1"} {
+		for _, active := range []bool{false, true} {
+			t.Run(enabled+"/"+map[bool]string{false: "native", true: "converted"}[active], func(t *testing.T) {
+				policy := rewriteEmptyTestPolicy
+				if active {
+					policy = rewriteActiveTestPolicy
+				}
+				_, policies := rewriteTestServer(t, policy, nil)
+				capturePath := captureRewriteGH(t)
+				t.Setenv("OCTOPOOL_DIAGNOSTICS", enabled)
+				t.Setenv("OCTOPOOL_TEST_REWRITE_EXIT", "17")
+				t.Setenv("GH_HOST", "synthetic.example")
+				t.Setenv("GH_REPO", "synthetic/repo")
+				// Only these explicitly seeded synthetic keys are captured.
+				t.Setenv("OCTOPOOL_TEST_SYNTHETIC_AUTH", "1")
+				for _, key := range []string{"GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"} {
+					t.Setenv(key, "synthetic-"+key)
+				}
+				bodyFile := filepath.Join(t.TempDir(), "body.txt")
+				if err := os.WriteFile(bodyFile, []byte("body"), 0600); err != nil {
+					t.Fatal(err)
+				}
+				args := append(mergeDiagnosticArgs(), "--subject=subject", "--body-file="+bodyFile)
+				var stdout, stderr bytes.Buffer
+				err := execRealGHWithStdin(t.Context(), args, strings.NewReader("body"), &stdout, &stderr)
+				var exit exitCodeError
+				if !errors.As(err, &exit) || exit.Code != 17 || stdout.String() != "child stdout\n" || stderr.String() != "child stderr\n" || policies.Load() != 1 {
+					t.Fatal("disabled diagnostics changed streams, exit, or policy reads")
+				}
+				capture := readRewriteCapture(t, capturePath)
+				for _, key := range []string{"GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"} {
+					if capture.Env[key] != "synthetic-"+key {
+						t.Fatal("synthetic child auth changed")
+					}
+				}
+				if active {
+					assertMergeSnapshot(t, capture, false, "subject", "body")
+				} else if !slices.Equal(args, capture.Args) || capture.Stdin != "body" || capture.Env["GH_HOST"] != "synthetic.example" || capture.Env["GH_REPO"] != "synthetic/repo" {
+					t.Fatal("native dispatch changed")
+				}
+			})
+		}
+	}
+}
+
+func TestGHMergeDiagnosticsFinalPolicy(t *testing.T) {
+	active := strings.Replace(rewriteActiveTestPolicy, `"revision":1`, `"revision":22`, 1)
+	empty := strings.Replace(rewriteEmptyTestPolicy, `"revision":1`, `"revision":33`, 1)
+	for _, test := range []struct {
+		name, first, final, want string
+		failure                  int
+	}{
+		{"active_to_empty", active, empty, "route=native server_policy_revision=33 effective_rule_count=0", 0},
+		{"empty_to_active", empty, active, "route=rest_put server_policy_revision=22 effective_rule_count=1", 0},
+		{"final_load_failure", active, "", "outcome=preparation_failed", 403},
+		{"final_structural_denial", empty, strings.Replace(active, "internal-model", "acme", 1), "outcome=preparation_failed", 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			policies := rewriteTestServerPolicySequence(t, func(n int64) (string, int) {
+				if n == 1 {
+					return test.first, 200
+				}
+				if n != 2 {
+					t.Error("unexpected extra policy request")
+				}
+				if test.failure != 0 {
+					return "", test.failure
+				}
+				return test.final, 200
+			}, nil)
+			capturePath := captureRewriteGH(t)
+			t.Setenv("OCTOPOOL_DIAGNOSTICS", "1")
+			t.Setenv("OCTOPOOL_TEST_REWRITE_STDOUT", mergeHeaderFrame(403, 4958))
+			var stdout, stderr bytes.Buffer
+			args := mergeDiagnosticArgs()
+			original := slices.Clone(args)
+			err := runGH(t.Context(), args, &stdout, &stderr)
+			line := mergeDiagnosticLine(t, stderr.String())
+			if !strings.Contains(line, test.want) || policies.Load() != 2 || !slices.Equal(args, original) {
+				t.Fatalf("final policy facts/count/argv incorrect: %s", line)
+			}
+			if strings.Contains(test.name, "failure") || strings.Contains(test.name, "denial") {
+				if err == nil || stdout.Len() != 0 || strings.Contains(line, "route=") || !strings.Contains(line, "child_started=false") {
+					t.Fatal("failed preparation claimed a dispatched child")
+				}
+				if test.failure != 0 && strings.Contains(line, "server_policy_revision=") {
+					t.Fatal("stale policy attributed on load failure")
+				}
+				if _, err := os.Stat(capturePath); !os.IsNotExist(err) {
+					t.Fatal("final failure launched child")
+				}
+				return
+			}
+			if err != nil || !strings.HasPrefix(stderr.String(), "child stderr\n") || !strings.Contains(line, "child_started=true outcome=succeeded") {
+				t.Fatal("child outcome changed")
+			}
+			capture := readRewriteCapture(t, capturePath)
+			if test.final == empty {
+				if !slices.Equal(capture.Args, args) || stdout.String() != mergeHeaderFrame(403, 4958) || strings.Contains(line, "http_status=") {
+					t.Fatal("native stream intercepted or guessed HTTP attribution")
+				}
+			} else if stdout.Len() != 0 || !slices.Contains(capture.Args, ghMergeIncludeFlag) || !strings.Contains(line, "http_status=403") {
+				t.Fatal("converted metadata was not captured")
+			}
+		})
+	}
+}
+
+type onceMergeReader struct {
+	read   bool
+	cancel context.CancelFunc
+}
+
+func (reader *onceMergeReader) Read(p []byte) (int, error) {
+	if reader.read {
+		return 0, errors.New("source reread sentinel")
+	}
+	reader.read = true
+	if reader.cancel != nil {
+		reader.cancel()
+	}
+	return copy(p, "body-private-sentinel"), io.EOF
+}
+
+type mergeDiagnosticWriter struct {
+	buffer           bytes.Buffer
+	rejectDiagnostic bool
+	rejectNative     bool
+}
+
+var errMergeWriter = errors.New("writer-private-sentinel")
+
+func (writer *mergeDiagnosticWriter) Write(p []byte) (int, error) {
+	if (writer.rejectDiagnostic && bytes.HasPrefix(p, []byte("octopool: merge_diagnostics"))) ||
+		(writer.rejectNative && bytes.Equal(p, []byte("child stderr\n"))) {
+		return 0, errMergeWriter
+	}
+	return writer.buffer.Write(p)
+}
+
+func (writer *mergeDiagnosticWriter) String() string { return writer.buffer.String() }
+
+func (writer *mergeDiagnosticWriter) WriteString(s string) (int, error) {
+	return writer.Write([]byte(s))
+}
+
+func TestGHMergeDiagnosticsConvertedOnce(t *testing.T) {
+	for _, test := range []struct {
+		name, frame string
+		exit        string
+		writerError bool
+	}{
+		{"success", mergeHeaderFrame(200, 4958), "0", false},
+		{"forbidden_zero", mergeHeaderFrame(403, 0), "1", false},
+		{"forbidden_positive", mergeHeaderFrame(403, 4958), "1", false},
+		{"throttled", mergeHeaderFrame(429, 0), "1", false},
+		{"malformed", mergeHeaderFrame(403, 0) + "body-private-sentinel", "1", false},
+		{"diagnostic_writer_failure_success", mergeHeaderFrame(200, 4958), "0", true},
+		{"diagnostic_writer_failure_exit", mergeHeaderFrame(403, 0), "17", true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, policies := rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+			capturePath := captureRewriteGH(t)
+			calls := filepath.Join(t.TempDir(), "calls")
+			t.Setenv("OCTOPOOL_TEST_REWRITE_CALLS", calls)
+			t.Setenv("OCTOPOOL_TEST_REWRITE_STDOUT", test.frame)
+			t.Setenv("OCTOPOOL_TEST_REWRITE_EXIT", test.exit)
+			t.Setenv("OCTOPOOL_DIAGNOSTICS", "1")
+			t.Setenv("GH_HOST", "host-private-sentinel")
+			t.Setenv("GH_REPO", "repo-private-sentinel")
+			t.Setenv("OCTOPOOL_TEST_SYNTHETIC_AUTH", "1")
+			for _, key := range []string{"GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"} {
+				t.Setenv(key, "synthetic-"+key)
+			}
+			reader := &onceMergeReader{}
+			var stdout bytes.Buffer
+			stderr := &mergeDiagnosticWriter{rejectDiagnostic: test.writerError}
+			err := execRealGHWithStdin(t.Context(), append(mergeDiagnosticArgs(), "--subject=title-private-sentinel", "--body-file=-"), reader, &stdout, stderr)
+			var exit exitCodeError
+			if test.exit == "0" {
+				if err != nil {
+					t.Fatal("diagnostics altered success")
+				}
+			} else if !errors.As(err, &exit) || test.exit != strconv.Itoa(exit.Code) {
+				t.Fatal("diagnostics altered native exit")
+			}
+			data, readErr := os.ReadFile(calls)
+			if readErr != nil || string(data) != "child\n" || policies.Load() != 1 || stdout.Len() != 0 {
+				t.Fatal("extra child/policy/output or retry")
+			}
+			capture := readRewriteCapture(t, capturePath)
+			assertMergeSnapshot(t, capture, true, "title-private-sentinel", "body-private-sentinel")
+			for _, key := range []string{"GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"} {
+				if capture.Env[key] != "synthetic-"+key {
+					t.Fatal("diagnostics changed synthetic child auth")
+				}
+			}
+			if !strings.HasPrefix(stderr.String(), "child stderr\n") {
+				t.Fatal("native stderr changed")
+			}
+			if test.writerError {
+				if stderr.String() != "child stderr\n" {
+					t.Fatal("failed diagnostic writer changed native output")
+				}
+				return
+			}
+			line := mergeDiagnosticLine(t, stderr.String())
+			for _, sentinel := range []string{"private-sentinel", "acme", "pulls", strings.Repeat("a", 40), "--input", capturePath} {
+				if strings.Contains(line, sentinel) {
+					t.Fatal("private material reached added diagnostic")
+				}
+			}
+			if test.name == "malformed" {
+				if !strings.Contains(line, "headers=unavailable") || strings.Contains(line, "http_status=") {
+					t.Fatal("body spoof retained fields")
+				}
+			} else if !strings.Contains(line, "headers=available") || !strings.Contains(line, "resource=core") {
+				t.Fatal("valid metadata missing")
+			}
+		})
+	}
+}
+
+func TestGHMergeDiagnosticsIncludeDenial(t *testing.T) {
+	for _, pattern := range []string{"^--include$", "^--include=true$", "^true$"} {
+		t.Run(pattern, func(t *testing.T) {
+			policy := strings.Replace(rewriteActiveTestPolicy, "internal-model", pattern, 1)
+			_, policies := rewriteTestServer(t, policy, nil)
+			capturePath := captureRewriteGH(t)
+			t.Setenv("OCTOPOOL_DIAGNOSTICS", "1")
+			var stdout, stderr bytes.Buffer
+			err := execRealGHWithStdin(t.Context(), append(mergeDiagnosticArgs(), "--subject=subject", "--body-file=-"), &onceMergeReader{}, &stdout, &stderr)
+			if err != nil || policies.Load() != 1 || stdout.String() != "child stdout\n" {
+				t.Fatal("optional include denial blocked or altered valid merge")
+			}
+			assertMergeSnapshot(t, readRewriteCapture(t, capturePath), false, "subject", "body-private-sentinel")
+			if !strings.Contains(mergeDiagnosticLine(t, stderr.String()), "headers=unavailable") {
+				t.Fatal("denied include claimed headers")
+			}
+		})
+	}
+}
+
+func TestGHMergeDiagnosticsLocalRules(t *testing.T) {
+	_, policies := rewriteTestServer(t, rewriteEmptyTestPolicy, nil)
+	captureRewriteGH(t)
+	file := filepath.Join(t.TempDir(), "synthetic-rules.json")
+	if err := os.WriteFile(file, []byte(`{"schema_version":1,"rules":[{"pattern":"private-sentinel","replacement":"safe"}]}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("OCTOPOOL_STRING_REWRITE_FILE", file)
+	t.Setenv("OCTOPOOL_DIAGNOSTICS", "1")
+	var stderr bytes.Buffer
+	if err := execRealGHWithStdin(t.Context(), mergeDiagnosticArgs(), strings.NewReader(""), io.Discard, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	line := mergeDiagnosticLine(t, stderr.String())
+	if policies.Load() != 1 || !strings.Contains(line, "route=rest_put server_policy_revision=1 effective_rule_count=1") || strings.Contains(line, file) {
+		t.Fatal("server revision was conflated with effective rules")
+	}
+}
+
+func TestGHMergeDiagnosticsFailures(t *testing.T) {
+	for _, mode := range []string{"resolve", "start", "cancel", "native_stderr_writer", "native_stdout_writer"} {
+		t.Run(mode, func(t *testing.T) {
+			policy := rewriteActiveTestPolicy
+			if mode == "native_stdout_writer" {
+				policy = rewriteEmptyTestPolicy
+			}
+			_, policies := rewriteTestServer(t, policy, nil)
+			capturePath := captureRewriteGH(t)
+			t.Setenv("OCTOPOOL_DIAGNOSTICS", "1")
+			if mode == "resolve" {
+				t.Setenv("OCTOPOOL_GH_PATH", filepath.Join(t.TempDir(), "missing-private-sentinel"))
+			}
+			if mode == "start" {
+				file := filepath.Join(t.TempDir(), "invalid-child")
+				if err := os.WriteFile(file, []byte("not an executable format"), 0700); err != nil {
+					t.Fatal(err)
+				}
+				t.Setenv("OCTOPOOL_GH_PATH", file)
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+			var canceled <-chan struct{}
+			if mode == "cancel" {
+				t.Setenv("OCTOPOOL_TEST_REWRITE_WAIT", "1")
+				done := make(chan struct{})
+				canceled = done
+				go func() {
+					defer close(done)
+					ticker := time.NewTicker(5 * time.Millisecond)
+					defer ticker.Stop()
+					for {
+						select {
+						case <-ctx.Done():
+							return
+						case <-ticker.C:
+							if data, err := os.ReadFile(capturePath); err == nil && json.Valid(data) {
+								cancel()
+								return
+							}
+						}
+					}
+				}()
+			}
+			stderr := &mergeDiagnosticWriter{rejectNative: mode == "native_stderr_writer"}
+			var stdout io.Writer = io.Discard
+			if mode == "native_stdout_writer" {
+				stdout = mergeFailWriter{}
+			}
+			snapshotRoot := t.TempDir()
+			t.Setenv("TMPDIR", snapshotRoot)
+			args := mergeDiagnosticArgs()
+			if mode != "native_stdout_writer" {
+				args = append(args, "--subject=subject", "--body-file=-")
+			}
+			err := execRealGHWithStdin(ctx, args, strings.NewReader("body"), stdout, stderr)
+			if canceled != nil {
+				<-canceled
+			}
+			if entries, err := os.ReadDir(snapshotRoot); err != nil || len(entries) != 0 {
+				t.Fatal("failed dispatch left a snapshot directory")
+			}
+			if err == nil || policies.Load() != 1 {
+				t.Fatal("failure lost or repeated policy request")
+			}
+			line := mergeDiagnosticLine(t, stderr.String())
+			if mode == "resolve" || mode == "start" {
+				if !strings.Contains(line, "child_started=false outcome=start_failed") || strings.Contains(line, "exit_code=") {
+					t.Fatal("launch failure attributed to executed child")
+				}
+				if _, err := os.Stat(capturePath); !os.IsNotExist(err) {
+					t.Fatal("start failure executed child")
+				}
+			} else {
+				want := "outcome=wait_failed"
+				if mode == "cancel" {
+					want = "outcome=canceled"
+				} else if !errors.Is(err, errMergeWriter) {
+					t.Fatal("native writer error changed")
+				}
+				if !strings.Contains(line, "child_started=true") || !strings.Contains(line, want) {
+					t.Fatalf("completion outcome incorrect: %s", line)
+				}
+				if mode != "native_stdout_writer" {
+					assertMergeSnapshot(t, readRewriteCapture(t, capturePath), true, "subject", "body")
+				}
+			}
+			if strings.Contains(line, "private-sentinel") {
+				t.Fatal("raw failure leaked into diagnostic")
+			}
+		})
+	}
+}
+
+type mergeFailWriter struct{}
+
+func (mergeFailWriter) Write([]byte) (int, error) { return 0, errMergeWriter }
+
+func TestGHMergeDiagnosticsUnrelated(t *testing.T) {
+	for _, args := range [][]string{
+		{"api", "user", "--include"},
+		{"api", "repos/acme/repo/pulls/7/merge", "--method=PUT", "--raw-field=sha=" + strings.Repeat("a", 40), "--raw-field=merge_method=squash", "--silent", "--include"},
+		{"api", "repos/acme/repo/issues", "--paginate"},
+		{"pr", "merge", "--help"},
+		{"pr", "view", "7", "--repo=acme/repo", "--json=number"},
+	} {
+		t.Run(strings.Join(args[:2], "_"), func(t *testing.T) {
+			rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+			capturePath := captureRewriteGH(t)
+			t.Setenv("OCTOPOOL_DIAGNOSTICS", "1")
+			frame := mergeHeaderFrame(200, 4958)
+			t.Setenv("OCTOPOOL_TEST_REWRITE_STDOUT", frame)
+			var stdout, stderr bytes.Buffer
+			if err := execRealGHWithStdin(t.Context(), args, strings.NewReader(""), &stdout, &stderr); err != nil {
+				t.Fatal(err)
+			}
+			if stdout.String() != frame || stderr.String() != "child stderr\n" {
+				t.Fatal("unrelated/native-owned output intercepted")
+			}
+			capture := readRewriteCapture(t, capturePath)
+			if slices.Contains(args, "--include") != slices.Contains(capture.Args, ghMergeIncludeFlag) {
+				t.Fatal("include ownership changed")
+			}
+		})
+	}
+}
+
+func TestGHMergeDiagnosticsCanceledPreparation(t *testing.T) {
+	policies := rewriteTestServerPolicySequence(t, func(int64) (string, int) { return rewriteActiveTestPolicy, http.StatusOK }, nil)
+	capturePath := captureRewriteGH(t)
+	t.Setenv("OCTOPOOL_DIAGNOSTICS", "1")
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	var stderr bytes.Buffer
+	if err := execRealGHWithStdin(ctx, mergeDiagnosticArgs(), strings.NewReader(""), io.Discard, &stderr); err == nil {
+		t.Fatal("canceled preparation succeeded")
+	}
+	line := mergeDiagnosticLine(t, stderr.String())
+	if policies.Load() != 0 || !strings.Contains(line, "child_started=false outcome=preparation_failed") {
+		t.Fatal("canceled preparation attributed to child")
+	}
+	if _, err := os.Stat(capturePath); !os.IsNotExist(err) {
+		t.Fatal("canceled preparation launched child")
+	}
+}
+
+func TestGHMergeDiagnosticsCanceledBeforeStart(t *testing.T) {
+	_, policies := rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	capturePath := captureRewriteGH(t)
+	t.Setenv("OCTOPOOL_DIAGNOSTICS", "1")
+	snapshotRoot := t.TempDir()
+	t.Setenv("TMPDIR", snapshotRoot)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	var stderr bytes.Buffer
+	err := execRealGHWithStdin(ctx, append(mergeDiagnosticArgs(), "--body-file=-"), &onceMergeReader{cancel: cancel}, io.Discard, &stderr)
+	if !errors.Is(err, context.Canceled) || policies.Load() != 1 {
+		t.Fatal("cancellation after preparation lost")
+	}
+	if !strings.Contains(mergeDiagnosticLine(t, stderr.String()), "child_started=false outcome=canceled_before_start") {
+		t.Fatal("pre-start cancellation attributed to executed child")
+	}
+	if entries, err := os.ReadDir(snapshotRoot); err != nil || len(entries) != 0 {
+		t.Fatal("canceled start left a snapshot")
+	}
+	if _, err := os.Stat(capturePath); !os.IsNotExist(err) {
+		t.Fatal("canceled start launched a child")
+	}
+}

--- a/cmd/octopool/gh_merge_diagnostics_test.go
+++ b/cmd/octopool/gh_merge_diagnostics_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func mergeHeaderFrame(code, remaining int) string {
+	return fmt.Sprintf("HTTP/1.1 %d Synthetic\nX-Github-Request-Id: ABCD:1234:5678:90EF\r\nX-Ratelimit-Resource: core\r\nX-Ratelimit-Limit: 5000\r\nX-Ratelimit-Remaining: %d\r\nX-Ratelimit-Used: 42\r\nX-Ratelimit-Reset: 1788523200\r\nRetry-After: 60\r\n\r\n", code, remaining)
+}
+
+func TestGHMergeHeaderCollector(t *testing.T) {
+	base := mergeHeaderFrame(403, 0)
+	field := func(value string) string { return strings.Replace(base, "Remaining: 0", "Remaining: "+value, 1) }
+	add := func(header string) string { return strings.TrimSuffix(base, "\r\n") + header + "\r\n\r\n" }
+	color := strings.ReplaceAll(base, "X-Ratelimit-Remaining:", "\x1b[1;34mX-Ratelimit-Remaining\x1b[m:")
+	for _, test := range []struct {
+		name, frame string
+		valid       bool
+	}{
+		{"success", mergeHeaderFrame(200, 4958), true},
+		{"forbidden_zero", base, true},
+		{"forbidden_positive", mergeHeaderFrame(403, 4958), true},
+		{"throttled", mergeHeaderFrame(429, 0), true},
+		{"missing_optional", "HTTP/1.1 200 OK\n\r\n", true},
+		{"http2_status", strings.Replace(base, "HTTP/1.1", "HTTP/2.0", 1), true},
+		{"unknown_header", add("X-Unknown: secret-sentinel"), true},
+		{"ansi_name", color, true},
+		{"maximum_integer", field("9223372036854775807"), true},
+		{"empty", "", false},
+		{"truncated", strings.TrimSuffix(base, "\r\n"), false},
+		{"partial_header", "HTTP/1.1 200 OK\nX-Github-Request-Id: ABCD:1234", false},
+		{"lf_header", strings.ReplaceAll(base, "\r\n", "\n"), false},
+		{"crlf_status", strings.Replace(base, "Synthetic\n", "Synthetic\r\n", 1), false},
+		{"bad_status", strings.Replace(base, "403", "999", 1), false},
+		{"unknown_protocol", strings.Replace(base, "HTTP/1.1", "HTTP/3.0", 1), false},
+		{"negative", field("-1"), false},
+		{"positive_sign", field("+1"), false},
+		{"decimal", field("1.5"), false},
+		{"overflow", field("9223372036854775808"), false},
+		{"too_many_digits", field(strings.Repeat("0", 20)), false},
+		{"empty_numeric", field(""), false},
+		{"space_numeric", field("0 "), false},
+		{"duplicate_numeric", add("x-ratelimit-remaining: 0"), false},
+		{"joined_numeric", field("0, 0"), false},
+		{"duplicate_id", add("X-Github-Request-Id: ABCD:1234"), false},
+		{"duplicate_resource", add("X-Ratelimit-Resource: core"), false},
+		{"joined_id", strings.Replace(base, "ABCD:1234:5678:90EF", "ABCD:1234,ABCD:1234", 1), false},
+		{"bad_id", strings.Replace(base, "ABCD:1234:5678:90EF", "private-sentinel", 1), false},
+		{"long_id", strings.Replace(base, "ABCD:1234:5678:90EF", strings.Repeat("A", 128)+":B", 1), false},
+		{"bad_resource", strings.Replace(base, "Resource: core", "Resource: private-sentinel", 1), false},
+		{"joined_resource", strings.Replace(base, "Resource: core", "Resource: core, core", 1), false},
+		{"date_retry_after", strings.Replace(base, "Retry-After: 60", "Retry-After: Wed, 01 Jan 2025 00:00:00 GMT", 1), false},
+		{"fold", add(" folded: 0"), false},
+		{"no_space", add("X-Foo:value"), false},
+		{"bad_name", add("X Foo: value"), false},
+		{"nul", add("X-Foo: value\x00"), false},
+		{"tab", field("\t0"), false},
+		{"delete", add("X-Foo: value\x7f"), false},
+		{"unicode", add("X-Foo: 日本"), false},
+		{"escape_value", field("\x1b[31m0\x1b[m"), false},
+		{"wrong_ansi", strings.Replace(color, "[1;34m", "[1m", 1), false},
+		{"wrong_reset", strings.Replace(color, "\x1b[m", "\x1b[0m", 1), false},
+		{"ansi_status", "\x1b[1;34m" + base, false},
+		{"body", base + `{"private":"sentinel"}`, false},
+		{"body_spoof", base + "X-Ratelimit-Remaining: 0\r\n", false},
+		{"multiple_frames", base + base, false},
+		{"leading_body", "secret-sentinel\n" + base, false},
+		{"extra_blank", base + "\r\n", false},
+		{"oversize_line", add("X-Pad: " + strings.Repeat("x", ghMergeHeaderLineLimit)), false},
+		{"oversize_block", strings.TrimSuffix(base, "\r\n") + strings.Repeat("X-Pad: "+strings.Repeat("x", 4000)+"\r\n", 9) + "\r\n", false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			for _, fragment := range []int{1, 7, 4096, len(test.frame) + 1} {
+				collector := &ghMergeHeaderCollector{}
+				for pos := 0; pos < len(test.frame); pos += fragment {
+					part := test.frame[pos:min(pos+fragment, len(test.frame))]
+					if n, err := io.WriteString(collector, part); err != nil || n != len(part) {
+						t.Fatal("collector must always drain")
+					}
+				}
+				headers, ok := collector.result()
+				if ok != test.valid {
+					t.Fatalf("valid=%t want=%t fragment=%d", ok, test.valid, fragment)
+				}
+				if !ok && (headers != ghMergeHeaders{}) {
+					t.Fatal("invalid block salvaged fields")
+				}
+				var output bytes.Buffer
+				(&ghMergeDiagnostic{attempt: time.Now(), headers: collector}).writeTo(&output)
+				if strings.Contains(output.String(), "sentinel") || strings.Contains(output.String(), "\x1b") {
+					t.Fatal("raw output reached diagnostics")
+				}
+				if !ok && strings.Contains(output.String(), "http_status=") {
+					t.Fatal("invalid block emitted claims")
+				}
+			}
+		})
+	}
+}
+
+func TestGHMergeHeaderBounds(t *testing.T) {
+	// Limits include the newline bytes; exactly-full frames remain accepted.
+	status := "HTTP/1.1 200 OK\n"
+	for _, target := range []int{ghMergeHeaderLineLimit, ghMergeHeaderBlockLimit} {
+		frame := status
+		for len(frame)+2 < target {
+			n := min(ghMergeHeaderLineLimit, target-len(frame)-2)
+			frame += "X: " + strings.Repeat("x", n-5) + "\r\n"
+		}
+		frame += "\r\n"
+		collector := &ghMergeHeaderCollector{}
+		_, _ = io.WriteString(collector, frame)
+		if _, ok := collector.result(); !ok || len(frame) != target {
+			t.Fatalf("exact bound rejected: %d", target)
+		}
+		if n, err := io.WriteString(collector, strings.Repeat("x", 100000)); n != 100000 || err != nil {
+			t.Fatal("overflow stopped drain")
+		}
+		if _, ok := collector.result(); ok {
+			t.Fatal("trailing bytes preserved metadata")
+		}
+	}
+}
+
+func TestGHMergeIncludePolicyAndBudget(t *testing.T) {
+	for _, pattern := range []string{"^--include$", "^--include=true$", "^true$"} {
+		if ghMergeIncludeAllowed(testRewritePolicy(t, stringRewriteRule{pattern, "safe"}), []string{"pr", "merge"}, []string{"api"}) {
+			t.Fatalf("generated spelling bypassed policy %q", pattern)
+		}
+	}
+	policy := testRewritePolicy(t, stringRewriteRule{"private-sentinel", "safe"})
+	for _, n := range []int{rewriteMaxContent - len(ghMergeIncludeFlag), rewriteMaxContent - len(ghMergeIncludeFlag) + 1} {
+		args := []string{strings.Repeat("x", n)}
+		want := n+len(ghMergeIncludeFlag) <= rewriteMaxContent
+		if ghMergeIncludeAllowed(policy, args, nil) != want || ghMergeIncludeAllowed(policy, nil, args) != want {
+			t.Fatal("generated flag byte budget incorrect")
+		}
+	}
+}
+
+func TestGHMergeIncludeFinalBudget(t *testing.T) {
+	policy := testRewritePolicy(t, stringRewriteRule{"private-sentinel", "safe"})
+	for _, remaining := range []int{0, len(ghMergeIncludeFlag) - 1, len(ghMergeIncludeFlag)} {
+		prepared := &rewritePreparation{ctx: t.Context(), outputBytes: rewriteMaxContent - remaining, mergeDiagnostics: &ghMergePreparation{}}
+		defer prepared.cleanup()
+		if err := prepareRewritePRLifecycle(policy, mergeDiagnosticArgs(), strings.NewReader(""), prepared); err != nil {
+			t.Fatal("instrumentation budget rejected otherwise valid preparation")
+		}
+		want := remaining == len(ghMergeIncludeFlag)
+		if prepared.mergeDiagnostics.captureHeaders != want || strings.Contains(strings.Join(prepared.args, " "), ghMergeIncludeFlag) != want {
+			t.Fatal("final include budget not honored")
+		}
+		if prepared.outputBytes > rewriteMaxContent {
+			t.Fatal("generated flag exceeded final budget")
+		}
+	}
+	collector := &ghMergeHeaderCollector{}
+	_, _ = io.WriteString(collector, "HTTP/1.1 200 OK\nX: "+strings.Repeat("x", ghMergeHeaderLineLimit-5)+"\r\n\r\n")
+	if _, ok := collector.result(); !ok {
+		t.Fatal("exactly 4 KiB header line rejected")
+	}
+}

--- a/cmd/octopool/gh_native_protocol_test.go
+++ b/cmd/octopool/gh_native_protocol_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Deliberately opt-in: ordinary tests must never discover or run an installed gh.
+func TestNativeGHMergeHeaderProtocol(t *testing.T) {
+	bin := os.Getenv("OCTOPOOL_TEST_NATIVE_GH")
+	if bin == "" {
+		t.Skip("set OCTOPOOL_TEST_NATIVE_GH to an explicit native test binary")
+	}
+	if !filepath.IsAbs(bin) {
+		t.Fatal("native test binary must be absolute")
+	}
+	for _, code := range []int{200, 403} {
+		for _, color := range []bool{false, true} {
+			t.Run(fmt.Sprintf("status_%d_color_%t", code, color), func(t *testing.T) {
+				const body = `{"message":"synthetic response"}`
+				var calls atomic.Int32
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					calls.Add(1)
+					if r.URL.Path != "/synthetic" || r.Method != "PUT" {
+						t.Error("unexpected synthetic request shape")
+					}
+					w.Header().Set("Content-Type", "application/json")
+					w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+					w.Header().Set("Date", "Wed, 01 Jan 2025 00:00:00 GMT")
+					w.Header().Set("X-Github-Request-Id", "ABCD:1234:5678:90EF")
+					w.Header().Set("X-Ratelimit-Remaining", "0")
+					w.WriteHeader(code)
+					_, _ = w.Write([]byte(body))
+				}))
+				defer server.Close()
+				if !strings.HasPrefix(server.URL, "http://127.0.0.1:") {
+					t.Fatal("fixture must use literal IPv4 loopback")
+				}
+				home := t.TempDir()
+				// No inherited environment, credential helpers, config, proxy, or tracing.
+				env := []string{
+					"HOME=" + home, "XDG_CONFIG_HOME=" + home, "GH_CONFIG_DIR=" + home,
+					"XDG_CACHE_HOME=" + home, "XDG_DATA_HOME=" + home, "TMPDIR=" + home,
+					"GH_TOKEN=synthetic", "GH_ENTERPRISE_TOKEN=synthetic", "GH_HOST=github.com",
+					"GH_NO_UPDATE_NOTIFIER=1", "GH_NO_EXTENSION_UPDATE_NOTIFIER=1",
+					"GH_PROMPT_DISABLED=1", "GH_PAGER=cat", "TERM=dumb",
+				}
+				if color {
+					env = append(env, "CLICOLOR_FORCE=1", "GH_FORCE_TTY=80")
+				} else {
+					env = append(env, "NO_COLOR=1")
+				}
+				run := func(include bool) (string, string, int) {
+					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+					defer cancel()
+					args := []string{"api", server.URL + "/synthetic", "--method=PUT", "--input=-", "--silent=true"}
+					if include {
+						args = append(args, "--include=true")
+					}
+					cmd := exec.CommandContext(ctx, bin, args...)
+					cmd.Env, cmd.Dir, cmd.Stdin = env, home, strings.NewReader(`{"synthetic":true}`)
+					var stdout, stderr bytes.Buffer
+					cmd.Stdout, cmd.Stderr = &stdout, &stderr
+					before := calls.Load()
+					err := cmd.Run()
+					if cmd.ProcessState == nil || ctx.Err() != nil {
+						t.Fatal("native fixture did not complete")
+					}
+					exit := cmd.ProcessState.ExitCode()
+					if (err != nil) != (exit != 0) || calls.Load()-before != 1 {
+						t.Fatal("expected exactly one completed loopback request")
+					}
+					return stdout.String(), stderr.String(), exit
+				}
+				plainOut, plainErr, plainExit := run(false)
+				includedOut, includedErr, includedExit := run(true)
+				wantExit := 0
+				if code == 403 {
+					wantExit = 1
+				}
+				if plainOut != "" || plainErr != includedErr || plainExit != wantExit || includedExit != wantExit {
+					t.Fatal("silent stdout, native stderr, or exit contract changed")
+				}
+				name := func(s string) string {
+					if color {
+						return "\x1b[1;34m" + s + "\x1b[m"
+					}
+					return s
+				}
+				want := fmt.Sprintf("HTTP/1.1 %d %s\n", code, http.StatusText(code))
+				for _, field := range [][2]string{
+					{"Content-Length", strconv.Itoa(len(body))}, {"Content-Type", "application/json"},
+					{"Date", "Wed, 01 Jan 2025 00:00:00 GMT"}, {"X-Github-Request-Id", "ABCD:1234:5678:90EF"},
+					{"X-Ratelimit-Remaining", "0"},
+				} {
+					want += name(field[0]) + ": " + field[1] + "\r\n"
+				}
+				want += "\r\n"
+				if includedOut != want {
+					t.Fatalf("synthetic header framing mismatch: got %q want %q", includedOut, want)
+				}
+				collector := &ghMergeHeaderCollector{}
+				for _, b := range []byte(includedOut) {
+					_, _ = collector.Write([]byte{b})
+				}
+				if fields, ok := collector.result(); !ok || fields.status != code || fields.requestID != "ABCD:1234:5678:90EF" || fields.numbers[1] == nil || *fields.numbers[1] != 0 {
+					t.Fatal("collector rejected proven native frame")
+				}
+				t.Log("one request per mode; exact header-only frame; native stderr and exit preserved")
+			})
+		}
+	}
+}

--- a/cmd/octopool/gh_quota_notice_test.go
+++ b/cmd/octopool/gh_quota_notice_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+type quotaNoticeWriter struct {
+	bytes.Buffer
+	stdout *bytes.Buffer
+	t      *testing.T
+}
+
+func (writer *quotaNoticeWriter) Write(p []byte) (int, error) {
+	if bytes.Contains(p, []byte(ghRelayQuotaNotice)) && writer.stdout.String() != "{\"remaining\":42}\n" {
+		writer.t.Error("quota notice preceded successful body output")
+	}
+	return writer.Buffer.Write(p)
+}
+func (writer *quotaNoticeWriter) WriteString(s string) (int, error) { return writer.Write([]byte(s)) }
+
+func TestGHRelayQuotaNotice(t *testing.T) {
+	for _, mode := range []string{"success", "leading_slash", "paginate", "pagination_fallback", "output_failure", "newline_failure", "short_write", "github_error", "relay_error", "fallback", "native_include", "other_path"} {
+		t.Run(mode, func(t *testing.T) {
+			data := 0
+			rewriteTestServer(t, rewriteEmptyTestPolicy, func(w http.ResponseWriter, r *http.Request) {
+				data++
+				switch mode {
+				case "relay_error":
+					w.WriteHeader(401)
+				case "fallback":
+					writeCLIFallback(t, w, "unsupported_route")
+				case "github_error":
+					writeRawCLIEnvelope(t, w, 403, "json", map[string]any{"message": "synthetic failure"})
+				case "paginate":
+					_ = json.NewEncoder(w).Encode(relayEnvelope{Status: 200, Body: json.RawMessage(`{"remaining":42}`), BodyEncoding: "json", Headers: map[string]string{"link": ""}})
+				default:
+					writeCLIEnvelope(t, w, map[string]any{"remaining": 42})
+				}
+			})
+			capturePath := captureRewriteGH(t)
+			t.Setenv("OCTOPOOL_NO_FALLBACK", "")
+			args := []string{"api", "rate_limit"}
+			if mode == "leading_slash" {
+				args[1] = "/rate_limit"
+			}
+			if mode == "other_path" {
+				args[1] = "user"
+			}
+			if mode == "native_include" {
+				args = append(args, "--include")
+			}
+			if mode == "paginate" || mode == "pagination_fallback" {
+				args = append(args, "--paginate")
+			}
+			var stdout bytes.Buffer
+			stderr := &quotaNoticeWriter{stdout: &stdout, t: t}
+			var output io.Writer = &stdout
+			if mode == "output_failure" {
+				output = mergeFailWriter{}
+			}
+			if mode == "newline_failure" || mode == "short_write" {
+				output = quotaEdgeWriter{short: mode == "short_write"}
+			}
+			err := runGH(t.Context(), args, output, stderr)
+			wantNotice := mode == "success" || mode == "leading_slash" || mode == "paginate"
+			if strings.Count(stderr.String(), ghRelayQuotaNotice) != map[bool]int{false: 0, true: 1}[wantNotice] {
+				t.Fatal("quota notice escaped successful relay boundary")
+			}
+			wantError := mode == "output_failure" || mode == "github_error" || mode == "relay_error"
+			if (err != nil) != wantError {
+				t.Fatalf("unexpected result: %v", err)
+			}
+			if wantNotice || mode == "other_path" {
+				if stdout.String() != "{\"remaining\":42}\n" {
+					t.Fatal("relay JSON changed")
+				}
+			}
+			_, childErr := os.Stat(capturePath)
+			wantChild := mode == "fallback" || mode == "native_include" || mode == "pagination_fallback"
+			if (childErr == nil) != wantChild || data != map[bool]int{false: 1, true: 0}[mode == "native_include"] {
+				t.Fatal("quota routing changed")
+			}
+		})
+	}
+}
+
+func TestGHRelayQuotaNoticeSavedLogin(t *testing.T) {
+	isolateTestConfig(t)
+	t.Setenv("OCTOPOOL_STRING_REWRITE_FILE", "")
+	for _, key := range []string{"OCTOPOOL_TOKEN", "OCTOPOOL_URL", "OCTOPOOL_POOL"} {
+		t.Setenv(key, "")
+	}
+	policies, health := 0, 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/pools/maintainers/string-rewrites":
+			policies++
+			_, _ = io.WriteString(w, rewriteEmptyTestPolicy)
+		case "/v1/pools/maintainers/health":
+			health++
+			w.WriteHeader(200)
+		default:
+			t.Error("saved login shortcut made a data request")
+			w.WriteHeader(400)
+		}
+	}))
+	defer server.Close()
+	if err := saveAuth(authFile{URL: server.URL, Pool: "maintainers", Token: "synthetic", Login: "synthetic", CreatedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	capturePath := captureRewriteGH(t)
+	var stdout, stderr bytes.Buffer
+	if err := runGH(t.Context(), []string{"api", "user", "--jq", ".login"}, &stdout, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	if stdout.String() != "synthetic\n" || stderr.Len() != 0 || policies != 1 || health != 1 {
+		t.Fatal("saved login shortcut acquired quota chatter or data reads")
+	}
+	if _, err := os.Stat(capturePath); !os.IsNotExist(err) {
+		t.Fatal("saved login shortcut ran a child")
+	}
+}
+
+type quotaEdgeWriter struct{ short bool }
+
+func (writer quotaEdgeWriter) Write(p []byte) (int, error) {
+	if writer.short {
+		return len(p) - 1, nil
+	}
+	if string(p) == "\n" {
+		return 0, errMergeWriter
+	}
+	return len(p), nil
+}

--- a/cmd/octopool/string_rewrites_args.go
+++ b/cmd/octopool/string_rewrites_args.go
@@ -89,6 +89,7 @@ type rewritePreparation struct {
 	bestEffortSources int
 	forceGitHubHost   bool
 	snapshots         map[string]bool
+	mergeDiagnostics  *ghMergePreparation
 }
 
 func (prepared *rewritePreparation) cleanup() {

--- a/cmd/octopool/string_rewrites_guard.go
+++ b/cmd/octopool/string_rewrites_guard.go
@@ -474,16 +474,27 @@ func rewriteBootstrapHelpTopic(topic []string) bool {
 
 func prepareProtectedGH(ctx context.Context, args []string, stdin io.Reader) (*rewritePreparation, error) {
 	prepared := &rewritePreparation{ctx: ctx, args: args, stdin: stdin}
+	if ghMergeDiagnosticsEnabled(args) {
+		prepared.mergeDiagnostics = &ghMergePreparation{}
+	}
 	if rewriteBootstrapInvocation(args) {
 		prepared.forceGitHubHost = true
 		return prepared, nil
 	}
 	policy, err := currentStringRewritePolicy(ctx)
 	if err != nil {
-		return nil, err
+		return prepared, err
+	}
+	if diagnostic := prepared.mergeDiagnostics; diagnostic != nil {
+		diagnostic.policyKnown = true
+		diagnostic.serverRevision = policy.Revision
+		diagnostic.effectiveRules = len(policy.Rules)
 	}
 	if len(policy.Rules) == 0 {
 		prepared.args = floorGHWatchDelegateArgs(args)
+		if prepared.mergeDiagnostics != nil {
+			prepared.mergeDiagnostics.route = ghMergeNative
+		}
 		return prepared, nil
 	}
 	prepared.forceGitHubHost = true
@@ -491,7 +502,7 @@ func prepareProtectedGH(ctx context.Context, args []string, stdin io.Reader) (*r
 	for _, arg := range args {
 		total += len(arg)
 		if total > rewriteMaxContent {
-			return nil, errRewriteBlocked
+			return prepared, errRewriteBlocked
 		}
 	}
 	switch {
@@ -517,7 +528,7 @@ func prepareProtectedGH(ctx context.Context, args []string, stdin io.Reader) (*r
 	}
 	if err != nil {
 		prepared.cleanup()
-		return nil, errRewriteBlocked
+		return prepared, errRewriteBlocked
 	}
 	return prepared, nil
 }

--- a/cmd/octopool/string_rewrites_pr.go
+++ b/cmd/octopool/string_rewrites_pr.go
@@ -79,7 +79,27 @@ func prepareRewritePRLifecycle(policy stringRewritePolicy, args []string, stdin 
 			// The API owner reads, rewrites, and snapshots the body before dispatch.
 			apiArgs = append(apiArgs, "--field=commit_message=@"+flags.values["--body-file"])
 		}
-		return prepareRewriteAPI(policy, apiArgs, stdin, prepared)
+		capture := prepared.mergeDiagnostics != nil && ghMergeIncludeAllowed(policy, args, apiArgs)
+		if capture {
+			apiArgs = append(apiArgs, ghMergeIncludeFlag)
+		}
+		// One preparation owns every input read and the sole publication snapshot.
+		if err := prepareRewriteAPI(policy, apiArgs, stdin, prepared); err != nil {
+			return err
+		}
+		if diagnostic := prepared.mergeDiagnostics; diagnostic != nil {
+			diagnostic.route = ghMergeREST
+			if capture && (ghMergeArgBytes(prepared.args) > rewriteMaxContent || prepared.outputBytes+len(ghMergeIncludeFlag) > rewriteMaxContent) {
+				// Instrumentation must never reject an otherwise valid merge.
+				prepared.args = prepared.args[:len(prepared.args)-1]
+				capture = false
+			}
+			if capture {
+				prepared.outputBytes += len(ghMergeIncludeFlag)
+			}
+			diagnostic.captureHeaders = capture
+		}
+		return nil
 	}
 	prepared.args = []string{"pr", args[1], flags.positionals[0], "--repo=" + flags.values["--repo"]}
 	for _, flag := range flags.ordered {

--- a/cmd/octopool/string_rewrites_process_test.go
+++ b/cmd/octopool/string_rewrites_process_test.go
@@ -44,6 +44,11 @@ func TestRewriteCaptureProcess(t *testing.T) {
 		}
 	}
 	capture := rewriteCapture{Args: args, Files: map[string]string{}, FileData: map[string][]byte{}, Modes: map[string]uint32{}, DirectoryModes: map[string]uint32{}, Env: map[string]string{"GH_HOST": os.Getenv("GH_HOST"), "GH_REPO": os.Getenv("GH_REPO")}}
+	if os.Getenv("OCTOPOOL_TEST_SYNTHETIC_AUTH") == "1" {
+		for _, name := range []string{"GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"} {
+			capture.Env[name] = os.Getenv(name)
+		}
+	}
 	input, _ := io.ReadAll(os.Stdin)
 	capture.Stdin = string(input)
 	if path := os.Getenv("OCTOPOOL_TEST_REWRITE_MUTATE_FILE"); path != "" {
@@ -105,7 +110,11 @@ func TestRewriteCaptureProcess(t *testing.T) {
 		<-interrupt
 		os.Exit(82)
 	}
-	_, _ = io.WriteString(os.Stdout, "child stdout\n")
+	output, customOutput := os.LookupEnv("OCTOPOOL_TEST_REWRITE_STDOUT")
+	if !customOutput {
+		output = "child stdout\n"
+	}
+	_, _ = io.WriteString(os.Stdout, output)
 	_, _ = io.WriteString(os.Stderr, "child stderr\n")
 	exit, _ := strconv.Atoi(os.Getenv("OCTOPOOL_TEST_REWRITE_EXIT"))
 	os.Exit(exit)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -175,6 +175,62 @@ against Octopool's pool-health endpoint, then prints the saved login without spe
 API or pooled-identity quota. Token/URL overrides, other projections, headers, queries, and
 full user-profile reads retain the normal relay or real-`gh` behavior.
 
+### Quota provenance and merge diagnostics
+
+Bare `gh api rate_limit` is noncacheable but can use a pooled reader. After successful
+relay output, Octopool prints one fixed stderr notice: this is pooled-reader quota, not
+proof of the native writer's quota or permissions. JSON stdout is unchanged. Errors,
+failed output, native fallback, and caller-owned `--include` probes do not get that notice.
+The saved-login shortcut above also stays quiet; a matching login is not a credential or
+quota comparison.
+
+For contemporaneous, read-only native evidence, request headers on an actual resource read:
+
+```sh
+gh api user --include --jq '{login,id}'
+gh api graphql --include -f query='query { viewer { login } rateLimit { limit remaining used resetAt } }'
+```
+
+Included-header probes delegate to native `gh` under the normal outbound policy checks.
+Inspect the response's resource and quota headers alongside its status and request ID.
+An adjacent `/rate_limit` response may disagree with actual REST or GraphQL reads; even
+a later successful resource read cannot explain an earlier write failure or prove that
+the earlier writer had quota or permission. These probes perform no merge.
+
+Set exactly `OCTOPOOL_DIAGNOSTICS=1` to add one fixed-field `merge_diagnostics` stderr
+record at the final `gh pr merge` dispatch boundary. Other values disable it. It reports
+the UTC attempt start, elapsed milliseconds (including final preparation and execution),
+whether the native child started, its outcome and available exit code, and the final
+route: `native` or internally converted `rest_put`. Failed preparation has no dispatched
+route. A known `server_policy_revision` belongs to the server; `effective_rule_count`
+includes merged local rules, which that revision does not identify. Initial-policy failures
+before reaching this boundary retain the existing policy-failure diagnostic.
+
+Only an internally converted silent, nonpaginated REST merge can capture response metadata.
+Octopool checks an added include flag against the same final policy and byte limits, then
+uses the existing single body preparation and request. If instrumentation cannot pass,
+the merge arguments remain unchanged and `headers=unavailable` is reported. Capture
+suppresses the newly requested raw headers and body, preserving native stderr and the
+child's outcome. Native merges, generic API calls, caller-owned include output, and
+pagination are not intercepted. No probe, retry, or extra policy lookup is added.
+
+Accepted metadata is limited to HTTP status, a bounded hex-and-colon GitHub request ID,
+an allowlisted quota resource (`core`, `search`, `graphql`, `integration_manifest`, or
+`code_search`), and nonnegative signed-64-bit decimal limit, remaining, used, reset, and
+Retry-After values. Missing fields may be absent. Any malformed selected value, duplicate
+selected field (including comma-joined values), malformed/truncated framing, extra response
+or body, line above 4 KiB, or block above 32 KiB invalidates the entire block. Nothing is
+salvaged. The collector recognizes native gh's tested plain framing and bold-blue header-name
+wrapper; other terminal escapes are rejected. A future native output-format change may
+make headers unavailable. Raw output is drained even after rejection.
+
+Added records contain no argv, repository, PR number, SHA, publication text, snapshot path,
+environment values, rule text, raw errors, credentials, or credential fingerprints. Native
+stderr remains native output. Diagnostic parse/render/write failures do not change the
+operation's result. A 403 alone never establishes quota exhaustion, and this observability
+does not change routing, authentication, permissions, or server behavior or establish the
+cause of a past failure.
+
 ### `octopool gh pr|issue|run|repo|release ...`
 
 The shim also handles common top-level GitHub CLI read commands by translating them to
@@ -941,7 +997,8 @@ covers readiness/CI projections, issue comment projections, and PR head filters 
 GraphQL shapes are not representable by the relay. Numeric `pr ready` (or a checked
 current/explicit nonnumeric Git branch) and metadata-only PR/issue edits with add/remove label
 or assignee flags are also allowed without free-form text. Exact-head
-`pr merge --squash --match-head-commit` is converted to the immediate pull-request merge REST
+`pr merge --squash --match-head-commit` with a numeric selector is converted, when the final
+policy has active rules, to the immediate pull-request merge REST
 endpoint with the checked SHA and squash method; it never enables auto-merge, so a branch
 that requires a merge queue fails closed. An explicit `--body-file`/`-F` (including `-` for
 stdin) supplies an optional commit message through the same bounded text rewriting and private
@@ -955,6 +1012,9 @@ lifecycle path. Other editor/web/template/fill modes, unmodeled uploads, aliases
 GraphQL, and newly introduced native commands/flags use best-effort filtering and retain
 native behavior. A denial reports only the generic unsafe-input boundary and never echoes the
 rejected text.
+
+An empty final policy retains native `gh pr merge`; the final policy decision can differ
+from an earlier check. Neither route changes the local writer's authentication.
 
 Admin imports always fetch the current revision before the conditional update:
 
@@ -1041,6 +1101,8 @@ These are dev/CI escape hatches, not the everyday UX:
 - `OCTOPOOL_TOKEN` — caller token override (required to use a non-saved URL).
 - `OCTOPOOL_POOL` — pool id (default `maintainers`).
 - `OCTOPOOL_GH_PATH` — path to the real `gh` binary.
+- `OCTOPOOL_DIAGNOSTICS=1` — opt-in final PR-merge dispatch and bounded response-metadata
+  diagnostics on stderr; only the exact value `1` enables them. See quota provenance above.
 - `OCTOPOOL_STRING_REWRITE_FILE` — optional local policy JSON; an explicit unreadable or
   missing file fails closed. Defaults to `string-rewrites.json` beside `auth.json`.
 - `OCTOPOOL_FRESH=1` — default every relayed read to `cache-control: max-age=0`, including


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers investigating `gh pr merge` failures could not tell whether the final command used native merge behavior or Octopool's protected REST conversion, and could mistake shared-reader quota for native-writer quota.

A successful later quota or identity probe does not establish which resource or quota state applied to the failed operation. This change makes the relevant dispatch and response evidence observable without guessing at the cause of historical 403s.

## Why This Change Was Made

The final native-dispatch boundary already owns the checked command and policy snapshot, so diagnostics belong there rather than in a separate credential-aware client or retry layer. Exactly `OCTOPOOL_DIAGNOSTICS=1` enables fixed-field merge diagnostics. Only internally converted, silent REST merges acquire bounded response-header capture, and the added include flag must pass the same final policy and byte limits.

Malformed, duplicate, truncated, oversized, or body-spoofed metadata is withheld. Instrumentation failure leaves the operation's result unchanged. Existing authentication, exact-head squash guards, snapshots, default-off merge streams, exit codes, and single-attempt behavior are preserved. Unconverted native merges report their route without inventing HTTP metadata; arbitrary API calls and caller-owned include output remain untouched.

This is an observability and provenance fix, not an attribution of an earlier failure to a token, resource, proxy, or quota reset. No broader transport refactor is needed.

## User Impact

- Opt-in merge diagnostics expose the final route, server-policy revision, effective rule count, child outcome, and validated HTTP/request-ID/quota evidence when available.
- Successful relay `/rate_limit` output gets a fixed stderr notice explaining that pooled-reader quota is not native-writer quota or permission proof. JSON stdout is unchanged; native probes and saved-login shortcuts stay quiet.
- Added diagnostics exclude credentials and fingerprints, raw headers, merge text, repository identifiers, SHA values, snapshot paths, and policy rules. They do not introduce probes or retry mutations.
- CLI documentation explains quota provenance and diagnostic limitations; the changelog records the operational changes. No version bump or publication is included.

## Evidence

- All nine stages of `pnpm check` passed locally, including 983 TypeScript tests, 958 Worker tests, the build, the full Go suite, and Go vet. The stages were run separately so the pinned SQL tool could perform its dependency-metadata lookup while test/build stages retained loopback-only networking.
- Native gh 2.98 was exercised against a loopback-only synthetic endpoint for HTTP 200/403 with plain and forced-color output. Silent versus include-plus-silent preserved stderr and exit codes, suppressed response bodies, and made exactly one request per invocation.
- Focused regressions and race tests cover final-policy changes, scope/default-off compatibility, framing and size bounds, privacy, launch/cancellation/writer failures, snapshot cleanup, quota notices, and no extra child/probe/retry.
- Formatting, lint, and `git diff --check` passed. Independent pre-commit blocker-level autoreview found no accepted/actionable findings.

All mutation-shaped test requests used synthetic local fixtures. No production merge was replayed to test this patch.
