### PR TITLE
fix(cli): support protected pull request base edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Support protected PR base changes with `gh pr edit --base` / `-B` and REST pull-request updates, including base-only edits, while retaining branch validation, authoritative rewrite checks, host pinning, and body sanitization.
+
 ## 0.6.2 - 2026-09-05
 
 ### Fixes

--- a/cmd/octopool/string_rewrites_api.go
+++ b/cmd/octopool/string_rewrites_api.go
@@ -357,10 +357,10 @@ func rewriteAPIPayload(policy stringRewritePolicy, prepared *rewritePreparation,
 		spec = "title:text body:text"
 		required = ""
 	case "pull-create":
-		spec = "title:text body:text head:string base:string draft:bool maintainer_can_modify:bool"
+		spec = "title:text body:text head:string base:branch draft:bool maintainer_can_modify:bool"
 		required = "title body head base"
 	case "pull-edit":
-		spec = "title:text body:text"
+		spec = "title:text body:text base:branch"
 		required = ""
 	case "pull-merge":
 		spec = "sha:string merge_method:squash commit_message:text commit_title:text"
@@ -418,9 +418,12 @@ func rewriteAPIPayload(policy stringRewritePolicy, prepared *rewritePreparation,
 				return errRewriteBlocked
 			}
 			payload[key] = rewritten
-		case "string":
+		case "string", "branch":
 			text, ok := value.(string)
 			if !ok || text == "" || (schema == "pull-merge" && key == "sha" && !rewriteCommitSHA.MatchString(text)) {
+				return errRewriteBlocked
+			}
+			if allowed[key] == "branch" && !validRewriteBaseBranch(text) {
 				return errRewriteBlocked
 			}
 			if err := policy.checkStructural(text); err != nil {

--- a/cmd/octopool/string_rewrites_args.go
+++ b/cmd/octopool/string_rewrites_args.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"os/exec"
 	"regexp"
 	"strings"
 )
@@ -139,6 +140,10 @@ func (prepared *rewritePreparation) snapshot(data []byte) (string, error) {
 var rewriteRepoPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
 var rewriteRefPattern = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_./:-]*$`)
 
+func validRewriteBaseBranch(branch string) bool {
+	return rewriteRefPattern.MatchString(branch) && exec.Command("git", "check-ref-format", "--branch", branch).Run() == nil
+}
+
 func rewriteRepo(flags *rewriteFlags, policy stringRewritePolicy) error {
 	repo := flags.values["--repo"]
 	// Pin explicit GitHub URLs and inferred repository context to owner/repo so
@@ -181,7 +186,7 @@ func prepareRewriteContent(policy stringRewritePolicy, args []string, stdin io.R
 		valueSpec += " --title,-t --body,-b --body-file,-F --head,-H --base,-B --label,-l --assignee,-a"
 		booleanSpec = "--draft,-d --no-maintainer-edit --dry-run"
 	case "pr edit":
-		valueSpec += " --title,-t --body,-b --body-file,-F --add-assignee --remove-assignee --add-label --remove-label"
+		valueSpec += " --title,-t --body,-b --body-file,-F --base,-B --add-assignee --remove-assignee --add-label --remove-label"
 	case "issue edit":
 		valueSpec += " --title,-t --body,-b --body-file,-F --add-label --remove-label --add-assignee --remove-assignee"
 	case "issue create":
@@ -259,8 +264,11 @@ func prepareRewriteContent(policy stringRewritePolicy, args []string, stdin io.R
 	if create && (!flags.has("--title") || !hasBody) {
 		return errRewriteBlocked
 	}
-	metadataEdit := flags.has("--add-assignee") || flags.has("--remove-assignee") || flags.has("--add-label") || flags.has("--remove-label")
+	metadataEdit := flags.has("--base") || flags.has("--add-assignee") || flags.has("--remove-assignee") || flags.has("--add-label") || flags.has("--remove-label")
 	if args[1] == "edit" && !flags.has("--title") && !hasBody && !metadataEdit {
+		return errRewriteBlocked
+	}
+	if flags.has("--base") && !validRewriteBaseBranch(flags.values["--base"]) {
 		return errRewriteBlocked
 	}
 	for _, name := range []string{"--assignee", "--add-assignee", "--remove-assignee"} {
@@ -290,9 +298,6 @@ func prepareRewriteContent(policy stringRewritePolicy, args []string, stdin io.R
 			flags.ordered = append(flags.ordered, rewriteFlag{name: "--head", value: head})
 		}
 		if !rewriteRefPattern.MatchString(flags.values["--head"]) {
-			return errRewriteBlocked
-		}
-		if flags.has("--base") && !rewriteRefPattern.MatchString(flags.values["--base"]) {
 			return errRewriteBlocked
 		}
 	}

--- a/cmd/octopool/string_rewrites_pr_base_test.go
+++ b/cmd/octopool/string_rewrites_pr_base_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestStringRewritePRBaseEditCLI(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	for _, test := range []struct {
+		name  string
+		flags []string
+		base  string
+	}{
+		{"long", []string{"--base", "main"}, "main"},
+		{"equals", []string{"--base=release/0.6"}, "release/0.6"},
+		{"short", []string{"-B", "123"}, "123"},
+		{"attached", []string{"-Bmain"}, "main"},
+		{"short equals", []string{"-B=main"}, "main"},
+		{"with content", []string{"--base=main", "--body=internal-model"}, "main"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			capturePath := captureRewriteGH(t)
+			args := append([]string{"pr", "edit", "3486", "--repo=acme/repo"}, test.flags...)
+			if err := execRealGHWithStdin(t.Context(), args, strings.NewReader("unrequested input"), io.Discard, io.Discard); err != nil {
+				t.Fatal(err)
+			}
+			capture := readRewriteCapture(t, capturePath)
+			if !slices.Contains(capture.Args, "--base="+test.base) || !slices.Contains(capture.Args, "--repo=acme/repo") {
+				t.Fatalf("base/repository not preserved: %v", capture.Args)
+			}
+			if capture.Stdin != "" || capture.Env["GH_HOST"] != "github.com" || capture.Env["GH_REPO"] != "" {
+				t.Fatalf("unexpected child input or host context: %+v", capture)
+			}
+			if test.name == "with content" {
+				if !rewriteCaptureHasContent(capture, "public") {
+					t.Fatalf("body was not rewritten: %+v", capture)
+				}
+			} else if len(capture.Files) != 0 {
+				t.Fatalf("base-only edit manufactured content: %+v", capture)
+			}
+		})
+	}
+}
+
+func TestStringRewritePRBaseEditAPI(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	for _, test := range []struct {
+		name  string
+		flags []string
+		input string
+		base  string
+	}{
+		{"raw field", []string{"-fbase=main"}, "", "main"},
+		{"typed field", []string{"-Fbase=release/0.6"}, "", "release/0.6"},
+		{"JSON", []string{"--input=-"}, `{"base":"123","body":"internal-model"}`, "123"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			capturePath := captureRewriteGH(t)
+			args := append([]string{"api", "repos/acme/repo/pulls/3486", "--method=PATCH"}, test.flags...)
+			if err := execRealGHWithStdin(t.Context(), args, strings.NewReader(test.input), io.Discard, io.Discard); err != nil {
+				t.Fatal(err)
+			}
+			capture := readRewriteCapture(t, capturePath)
+			if len(capture.Files) != 1 || capture.Stdin != "" {
+				t.Fatalf("expected one immutable JSON input: %+v", capture)
+			}
+			for _, content := range capture.Files {
+				var payload map[string]any
+				if err := json.Unmarshal([]byte(content), &payload); err != nil {
+					t.Fatal(err)
+				}
+				if payload["base"] != test.base {
+					t.Fatalf("base changed: %v", payload)
+				}
+				if test.name == "JSON" && payload["body"] != "public" {
+					t.Fatalf("body was not rewritten: %v", payload)
+				}
+				if test.name != "JSON" && len(payload) != 1 {
+					t.Fatalf("base-only edit manufactured fields: %v", payload)
+				}
+			}
+		})
+	}
+}
+
+func TestStringRewritePRBaseEditRejectsUnsafeRefs(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	for _, base := range []string{"", "bad base", "../main", "topic..main", "topic.lock", "owner:main", "@{-1}", "-main", "topic//main", "internal-model", "release/internal-model"} {
+		for _, transport := range []string{"cli", "api"} {
+			t.Run(transport+"/"+base, func(t *testing.T) {
+				capturePath := captureRewriteGH(t)
+				args := []string{"pr", "edit", "3486", "--repo=acme/repo", "--base=" + base}
+				if transport == "api" {
+					args = []string{"api", "repos/acme/repo/pulls/3486", "--method=PATCH", "--raw-field=base=" + base}
+				}
+				if err := execRealGHWithStdin(t.Context(), args, strings.NewReader(""), io.Discard, io.Discard); err != errRewriteBlocked {
+					t.Fatalf("expected protected rejection, got %v", err)
+				}
+				if _, err := os.Stat(capturePath); !os.IsNotExist(err) {
+					t.Fatal("rejected base reached native gh")
+				}
+			})
+		}
+	}
+}
+
+func TestStringRewritePRBaseEditRejectsAmbiguousInputs(t *testing.T) {
+	rewriteTestServer(t, rewriteActiveTestPolicy, nil)
+	for _, args := range [][]string{
+		{"pr", "edit", "3486", "--repo=acme/repo", "--base=main", "-Bother"},
+		{"pr", "edit", "3486", "--repo=acme/repo", "--base=main", "--editor"},
+		{"api", "repos/acme/repo/pulls/3486", "--method=PATCH", "--field=base=true"},
+		{"api", "repos/acme/repo/pulls/3486", "--method=PATCH", "--field=base=null"},
+		{"api", "repos/acme/repo/pulls/3486", "--method=PATCH", "--field=base=123"},
+		{"api", "repos/acme/repo/pulls/3486", "--method=PATCH", "--raw-field=base=main", "--field=maintainer_can_modify=true"},
+	} {
+		capturePath := captureRewriteGH(t)
+		if err := execRealGHWithStdin(t.Context(), args, strings.NewReader(""), io.Discard, io.Discard); err != errRewriteBlocked {
+			t.Fatalf("ambiguous edit accepted: %v: %v", args, err)
+		}
+		if _, err := os.Stat(capturePath); !os.IsNotExist(err) {
+			t.Fatal("ambiguous edit reached native gh")
+		}
+	}
+}
+
+func TestStringRewritePRBasePreparationPortable(t *testing.T) {
+	policy := testRewritePolicy(t, stringRewriteRule{"internal-model", "public"})
+	for _, base := range []string{"main", "release/0.6", "123"} {
+		t.Run(base, func(t *testing.T) {
+			prepared := &rewritePreparation{}
+			defer prepared.cleanup()
+			args := []string{"pr", "edit", "3486", "--repo=acme/repo", "--base=" + base}
+			if err := prepareRewriteContent(policy, args, strings.NewReader(""), prepared); err != nil {
+				t.Fatal(err)
+			}
+			if !slices.Contains(prepared.args, "--base="+base) {
+				t.Fatalf("base not preserved: %v", prepared.args)
+			}
+			payload := map[string]any{"base": base, "body": "internal-model"}
+			if err := rewriteAPIPayload(policy, prepared, payload, "pull-edit"); err != nil {
+				t.Fatal(err)
+			}
+			if payload["base"] != base || payload["body"] != "public" {
+				t.Fatalf("unexpected rewritten payload: %v", payload)
+			}
+		})
+	}
+	for _, base := range []any{nil, 123, true, "", "bad base", "topic..main", "internal-model"} {
+		prepared := &rewritePreparation{}
+		payload := map[string]any{"base": base}
+		if err := rewriteAPIPayload(policy, prepared, payload, "pull-edit"); err != errRewriteBlocked {
+			t.Fatalf("invalid base accepted: %v", err)
+		}
+	}
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -798,7 +798,10 @@ With active rules, the initial local publication vocabulary is deliberately cons
   the repository's default branch. `--dry-run` is accepted. Reviews require one
   explicit review action. PR/issue creation
   accepts one `--label`/`-l` and one `--assignee`/`-a` value (use comma-separated lists),
-  while PR/issue edits accept metadata-only add/remove label and assignee flags. Assignees may
+  while PR/issue edits accept metadata-only add/remove label and assignee flags. PR edits also
+  accept `--base` / `-B`, alone or with explicit title/body updates. Base branches must pass
+  Git branch-name validation and structural rewrite checks; branch names are never rewritten.
+  Assignees may
   include native `@me` or `@copilot`. PR/issue create/edit/comment also accept repeated
   `--attach` image/video files as described below.
 - Release `create`/`edit`: explicit title/notes or notes files and one tag.
@@ -812,6 +815,9 @@ With active rules, the initial local publication vocabulary is deliberately cons
   use `--input` JSON. Exact issue-assignee POSTs accept repeated raw `assignees[]` values;
   exact pull-request merge PUTs require a full 40-hex `sha` and `merge_method: squash`,
   with optional rewritten `commit_message` and `commit_title` strings.
+  Pull-request PATCHes accept a string `base` field with the same branch checks as the CLI;
+  base-only updates do not republish an implicit title or body. Numeric branch names must be
+  supplied as strings, such as `-f base=123` or JSON `{"base":"123"}`.
   Other bracket accumulation, duplicate keys, mixed input/field sources, unknown properties,
   and custom authentication headers are rejected. Raw release creation first verifies the
   existing remote tag with a local authenticated GET.


### PR DESCRIPTION
With active outbound rewrite rules, `gh pr edit --base main` failed locally with “string rewrite protection blocked unsafe input” because the strict edit grammar omitted `--base`. The REST edit schema also omitted `base`.

Add explicit `--base` / `-B` and REST base-field support, including base-only edits. CLI and API base names share Git branch-name validation and retain structural policy checks; bodies still use sanitized snapshots, and host/repository pinning remains enforced. Unknown flags, unknown fields, non-string API bases, duplicate aliases, and policy-matching branch names remain rejected.

Validation:
- New CLI and REST regression cases fail against 0.6.2 and pass with the fix, including portable preparation coverage.
- `pnpm check` passes: 983 unit tests, 958 Worker integration tests, format/lint/types, Go tests, and vet.
- `pnpm test:e2e:cli-worker` passes with a token-free miss followed by a cache hit.
- A freshly Foundation-signed candidate successfully changed steipete/CodexBar#3486 to base `main` using the existing live policy and native writer.
- Independent Codex review through P2 found no actionable issues.

Release target: 0.6.3 CLI patch.
