### PR TITLE
fix(cli): allow slow authoritative policy requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog
 
-## Unreleased
+## 0.6.2 - 2026-09-05
 
 ### Fixes
 
+- Allow authoritative policy requests up to 30 seconds so slow connections do not prematurely block guarded GitHub commands; preserve earlier caller deadlines, cancellation, and fail-closed policy checks.
 - Add opt-in final PR-merge route, policy, child-outcome, and bounded REST-header diagnostics without changing authentication, merge behavior, or retries or attributing historical failures.
 - Identify successful relay `/rate_limit` output as pooled-reader quota rather than native-writer quota or permission proof, preserving JSON stdout and quiet native probes.
+
+### Upgrade notes
+
+- This is a CLI-only patch release; no Worker deployment or database migration is required.
 
 ## 0.6.1 - 2026-09-02
 

--- a/cmd/octopool/string_rewrites_policy.go
+++ b/cmd/octopool/string_rewrites_policy.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-const rewritePolicyTimeout = 5 * time.Second
+const rewritePolicyTimeout = 30 * time.Second
 
 func validRewriteTimestamp(value string) bool {
 	_, err := time.Parse(time.RFC3339Nano, value)

--- a/cmd/octopool/string_rewrites_policy_test.go
+++ b/cmd/octopool/string_rewrites_policy_test.go
@@ -493,13 +493,34 @@ func TestRewritePolicyTransportDiagnostics(t *testing.T) {
 	}
 }
 
+func TestRewritePolicyAllowsSlowResponse(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		useRewritePolicyTestTransport(t, func(r *http.Request) (*http.Response, error) {
+			select {
+			case <-time.After(6 * time.Second):
+				return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(rewriteEmptyTestPolicy))}, nil
+			case <-r.Context().Done():
+				return nil, r.Context().Err()
+			}
+		})
+		started := time.Now()
+		result, err := rewritePolicyHTTP(t.Context(), "https://synthetic.invalid", "/policy", "synthetic-token", "GET", nil)
+		if err != nil || string(result.data) != rewriteEmptyTestPolicy {
+			t.Fatalf("slow policy response failed: %v", err)
+		}
+		if time.Since(started) != 6*time.Second {
+			t.Fatal("policy returned before the delayed response")
+		}
+	})
+}
+
 func TestRewritePolicyControlledTiming(t *testing.T) {
 	for _, test := range []struct {
 		name     string
 		duration time.Duration
 		class    rewritePolicyClass
 	}{
-		{"five second deadline", 5 * time.Second, rewritePolicyTimeoutClass},
+		{"thirty second deadline", 30 * time.Second, rewritePolicyTimeoutClass},
 		{"parent deadline", 23 * time.Millisecond, rewritePolicyTimeoutClass},
 		{"parent cancellation", 17 * time.Millisecond, rewritePolicyCanceled},
 	} {
@@ -522,7 +543,7 @@ func TestRewritePolicyControlledTiming(t *testing.T) {
 					if test.name == "parent deadline" {
 						want = test.duration
 					}
-					if !ok || deadline.Sub(time.Now()) != want || rewritePolicyTimeout != 5*time.Second {
+					if !ok || deadline.Sub(time.Now()) != want || rewritePolicyTimeout != 30*time.Second {
 						t.Error("policy context deadline changed")
 					}
 					<-r.Context().Done()

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -689,7 +689,7 @@ Every protected `gh` command requires an Octopool login and a fresh authoritativ
 from `GET /v1/pools/<pool>/string-rewrites`. Each relay request and every final real-`gh`
 dispatch checks policy; a fallback cannot reuse approval for different arguments. There is
 no persistent policy cache, offline allowance, or fallback on authentication/policy errors.
-Policy HTTP requests reject redirects, use a five-second deadline, and bound the response
+Policy HTTP requests reject redirects, use a 30-second deadline, and bound the response
 to 65,536 bytes. Empty invocations, singleton help/version, known built-in topic help,
 and narrowly parsed GitHub authentication bootstrap commands remain available without a policy.
 
@@ -757,8 +757,9 @@ The fixed `class` identifies the failing check, not its underlying cause:
 to whole milliseconds. It includes GET/body reading and any subsequent server/local/merge
 checks reached, but excludes caller client setup and final stderr formatting. For `setup`
 only, both fields instead cover client setup. They do not measure a whole `gh` invocation;
-each guarded boundary reloads policy and starts another attempt. The existing five-second
-context and HTTP-client deadlines are unchanged, and do not bound later local/merge work.
+each guarded boundary reloads policy and starts another attempt. The 30-second context
+and HTTP-client deadlines do not bound later local/merge work. An earlier caller deadline
+or cancellation still takes precedence.
 
 `http_status` is omitted without an observed response. For `server_validation`, `local_read`,
 `local_validation`, or `merge`, `http_status=200` belongs to the preceding policy **GET**,


### PR DESCRIPTION
## What Problem This Solves

Guarded GitHub commands fail before dispatch when fetching the authoritative rewrite policy takes more than five seconds, even if the service responds successfully shortly afterward. Observed connection and response latency exceeded that limit during maintainer work.

## Why This Change Was Made

Raise the policy request's context and HTTP-client deadline to 30 seconds. Earlier caller deadlines and cancellation still win; redirect rejection, bounded response reads, policy freshness, and fail-closed behavior stay intact. Update the CLI documentation and finalize the 0.6.2 patch-release notes, including the already-landed CLI diagnostic improvements.

## User Impact

Slow valid policy responses can complete instead of prematurely blocking GitHub commands. Truly stalled policy requests can now take up to 30 seconds to fail. This is a CLI-only release with no Worker deployment or database migration.

## Evidence

- New virtual-time six-second response regression fails against the old code at exactly five seconds and passes after the change.
- Focused policy suite passes, including the 30-second deadline, earlier parent deadline/cancellation, response limits, redirects, and failure behavior.
- Full Go suite and go vet pass; documentation formatting and diff checks pass.
- Independent Codex P2 review found no actionable findings.
- Hosted [CI run34010701136](https://github.com/openclaw/octopool/actions/runs/34010701136) passed both Linux full checks/release snapshot and native Windows Go checks. The full local pnpm check also passed, including unit and Worker integration tests, build/type checks, Go tests, and vet.

## Real HTTP timing proof

Executed the released 0.6.1 CLI and the candidate built from 595fbe34ef5f1a7984962e37cc103f51e3d1d2c5 against an isolated loopback HTTP server. The normal `admin string-rewrites status` command uses the production policy HTTP client and default TCP transport; no virtual clock or replacement RoundTripper was used. The server returned a valid synthetic policy after a controlled delay, and all server processes were joined.

| Client | Server delay | Observed CLI elapsed | Result |
| --- | ---: | ---: | --- |
| Released 0.6.1 | 6s | 5.021s | Exit 1, policy timeout at 5001ms |
| Candidate | 6s | 7.433s | Exit 0, revision 1 / rule_count 0 |
| Candidate | 31s | 30.024s | Exit 1, policy timeout at 30005ms |

The elapsed CLI measurements include process startup. This verifies acceptance beyond the former five-second cutoff and the retained 30-second bound with real HTTP transport. Earlier caller deadline/cancellation, no retry or fallback on policy errors, and redirect/response-size protections remain covered by the passing Go suite.
